### PR TITLE
Lineage: sort details list items, remove duplicate node processing

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.368.1",
+  "version": "2.368.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.368.2
+*Released*: 14 September 2023
+- Issue 48458: remove duplicate processing of combined nodes.
+- Issue 48459: sort items in `DetailsListLineageItems` by name
+
 ### version 2.368.1
 *Released*: 14 September 2023
 - Add missing toLocaleString() calls

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -5,7 +5,7 @@ import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
 import { LabelHelpTip } from '../base/LabelHelpTip';
 
 import { LINEAGE_GROUPING_GENERATIONS, LineageFilter, LineageOptions } from './types';
-import { DEFAULT_GROUPING_OPTIONS } from './constants';
+import { DEFAULT_GROUPING_OPTIONS, GROUPING_COMBINED_SIZE_MIN } from './constants';
 
 interface LineageSettingsOptions extends LineageOptions {
     originalFilters?: LineageFilter[];
@@ -86,10 +86,13 @@ export const LineageSettings: FC<Props> = memo(props => {
     const onGroupingChange = useCallback(
         (evt: ChangeEvent<HTMLInputElement>) => {
             const { name, value } = evt.target;
-            applyOptions(options_ => ({
-                ...options_,
-                grouping: { ...options_.grouping, [name]: value },
-            }));
+            const nValue = parseInt(value, 10);
+            if (GROUPING_COMBINED_SIZE_MIN < nValue) {
+                applyOptions(options_ => ({
+                    ...options_,
+                    grouping: { ...options_.grouping, [name]: nValue },
+                }));
+            }
         },
         [applyOptions]
     );
@@ -178,9 +181,10 @@ export const LineageSettings: FC<Props> = memo(props => {
                     <LabelHelpTip placement="top" title="Combine Generation Threshold">
                         <div className="lineage-settings__tip-body">
                             If the number of nodes in a generation is greater than or equal to this threshold, then all
-                            the nodes in this generation will be combined into a single node.
+                            the nodes in this generation will be combined into a single node. Minimum value of{' '}
+                            {GROUPING_COMBINED_SIZE_MIN}.
                             <div>
-                                <b>Note:</b> Aliquots are combined separately and may appear as a single combined node
+                                <b>Note:</b> Aliquots are combined separately and may appear as a single combined node.
                             </div>
                         </div>
                     </LabelHelpTip>
@@ -188,7 +192,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                 <input
                     defaultValue={options.grouping?.combineSize ?? DEFAULT_GROUPING_OPTIONS.combineSize}
                     className="form-control"
-                    min={2}
+                    min={GROUPING_COMBINED_SIZE_MIN}
                     name="combineSize"
                     onChange={onGroupingChange}
                     type="number"

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -373,7 +373,9 @@ export class ServerLineageAPIWrapper implements LineageAPIWrapper {
                     // TODO: Is there a better way to determine set of columns? Can we follow convention for detail views?
                     // See LineageNodeMetadata (and it's usages) for why this is currently necessary
                     columns: LINEAGE_METADATA_COLUMNS.add(fieldKey).join(','),
-                    filterArray: [Filter.create(fieldKey, nodes.map(n => n.pkFilters[0].value).toArray(), Filter.Types.IN)],
+                    filterArray: [
+                        Filter.create(fieldKey, nodes.map(n => n.pkFilters[0].value).toArray(), Filter.Types.IN),
+                    ],
                 });
             })
             .toArray();

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -101,8 +101,8 @@ function applyItemMetadata(
 ): Partial<LineageItemWithIOMetadata> {
     return {
         ...applyLineageIOMetadata(item, iconURLByLsid, urlResolver),
-        ...{ iconProps: resolveIconAndShapeForNode(item, iconURLByLsid[item.lsid], isSeed) },
-        ...{ links: urlResolver.resolveItem(item) ?? ({} as LineageLinkMetadata) },
+        iconProps: resolveIconAndShapeForNode(item, iconURLByLsid[item.lsid], isSeed),
+        links: urlResolver.resolveItem(item) ?? ({} as LineageLinkMetadata),
     };
 }
 

--- a/packages/components/src/internal/components/lineage/constants.tsx
+++ b/packages/components/src/internal/components/lineage/constants.tsx
@@ -19,6 +19,7 @@ import {
 // Default depth to fetch with the lineage API
 export const DEFAULT_LINEAGE_DISTANCE = 5;
 export const DEFAULT_LINEAGE_DIRECTION = LINEAGE_DIRECTIONS.Children;
+export const GROUPING_COMBINED_SIZE_MIN = 2;
 
 export const DEFAULT_GROUPING_OPTIONS: LineageGroupingOptions = {
     childDepth: DEFAULT_LINEAGE_DISTANCE,

--- a/packages/components/src/internal/components/lineage/constants.tsx
+++ b/packages/components/src/internal/components/lineage/constants.tsx
@@ -5,8 +5,10 @@
 import { List, Map } from 'immutable';
 import React from 'react';
 import { Button } from 'react-bootstrap';
+
 import { AppURL } from '../../url/AppURL';
 import { GridColumn } from '../base/models/GridColumn';
+
 import { Tag } from './Tag';
 import {
     LineageGroupingOptions,

--- a/packages/components/src/internal/components/lineage/node/DetailsList.tsx
+++ b/packages/components/src/internal/components/lineage/node/DetailsList.tsx
@@ -1,5 +1,6 @@
-import React, { Fragment, PureComponent, ReactNode } from 'react';
+import React, { FC, Fragment, memo, ReactNode, useCallback, useMemo, useState } from 'react';
 
+import { naturalSortByProperty } from '../../../../public/sort';
 import {
     getLineageNodeTitle,
     LineageNodeCollection,
@@ -8,7 +9,7 @@ import {
     LineageNode,
 } from '../models';
 import { DEFAULT_ICON_URL } from '../utils';
-import { NodeInteractionConsumer, WithNodeInteraction } from '../actions';
+import { NodeInteractionConsumer } from '../actions';
 import { LineageDataLink } from '../LineageDataLink';
 import { SVGIcon } from '../../base/SVGIcon';
 
@@ -20,124 +21,183 @@ export interface DetailsListProps {
     title: string;
 }
 
-interface DetailsListState {
-    expanded: boolean;
+export const DetailsList: FC<DetailsListProps> = memo(props => {
+    const { children, collapsedCount, headerLinks, open, showCount, title } = props;
+    const [expanded, setExpanded] = useState<boolean>(false);
+
+    const onToggle = useCallback(() => {
+        setExpanded(ex => !ex);
+    }, []);
+
+    return (
+        <details open={open}>
+            <summary className="lineage-name">
+                <h6 className="no-margin-bottom">
+                    {title}
+                    {showCount && <span className="spacer-left">({React.Children.count(children)})</span>}
+                    {headerLinks &&
+                        headerLinks.map(
+                            (link, i) =>
+                                link && (
+                                    <span className="spacer-left" key={i}>
+                                        {link}
+                                    </span>
+                                )
+                        )}
+                </h6>
+            </summary>
+            <ul className="lineage-details-list">
+                {React.Children.map(children, (child, i) => {
+                    const showChild = expanded || i < collapsedCount;
+
+                    if (i === collapsedCount) {
+                        return (
+                            <Fragment key="__skip">
+                                <li>
+                                    <SVGIcon className="lineage-sm-icon" />
+                                    <a className="lineage-link spacer-left" onClick={onToggle}>
+                                        Show {React.Children.count(children) - collapsedCount}{' '}
+                                        {expanded ? 'less' : 'more'}...
+                                    </a>
+                                </li>
+                                {showChild ? <li key={i}>{child}</li> : null}
+                            </Fragment>
+                        );
+                    }
+
+                    return showChild ? <li key={i}>{child}</li> : null;
+                })}
+            </ul>
+        </details>
+    );
+});
+
+DetailsList.defaultProps = {
+    collapsedCount: 4,
+    open: true,
+    showCount: true,
+};
+
+DetailsList.displayName = 'DetailsList';
+
+interface DetailsListStepProps {
+    node: LineageNode;
+    onSelect: (stepIdx: number) => void;
 }
 
-export class DetailsList extends PureComponent<DetailsListProps, DetailsListState> {
-    static defaultProps = {
-        collapsedCount: 4,
-        open: true,
-        showCount: true,
-    };
-
-    readonly state: DetailsListState = { expanded: false };
-
-    toggle = (): void => {
-        this.setState(state => ({ expanded: !state.expanded }));
-    };
-
-    render(): ReactNode {
-        const { children, collapsedCount, headerLinks, open, showCount, title } = this.props;
-        const { expanded } = this.state;
-
-        return (
-            <details open={open}>
-                <summary className="lineage-name">
-                    <h6 className="no-margin-bottom">
-                        {title}
-                        {showCount && <span className="spacer-left">({React.Children.count(children)})</span>}
-                        {headerLinks &&
-                            headerLinks.map(
-                                (link, i) =>
-                                    link && (
-                                        <span className="spacer-left" key={i}>
-                                            {link}
-                                        </span>
-                                    )
-                            )}
-                    </h6>
-                </summary>
-                <ul className="lineage-details-list">
-                    {React.Children.map(children, (child, i) => {
-                        const showChild = expanded || i < collapsedCount;
-
-                        if (i === collapsedCount) {
-                            return (
-                                <Fragment key="__skip">
-                                    <li>
-                                        <SVGIcon className="lineage-sm-icon" />
-                                        <a className="lineage-link spacer-left" onClick={this.toggle}>
-                                            Show {React.Children.count(children) - collapsedCount}{' '}
-                                            {expanded ? 'less' : 'more'}...
-                                        </a>
-                                    </li>
-                                    {showChild ? <li key={i}>{child}</li> : null}
-                                </Fragment>
-                            );
-                        }
-
-                        return showChild ? <li key={i}>{child}</li> : null;
-                    })}
-                </ul>
-            </details>
-        );
+export const DetailsListSteps: FC<DetailsListStepProps> = memo(({ node, onSelect }) => {
+    if (!node.isRun) {
+        return null;
     }
+
+    return (
+        <DetailsList title="Run steps">
+            {node.steps.map((step, i) => (
+                <div className="lineage-name" key={`${node.lsid}.step.${i}`}>
+                    <SVGIcon className="lineage-sm-icon" iconSrc={step.iconProps?.iconURL ?? DEFAULT_ICON_URL} />
+                    <span className="lineage-sm-name spacer-right">{step.protocol?.name || step.name}</span>
+                    <LineageDataLink
+                        onClick={() => {
+                            onSelect(i);
+                        }}
+                    >
+                        Details
+                    </LineageDataLink>
+                </div>
+            ))}
+        </DetailsList>
+    );
+});
+
+DetailsListSteps.displayName = 'DetailsListSteps';
+
+interface DetailsListLineageItemProps {
+    highlighted: boolean;
+    item: LineageItemWithMetadata;
 }
+
+const DetailsListLineageItem: FC<DetailsListLineageItemProps> = memo(({ highlighted, item }) => {
+    const style = useMemo(
+        () => ({
+            fontWeight: highlighted ? 'bold' : 'normal',
+        }),
+        [highlighted]
+    );
+
+    return (
+        <div className="lineage-item-test lineage-name" style={style} title={getLineageNodeTitle(item as LineageNode)}>
+            <SVGIcon className="lineage-sm-icon" iconSrc={item.iconProps?.iconURL ?? DEFAULT_ICON_URL} />
+            <NodeInteractionConsumer>
+                {context => {
+                    if (context.isNodeInGraph(item)) {
+                        return (
+                            <a
+                                className="lineage-link spacer-horizontal"
+                                onClick={e => context.onNodeClick(item)}
+                                onMouseOver={e => context.onNodeMouseOver(item)}
+                                onMouseOut={e => context.onNodeMouseOut(item)}
+                            >
+                                {item.name}
+                            </a>
+                        );
+                    }
+
+                    return <span className="spacer-horizontal">{item.name}</span>;
+                }}
+            </NodeInteractionConsumer>
+            <LineageDataLink href={item.links.overview}>Overview</LineageDataLink>
+            <LineageDataLink href={item.links.lineage}>Lineage</LineageDataLink>
+        </div>
+    );
+});
+
+DetailsListLineageItem.displayName = 'DetailsListLineageItem';
+
+export interface DetailsListLineageItemsProps extends DetailsListProps {
+    highlightNode?: string;
+    items: LineageItemWithMetadata[];
+}
+
+export const DetailsListLineageItems: FC<DetailsListLineageItemsProps> = memo(props => {
+    const { highlightNode, items, ...detailsListProps } = props;
+
+    // Issue 48459: Sort lineage detail list items
+    const sortedItems = useMemo<LineageItemWithMetadata[]>(() => {
+        if (!items || items.length === 0) return [];
+        return items.sort(naturalSortByProperty('name'));
+    }, [items]);
+
+    if (sortedItems.length === 0) {
+        return null;
+    }
+
+    return (
+        <DetailsList {...detailsListProps}>
+            {items.map(item => (
+                <DetailsListLineageItem highlighted={item.lsid === highlightNode} item={item} key={item.lsid} />
+            ))}
+        </DetailsList>
+    );
+});
+
+DetailsListLineageItems.displayName = 'DetailsListLineageItems';
 
 export interface DetailsListLineageIOProps {
     item: LineageIOWithMetadata;
 }
 
-export class DetailsListLineageIO extends PureComponent<DetailsListLineageIOProps> {
-    render(): ReactNode {
-        const { item } = this.props;
+export const DetailsListLineageIO: FC<DetailsListLineageIOProps> = memo(({ item }) => (
+    <>
+        <DetailsListLineageItems items={item.dataInputs} title="Data Inputs" />
+        <DetailsListLineageItems items={item.materialInputs} title="Material Inputs" />
+        <DetailsListLineageItems items={item.dataOutputs} title="Data Outputs" />
+        <DetailsListLineageItems items={item.materialOutputs} title="Material Outputs" />
+        <DetailsListLineageItems items={item.objectInputs} title="Object Inputs" />
+        <DetailsListLineageItems items={item.objectOutputs} title="Object Outputs" />
+    </>
+));
 
-        return (
-            <>
-                <DetailsListLineageItems items={item.dataInputs} title="Data Inputs" />
-                <DetailsListLineageItems items={item.materialInputs} title="Material Inputs" />
-                <DetailsListLineageItems items={item.dataOutputs} title="Data Outputs" />
-                <DetailsListLineageItems items={item.materialOutputs} title="Material Outputs" />
-                <DetailsListLineageItems items={item.objectInputs} title="Object Inputs" />
-                <DetailsListLineageItems items={item.objectOutputs} title="Object Outputs" />
-            </>
-        );
-    }
-}
-
-interface DetailsListStepProps {
-    node: LineageNode;
-    onSelect: (stepIdx: number) => any;
-}
-
-export class DetailsListSteps extends PureComponent<DetailsListStepProps> {
-    render(): ReactNode {
-        const { node, onSelect } = this.props;
-
-        if (!node.isRun) {
-            return null;
-        }
-
-        return (
-            <DetailsList title="Run steps">
-                {node.steps.map((step, i) => (
-                    <div className="lineage-name" key={`${node.lsid}.step.${i}`}>
-                        <SVGIcon className="lineage-sm-icon" iconSrc={step.iconProps?.iconURL ?? DEFAULT_ICON_URL} />
-                        <span className="lineage-sm-name spacer-right">{step.protocol?.name || step.name}</span>
-                        <LineageDataLink
-                            onClick={() => {
-                                onSelect(i);
-                            }}
-                        >
-                            Details
-                        </LineageDataLink>
-                    </div>
-                ))}
-            </DetailsList>
-        );
-    }
-}
+DetailsListLineageIO.displayName = 'DetailsListLineageIO';
 
 interface DetailsListNodesProps {
     highlightNode?: string;
@@ -145,71 +205,17 @@ interface DetailsListNodesProps {
     title: string;
 }
 
-export class DetailsListNodes extends PureComponent<DetailsListNodesProps> {
-    render(): ReactNode {
-        const { highlightNode, nodes, title } = this.props;
+export const DetailsListNodes: FC<DetailsListNodesProps> = memo(({ highlightNode, nodes, title }) => (
+    <DetailsListLineageItems
+        headerLinks={[
+            <LineageDataLink key="grid" href={nodes.listURL}>
+                View in grid
+            </LineageDataLink>,
+        ]}
+        highlightNode={highlightNode}
+        items={nodes.nodes}
+        title={title}
+    />
+));
 
-        return (
-            <DetailsListLineageItems
-                headerLinks={[
-                    <LineageDataLink key="grid" href={nodes.listURL}>
-                        View in grid
-                    </LineageDataLink>,
-                ]}
-                highlightNode={highlightNode}
-                items={nodes.nodes}
-                title={title}
-            />
-        );
-    }
-}
-
-export interface DetailsListLineageItemsProps extends DetailsListProps {
-    highlightNode?: string;
-    items: LineageItemWithMetadata[];
-}
-
-export class DetailsListLineageItems extends PureComponent<DetailsListLineageItemsProps> {
-    render(): ReactNode {
-        const { highlightNode, items } = this.props;
-
-        if (!items || items.length === 0) {
-            return null;
-        }
-
-        return (
-            <DetailsList {...this.props}>
-                {items.map(item => (
-                    <div
-                        className="lineage-item-test lineage-name"
-                        key={item.lsid}
-                        style={{ fontWeight: highlightNode === item.lsid ? 'bold' : 'normal' }}
-                        title={getLineageNodeTitle(item as LineageNode)}
-                    >
-                        <SVGIcon className="lineage-sm-icon" iconSrc={item.iconProps?.iconURL ?? DEFAULT_ICON_URL} />
-                        <NodeInteractionConsumer>
-                            {(context: WithNodeInteraction) => {
-                                if (context.isNodeInGraph(item)) {
-                                    return (
-                                        <a
-                                            className="lineage-link spacer-horizontal"
-                                            onClick={e => context.onNodeClick(item)}
-                                            onMouseOver={e => context.onNodeMouseOver(item)}
-                                            onMouseOut={e => context.onNodeMouseOut(item)}
-                                        >
-                                            {item.name}
-                                        </a>
-                                    );
-                                }
-
-                                return <span className="spacer-horizontal">{item.name}</span>;
-                            }}
-                        </NodeInteractionConsumer>
-                        <LineageDataLink href={item.links.overview}>Overview</LineageDataLink>
-                        <LineageDataLink href={item.links.lineage}>Lineage</LineageDataLink>
-                    </div>
-                ))}
-            </DetailsList>
-        );
-    }
-}
+DetailsListNodes.displayName = 'DetailsListNodes';

--- a/packages/components/src/internal/components/lineage/types.ts
+++ b/packages/components/src/internal/components/lineage/types.ts
@@ -11,7 +11,7 @@ export enum LINEAGE_DIRECTIONS {
 }
 
 export enum LINEAGE_GROUPING_GENERATIONS {
-    /** Include all nodes from the seed available in the lineage response (which has it's own depth option). */
+    /** Include all nodes from the seed available in the lineage response (which has its own depth option). */
     All = 'all',
     /** Include all nodes from the seed until a depth is found that contains multiple nodes. */
     Multi = 'multi',


### PR DESCRIPTION
#### Rationale
This addresses a couple of prioritized lineage issues.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1286
- https://github.com/LabKey/labkey-ui-premium/pull/184
- https://github.com/LabKey/biologics/pull/2364
- https://github.com/LabKey/sampleManagement/pull/2093
- https://github.com/LabKey/inventory/pull/1015
- https://github.com/LabKey/labbook/pull/537
- https://github.com/LabKey/platform/pull/4740

#### Changes
- Address [Issue 48458](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48458) by removing duplicate processing of combined nodes. Formerly, combined nodes were being queued up for additional processing resulting in replicated nodes in the rendered graph.
- Address [Issue 48459](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48459) by sorting items in `DetailsListLineageItems` by name.
- Update lineage `DetailsList` components to be functional components.
- Factor out `groupingBoundary` logic to make `processNodes` more readable.
- Improve value handling for `combinedSize` property in `LineageSettings`.
