### PR TITLE
QueryModel: save settings between page visits

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.368.2",
+  "version": "2.369.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 2.36?.0
 *Released*: ?? September 2023
 * QueryModel: add useSavedSettings flag
+* QueryModel: serialize maxRows to URl when using bindURL
+  * Serialized as `pageSize` to match the page offset param
 * withQueryModels: honor useSavedSettings flag
 
 ### version 2.368.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,12 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.36?.0
+### version 2.369.0
 *Released*: ?? September 2023
-* QueryModel: add useSavedSettings flag
-* QueryModel: serialize maxRows to URl when using bindURL
+* `QueryModel`: add `useSavedSettings` flag
+* `QueryModel`: serialize `maxRows` to URl when using `bindURL`
   * Serialized as `pageSize` to match the page offset param
-* withQueryModels: honor useSavedSettings flag
+* `withQueryModels`: honor `useSavedSettings` flag
 
 ### version 2.368.2
 *Released*: 14 September 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.369.0
-*Released*: ?? September 2023
+*Released*: 21 September 2023
 * `QueryModel`: add `useSavedSettings` flag
 * `QueryModel`: serialize `maxRows` to URl when using `bindURL`
   * Serialized as `pageSize` to match the page offset param

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.36?.0
+*Released*: ?? September 2023
+* QueryModel: add useSavedSettings flag
+* withQueryModels: honor useSavedSettings flag
+
 ### version 2.368.2
 *Released*: 14 September 2023
 - Issue 48458: remove duplicate processing of combined nodes.

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -159,6 +159,7 @@ class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
                     containerFilter: this.containerFilter,
                     bindURL: isFirstModel,
                     includeTotalCount: true,
+                    useSavedSettings: true,
                 },
                 true,
                 true

--- a/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
+++ b/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
@@ -54,6 +54,7 @@ export class PipelineJobsPageImpl extends React.PureComponent<Props & InjectedQu
             sorts: [new QuerySort({ fieldKey: 'Created', dir: '-' })],
             requiredColumns: ['Provider'],
             includeTotalCount: true,
+            useSavedSettings: true,
         };
         actions.addModel(queryConfig, true);
     }

--- a/packages/components/src/internal/components/project/ProjectManagementPage.tsx
+++ b/packages/components/src/internal/components/project/ProjectManagementPage.tsx
@@ -39,6 +39,7 @@ export const ProjectManagementPage: FC = memo(() => {
             bindURL: true,
             schemaQuery: new SchemaQuery('core', 'ProjectManagement'),
             includeTotalCount: true,
+            useSavedSettings: true,
         }),
         []
     );

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -144,6 +144,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                 bindURL: true,
                 urlPrefix: usersView, // each model needs to have its own urlPrefix for paging to work across models
                 includeTotalCount: true,
+                useSavedSettings: true,
             },
             true,
             true

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -1172,7 +1172,15 @@ export function getSettingsFromLocalStorage(id: string): QueryModelSettings {
     };
 }
 
