### PR TITLE
LabelPrintingContext Updates

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.374.2",
+  "version": "2.375.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.374.2",
+      "version": "2.375.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.374.2",
+  "version": "2.375.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.375.0
+*Released*: 4 October 2023
+- Rename `LabelPrintingProviderProps` to `LabelPrintingContext`. Rename `LabelPrintingProvider` to `LabelPrintingContextProvider`.
+- Add `createLabelTemplateList` to APIWrapper
+- Streamline request creation and error handling in APIWrapper
+- Add error handling to `LabelPrintingContextProvider`
+- Update `BarTenderSettingsForm` to no longer use `withLabelPrintingContext` as this component does not rely on label context. Improve loading/error rendering.
+- Remove `withLabelPrintingContext`
+
 ### version 2.374.2
 *Released*: 4 October 2023
 * Merge release23.10-SNAPSHOT to develop:

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -654,7 +654,6 @@ import {
     deletePicklists,
     updatePicklist,
 } from './internal/components/picklist/actions';
-import { BarTenderSettingsForm } from './internal/components/labels/BarTenderSettingsForm';
 import { PrintLabelsModal } from './internal/components/labels/PrintLabelsModal';
 import { BarTenderConfiguration } from './internal/components/labels/models';
 import { useLabelPrintingContext } from './internal/components/labels/LabelPrintingContextProvider';
