### PR TITLE
AuditQueriesListingPage: load via withQueryModels

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.1",
+  "version": "2.373.2-fb-audit-load.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.373.1",
+      "version": "2.373.2-fb-audit-load.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.2-fb-audit-load.0",
+  "version": "2.373.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.373.2-fb-audit-load.0",
+      "version": "2.373.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.1",
+  "version": "2.373.2-fb-audit-load.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.2-fb-audit-load.0",
+  "version": "2.373.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.373.2
+*Released*: 29 September 2023
+* AuditQueriesListingPage: load via withQueryModels
+
 ### version 2.373.1
 *Released*: 29 September 2023
 * Update help text for alias fields in support of defaulting to using the aliases as parents when inserting entities
@@ -33,10 +37,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Display dropdown indicator on date cells in `EditableGrid`.
 - Update `DatePickerInput` to expose `onCalendarClose` and use to handle selecting a date cell after the calendar has closed.
 - Update `UserLink` to not attempt to fetch details for negative `userId` values (as you might find in the audit log)
-
-### version 2.371.1
-*Released*: 29 September 2023
-* AuditQueriesListingPage: load via withQueryModels
 
 ### version 2.371.0
 *Released*: 25 September 2023

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -34,6 +34,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Update `DatePickerInput` to expose `onCalendarClose` and use to handle selecting a date cell after the calendar has closed.
 - Update `UserLink` to not attempt to fetch details for negative `userId` values (as you might find in the audit log)
 
+### version 2.371.1
+*Released*: 29 September 2023
+* AuditQueriesListingPage: load via withQueryModels
+
 ### version 2.371.0
 *Released*: 25 September 2023
 * Render file output in R Reports

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -99,7 +99,7 @@ const AuditQueriesListingPageBody: FC<InjectedQueryModels & OwnProps> = memo(pro
         return (
             <Row>
                 <Col xs={12} md={8}>
-                    <GridPanel actions={actions} highlightLastSelectedRow key={eventType} model={model} />
+                    <GridPanel actions={actions} highlightLastSelectedRow model={model} />
                 </Col>
                 <Col xs={12} md={4}>
                     <AuditDetails
@@ -117,7 +117,7 @@ const AuditQueriesListingPageBody: FC<InjectedQueryModels & OwnProps> = memo(pro
         );
     }
 
-    return <GridPanel actions={actions} key={eventType} model={model} />;
+    return <GridPanel actions={actions} model={model} />;
 });
 
 const AuditQueriesListingBodyWithModels = withQueryModels<OwnProps>(AuditQueriesListingPageBody);

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -11,25 +11,29 @@ import { WithRouterProps } from 'react-router';
 
 import { GridPanel } from '../../../public/QueryModel/GridPanel';
 
-import { getLocation, replaceParameters } from '../../util/URL';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { Alert } from '../base/Alert';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { Page } from '../base/Page';
 import { PageHeader } from '../base/PageHeader';
 import { SelectInput, SelectInputChange } from '../forms/input/SelectInput';