+const UNIQUE_ERROR =
+    'Model ID is not unique, cannot save settings to local storage. Use a model ID that is unique and stable.';
+
 export function saveSettingsToLocalStorage(model: QueryModel): void {
+    // We often use "model" as the default model ID, which is not sufficiently unique to store saved settings.
+    if (model.id === 'model') {
+        console.error(UNIQUE_ERROR);
+        return;
+    }
     const settings = {
         filterArray: model.filterArray.map(f => ({
             columnName: f.getColumnName(),

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -1147,14 +1147,14 @@ type QueryModelURLState = Pick<
     'filterArray' | 'maxRows' | 'offset' | 'schemaQuery' | 'selectedReportId' | 'sorts'
 >;
 type QueryModelSettings = Partial<Pick<QueryModel, 'filterArray' | 'maxRows' | 'sorts' | 'viewName'>>;
-const LOCAL_STORAGE_PREFIX = 'QUERY_MODEL_SETTINGS.';
+const LOCAL_STORAGE_PREFIX = 'QUERY_MODEL_SETTINGS';
 
-function localStorageKey(modelId: string): string {
-    return LOCAL_STORAGE_PREFIX + modelId;
+function localStorageKey(modelId: string, containerPath: string): string {
+    return [LOCAL_STORAGE_PREFIX, containerPath, modelId].join(';');
 }
 
-export function getSettingsFromLocalStorage(id: string): QueryModelSettings {
-    const savedSettings = JSON.parse(localStorage.getItem(localStorageKey(id)));
+export function getSettingsFromLocalStorage(id: string, containerPath: string): QueryModelSettings {
+    const savedSettings = JSON.parse(localStorage.getItem(localStorageKey(id, containerPath)));
 
     if (savedSettings === null) return undefined;
 
@@ -1195,5 +1195,5 @@ export function saveSettingsToLocalStorage(model: QueryModel): void {
     // root object, because we have to serialize to/from JSON, and it could get very expensive if we had to
     // read/write a large JSON object that stored all settings for all models every time we needed settings for
     // a single model.
-    localStorage.setItem(localStorageKey(model.id), JSON.stringify(settings));
+    localStorage.setItem(localStorageKey(model.id, model.containerPath), JSON.stringify(settings));
 }

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -202,7 +202,9 @@ export interface QueryConfig {
 
     /**
      * If true we will load filters, sorts, pageSize, and viewName from localStorage when initially loading the model,
-     * but only if there are no settings on the URL.
+     * but only if there are no settings on the URL. Important: If you are using this flag you must ensure your grid id
+     * is stable and unique. It must be stable between page loads/visits, or we won't be able to fetch the settings. It
+     * must be unique, or we'll override settings for other grid models.
      */
     useSavedSettings?: boolean;
 }
@@ -325,7 +327,9 @@ export class QueryModel {
     readonly urlPrefix?: string;
     /**
      * If true we will load filters, sorts, pageSize, and viewName from localStorage when initially loading the model,
-     * but only if there are no settings on the URL. Defaults to false.
+     * but only if there are no settings on the URL. Defaults to false. Important: If you are using this flag you must
+     * ensure your grid id is stable and unique. It must be stable between page loads/visits, or we won't be able to
+     * fetch the settings. It must be unique, or we'll override settings for other grid models.
      */
     useSavedSettings?: boolean;
 

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -1176,6 +1176,11 @@ const UNIQUE_ERROR =
     'Model ID is not unique, cannot save settings to local storage. Use a model ID that is unique and stable.';
 
 export function saveSettingsToLocalStorage(model: QueryModel): void {
+    // Don't serialize anything to localStorage if we're not supposed to use saved settings
+    if (!model.useSavedSettings) {
+        return;
+    }
+
     // We often use "model" as the default model ID, which is not sufficiently unique to store saved settings.
     if (model.id === 'model') {
         console.error(UNIQUE_ERROR);

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -172,9 +172,9 @@ export function withQueryModels<Props>(
             if (model.bindURL && hasQueryParamSettings) {
                 model = model.mutate(model.attributesForURLQueryParams(queryParams, true));
             } else if (model.useSavedSettings) {
-                const settings = getSettingsFromLocalStorage(id);
+                const settings = getSettingsFromLocalStorage(id, model.containerPath);
                 if (settings !== undefined) {
-                    const { filterArray, maxRows, sorts, viewName } = getSettingsFromLocalStorage(id);
+                    const { filterArray, maxRows, sorts, viewName } = settings;
                     let schemaQuery = model.schemaQuery;
                     if (viewName !== undefined) {
                         schemaQuery = new SchemaQuery(model.schemaName, model.queryName, viewName);

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -570,8 +570,20 @@ export function withQueryModels<Props>(
             try {
                 const loadRowsConfig = this.state.queryModels[id].loadRowsConfig;
                 const queryInfo = this.state.queryModels[id].queryInfo;
+                const columns = getSelectRowCountColumnsStr(
+                    loadRowsConfig.columns,
+                    loadRowsConfig.filterArray,
+                    queryInfo?.getPkCols()
+                );
                 const { rowCount } = await selectRows({
                     ...loadRowsConfig,
+                    columns,
+                    includeDetailsColumn: false,
+                    // includeMetadata: false, // TODO don't require metadata in selectRows response processing
+                    includeTotalCount: true,
+                    includeUpdateColumn: false,
+                    maxRows: 1,
+                    offset: 0,
                     sort: undefined,
                     maxRows: 1,
                     offset: 0,

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -320,6 +320,7 @@ export function withQueryModels<Props>(
                 }),
                 () => {
                     this.maybeLoad(id, false, true, loadSelections);
+                    saveSettingsToLocalStorage(this.state.queryModels[id]);
                 }
             );
         };


### PR DESCRIPTION
#### Rationale
This PR adds a useSavedSettings flag to QueryModel which allows us to indicate whether or not we should save filters, sorts, viewName, and pageSize for a particular QueryModel in localStorage, so it can be retrieved in subsequent page views. This allows a user to navigate to a page, set some filters, click a link on the grid, then navigate back to the original grid without having to re-enter their filters.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1287
- https://github.com/LabKey/labkey-ui-premium/pull/185
- https://github.com/LabKey/biologics/pull/2365
- https://github.com/LabKey/inventory/pull/1016
- https://github.com/LabKey/sampleManagement/pull/2095
- https://github.com/LabKey/testAutomation/pull/1644

#### Changes
* QueryModel: add useSavedSettings flag
* QueryModel: serialize maxRows to URl when using bindURL
  * Serialized as `pageSize` to match the page offset param
* withQueryModels: honor useSavedSettings flag
