### PR TITLE
Issue 48240: Assay Result field creation using JSON file results in lookup failure

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.2-fb-assayFixes2311CAN.0",
+  "version": "2.375.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.2-fb-assayFixes2311CAN.0",
+      "version": "2.375.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.2",
+  "version": "2.375.2-fb-assayFixes2311CAN.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.2",
+      "version": "2.375.2-fb-assayFixes2311CAN.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.0",
+  "version": "2.375.0-fb-assayFixes2311CAN.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.0",
+      "version": "2.375.0-fb-assayFixes2311CAN.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.0",
+  "version": "2.375.0-fb-assayFixes2311CAN.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.2",
+  "version": "2.375.2-fb-assayFixes2311CAN.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.2-fb-assayFixes2311CAN.0",
+  "version": "2.375.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2023
+- Issue 48240: Assay Result field creation using JSON file results in lookup failure
+
 ### version 2.375.0
 *Released*: 4 October 2023
 - Rename `LabelPrintingProviderProps` to `LabelPrintingContext`. Rename `LabelPrintingProvider` to `LabelPrintingContextProvider`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2023
+### version 2.375.3
+*Released*: 6 October 2023
 - Issue 48240: Assay Result field creation using JSON file results in lookup failure
 
 ### version 2.375.2

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -928,7 +928,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
             const reader = new FileReader();
 
             // Waits until file is loaded
-            reader.onloadend = function (e: any) {
+            reader.onloadend = async (e: any) => {
                 // Catches malformed JSON
                 try {
                     content = e.target.result;
@@ -938,7 +938,8 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                         return resolve(response);
                     } else {
                         const tsFields = response.fields;
-                        onChange?.(mergeDomainFields(domain, tsFields), true);
+                        const mergedFields = await mergeDomainFields(domain, tsFields);
+                        onChange?.(mergedFields, true);
                         resolve({ success: true });
                     }
                 } catch (e) {

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -37,6 +37,8 @@ import { handleRequestFailure } from '../../util/utils';
 
 import { getExcludedDataTypeNames } from '../entities/actions';
 
+import { getQueryDetails } from '../../query/api';
+
 import {
     DOMAIN_FIELD_CLIENT_SIDE_ERROR,
     DOMAIN_FIELD_LOOKUP_CONTAINER,
@@ -88,7 +90,6 @@ import {
 } from './models';
 import { createFormInputId, createFormInputName, getIndexFromId, getNameFromId } from './utils';
 import { DomainPropertiesAPIWrapper } from './APIWrapper';
-import { getQueryDetails } from '../../query/api';
 
 let sharedCache = Map<string, Promise<any>>();
 


### PR DESCRIPTION
#### Rationale
Issue [48240](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48240): Assay: Result field creation using JSON file & lookup failure
When importing domain fields from a JSON file, the lookups were getting marked as invalid. This PR updates that so that after a new field is added via the JSON file, we use a getQueryDetails call to determine if the lookup target is valid or not.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1305
- https://github.com/LabKey/labkey-ui-premium/pull/210
- https://github.com/LabKey/platform/pull/4807
- https://github.com/LabKey/biologics/pull/2416
- https://github.com/LabKey/sampleManagement/pull/2141

#### Changes
- after a new domain field is added via the JSON file, we use a getQueryDetails call to determine if the lookup target is valid