@@ -1667,7 +1666,6 @@ export {
     SubNavWithContext,
     // BarTender
     BarTenderConfiguration,
-    BarTenderSettingsForm,
     PrintLabelsModal,
     useLabelPrintingContext,
     usePortalRef,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -657,11 +657,7 @@ import {
 import { BarTenderSettingsForm } from './internal/components/labels/BarTenderSettingsForm';
 import { PrintLabelsModal } from './internal/components/labels/PrintLabelsModal';
 import { BarTenderConfiguration } from './internal/components/labels/models';
-import {
-    LabelPrintingProvider,
-    useLabelPrintingContext,
-    withLabelPrintingContext,
-} from './internal/components/labels/LabelPrintingContextProvider';
+import { useLabelPrintingContext } from './internal/components/labels/LabelPrintingContextProvider';
 import { ColumnSelectionModal } from './internal/components/ColumnSelectionModal';
 
 import {
@@ -992,6 +988,8 @@ const Hooks = {
     useAppContext,
     useContainerUser,
     useEnterEscape,
+    useLabelPrintingContext,
+    useNotificationsContext,
     useRouteLeave,
     useServerContext,
     useUserProperties,
@@ -1671,8 +1669,6 @@ export {
     BarTenderConfiguration,
     BarTenderSettingsForm,
     PrintLabelsModal,
-    LabelPrintingProvider,
-    withLabelPrintingContext,
     useLabelPrintingContext,
     usePortalRef,
     ExtendedMap,
@@ -1790,7 +1786,7 @@ export type { HorizontalBarData } from './internal/components/chart/HorizontalBa
 export type { HorizontalBarLegendData } from './internal/components/chart/utils';
 export type { InjectedLineage } from './internal/components/lineage/withLineage';
 export type {
-    LabelPrintingProviderProps,
+    LabelPrintingContext,
     LabelPrintingContextProps,
 } from './internal/components/labels/LabelPrintingContextProvider';
 export type { SamplesEditableGridProps } from './internal/sampleModels';

--- a/packages/components/src/internal/AppContexts.tsx
+++ b/packages/components/src/internal/AppContexts.tsx
@@ -7,7 +7,7 @@ import { AppContextProvider, ExtendableAppContext } from './AppContext';
 import { GlobalStateContextProvider } from './GlobalStateContext';
 import { ServerContextProvider, withAppUser } from './components/base/ServerContext';
 import { NotificationsContextProvider } from './components/notifications/NotificationsContext';
-import { LabelPrintingProvider } from './components/labels/LabelPrintingContextProvider';
+import { LabelPrintingContextProvider } from './components/labels/LabelPrintingContextProvider';
 
 interface Props<T = {}> {
     history: any;
@@ -28,11 +28,11 @@ export const AppContexts: FC<Props> = props => {
             <AppContextProvider initialContext={initialAppContext}>
                 <GlobalStateContextProvider>
                     <NotificationsContextProvider>
-                        <LabelPrintingProvider>
+                        <LabelPrintingContextProvider>
                             <Provider store={store}>
                                 <Router history={history}>{children}</Router>
                             </Provider>
-                        </LabelPrintingProvider>
+                        </LabelPrintingContextProvider>
                     </NotificationsContextProvider>
                 </GlobalStateContextProvider>
             </AppContextProvider>

--- a/packages/components/src/internal/components/labels/BarTenderSettingsForm.spec.tsx
+++ b/packages/components/src/internal/components/labels/BarTenderSettingsForm.spec.tsx
@@ -9,7 +9,7 @@ import { Container } from '../base/models/Container';
 
 import { getLabelPrintingTestAPIWrapper } from './APIWrapper';
 
-import { BarTenderSettingsFormImpl } from './BarTenderSettingsForm';
+import { BarTenderSettingsForm } from './BarTenderSettingsForm';
 import { BarTenderConfiguration } from './models';
 import { LabelsConfigurationPanel } from './LabelsConfigurationPanel';
 
@@ -45,7 +45,7 @@ describe('BarTenderSettingsForm', () => {
 
     test('default props, home project', async () => {
         const wrapper = mountWithAppServerContext(
-            <BarTenderSettingsFormImpl {...DEFAULT_PROPS} container={new Container({ path: '/Test' })} />
+            <BarTenderSettingsForm {...DEFAULT_PROPS} container={new Container({ path: '/Test' })} />
         );
         await waitForLifecycle(wrapper);
         validate(wrapper);
@@ -55,7 +55,7 @@ describe('BarTenderSettingsForm', () => {
 
     test('default props, product project', async () => {
         const wrapper = mountWithAppServerContext(
-            <BarTenderSettingsFormImpl
+            <BarTenderSettingsForm
                 {...DEFAULT_PROPS}
                 container={new Container({ path: '/Test/Folder', type: 'folder' })}
             />,
@@ -75,7 +75,7 @@ describe('BarTenderSettingsForm', () => {
 
     test('default props, subfolder without projects', async () => {
         const wrapper = mountWithAppServerContext(
-            <BarTenderSettingsFormImpl
+            <BarTenderSettingsForm
                 {...DEFAULT_PROPS}
                 container={new Container({ path: '/Test/Folder', type: 'folder' })}
             />,
@@ -95,17 +95,14 @@ describe('BarTenderSettingsForm', () => {
 
     test('with initial form values', async () => {
         const wrapper = mountWithAppServerContext(
-            <BarTenderSettingsFormImpl
+            <BarTenderSettingsForm
                 {...DEFAULT_PROPS}
                 container={new Container({ path: '/Test' })}
                 api={getTestAPIWrapper(jest.fn, {
                     labelprinting: getLabelPrintingTestAPIWrapper(jest.fn, {
-                        fetchBarTenderConfiguration: () =>
-                            Promise.resolve(
-                                new BarTenderConfiguration({
-                                    serviceURL: 'testServerURL',
-                                })
-                            ),
+                        fetchBarTenderConfiguration: jest
+                            .fn()
+                            .mockResolvedValue(new BarTenderConfiguration({ serviceURL: 'testServerURL' })),
                     }),
                 })}
             />

--- a/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
+++ b/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
@@ -20,19 +20,16 @@ import { useServerContext } from '../base/ServerContext';
 import { Container } from '../base/models/Container';
 
 import { BarTenderConfiguration, BarTenderResponse } from './models';
-import { withLabelPrintingContext, LabelPrintingProviderProps } from './LabelPrintingContextProvider';
 import { BAR_TENDER_TOPIC, BARTENDER_CONFIGURATION_TITLE } from './constants';
 import { LabelsConfigurationPanel } from './LabelsConfigurationPanel';
 
-interface OwnProps extends InjectedRouteLeaveProps {
+interface Props extends InjectedRouteLeaveProps {
     api?: ComponentsAPIWrapper;
     container: Container;
     onChange: () => void;
     onSuccess: () => void;
     title?: string;
 }
-
-type Props = LabelPrintingProviderProps & OwnProps;
 
 const SUCCESSFUL_NOTIFICATION_MESSAGE = 'Successfully connected to BarTender web service.';
 const FAILED_NOTIFICATION_MESSAGE = 'Failed to connect to BarTender web service.';
@@ -109,8 +106,8 @@ const btTestConnectionTemplate = (): string => {
 };
 
 // exported for jest testing
-export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
-    const { api, title = BARTENDER_CONFIGURATION_TITLE, onChange, onSuccess, container } = props;
+export const BarTenderSettingsForm: FC<Props> = memo(props => {
+    const { api, container, title = BARTENDER_CONFIGURATION_TITLE, onChange, onSuccess } = props;
     const [btServiceURL, setBtServiceURL] = useState<string>();
     const [defaultLabel, setDefaultLabel] = useState<number>();
     const { moduleContext } = useServerContext();
@@ -132,7 +129,7 @@ export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
             .catch(reason => {
                 setFailureMessage(reason);
             });
-    }, [api?.labelprinting, container?.path]);
+    }, [api, container?.path]);
 
     const onChangeHandler = useCallback(
         (name: string, value: string): void => {
@@ -253,8 +250,8 @@ export const BarTenderSettingsFormImpl: FC<Props> = memo(props => {
     );
 });
 
-BarTenderSettingsFormImpl.defaultProps = {
+BarTenderSettingsForm.defaultProps = {
     api: getDefaultAPIWrapper(),
 };
 
-export const BarTenderSettingsForm = withLabelPrintingContext(BarTenderSettingsFormImpl);
+BarTenderSettingsForm.displayName = 'BarTenderSettingsForm';

--- a/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labels/LabelsConfigurationPanel.tsx
@@ -51,6 +51,7 @@ interface LabelTemplatesListProps {
 
 interface LabelTemplateDetailsProps {
     api?: ComponentsAPIWrapper;
+    container: Container;
     defaultLabel?: number;
     isDefaultable: boolean;
     isNew: boolean;
@@ -58,7 +59,6 @@ interface LabelTemplateDetailsProps {
     onChange: () => void;
     onDefaultChanged: (newDefault: number) => void;
     template: LabelTemplate;
-    container: Container;
 }
 
 export const LabelTemplatesList: FC<LabelTemplatesListProps> = memo(props => {
@@ -242,7 +242,7 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
         } finally {
             setSaving(false);
         }
-    }, [api, defaultLabel, isDefault, onActionCompleted, onDefaultChanged, updatedTemplate]);
+    }, [api, container.path, defaultLabel, isDefault, onActionCompleted, onDefaultChanged, updatedTemplate]);
 
     return (
         <>

--- a/packages/components/src/internal/test/enzymeTestHelpers.tsx
+++ b/packages/components/src/internal/test/enzymeTestHelpers.tsx
@@ -6,7 +6,7 @@ import { AppContext } from '../AppContext';
 
 import { NotificationsContextState } from '../components/notifications/NotificationsContext';
 import { ServerContext, ServerContextProvider } from '../components/base/ServerContext';
-import { LabelPrintingProviderProps } from '../components/labels/LabelPrintingContextProvider';
+import { LabelPrintingContext } from '../components/labels/LabelPrintingContextProvider';
 
 import { AppContextTestProvider, sleep } from './testHelpers';
 
@@ -26,7 +26,7 @@ export const mountWithAppServerContextOptions = (
     serverContext?: Partial<ServerContext>,
     notificationContext?: Partial<NotificationsContextState>,
     options?: MountRendererProps,
-    printLabelsContext?: Partial<LabelPrintingProviderProps>
+    printLabelsContext?: Partial<LabelPrintingContext>
 ): MountRendererProps => {
     return {
         wrappingComponent: AppContextTestProvider,
@@ -58,7 +58,7 @@ export const mountWithAppServerContext = (
     serverContext?: Partial<ServerContext>,
     notificationContext?: Partial<NotificationsContextState>,
     options?: MountRendererProps,
-    printLabelsContext?: Partial<LabelPrintingProviderProps>
+    printLabelsContext?: Partial<LabelPrintingContext>
 ): ReactWrapper => {
     return mount(
         node,

--- a/packages/components/src/internal/test/testHelpers.tsx
+++ b/packages/components/src/internal/test/testHelpers.tsx
@@ -10,7 +10,10 @@ import {
     NotificationsContextState,
 } from '../components/notifications/NotificationsContext';
 import { ServerContext, ServerContextProvider } from '../components/base/ServerContext';
-import { LabelPrintingContextProps, LabelPrintingProvider } from '../components/labels/LabelPrintingContextProvider';
+import {
+    LabelPrintingContextProps,
+    LabelPrintingContextProvider,
+} from '../components/labels/LabelPrintingContextProvider';
 import { GlobalStateContextProvider } from '../GlobalStateContext';
 import { URL_MAPPERS, URLService } from '../url/URLResolver';
 
@@ -34,9 +37,9 @@ export const AppContextTestProvider: FC<AppContextTestProviderProps> = props => 
             <AppContextProvider initialContext={initialAppContext}>
                 <GlobalStateContextProvider>
                     <NotificationsContextProvider initialContext={notificationContext as NotificationsContextState}>
-                        <LabelPrintingProvider initialContext={printLabelsContext as LabelPrintingContextProps}>
+                        <LabelPrintingContextProvider initialContext={printLabelsContext as LabelPrintingContextProps}>
                             {children}
-                        </LabelPrintingProvider>
+                        </LabelPrintingContextProvider>
                     </NotificationsContextProvider>
                 </GlobalStateContextProvider>
             </AppContextProvider>


### PR DESCRIPTION
#### Rationale
This updates the `LabelPrintingContext` to better handle errors during initialization.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1301
- https://github.com/LabKey/labkey-ui-premium/pull/205
- https://github.com/LabKey/biologics/pull/2409
- https://github.com/LabKey/sampleManagement/pull/2133
- https://github.com/LabKey/inventory/pull/1045

#### Changes
- Rename `LabelPrintingProviderProps` to `LabelPrintingContext`. Rename `LabelPrintingProvider` to `LabelPrintingContextProvider`.
- Add `createLabelTemplateList` to APIWrapper
- Streamline request creation and error handling in APIWrapper
- Add error handling to `LabelPrintingContextProvider`
- Update `BarTenderSettingsForm` to no longer use `withLabelPrintingContext` as this component does not rely on label context. Improve loading/error rendering.
- Remove `withLabelPrintingContext`