### PR TITLE
Issue 48781: LKSM/LKB: Groups using wrong icon

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.4-fb-issue48781.1",
+  "version": "2.373.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.373.4-fb-issue48781.1",
+      "version": "2.373.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.3",
+  "version": "2.373.4-fb-issue48781.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.373.3",
+      "version": "2.373.4-fb-issue48781.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.4-fb-issue48781.1",
+  "version": "2.373.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.373.3",
+  "version": "2.373.4-fb-issue48781.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,11 +2,11 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 2.373.4
-*Released*: 2 Octoeber 2023
+*Released*: 2 October 2023
 * Issue 48781: LKSM/LKB: Groups using wrong icon
 
 ### version 2.373.3
-*Released*: 2 Octoeber 2023
+*Released*: 2 October 2023
 * add some keys to Fragments to get rid of warnings about missing keys
 
 ### version 2.373.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.373.4
+*Released*: 2 Octoeber 2023
+* Issue 48781: LKSM/LKB: Groups using wrong icon
+
 ### version 2.373.3
 *Released*: 2 Octoeber 2023
 * add some keys to Fragments to get rid of warnings about missing keys

--- a/packages/components/src/internal/components/administration/Group.tsx
+++ b/packages/components/src/internal/components/administration/Group.tsx
@@ -110,7 +110,7 @@ export const Group: FC<GroupProps> = memo(props => {
             clause={generateClause}
             links={generateLinks}
             initExpanded={initExpanded}
-            iconFaCls="unlock-alt fa-3x"
+            iconFaCls="users fa-3x"
             useGreyTheme={true}
             isExpandable={true}
         >


### PR DESCRIPTION
#### Rationale
revert to the old icon for group settings

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1302
- https://github.com/LabKey/biologics/pull/2404
- https://github.com/LabKey/sampleManagement/pull/2130

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
