### PR TITLE
Remove “Plate Metadata” field in Assay Import Wizard

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.369.0",
+  "version": "2.369.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.369.1
+*Released*: 21 September 2023
+- Remove “Plate Metadata” field in Assay Import Wizard
+
 ### version 2.369.0
 *Released*: 21 September 2023
 * `QueryModel`: add `useSavedSettings` flag

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -75,7 +75,7 @@ import {
 import { AssayReimportHeader } from './AssayReimportHeader';
 import { AssayWizardModel, AssayUploadOptions } from './AssayWizardModel';
 import { BatchPropertiesPanel } from './BatchPropertiesPanel';
-import { PLATE_METADATA_COLUMN, PLATE_TEMPLATE_COLUMN, RUN_PROPERTIES_REQUIRED_COLUMNS } from './constants';
+import { PLATE_TEMPLATE_COLUMN, RUN_PROPERTIES_REQUIRED_COLUMNS } from './constants';
 import { ImportWithRenameConfirmModal } from './ImportWithRenameConfirmModal';
 
 import { AssayUploadResultModel } from './models';
@@ -300,23 +300,6 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 plateColumns = plateColumns.set(plateTemplateFieldKey, runColumns.get(plateTemplateFieldKey));
                 runColumns = runColumns.remove(plateTemplateFieldKey);
             }
-
-            plateColumns = plateColumns.set(
-                PLATE_METADATA_COLUMN.toLowerCase(),
-                new QueryColumn({
-                    caption: 'Plate Metadata',
-                    fieldKey: PLATE_METADATA_COLUMN,
-                    fieldKeyArray: [PLATE_METADATA_COLUMN],
-                    inputType: 'file',
-                    name: PLATE_METADATA_COLUMN,
-                    required: true,
-                    shortCaption: 'Plate Metadata',
-                    shownInInsertView: true,
-                    shownInUpdateView: true,
-                    type: 'File',
-                    userEditable: true,
-                })
-            );
         }
 
         return { plateColumns, runColumns };
@@ -567,10 +550,6 @@ class AssayImportPanelsBody extends Component<Props, State> {
         dismissNotifications();
 
         try {
-            if (this.plateSupportEnabled) {
-                data = await model.processPlateData(data);
-            }
-
             const processedData = await uploadAssayRunFiles(data);
 
             const backgroundUpload = assayProtocol?.backgroundUpload;

--- a/packages/components/src/internal/components/assay/AssayWizardModel.test.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.test.ts
@@ -23,8 +23,7 @@ import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { LoadingState } from '../../../public/LoadingState';
 import { EditorModel } from '../editable/models';
 
-import { AssayUploadOptions, AssayWizardModel } from './AssayWizardModel';
-import { PLATE_METADATA_COLUMN } from './constants';
+import { AssayWizardModel } from './AssayWizardModel';
 
 const DATA_TEXT = 'test1\ttest2\n1\t2';
 
@@ -78,27 +77,5 @@ describe('AssayWizardModel', () => {
         expect(data.name.indexOf(model.assayDef.name) === 0).toBeTruthy();
         expect(data.files === undefined).toBeTruthy();
         expect(Array.isArray(data.dataRows) && data.dataRows.length === 0).toBeTruthy();
-    });
-
-    test('processPlateData', async () => {
-        const model = ASSAY_WIZARD_MODEL;
-        const plateMetadataJson = {
-            SAMPLE: {
-                Sample1: { dilution: 0.1 },
-                Sample2: { dilution: 0.2 },
-                Sample3: { dilution: 0.3 },
-            },
-        };
-        const blob = new Blob([JSON.stringify(plateMetadataJson)], { type: 'application/json' });
-        const file = new File([blob], 'plateMetadata.json');
-        let data: AssayUploadOptions = {
-            properties: {
-                [PLATE_METADATA_COLUMN]: file,
-            },
-        };
-
-        data = await model.processPlateData(data);
-        expect(data.properties[PLATE_METADATA_COLUMN]).toBeUndefined();
-        expect(data.plateMetadata).toEqual(plateMetadataJson);
     });
 });

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -12,8 +12,6 @@ import { QueryInfo } from '../../../public/QueryInfo';
 import { EditorModel } from '../editable/models';
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
-import { PLATE_METADATA_COLUMN } from './constants';
-
 export interface AssayUploadOptions extends AssayDOM.ImportRunOptions {
     dataRows?: any; // Array<any>
     maxFileSize?: number;
@@ -222,15 +220,5 @@ export class AssayWizardModel
         const queryModelData = this.getInitialQueryModelData();
         const editorModelData = await loadEditorModelData(queryModelData);
         return { editorModel: editorModelData, queryModel: queryModelData };
-    }
-
-    async processPlateData(data: AssayUploadOptions): Promise<AssayUploadOptions> {
-        if (data.properties?.[PLATE_METADATA_COLUMN] instanceof File) {
-            const text = await data.properties[PLATE_METADATA_COLUMN].text();
-            data.plateMetadata = JSON.parse(text);
-            delete data.properties[PLATE_METADATA_COLUMN];
-        }
-
-        return data;
     }
 }

--- a/packages/components/src/internal/components/assay/constants.ts
+++ b/packages/components/src/internal/components/assay/constants.ts
@@ -2,7 +2,6 @@ import { SCHEMAS } from '../../schemas';
 
 export const GENERAL_ASSAY_PROVIDER_NAME = 'General';
 
-export const PLATE_METADATA_COLUMN = 'PlateMetadata';
 export const PLATE_TEMPLATE_COLUMN = 'PlateTemplate';
 
 // Columns are required for us to render the WorkflowTask in EditableDetails components


### PR DESCRIPTION
#### Rationale
This removes the "Plate Metadata" field from the Assay Import Wizard now that plate metadata is supported from the plate directly.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1288
- https://github.com/LabKey/labkey-ui-premium/pull/187
- https://github.com/LabKey/biologics/pull/2370
- https://github.com/LabKey/sampleManagement/pull/2099
- https://github.com/LabKey/inventory/pull/1024
- https://github.com/LabKey/platform/pull/4753

#### Changes
- Remove "PlateMetadata" processing and interactions
