### PR TITLE
Address 23.10 Issues

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.370.0",
+  "version": "2.371.1-fb-audit-47512.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.370.0",
+      "version": "2.371.1-fb-audit-47512.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.371.1-fb-audit-47512.0",
+  "version": "2.372.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.371.1-fb-audit-47512.0",
+      "version": "2.372.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.371.1-fb-audit-47512.0",
+  "version": "2.372.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.371.0",
+  "version": "2.371.1-fb-audit-47512.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.372.0
+*Released*: 27 September 2023
+- Add container filter to `PROJECT_AUDIT_QUERY` configuration and filter by `projectId` to get desired results.
+- Support displaying `children` in `AuditDetails` component for displaying error/loading state.
+- Display dropdown indicator on date cells in `EditableGrid`.
+- Update `DatePickerInput` to expose `onCalendarClose` and use to handle selecting a date cell after the calendar has closed.
+- Update `UserLink` to not attempt to fetch details for negative `userId` values (as you might find in the audit log)
+
 ### version 2.371.0
 *Released*: 25 September 2023
 * Render file output in R Reports

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -22,7 +22,7 @@ interface Props {
     fieldValueRenderer?: (label, value, displayValue) => any;
     gridColumnRenderer?: (data: any, row: any, displayValue: any) => any;
     gridData?: List<Map<string, any>>;
-    rowId: number;
+    rowId?: number;
     summary?: string;
     title?: string;
     user: User;

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -38,29 +38,6 @@ export class AuditDetails extends Component<Props> {
         return ['created by', 'createdby', 'modified by', 'modifiedby'].indexOf(field.toLowerCase()) > -1;
     }
 
-    renderUpdateValue = (oldVal: string, newVal: string): ReactNode => {
-        const changed = oldVal !== newVal;
-        const oldDisplay = <span className="display-light old-audit-value right-spacing">{oldVal}</span>;
-
-        if (!changed) return oldDisplay;
-
-        return (
-            <>
-                {oldDisplay}
-                <i className="fa fa-long-arrow-right right-spacing" />
-                <span className="new-audit-value">{newVal}</span>
-            </>
-        );
-    };
-
-    renderInsertValue(oldVal: string, newVal: string) {
-        return <span className="new-audit-value">{newVal}</span>;
-    }
-
-    renderDeleteValue(oldVal: string, newVal: string) {
-        return <span className="display-light old-audit-value">{oldVal}</span>;
-    }
-
     getValueDisplay = (field: string, value: string): any => {
         const { fieldValueRenderer } = this.props;
 
@@ -76,15 +53,14 @@ export class AuditDetails extends Component<Props> {
         return displayVal;
     };
 
-    renderRow(field: string, oldVal: string, newVal: string, isUpdate: boolean, isInsert: boolean) {
+    renderRow(field: string, oldVal: string, newVal: string, isUpdate: boolean, isInsert: boolean): ReactNode {
         const { user } = this.props;
 
-        let valueRenderer;
-        if (isUpdate) valueRenderer = this.renderUpdateValue;
-        else if (isInsert) valueRenderer = this.renderInsertValue;
-        else valueRenderer = this.renderDeleteValue;
-
         if (!user.isSignedIn && AuditDetails.isUserFieldLabel(field)) return null;
+
+        const oldValue = this.getValueDisplay(field, oldVal);
+        const newValue = this.getValueDisplay(field, newVal);
+        const changed = oldValue !== newValue;
 
         return (
             <Row className="margin-bottom" key={field}>
@@ -92,7 +68,18 @@ export class AuditDetails extends Component<Props> {
                     <span className="audit-detail-row-label right-spacing">{capitalizeFirstChar(field)}</span>
                 </Col>
                 <Col className="left-spacing right-spacing">
-                    {valueRenderer(this.getValueDisplay(field, oldVal), this.getValueDisplay(field, newVal))}
+                    {isInsert && <span className="new-audit-value">{newValue}</span>}
+                    {isUpdate && changed && (
+                        <>
+                            <span className="display-light old-audit-value right-spacing">{oldValue}</span>
+                            <i className="fa fa-long-arrow-right right-spacing" />
+                            <span className="new-audit-value">{newValue}</span>
+                        </>
+                    )}
+                    {isUpdate && !changed && (
+                        <span className="display-light old-audit-value right-spacing">{oldValue}</span>
+                    )}
+                    {!isInsert && !isUpdate && <span className="display-light old-audit-value">{oldValue}</span>}
                 </Col>
             </Row>
         );
@@ -164,33 +151,27 @@ export class AuditDetails extends Component<Props> {
         ]);
     };
 
-    renderBody() {
-        const { gridData, changeDetails, rowId, summary, emptyMsg } = this.props;
-
-        if (!rowId) {
-            return <div>{emptyMsg}</div>;
-        }
-
-        return (
-            <>
-                {summary && (
-                    <Row className="margin-bottom display-light">
-                        <Col xs={12}>{summary}</Col>
-                    </Row>
-                )}
-                {gridData && <Grid data={gridData} columns={this.getGridColumns()} showHeader={false} />}
-                {changeDetails && this.renderChanges()}
-            </>
-        );
-    }
-
     render() {
-        const { title } = this.props;
+        const { changeDetails, children, emptyMsg, gridData, rowId, summary, title } = this.props;
 
         return (
             <div className="panel panel-default">
                 <div className="panel-heading">{title}</div>
-                <div className="panel-body">{this.renderBody()}</div>
+                <div className="panel-body">
+                    {children}
+                    {!rowId && <div>{emptyMsg}</div>}
+                    {!!rowId && (
+                        <>
+                            {summary && (
+                                <Row className="margin-bottom display-light">
+                                    <Col xs={12}>{summary}</Col>
+                                </Row>
+                            )}
+                            {gridData && <Grid data={gridData} columns={this.getGridColumns()} showHeader={false} />}
+                            {changeDetails && this.renderChanges()}
+                        </>
+                    )}
+                </div>
             </div>
         );
     }

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -2,35 +2,34 @@
  * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, PureComponent, ReactNode } from 'react';
-import { fromJS, List, Map } from 'immutable';
+import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { fromJS } from 'immutable';
 import { Col, Row } from 'react-bootstrap';
-import { Filter, getServerContext } from '@labkey/api';
+import { Filter } from '@labkey/api';
 
 import { WithRouterProps } from 'react-router';
 
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { GridPanel } from '../../../public/QueryModel/GridPanel';
 
-import { User } from '../base/models/User';
 import { getLocation, replaceParameters } from '../../util/URL';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { Alert } from '../base/Alert';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { Page } from '../base/Page';
 import { PageHeader } from '../base/PageHeader';
-import { SelectInput } from '../forms/input/SelectInput';
+import { SelectInput, SelectInputChange } from '../forms/input/SelectInput';
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
-import { ModuleContext, useServerContext } from '../base/ServerContext';
+import { useServerContext } from '../base/ServerContext';
 
 import { SCHEMAS } from '../../schemas';
+
+import { resolveErrorMessage } from '../../util/messaging';
 
 import { getAuditQueries } from './utils';
 import { getAuditDetail } from './actions';
 import { AuditDetailsModel } from './models';
 import { AuditDetails } from './AuditDetails';
 import {
-    AuditQuery,
     AUDIT_EVENT_TYPE_PARAM,
     SAMPLE_TIMELINE_AUDIT_QUERY,
     SOURCE_AUDIT_QUERY,
@@ -38,122 +37,46 @@ import {
     PROJECT_AUDIT_QUERY,
 } from './constants';
 
-interface BodyProps {
-    moduleContext: ModuleContext;
-    user: User;
+interface OwnProps {
+    eventType?: string;
+    onChange: (eventType: string) => void;
 }
 
-type Props = BodyProps & InjectedQueryModels & WithRouterProps;
+const AuditQueriesListingPageImpl: FC<InjectedQueryModels & OwnProps> = memo(props => {
+    const { actions, onChange, queryModels } = props;
+    const { moduleContext, project, user } = useServerContext();
 
-interface State {
-    auditQueries: AuditQuery[];
-    detail?: AuditDetailsModel;
-    error?: ReactNode;
-    selected: string;
-    selectedRowId: number;
-}
+    const [detail, setDetail] = useState<AuditDetailsModel>();
+    const [error, setError] = useState<string>();
+    const [eventType, setEventType] = useState<string>(() => props.eventType ?? SAMPLE_TIMELINE_AUDIT_QUERY.value);
+    const [selectedRowId, setSelectedRowId] = useState<number>();
+    const auditQueries = useMemo(() => getAuditQueries(moduleContext), [moduleContext]);
+    const selectedQuery = useMemo(() => auditQueries.find(q => q.value === eventType), [auditQueries, eventType]);
+    const id = useMemo<string>(
+        () => (selectedQuery ? `audit-log-querymodel-${selectedQuery.value}` : undefined),
+        [selectedQuery]
+    );
+    const model = queryModels[id];
+    const lastSelectedId = useMemo<number>(() => {
+        if (!model?.selections) return undefined;
+        return parseInt(Array.from(model.selections).pop(), 10);
+    }, [model?.selections]);
 
-class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
-    constructor(props: Props) {
-        super(props);
-
-        this.state = {
-            auditQueries: getAuditQueries(props.moduleContext),
-            selected: props.location.query?.eventType ?? SAMPLE_TIMELINE_AUDIT_QUERY.value,
-            selectedRowId: undefined,
-        };
-    }
-
-    componentDidMount = (): void => {
-        this.setLastSelectedId();
-    };
-
-    componentDidUpdate = (prevProps: Readonly<Props>): void => {
-        const { eventType } = this.props.location?.query;
-        if (eventType !== undefined && eventType !== prevProps.location.query?.eventType) {
-            this.onSelectionChange(null, eventType);
+    useEffect(() => {
+        if (props.eventType) {
+            setEventType(props.eventType);
         }
+    }, [props.eventType]);
 
-        this.setLastSelectedId();
-    };
-
-    onSelectionChange = (_: any, selected: string): void => {
-        const location = getLocation();
-        const paramUpdates = location.query.map((value: string, key: string) => {
-            if (key.startsWith('query')) {
-                return undefined; // get rid of filtering parameters that are likely not applicable to this new audit log
-            } else if (key === AUDIT_EVENT_TYPE_PARAM) {
-                return selected;
-            } else {
-                return value;
-            }
-        });
-        replaceParameters(location, paramUpdates);
-        this.setState({ selected, selectedRowId: undefined });
-    };
-
-    setLastSelectedId = async (): Promise<void> => {
-        if (!this.hasDetailView()) return;
-
-        const model = this.getQueryModel();
-        if (!model) return;
-
-        // if the model has already loaded selections, we can use that to reselect the last row
-        if (!model.isLoadingSelections) {
-            this.updateSelectedRowId(this.getLastSelectedId());
-        }
-    };
-
-    getLastSelectedId = (): number => {
-        const model = this.getQueryModel();
-        if (!model) return undefined;
-        const selectedIds = model.selections;
-        return selectedIds.size > 0 ? parseInt(Array.from(selectedIds).pop(), 10) : undefined;
-    };
-
-    updateSelectedRowId = (selectedRowId: number): void => {
-        const { selected } = this.state;
-        if (this.state.selectedRowId === selectedRowId) return;
-
-        this.setState({ selectedRowId, detail: undefined }, async () => {
-            if (selectedRowId) {
-                try {
-                    const auditEventType =
-                        selected === SOURCE_AUDIT_QUERY.value ? DATA_UPDATE_AUDIT_QUERY.value : selected;
-                    const detail = await getAuditDetail(selectedRowId, auditEventType);
-
-                    this.setState({
-                        detail: detail.merge({ rowId: selectedRowId }) as AuditDetailsModel,
-                    });
-                } catch (error) {
-                    this.setState({ error });
-                }
-            }
-        });
-    };
-
-    get selectedQuery(): AuditQuery {
-        const { auditQueries, selected } = this.state;
-        if (!selected) return undefined;
-        return auditQueries.find(q => q.value === selected);
-    }
-
-    hasDetailView(): boolean {
-        return this.state.selected && this.selectedQuery?.hasDetail === true;
-    }
-
-    getQueryModel = (): QueryModel => {
-        const { queryModels, actions } = this.props;
-        const { selected } = this.state;
-        if (!selected) return undefined;
-
-        const id = `audit-log-querymodel-${selected}`;
+    useEffect(() => {
+        if (!selectedQuery) return undefined;
+        const { value } = selectedQuery;
 
         if (!queryModels[id]) {
             // Issue 47512: App audit log filters out container events for deleted containers
             const baseFilters: Filter.IFilter[] = [];
-            if (PROJECT_AUDIT_QUERY.value === selected) {
-                baseFilters.push(Filter.create('projectId', getServerContext().project.id));
+            if (PROJECT_AUDIT_QUERY.value === value) {
+                baseFilters.push(Filter.create('projectId', project.id));
             }
 
             actions.addModel(
@@ -161,92 +84,120 @@ class AuditQueriesListingPageImpl extends PureComponent<Props, State> {
                     baseFilters,
                     // only bind first model to URL so that it can pick up any filters passed from the caller
                     bindURL: Object.keys(queryModels).length === 0,
-                    containerFilter: this.selectedQuery?.containerFilter,
+                    containerFilter: selectedQuery.containerFilter,
                     id,
                     includeTotalCount: true,
-                    schemaQuery: new SchemaQuery(SCHEMAS.AUDIT_TABLES.SCHEMA, selected),
-                    useSavedSettings: true,
+                    schemaQuery: new SchemaQuery(SCHEMAS.AUDIT_TABLES.SCHEMA, value),
                 },
                 true,
                 true
             );
         }
+    }, [actions, id, project, queryModels, selectedQuery]);
 
-        return queryModels[id];
-    };
+    useEffect(() => {
+        setSelectedRowId(lastSelectedId);
+        setDetail(detail_ => (lastSelectedId === detail_?.rowId ? detail_ : undefined));
+    }, [lastSelectedId]);
 
-    getDetailsGridData = (): List<Map<string, any>> => {
-        const { detail } = this.state;
-        if (!detail) return null;
+    useEffect(() => {
+        if (!lastSelectedId || selectedQuery?.hasDetail !== true) return;
 
+        (async () => {
+            try {
+                const { value } = selectedQuery;
+                const auditEventType = value === SOURCE_AUDIT_QUERY.value ? DATA_UPDATE_AUDIT_QUERY.value : value;
+                const detail_ = await getAuditDetail(lastSelectedId, auditEventType);
+                setDetail(detail_.merge({ rowId: lastSelectedId }) as AuditDetailsModel);
+            } catch (e) {
+                setError(resolveErrorMessage(e) ?? 'Failed to load audit details');
+            }
+        })();
+    }, [lastSelectedId, selectedQuery]);
+
+    const onSelectionChange = useCallback<SelectInputChange>(
+        (_, eventType_) => {
+            setEventType(eventType_);
+            setSelectedRowId(undefined);
+            onChange(eventType_);
+        },
+        [onChange]
+    );
+
+    const gridData = useMemo(() => {
+        if (!detail) return undefined;
         const { eventUserId, eventDateFormatted, userComment } = detail;
-
         const rows = [];
-        if (eventUserId) {
-            rows.push({ field: detail.getActionLabel() + ' By', value: eventUserId, isUser: true });
-        }
 
+        if (eventUserId) {
+            rows.push({ field: detail.getActionLabel() + ' By', isUser: true, value: eventUserId });
+        }
         if (eventDateFormatted) {
             rows.push({ field: 'Date', value: eventDateFormatted });
         }
-
         if (userComment) {
             rows.push({ field: 'User Comment', value: userComment });
         }
 
         return fromJS(rows);
-    };
+    }, [detail]);
 
-    render = (): ReactNode => {
-        const title = 'Audit Logs';
-        const { actions, user } = this.props;
-        const { auditQueries, detail, error, selected, selectedRowId } = this.state;
-        const hasDetailView = this.hasDetailView();
-        const model = this.getQueryModel();
+    const hasDetailView = selectedQuery?.hasDetail === true;
+    const title = 'Audit Logs';
 
-        return (
-            <Page hasHeader title={title}>
-                <PageHeader title={title} />
-                <SelectInput
-                    inputClass="col-xs-6"
-                    key="audit-log-query-select"
-                    name="audit-log-query-select"
-                    onChange={this.onSelectionChange}
-                    options={auditQueries}
-                    placeholder="Select an audit event type..."
-                    value={selected}
-                />
-                {hasDetailView && model && (
-                    <Row>
-                        <Col xs={12} md={8}>
-                            <GridPanel actions={actions} highlightLastSelectedRow model={model} />
-                        </Col>
-                        <Col xs={12} md={4}>
-                            {error && <Alert>{error}</Alert>}
-                            {selectedRowId && !detail && !error && <LoadingSpinner />}
-                            {selectedRowId && detail && !error && (
-                                <AuditDetails
-                                    changeDetails={detail}
-                                    gridData={this.getDetailsGridData()}
-                                    rowId={selectedRowId}
-                                    summary={detail.comment}
-                                    user={user}
-                                />
-                            )}
-                        </Col>
-                    </Row>
-                )}
-                {!hasDetailView && model && <GridPanel actions={actions} model={model} />}
-            </Page>
-        );
-    };
-}
+    return (
+        <Page hasHeader title={title}>
+            <PageHeader title={title} />
+            <SelectInput
+                inputClass="col-xs-6"
+                key="audit-log-query-select"
+                name="audit-log-query-select"
+                onChange={onSelectionChange}
+                options={auditQueries}
+                placeholder="Select an audit event type..."
+                value={eventType}
+            />
+            {hasDetailView && model && (
+                <Row>
+                    <Col xs={12} md={8}>
+                        <GridPanel actions={actions} highlightLastSelectedRow model={model} />
+                    </Col>
+                    <Col xs={12} md={4}>
+                        {error && <Alert>{error}</Alert>}
+                        {selectedRowId && !detail && !error && <LoadingSpinner />}
+                        {!error && (
+                            <AuditDetails
+                                changeDetails={detail}
+                                gridData={gridData}
+                                rowId={selectedRowId}
+                                summary={detail?.comment}
+                                user={user}
+                            />
+                        )}
+                    </Col>
+                </Row>
+            )}
+            {!hasDetailView && model && <GridPanel actions={actions} model={model} />}
+        </Page>
+    );
+});
 
-const AuditQueriesListingPageWithQueryModels = withQueryModels<BodyProps & WithRouterProps>(
-    AuditQueriesListingPageImpl
-);
+const AuditQueriesListingPageWithModels = withQueryModels<OwnProps>(AuditQueriesListingPageImpl);
 
-export const AuditQueriesListingPage: FC<WithRouterProps> = props => {
-    const { moduleContext, user } = useServerContext();
-    return <AuditQueriesListingPageWithQueryModels {...props} moduleContext={moduleContext} user={user} />;
-};
+export const AuditQueriesListingPage: FC<WithRouterProps> = memo(({ location }) => {
+    const onChange = useCallback(eventType => {
+        const location_ = getLocation();
+        const paramUpdates = location_.query.map((value: string, key: string) => {
+            if (key.startsWith('query')) {
+                return undefined; // get rid of filtering parameters that are likely not applicable to this new audit log
+            } else if (key === AUDIT_EVENT_TYPE_PARAM) {
+                return eventType;
+            } else {
+                return value;
+            }
+        });
+        replaceParameters(location_, paramUpdates);
+    }, []);
+
+    return <AuditQueriesListingPageWithModels eventType={location.query?.eventType} onChange={onChange} />;
+});

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -109,6 +109,7 @@ const AuditQueriesListingPageImpl: FC<InjectedQueryModels & OwnProps> = memo(pro
                 const auditEventType = value === SOURCE_AUDIT_QUERY.value ? DATA_UPDATE_AUDIT_QUERY.value : value;
                 const detail_ = await getAuditDetail(lastSelectedId, auditEventType);
                 setDetail(detail_.merge({ rowId: lastSelectedId }) as AuditDetailsModel);
+                setError(undefined);
             } catch (e) {
                 setError(resolveErrorMessage(e) ?? 'Failed to load audit details');
             }
@@ -163,17 +164,16 @@ const AuditQueriesListingPageImpl: FC<InjectedQueryModels & OwnProps> = memo(pro
                         <GridPanel actions={actions} highlightLastSelectedRow model={model} />
                     </Col>
                     <Col xs={12} md={4}>
-                        {error && <Alert>{error}</Alert>}
-                        {selectedRowId && !detail && !error && <LoadingSpinner />}
-                        {!error && (
-                            <AuditDetails
-                                changeDetails={detail}
-                                gridData={gridData}
-                                rowId={selectedRowId}
-                                summary={detail?.comment}
-                                user={user}
-                            />
-                        )}
+                        <AuditDetails
+                            changeDetails={detail}
+                            gridData={gridData}
+                            rowId={selectedRowId}
+                            summary={detail?.comment}
+                            user={user}
+                        >
+                            {error && <Alert>{error}</Alert>}
+                            {!!selectedRowId && !detail && !error && <LoadingSpinner />}
+                        </AuditDetails>
                     </Col>
                 </Row>
             )}

--- a/packages/components/src/internal/components/auditlog/actions.ts
+++ b/packages/components/src/internal/components/auditlog/actions.ts
@@ -15,7 +15,7 @@ export function getAuditDetail(
 ): Promise<AuditDetailsModel> {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: ActionURL.buildURL('audit', 'GetDetailedAuditChanges.api'),
+            url: ActionURL.buildURL('audit', 'getDetailedAuditChanges.api'),
             params: { auditRowId, auditEventType, containerFilter: containerFilter ?? getContainerFilter() },
             success: Utils.getCallbackWrapper(response => {
                 resolve(AuditDetailsModel.create(response));

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -7,47 +7,66 @@ export type AuditQuery = {
     value: string;
 };
 
-export const ATTACHMENT_AUDIT_QUERY: AuditQuery = { value: 'attachmentauditevent', label: 'Attachment Events' };
-export const DOMAIN_AUDIT_QUERY: AuditQuery = { value: 'domainauditevent', label: 'Domain Events' };
+export const ATTACHMENT_AUDIT_QUERY: AuditQuery = { label: 'Attachment Events', value: 'attachmentauditevent' };
+export const DOMAIN_AUDIT_QUERY: AuditQuery = { label: 'Domain Events', value: 'domainauditevent' };
 export const DOMAIN_PROPERTY_AUDIT_QUERY: AuditQuery = {
-    value: 'domainpropertyauditevent',
     label: 'Domain Property Events',
+    value: 'domainpropertyauditevent',
 };
 export const DATA_UPDATE_AUDIT_QUERY: AuditQuery = {
-    value: 'queryupdateauditevent',
-    label: 'Data Update Events',
     hasDetail: true,
+    label: 'Data Update Events',
+    value: 'queryupdateauditevent',
 };
 export const INVENTORY_AUDIT_QUERY: AuditQuery = {
-    value: 'inventoryauditevent',
+    hasDetail: true,
     label: 'Storage Management Events',
-    hasDetail: true,
+    value: 'inventoryauditevent',
 };
-export const LIST_AUDIT_QUERY: AuditQuery = { value: 'listauditevent', label: 'List Events' };
+export const LIST_AUDIT_QUERY: AuditQuery = { label: 'List Events', value: 'listauditevent' };
 export const GROUP_AUDIT_QUERY: AuditQuery = {
-    value: 'groupauditevent',
-    label: 'Roles and Assignment Events',
     containerFilter: Query.ContainerFilter.allFolders,
+    label: 'Roles and Assignment Events',
+    value: 'groupauditevent',
 };
-export const PROJECT_AUDIT_QUERY: AuditQuery = { value: 'containerauditevent', label: 'Project Events' };
-export const SAMPLE_TYPE_AUDIT_QUERY: AuditQuery = { value: 'samplesetauditevent', label: 'Sample Type Events' };
+export const PROJECT_AUDIT_QUERY: AuditQuery = {
+    containerFilter: Query.ContainerFilter.allFolders,
+    label: 'Project Events',
+    value: 'containerauditevent',
+};
+export const SAMPLE_TYPE_AUDIT_QUERY: AuditQuery = { label: 'Sample Type Events', value: 'samplesetauditevent' };
 export const SAMPLE_TIMELINE_AUDIT_QUERY: AuditQuery = {
-    value: 'sampletimelineevent',
-    label: 'Sample Timeline Events',
     hasDetail: true,
+    label: 'Sample Timeline Events',
+    value: 'sampletimelineevent',
 };
 export const USER_AUDIT_QUERY: AuditQuery = {
-    value: 'userauditevent',
-    label: 'User Events',
     containerFilter: Query.ContainerFilter.allFolders,
+    label: 'User Events',
+    value: 'userauditevent',
 };
 export const ASSAY_AUDIT_QUERY: AuditQuery = { value: 'experimentauditevent', label: 'Assay Events' };
 export const WORKFLOW_AUDIT_QUERY: AuditQuery = {
-    value: 'samplesworkflowauditevent',
-    label: 'Sample Workflow Events',
     hasDetail: true,
+    label: 'Sample Workflow Events',
+    value: 'samplesworkflowauditevent',
 };
-export const SOURCE_AUDIT_QUERY: AuditQuery = { value: 'sourcesauditevent', label: 'Sources Events', hasDetail: true };
+export const SOURCE_AUDIT_QUERY: AuditQuery = { hasDetail: true, label: 'Sources Events', value: 'sourcesauditevent' };
+
+export const NOTEBOOK_AUDIT_QUERY: AuditQuery = {
+    label: 'Notebook Events',
+    value: 'LabBookEvent',
+};
+
+export const NOTEBOOK_REVIEW_AUDIT_QUERY: AuditQuery = {
+    label: 'Notebook Review Events',
+    value: 'NotebookEvent',
+};
+
+export const REGISTRY_AUDIT_QUERY: AuditQuery = { label: 'Registry Events', value: 'RegistryEvent' };
+
+export const AUDIT_EVENT_TYPE_PARAM = 'eventType';
+
 export const COMMON_AUDIT_QUERIES: AuditQuery[] = [
     ATTACHMENT_AUDIT_QUERY,
     DOMAIN_AUDIT_QUERY,
@@ -60,17 +79,3 @@ export const COMMON_AUDIT_QUERIES: AuditQuery[] = [
     SAMPLE_TIMELINE_AUDIT_QUERY,
     USER_AUDIT_QUERY,
 ];
-
-export const NOTEBOOK_AUDIT_QUERY: AuditQuery = {
-    value: 'LabBookEvent',
-    label: 'Notebook Events',
-};
-
-export const NOTEBOOK_REVIEW_AUDIT_QUERY: AuditQuery = {
-    value: 'NotebookEvent',
-    label: 'Notebook Review Events',
-};
-
-export const REGISTRY_AUDIT_QUERY: AuditQuery = { value: 'RegistryEvent', label: 'Registry Events' };
-
-export const AUDIT_EVENT_TYPE_PARAM = 'eventType';

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -327,10 +327,8 @@ export class Cell extends React.PureComponent<CellProps, State> {
         } = this.props;
 
         const { filteredLookupKeys } = this.state;
-
-        const showLookup = col.isPublicLookup() || col.validValues;
-
         const isDateField = col.jsonType === 'date';
+        const showLookup = col.isPublicLookup() || isDateField || col.validValues;
 
         if (!focused) {
             let valueDisplay = values
@@ -423,7 +421,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
             );
         }
 
-        if (showLookup) {
+        if (showLookup && !isDateField) {
             return (
                 <LookupCell
                     col={col}

--- a/packages/components/src/internal/components/editable/DateInputCell.tsx
+++ b/packages/components/src/internal/components/editable/DateInputCell.tsx
@@ -7,6 +7,7 @@ import { formatDate, formatDateTime, isDateTimeCol } from '../../util/Date';
 
 import { MODIFICATION_TYPES, SELECTION_TYPES } from './constants';
 import { ValueDescriptor } from './models';
+import { genCellKey } from './utils';
 
 export interface DateInputCellProps {
     col: QueryColumn;
@@ -20,38 +21,44 @@ export interface DateInputCellProps {
 }
 
 export const DateInputCell: FC<DateInputCellProps> = memo(props => {
-    const { col, defaultValue, colIdx, rowIdx, disabled, onKeyDown, modifyCell } = props;
+    const { col, defaultValue, colIdx, rowIdx, disabled, modifyCell, onKeyDown, select } = props;
+
+    const onCalendarClose = useCallback(() => {
+        select(colIdx, rowIdx);
+    }, [colIdx, rowIdx, select]);
 
     const onDateInputChange = useCallback(
         (newDate: Date) => {
-            let displayValue = null;
+            let display = null;
             if (newDate) {
-                if (isDateTimeCol(col)) displayValue = formatDateTime(newDate);
-                else displayValue = formatDate(newDate);
+                display = isDateTimeCol(col) ? formatDateTime(newDate) : formatDate(newDate);
             }
 
-            modifyCell(colIdx, rowIdx, [{ raw: newDate, display: displayValue }], MODIFICATION_TYPES.REPLACE);
+            modifyCell(colIdx, rowIdx, [{ raw: newDate, display }], MODIFICATION_TYPES.REPLACE);
         },
         [col, colIdx, modifyCell, rowIdx]
     );
 
     return (
         <DatePickerInput
-            key={colIdx + '-' + rowIdx}
-            queryColumn={col}
-            value={defaultValue}
-            initValueFormatted={false}
             allowDisable={false}
+            autoFocus
             disabled={disabled}
-            wrapperClassName="date-input-cell-container"
+            formsy={false}
+            initValueFormatted={false}
             inputClassName="date-input-cell cellular-input"
             inputWrapperClassName=""
-            onChange={onDateInputChange}
-            formsy={false}
             isClearable={false}
-            autoFocus={true}
             isFormInput={false}
+            key={genCellKey(colIdx, rowIdx)}
+            onCalendarClose={onCalendarClose}
+            onChange={onDateInputChange}
             onKeyDown={onKeyDown}
+            queryColumn={col}
+            value={defaultValue}
+            wrapperClassName="date-input-cell-container"
         />
     );
 });
+
+DateInputCell.displayName = 'DateInputCell';

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -48,6 +48,7 @@ export interface DatePickerInputProps extends DisableableInputProps, WithFormsyP
     label?: any;
     labelClassName?: string;
     name?: string;
+    onCalendarClose?: () => void;
     onChange?: (newDate?: Date | string) => void;
     onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
     placeholderText?: string;
@@ -169,6 +170,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
             label,
             labelClassName,
             name,
+            onCalendarClose,
             onKeyDown,
             placeholderText,
             queryColumn,
@@ -190,6 +192,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
                 id={queryColumn.fieldKey}
                 isClearable={isClearable}
                 name={name ? name : queryColumn.fieldKey}
+                onCalendarClose={onCalendarClose}
                 onChange={this.onChange}
                 onChangeRaw={allowRelativeInput ? this.onChangeRaw : undefined}
                 onKeyDown={onKeyDown}

--- a/packages/components/src/internal/components/user/UserLink.tsx
+++ b/packages/components/src/internal/components/user/UserLink.tsx
@@ -27,7 +27,7 @@ export const UserLink: FC<UserLinkProps> = props => {
     useEffect(() => {
         (async () => {
             try {
-                if (!!userId && userDisplayValue === undefined) {
+                if (userId > 0 && userDisplayValue === undefined) {
                     const targetUser = await api.security.getUserPropertiesForOther(userId);
                     setTargetUserDisplayValue(caseInsensitive(targetUser, 'DisplayName'));
                 } else {


### PR DESCRIPTION
#### Rationale
This address a couple of prioritized issues for v23.10.

- [Issue 47512](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47512): The audit log for "Project Events" is not displaying events for deleted containers. This changes the associated `containerFilter` to `AllFolders` (as has been done for other audit event types) and then filters on the `projectId` column to scope the audit records to the specific LKS Project.
- [Issue 48440](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48440): Editable grid cells on date columns will now display a dropdown indicator to support single-click open. Additionally, the focused/selected state for date cell inputs has been updated to be consistent with closing other lookup fields.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1295
- https://github.com/LabKey/labkey-ui-premium/pull/196
- https://github.com/LabKey/biologics/pull/2383
- https://github.com/LabKey/sampleManagement/pull/2111
- https://github.com/LabKey/inventory/pull/1034

#### Changes
- Add container filter to `PROJECT_AUDIT_QUERY` configuration and filter by `projectId` to get desired results.
- Support displaying `children` in `AuditDetails` component for displaying error/loading state.
- Display dropdown indicator on date cells in `EditableGrid`.
- Update `DatePickerInput` to expose `onCalendarClose` and use to handle selecting a date cell after the calendar has closed.
- Update `UserLink` to not attempt to fetch details for negative `userId` values (as you might find in the audit log)
