### PR TITLE
Use the first filter type as the default when there are no distinct values

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.0",
+  "version": "2.375.1-filterDefaults.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.0",
+      "version": "2.375.1-filterDefaults.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.2-filterDefaults.1",
+  "version": "2.375.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.2-filterDefaults.1",
+      "version": "2.375.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.1-filterDefaults.0",
+  "version": "2.375.2-filterDefaults.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.1-filterDefaults.0",
+      "version": "2.375.2-filterDefaults.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.0",
+  "version": "2.375.1-filterDefaults.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.2-filterDefaults.0",
+  "version": "2.375.2-filterDefaults.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.2-filterDefaults.1",
+  "version": "2.375.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.375.2
+*Released*: 5 October 2023
 - Choose a default filter for field types that don't offer text choices
 
 ### version 2.375.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Choose a default filter for field types that don't offer text choices
+
 ### version 2.375.0
 *Released*: 4 October 2023
 - Rename `LabelPrintingProviderProps` to `LabelPrintingContext`. Rename `LabelPrintingProvider` to `LabelPrintingContextProvider`.

--- a/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
@@ -113,7 +113,7 @@ describe('FilterExpressionView', () => {
         firstInputValue?: any,
         secondInputValue?: any,
         disabled?: boolean
-    ) {
+    ): void {
         expect(wrapper.find(SelectInput)).toHaveLength(numFilters);
         validateFilterTypeDropdown(wrapper, operators, filterIndex, selectedOp);
 
@@ -137,12 +137,12 @@ describe('FilterExpressionView', () => {
         operators: string[],
         filterIndex: number,
         selectedOp?: string
-    ) {
+    ): void {
         const selectInput = wrapper.find(SelectInput).at(filterIndex);
         const options = selectInput.props()['options'];
         const selectedFilter = selectInput.props()['value'];
         if (selectedOp) expect(selectedFilter).toEqual(selectedOp);
-        else expect(selectedFilter).toEqual("contains");
+        else expect(selectedFilter).toEqual('contains');
 
         const ops = [];
         options.map(op => ops.push(op['value']));
@@ -157,7 +157,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('string field, equals operator', async () => {
+    test('string field, equals operator', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={stringField}
@@ -169,7 +169,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, between operator', async () => {
+    test('int field, between operator', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -181,7 +181,19 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('double field, greater than operator', async () => {
+    test('int field, no filter selected',  () => {
+        const wrapper = mount(
+            <FilterExpressionView
+                field={intField}
+                fieldFilters={null}
+            />
+        );
+
+        validateFilterTypeDropdown(wrapper, Ops, 0, Ops[0]);
+        wrapper.unmount();
+    });
+
+    test('double field, greater than operator', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -193,7 +205,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('date field, not equal', async () => {
+    test('date field, not equal', () => {
         const datePOSIX = 1596750283812; // Aug 6, 2020 14:44 America/Los_Angeles
         const testDate = new Date(datePOSIX);
 
@@ -208,7 +220,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('boolean field, equal', async () => {
+    test('boolean field, equal', () => {
         const wrapper = mount(
             <FilterExpressionView field={booleanField} fieldFilters={[Filter.create('BooleanField', 'true')]} />
         );
@@ -227,7 +239,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('not sole filter, without value', async () => {
+    test('not sole filter, without value', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -238,7 +250,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('between filter missing all values', async () => {
+    test('between filter missing all values', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -250,7 +262,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('between filter missing one value', async () => {
+    test('between filter missing one value', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -262,7 +274,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('multiple filters with values', async () => {
+    test('multiple filters with values', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -296,7 +308,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('multiple filters, no input required', async () => {
+    test('multiple filters, no input required', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -307,7 +319,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, between operator, disabled', async () => {
+    test('int field, between operator, disabled', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}

--- a/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
@@ -149,7 +149,7 @@ describe('FilterExpressionView', () => {
         expect(ops).toEqual(operators);
     }
 
-    test('string field, no filter selected', () => {
+    test('string field, no filter selected', async () => {
         const wrapper = mount(<FilterExpressionView field={stringField} fieldFilters={null} />);
 
         validateFilterTypeDropdown(wrapper, StringOps, 0, null);
@@ -157,7 +157,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('string field, equals operator', () => {
+    test('string field, equals operator', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={stringField}
@@ -169,7 +169,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, between operator', () => {
+    test('int field, between operator', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -181,7 +181,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, no filter selected',  () => {
+    test('int field, no filter selected',  async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -193,7 +193,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('double field, greater than operator', () => {
+    test('double field, greater than operator', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -205,7 +205,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('date field, not equal', () => {
+    test('date field, not equal', async () => {
         const datePOSIX = 1596750283812; // Aug 6, 2020 14:44 America/Los_Angeles
         const testDate = new Date(datePOSIX);
 
@@ -220,7 +220,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('boolean field, equal', () => {
+    test('boolean field, equal', async () => {
         const wrapper = mount(
             <FilterExpressionView field={booleanField} fieldFilters={[Filter.create('BooleanField', 'true')]} />
         );
@@ -239,7 +239,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('not sole filter, without value', () => {
+    test('not sole filter, without value', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -250,7 +250,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('between filter missing all values', () => {
+    test('between filter missing all values', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -262,7 +262,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('between filter missing one value', () => {
+    test('between filter missing one value', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -274,7 +274,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('multiple filters with values', () => {
+    test('multiple filters with values', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -308,7 +308,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('multiple filters, no input required', () => {
+    test('multiple filters, no input required', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -319,7 +319,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, between operator, disabled', () => {
+    test('int field, between operator, disabled', async () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}

--- a/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.spec.tsx
@@ -149,7 +149,7 @@ describe('FilterExpressionView', () => {
         expect(ops).toEqual(operators);
     }
 
-    test('string field, no filter selected', async () => {
+    test('string field, no filter selected', () => {
         const wrapper = mount(<FilterExpressionView field={stringField} fieldFilters={null} />);
 
         validateFilterTypeDropdown(wrapper, StringOps, 0, null);
@@ -157,7 +157,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('string field, equals operator', async () => {
+    test('string field, equals operator', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={stringField}
@@ -169,7 +169,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, between operator', async () => {
+    test('int field, between operator', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -181,7 +181,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, no filter selected',  async () => {
+    test('int field, no filter selected',  () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -193,7 +193,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('double field, greater than operator', async () => {
+    test('double field, greater than operator', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -205,7 +205,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('date field, not equal', async () => {
+    test('date field, not equal', () => {
         const datePOSIX = 1596750283812; // Aug 6, 2020 14:44 America/Los_Angeles
         const testDate = new Date(datePOSIX);
 
@@ -220,7 +220,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('boolean field, equal', async () => {
+    test('boolean field, equal', () => {
         const wrapper = mount(
             <FilterExpressionView field={booleanField} fieldFilters={[Filter.create('BooleanField', 'true')]} />
         );
@@ -239,7 +239,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('not sole filter, without value', async () => {
+    test('not sole filter, without value', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -250,7 +250,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('between filter missing all values', async () => {
+    test('between filter missing all values', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -262,7 +262,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('between filter missing one value', async () => {
+    test('between filter missing one value', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}
@@ -274,7 +274,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('multiple filters with values', async () => {
+    test('multiple filters with values', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -308,7 +308,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('multiple filters, no input required', async () => {
+    test('multiple filters, no input required', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={doubleField}
@@ -319,7 +319,7 @@ describe('FilterExpressionView', () => {
         wrapper.unmount();
     });
 
-    test('int field, between operator, disabled', async () => {
+    test('int field, between operator, disabled', () => {
         const wrapper = mount(
             <FilterExpressionView
                 field={intField}

--- a/packages/components/src/internal/components/search/utils.spec.ts
+++ b/packages/components/src/internal/components/search/utils.spec.ts
@@ -712,20 +712,23 @@ describe('getFilterSelections', () => {
     });
 
     test('no matching filter option', () => {
+        const filterOptions = [
+            {
+                value: 'none-such',
+                label: 'Not Valid',
+                valueRequired: true,
+                multiValue: true,
+                betweenOperator: false,
+                isSoleFilter: false,
+            },
+        ];
         const filterSelections = getFilterSelections(
             [Filter.create('strField', 'test')],
-            [
-                {
-                    value: 'none-such',
-                    label: 'Not Valid',
-                    valueRequired: true,
-                    multiValue: true,
-                    betweenOperator: false,
-                    isSoleFilter: false,
-                },
-            ]
+            filterOptions
         );
-        expect(filterSelections).toStrictEqual([]);
+        expect(filterSelections).toStrictEqual([{
+                filterType: filterOptions[0],
+            }]);
     });
 
     test('single filter, single value', () => {

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -409,6 +409,10 @@ export function getFilterSelections(
             filters.push({
                 filterType: filterOption,
             });
+        } else {
+            filters.push({
+               filterType: filterOptions[0]
+            });
         }
     }
     return filters;

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -401,7 +401,7 @@ export function getFilterSelections(
             filters.push(filter);
         }
     });
-    if (filters.length == 0) {
+    if (filters.length === 0) {
         const filterOption = filterOptions?.find(option => {
             return isFilterUrlSuffixMatch(option.value, Filter.Types.CONTAINS);
         });
@@ -409,9 +409,9 @@ export function getFilterSelections(
             filters.push({
                 filterType: filterOption,
             });
-        } else {
+        } else if (filterOptions?.length) {
             filters.push({
-               filterType: filterOptions[0]
+                filterType: filterOptions[0],
             });
         }
     }


### PR DESCRIPTION
#### Rationale
[Issue 48463](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48463) We currently require you to choose a filter type when filtering fields other than the ones that start out on the panel listing the distinct values. It will ease user experience to choose the first filter type (usually Equals) as a default.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/208
- https://github.com/LabKey/biologics/pull/2418
- https://github.com/LabKey/inventory/pull/1047
- https://github.com/LabKey/sampleManagement/pull/2143

#### Changes
- Default to first filter option