-import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
+import { InjectedQueryModels, QueryConfigMap, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 import { useServerContext } from '../base/ServerContext';
 
 import { SCHEMAS } from '../../schemas';
 
 import { resolveErrorMessage } from '../../util/messaging';
 
+import { isAppHomeFolder } from '../../app/utils';
+
+import { User } from '../base/models/User';
+
 import { getAuditQueries } from './utils';
 import { getAuditDetail } from './actions';
 import { AuditDetailsModel } from './models';
 import { AuditDetails } from './AuditDetails';
 import {
+    AuditQuery,
     AUDIT_EVENT_TYPE_PARAM,
     SAMPLE_TIMELINE_AUDIT_QUERY,
     SOURCE_AUDIT_QUERY,
@@ -38,92 +42,42 @@ import {
 } from './constants';
 
 interface OwnProps {
-    eventType?: string;
-    onChange: (eventType: string) => void;
+    eventType: string;
+    selectedQuery: AuditQuery;
+    user: User;
 }
 
-const AuditQueriesListingPageImpl: FC<InjectedQueryModels & OwnProps> = memo(props => {
-    const { actions, onChange, queryModels } = props;
-    const { moduleContext, project, user } = useServerContext();
+const AuditQueriesListingPageBody: FC<InjectedQueryModels & OwnProps> = memo(props => {
+    const { actions, eventType, queryModels, selectedQuery, user } = props;
+    const { hasDetail } = selectedQuery;
+    const model = queryModels[eventType];
 
     const [detail, setDetail] = useState<AuditDetailsModel>();
     const [error, setError] = useState<string>();
-    const [eventType, setEventType] = useState<string>(() => props.eventType ?? SAMPLE_TIMELINE_AUDIT_QUERY.value);
-    const [selectedRowId, setSelectedRowId] = useState<number>();
-    const auditQueries = useMemo(() => getAuditQueries(moduleContext), [moduleContext]);
-    const selectedQuery = useMemo(() => auditQueries.find(q => q.value === eventType), [auditQueries, eventType]);
-    const id = useMemo<string>(
-        () => (selectedQuery ? `audit-log-querymodel-${selectedQuery.value}` : undefined),
-        [selectedQuery]
-    );
-    const model = queryModels[id];
-    const lastSelectedId = useMemo<number>(() => {
-        if (!model?.selections) return undefined;
+    const selectedRowId = useMemo<number>(() => {
+        if (model.isLoading || model.hasLoadErrors || !model.selections) return undefined;
         return parseInt(Array.from(model.selections).pop(), 10);
-    }, [model?.selections]);
+    }, [model]);
 
     useEffect(() => {
-        if (props.eventType) {
-            setEventType(props.eventType);
+        if (!selectedRowId || !selectedQuery.hasDetail) {
+            setError(undefined);
+            setDetail(undefined);
+            return;
         }
-    }, [props.eventType]);
-
-    useEffect(() => {
-        if (!selectedQuery) return undefined;
-        const { value } = selectedQuery;
-
-        if (!queryModels[id]) {
-            // Issue 47512: App audit log filters out container events for deleted containers
-            const baseFilters: Filter.IFilter[] = [];
-            if (PROJECT_AUDIT_QUERY.value === value) {
-                baseFilters.push(Filter.create('projectId', project.id));
-            }
-
-            actions.addModel(
-                {
-                    baseFilters,
-                    // only bind first model to URL so that it can pick up any filters passed from the caller
-                    bindURL: Object.keys(queryModels).length === 0,
-                    containerFilter: selectedQuery.containerFilter,
-                    id,
-                    includeTotalCount: true,
-                    schemaQuery: new SchemaQuery(SCHEMAS.AUDIT_TABLES.SCHEMA, value),
-                },
-                true,
-                true
-            );
-        }
-    }, [actions, id, project, queryModels, selectedQuery]);
-
-    useEffect(() => {
-        setSelectedRowId(lastSelectedId);
-        setDetail(detail_ => (lastSelectedId === detail_?.rowId ? detail_ : undefined));
-    }, [lastSelectedId]);
-
-    useEffect(() => {
-        if (!lastSelectedId || selectedQuery?.hasDetail !== true) return;
 
         (async () => {
             try {
                 const { value } = selectedQuery;
                 const auditEventType = value === SOURCE_AUDIT_QUERY.value ? DATA_UPDATE_AUDIT_QUERY.value : value;
-                const detail_ = await getAuditDetail(lastSelectedId, auditEventType);
-                setDetail(detail_.merge({ rowId: lastSelectedId }) as AuditDetailsModel);
+                const detail_ = await getAuditDetail(selectedRowId, auditEventType);
+                setDetail(detail_.merge({ rowId: selectedRowId }) as AuditDetailsModel);
                 setError(undefined);
             } catch (e) {
                 setError(resolveErrorMessage(e) ?? 'Failed to load audit details');
             }
         })();
-    }, [lastSelectedId, selectedQuery]);
-
-    const onSelectionChange = useCallback<SelectInputChange>(
-        (_, eventType_) => {
-            setEventType(eventType_);
-            setSelectedRowId(undefined);
-            onChange(eventType_);
-        },
-        [onChange]
-    );
+    }, [selectedQuery, selectedRowId]);
 
     const gridData = useMemo(() => {
         if (!detail) return undefined;
@@ -143,61 +97,119 @@ const AuditQueriesListingPageImpl: FC<InjectedQueryModels & OwnProps> = memo(pro
         return fromJS(rows);
     }, [detail]);
 
-    const hasDetailView = selectedQuery?.hasDetail === true;
-    const title = 'Audit Logs';
+    if (hasDetail) {
+        return (
+            <Row>
+                <Col xs={12} md={8}>
+                    <GridPanel actions={actions} highlightLastSelectedRow key={eventType} model={model} />
+                </Col>
+                <Col xs={12} md={4}>
+                    <AuditDetails
+                        changeDetails={detail}
+                        gridData={gridData}
+                        rowId={selectedRowId}
+                        summary={detail?.comment}
+                        user={user}
+                    >
+                        {error && <Alert>{error}</Alert>}
+                        {!!selectedRowId && !detail && !error && <LoadingSpinner />}
+                    </AuditDetails>
+                </Col>
+            </Row>
+        );
+    }
 
+    return <GridPanel actions={actions} key={eventType} model={model} />;
+});
+
+const AuditQueriesListingBodyWithModels = withQueryModels<OwnProps>(AuditQueriesListingPageBody);
+
+export const AuditQueriesListingPage: FC<WithRouterProps> = memo(({ location, router }) => {
+    const locationEventType = location.query?.eventType;
+    const [eventType, setEventType] = useState<string>(() => locationEventType ?? SAMPLE_TIMELINE_AUDIT_QUERY.value);
+    const { container, moduleContext, project, user } = useServerContext();
+    const auditQueries = useMemo(() => getAuditQueries(moduleContext), [moduleContext]);
+    const selectedQuery = useMemo(() => auditQueries.find(q => q.value === eventType), [auditQueries, eventType]);
+    const queryConfigs = useMemo<QueryConfigMap>(() => {
+        if (!selectedQuery) return undefined;
+        const { value } = selectedQuery;
+        const baseFilters: Filter.IFilter[] = [];
+        if (PROJECT_AUDIT_QUERY.value === value) {
+            // Issue 47512: App audit log filters out container events for deleted containers
+            baseFilters.push(Filter.create('projectId', project.id));
+
+            if (!isAppHomeFolder(container, moduleContext)) {
+                baseFilters.push(Filter.create('container', container.id));
+            }
+        }
+
+        return {
+            [value]: {
+                baseFilters,
+                bindURL: true,
+                containerFilter: selectedQuery.containerFilter,
+                id: value,
+                includeTotalCount: true,
+                schemaQuery: new SchemaQuery(SCHEMAS.AUDIT_TABLES.SCHEMA, value),
+                // Not using saved settings here since we reuse the same urlPrefix for all models
+                useSavedSettings: false,
+            },
+        };
+    }, [container, moduleContext, project.id, selectedQuery]);
+
+    useEffect(() => {
+        if (locationEventType) {
+            setEventType(locationEventType);
+        }
+    }, [locationEventType]);
+
+    const onChange = useCallback<SelectInputChange>(
+        (_, eventType_) => {
+            if (eventType_ === eventType) return;
+            const query = Object.keys(location.query).reduce((query_, key) => {
+                // remove query parameters from next model event type
+                if (!key.startsWith('query.')) {
+                    if (key === AUDIT_EVENT_TYPE_PARAM) {
+                        query_[key] = eventType_;
+                    } else {
+                        query_[key] = location.query[key];
+                    }
+                }
+
+                return query_;
+            }, {});
+            router.replace({ ...location, query });
+            setEventType(eventType_);
+        },
+        [eventType, location, router]
+    );
+
+    const title = 'Audit Logs';
     return (
         <Page hasHeader title={title}>
             <PageHeader title={title} />
             <SelectInput
+                clearable={false}
                 inputClass="col-xs-6"
                 key="audit-log-query-select"
                 name="audit-log-query-select"
-                onChange={onSelectionChange}
+                onChange={onChange}
                 options={auditQueries}
                 placeholder="Select an audit event type..."
-                value={eventType}
+                value={selectedQuery ? eventType : undefined}
             />
-            {hasDetailView && model && (
-                <Row>
-                    <Col xs={12} md={8}>
-                        <GridPanel actions={actions} highlightLastSelectedRow model={model} />
-                    </Col>
-                    <Col xs={12} md={4}>
-                        <AuditDetails
-                            changeDetails={detail}
-                            gridData={gridData}
-                            rowId={selectedRowId}
-                            summary={detail?.comment}
-                            user={user}
-                        >
-                            {error && <Alert>{error}</Alert>}
-                            {!!selectedRowId && !detail && !error && <LoadingSpinner />}
-                        </AuditDetails>
-                    </Col>
-                </Row>
+            {!selectedQuery && eventType && (
+                <Alert>Audit Event Type "{eventType}" Not Found. Please select an audit event type above.</Alert>
             )}
-            {!hasDetailView && model && <GridPanel actions={actions} model={model} />}
+            {selectedQuery && (
+                <AuditQueriesListingBodyWithModels
+                    eventType={eventType}
+                    key={eventType}
+                    queryConfigs={queryConfigs}
+                    selectedQuery={selectedQuery}
+                    user={user}
+                />
+            )}
         </Page>
     );
-});
-
-const AuditQueriesListingPageWithModels = withQueryModels<OwnProps>(AuditQueriesListingPageImpl);
-
-export const AuditQueriesListingPage: FC<WithRouterProps> = memo(({ location }) => {
-    const onChange = useCallback(eventType => {
-        const location_ = getLocation();
-        const paramUpdates = location_.query.map((value: string, key: string) => {
-            if (key.startsWith('query')) {
-                return undefined; // get rid of filtering parameters that are likely not applicable to this new audit log
-            } else if (key === AUDIT_EVENT_TYPE_PARAM) {
-                return eventType;
-            } else {
-                return value;
-            }
-        });
-        replaceParameters(location_, paramUpdates);
-    }, []);
-
-    return <AuditQueriesListingPageWithModels eventType={location.query?.eventType} onChange={onChange} />;
 });

--- a/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditQueriesListingPage.tsx
@@ -24,8 +24,6 @@ import { SCHEMAS } from '../../schemas';
 
 import { resolveErrorMessage } from '../../util/messaging';
 
-import { isAppHomeFolder } from '../../app/utils';
-
 import { User } from '../base/models/User';
 
 import { getAuditQueries } from './utils';
@@ -127,7 +125,7 @@ const AuditQueriesListingBodyWithModels = withQueryModels<OwnProps>(AuditQueries
 export const AuditQueriesListingPage: FC<WithRouterProps> = memo(({ location, router }) => {
     const locationEventType = location.query?.eventType;
     const [eventType, setEventType] = useState<string>(() => locationEventType ?? SAMPLE_TIMELINE_AUDIT_QUERY.value);
-    const { container, moduleContext, project, user } = useServerContext();
+    const { moduleContext, project, user } = useServerContext();
     const auditQueries = useMemo(() => getAuditQueries(moduleContext), [moduleContext]);
     const selectedQuery = useMemo(() => auditQueries.find(q => q.value === eventType), [auditQueries, eventType]);
     const queryConfigs = useMemo<QueryConfigMap>(() => {
@@ -137,10 +135,6 @@ export const AuditQueriesListingPage: FC<WithRouterProps> = memo(({ location, ro
         if (PROJECT_AUDIT_QUERY.value === value) {
             // Issue 47512: App audit log filters out container events for deleted containers
             baseFilters.push(Filter.create('projectId', project.id));
-
-            if (!isAppHomeFolder(container, moduleContext)) {
-                baseFilters.push(Filter.create('container', container.id));
-            }
         }
 
         return {
@@ -155,7 +149,7 @@ export const AuditQueriesListingPage: FC<WithRouterProps> = memo(({ location, ro
                 useSavedSettings: false,
             },
         };
-    }, [container, moduleContext, project.id, selectedQuery]);
+    }, [project.id, selectedQuery]);
 
     useEffect(() => {
         if (locationEventType) {


### PR DESCRIPTION
#### Rationale
This updates `AuditQueriesListingPage` to load via `withQueryModels` as well as apply `bindUrl` to all models. This remedies redundant loading that is occurring and allows for deep linking into audit results via the URL.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1297
- https://github.com/LabKey/labkey-ui-premium/pull/200
- https://github.com/LabKey/biologics/pull/2395
- https://github.com/LabKey/sampleManagement/pull/2120
- https://github.com/LabKey/inventory/pull/1038

#### Changes
- Refactor loading to use `withQueryModels` instead of `actions.addModels`. Addresses [Issue 48756](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48756).
- Improve page handling of invalid event types specified via URL
- The audit event type selection dropdown is no longer clearable
- Use `router.replace` instead of `getLocation / replaceParameter` paradigm to support URL updates
