### PR TITLE
Issue 48287: Improve behavior for Picklist buttons

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.3-picklistButtonUpdates.1",
+  "version": "2.375.3-picklistButtonUpdates.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.3-picklistButtonUpdates.1",
+      "version": "2.375.3-picklistButtonUpdates.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.3-picklistButtonUpdates.2",
+  "version": "2.376.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.3-picklistButtonUpdates.2",
+      "version": "2.376.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.1",
+  "version": "2.375.2-picklistButtonUpdates.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.375.1",
+      "version": "2.375.2-picklistButtonUpdates.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.24.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.4-picklistButtonUpdates.2",
+  "version": "2.376.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.1",
+  "version": "2.375.2-picklistButtonUpdates.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.375.3-picklistButtonUpdates.1",
+  "version": "2.375.3-picklistButtonUpdates.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 48287: Improve behavior for Picklist buttons
+  * Don't check sample status before adding to picklists since there is no restriction for picklists
+  * Limit the number of samples that can be added at one time
+
 ### version 2.375.1
 *Released*: 4 October 2023
 * Show SourceID on SourceEvents Audit Table

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -12,6 +12,7 @@ import { User } from '../base/models/User';
 
 import { PicklistEditModal } from './PicklistEditModal';
 import { ChoosePicklistModal } from './ChoosePicklistModal';
+import { MAX_SELECTIONS_PER_ADD } from './constants';
 
 interface Props {
     currentProductId?: string;
@@ -81,6 +82,7 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
                     text={itemText}
                     onClick={onClick}
                     queryModel={queryModel}
+                    maxSelection={MAX_SELECTIONS_PER_ADD}
                     nounPlural="samples"
                 />
             ) : (

--- a/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/AddToPicklistMenuItem.tsx
@@ -113,8 +113,6 @@ export const AddToPicklistMenuItem: FC<Props> = memo(props => {
             )}
             {showCreatePicklist && (
                 <PicklistEditModal
-                    selectionKey={sampleFieldKey ? undefined : selectionKey} // If a sampleField is being used it, the id may not map correctly
-                    selectedQuantity={numSelected}
                     sampleIds={sampleIds}
                     onFinish={afterCreatePicklist}
                     onCancel={closeCreatePicklist}

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.spec.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.spec.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 
 import { mount, shallow } from 'enzyme';
 
-import { Button, ModalBody, ModalTitle, NavItem } from 'react-bootstrap';
+import { ModalBody } from 'react-bootstrap';
 
 import { TEST_USER_EDITOR } from '../../userFixtures';
 import { mountWithAppServerContext, waitForLifecycle } from '../../test/enzymeTestHelpers';
 
 import { getTestAPIWrapper } from '../../APIWrapper';
-import { OperationConfirmationData } from '../entities/models';
 
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
 
@@ -302,7 +301,6 @@ describe('AddToPicklistNotification', () => {
 
 describe('ChoosePicklistModalDisplay', () => {
     test('loading', async () => {
-        const statusData = new OperationConfirmationData({ allowed: [1, 2], notAllowed: [] });
         const wrapper = mountWithAppServerContext(
             <ChoosePicklistModalDisplay
                 picklists={[]}
@@ -313,8 +311,7 @@ describe('ChoosePicklistModalDisplay', () => {
                 user={TEST_USER_EDITOR}
                 sampleIds={['1', '2']}
                 numSelected={2}
-                statusData={statusData}
-                validCount={statusData.allowed.length}
+                validCount={2}
             />
         );
 
@@ -328,7 +325,6 @@ describe('ChoosePicklistModalDisplay', () => {
 
     test('loading error', async () => {
         const errorText = "Couldn't get your data";
-        const statusData = new OperationConfirmationData({ allowed: [1, 2], notAllowed: [] });
         const wrapper = mountWithAppServerContext(
             <ChoosePicklistModalDisplay
                 picklists={[]}
@@ -339,8 +335,7 @@ describe('ChoosePicklistModalDisplay', () => {
                 user={TEST_USER_EDITOR}
                 sampleIds={['1', '2']}
                 numSelected={2}
-                statusData={statusData}
-                validCount={statusData.allowed.length}
+                validCount={2}
             />
         );
         await waitForLifecycle(wrapper);
@@ -352,7 +347,6 @@ describe('ChoosePicklistModalDisplay', () => {
     });
 
     test('adding one sample', async () => {
-        const statusData = new OperationConfirmationData({ allowed: [1], notAllowed: [] });
         const wrapper = mountWithAppServerContext(
             <ChoosePicklistModalDisplay
                 picklists={[]}
@@ -363,8 +357,7 @@ describe('ChoosePicklistModalDisplay', () => {
                 user={TEST_USER_EDITOR}
                 sampleIds={['1']}
                 numSelected={1}
-                statusData={statusData}
-                validCount={statusData.allowed.length}
+                validCount={1}
             />
         );
         await waitForLifecycle(wrapper);
@@ -376,7 +369,6 @@ describe('ChoosePicklistModalDisplay', () => {
     });
 
     test('with active item', async () => {
-        const statusData = new OperationConfirmationData({ allowed: [1], notAllowed: [] });
         const wrapper = mountWithAppServerContext(
             <ChoosePicklistModalDisplay
                 picklists={[PUBLIC_EDITOR_PICKLIST]}
@@ -387,8 +379,7 @@ describe('ChoosePicklistModalDisplay', () => {
                 user={TEST_USER_EDITOR}
                 sampleIds={['1']}
                 numSelected={1}
-                statusData={statusData}
-                validCount={statusData.allowed.length}
+                validCount={1}
             />
         );
         await waitForLifecycle(wrapper);
@@ -396,60 +387,6 @@ describe('ChoosePicklistModalDisplay', () => {
         const picklistButtons = wrapper.find('.list-group-item');
         picklistButtons.at(0).simulate('click');
         expect(wrapper.find('.choice-details')).toHaveLength(1);
-        wrapper.unmount();
-    });
-
-    test('some not allowed', async () => {
-        const statusData = new OperationConfirmationData({ allowed: [1], notAllowed: [2, 3] });
-        const wrapper = mountWithAppServerContext(
-            <ChoosePicklistModalDisplay
-                picklists={[PUBLIC_EDITOR_PICKLIST]}
-                picklistLoadError={undefined}
-                loading={false}
-                onCancel={jest.fn()}
-                afterAddToPicklist={jest.fn()}
-                user={TEST_USER_EDITOR}
-                sampleIds={['1', '2', '3']}
-                numSelected={1}
-                statusData={statusData}
-                validCount={statusData.allowed.length}
-            />
-        );
-        await waitForLifecycle(wrapper);
-        const alert = wrapper.find('.alert-info');
-        expect(alert).toHaveLength(1);
-        expect(alert.text()).toBe(
-            'Adding 1 sample to selected picklist. ' +
-                'The current status of 2 selected samples prevents adding them to a picklist.'
-        );
-        wrapper.unmount();
-    });
-
-    test('none allowed', async () => {
-        const statusData = new OperationConfirmationData({ allowed: [], notAllowed: [1, 2, 3] });
-        const wrapper = mountWithAppServerContext(
-            <ChoosePicklistModalDisplay
-                picklists={[PUBLIC_EDITOR_PICKLIST]}
-                picklistLoadError={undefined}
-                loading={false}
-                onCancel={jest.fn()}
-                afterAddToPicklist={jest.fn()}
-                user={TEST_USER_EDITOR}
-                sampleIds={['1', '2', '3']}
-                numSelected={1}
-                statusData={statusData}
-                validCount={statusData.allowed.length}
-            />
-        );
-        await waitForLifecycle(wrapper);
-        const modalTitle = wrapper.find(ModalTitle);
-        expect(modalTitle.text()).toBe('Cannot Add to Picklist');
-        expect(wrapper.find(ModalBody).text()).toBe(
-            'All selected samples have a status that prevents adding them to a picklist.'
-        );
-        const buttons = wrapper.find(Button);
-        expect(buttons).toHaveLength(1);
-        expect(buttons.at(0).text()).toBe('Dismiss');
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/picklist/PicklistButton.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistButton.spec.tsx
@@ -25,8 +25,6 @@ describe('PicklistButton', () => {
         expect(wrapper.find(SubMenuItem)).toHaveLength(0);
         const menuItem = wrapper.find(PicklistCreationMenuItem);
         expect(menuItem).toHaveLength(1);
-        expect(menuItem.prop('selectionKey')).toBe(queryModel.id);
-        expect(menuItem.prop('selectedQuantity')).toBeFalsy();
         expect(menuItem.prop('metricFeatureArea')).toBe(featureArea);
         const addMenuItem = wrapper.find(AddToPicklistMenuItem);
         expect(addMenuItem).toHaveLength(1);
@@ -52,7 +50,6 @@ describe('PicklistButton', () => {
         });
         const menuItem = wrapper.find(PicklistCreationMenuItem);
         expect(menuItem).toHaveLength(1);
-        expect(menuItem.prop('selectionKey')).toBe(queryModel.id);
-        expect(menuItem.prop('selectedQuantity')).toBe(2);
+        expect(menuItem.prop('queryModel')).toBeDefined();
     });
 });

--- a/packages/components/src/internal/components/picklist/PicklistButton.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistButton.tsx
@@ -36,9 +36,7 @@ export const PicklistButton: FC<Props> = memo(props => {
                 picklistProductId={picklistProductId}
             />
             <PicklistCreationMenuItem
-                selectionKey={sampleIds ? undefined : model?.selectionKey}
                 queryModel={sampleIds ? undefined : model}
-                selectedQuantity={sampleIds ? undefined : model?.selections?.size}
                 sampleIds={sampleIds}
                 key="picklist"
                 user={user}

--- a/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistCreationMenuItem.tsx
@@ -8,6 +8,7 @@ import { SelectionMenuItem } from '../menus/SelectionMenuItem';
 import { User } from '../base/models/User';
 
 import { PicklistEditModal, PicklistEditModalProps } from './PicklistEditModal';
+import { MAX_SELECTIONS_PER_ADD } from './constants';
 
 interface Props extends Omit<PicklistEditModalProps, 'onCancel' | 'onFinish' | 'showNotification'> {
     asMenuItem?: boolean;
@@ -46,6 +47,7 @@ export const PicklistCreationMenuItem: FC<Props> = props => {
                     onClick={onClick}
                     queryModel={queryModel}
                     nounPlural="samples"
+                    maxSelection={MAX_SELECTIONS_PER_ADD}
                 />
             )}
             {!queryModel && asMenuItem && <MenuItem onClick={onClick}>{itemText}</MenuItem>}

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.spec.tsx
@@ -2,67 +2,19 @@ import React from 'react';
 
 import { ReactWrapper } from 'enzyme';
 import { Button, Modal, ModalFooter, ModalTitle } from 'react-bootstrap';
-
-import { getTestAPIWrapper } from '../../APIWrapper';
-import { getSamplesTestAPIWrapper } from '../samples/APIWrapper';
-import { mountWithAppServerContext, waitForLifecycle } from '../../test/enzymeTestHelpers';
-
-import { OperationConfirmationData } from '../entities/models';
-
-import { Alert } from '../base/Alert';
+import { mountWithAppServerContext } from '../../test/enzymeTestHelpers';
 
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
 
 import { PicklistEditModal } from './PicklistEditModal';
 import { Picklist } from './models';
+import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
+import { SchemaQuery } from '../../../public/SchemaQuery';
 
 describe('PicklistEditModal', () => {
-    const allAllowedStatus = new OperationConfirmationData({
-        allowed: [
-            {
-                Name: 'T-1',
-                RowId: 1,
-            },
-            {
-                Name: 'T-2',
-                RowId: 2,
-            },
-        ],
-    });
+    const queryModel = makeTestQueryModel(new SchemaQuery('test', 'query'));
 
-    const noneAllowedStatus = new OperationConfirmationData({
-        notAllowed: [
-            {
-                Name: 'T-1',
-                RowId: 1,
-            },
-            {
-                Name: 'T-2',
-                RowId: 2,
-            },
-        ],
-    });
-
-    const someAllowedStatus = new OperationConfirmationData({
-        allowed: [
-            {
-                Name: 'T-3',
-                RowId: 3,
-            },
-        ],
-        notAllowed: [
-            {
-                Name: 'T-1',
-                RowId: 1,
-            },
-            {
-                Name: 'T-2',
-                RowId: 2,
-            },
-        ],
-    });
-
-    function validateText(wrapper: ReactWrapper, expectedTitle: string, expectedFinishText: string) {
+    function validateText(wrapper: ReactWrapper, expectedTitle: string, expectedFinishText: string): void {
         const modal = wrapper.find(Modal);
         const title = modal.find(ModalTitle);
         expect(title.text()).toBe(expectedTitle);
@@ -72,7 +24,7 @@ describe('PicklistEditModal', () => {
         expect(buttons.at(1).text()).toBe(expectedFinishText);
     }
 
-    function validateForm(wrapper: ReactWrapper, existingList?: Picklist) {
+    function validateForm(wrapper: ReactWrapper, existingList?: Picklist): void {
         const labels = wrapper.find('label');
         expect(labels).toHaveLength(3);
         expect(labels.at(0).text()).toBe('Name *');
@@ -98,8 +50,6 @@ describe('PicklistEditModal', () => {
     test('create empty picklist', () => {
         const wrapper = mountWithAppServerContext(
             <PicklistEditModal
-                selectionKey="selection"
-                selectedQuantity={0}
                 onCancel={jest.fn()}
                 onFinish={jest.fn()}
             />
@@ -112,10 +62,9 @@ describe('PicklistEditModal', () => {
     test('create picklist from multiple selections', () => {
         const wrapper = mountWithAppServerContext(
             <PicklistEditModal
-                selectionKey="selection"
-                selectedQuantity={2}
                 onCancel={jest.fn()}
                 onFinish={jest.fn()}
+                queryModel={queryModel.mutate({ selections: new Set(['1', '2']) })}
             />
         );
         validateText(wrapper, 'Create a New Picklist with the 2 Selected Samples', 'Create Picklist');
@@ -126,8 +75,7 @@ describe('PicklistEditModal', () => {
     test('create picklist from one selection', () => {
         const wrapper = mountWithAppServerContext(
             <PicklistEditModal
-                selectionKey="selection"
-                selectedQuantity={1}
+                queryModel={queryModel.mutate({ selections: new Set(['1']) })}
                 onCancel={jest.fn()}
                 onFinish={jest.fn()}
             />
@@ -196,69 +144,5 @@ describe('PicklistEditModal', () => {
         );
         expect(wrapper.find('input').at(1).prop('checked')).toBe(true);
         wrapper.unmount();
-    });
-
-    test('Create picklist, none allowed', async () => {
-        const wrapper = mountWithAppServerContext(
-            <PicklistEditModal
-                sampleIds={['1', '2']}
-                onCancel={jest.fn()}
-                onFinish={jest.fn()}
-                api={getTestAPIWrapper(jest.fn, {
-                    samples: getSamplesTestAPIWrapper(jest.fn, {
-                        getSampleOperationConfirmationData: () => Promise.resolve(noneAllowedStatus),
-                    }),
-                })}
-            />
-        );
-        await waitForLifecycle(wrapper);
-        validateText(wrapper, 'Create an Empty Picklist', 'Create Picklist');
-        const alerts = wrapper.find(Alert);
-        expect(alerts).toHaveLength(2);
-        expect(alerts.at(0).text()).toBeFalsy();
-        expect(alerts.at(1).text()).toBe('All selected samples have a status that prevents adding them to a picklist.');
-    });
-
-    test('Create picklist, some allowed', async () => {
-        const wrapper = mountWithAppServerContext(
-            <PicklistEditModal
-                sampleIds={['1', '2']}
-                onCancel={jest.fn()}
-                onFinish={jest.fn()}
-                api={getTestAPIWrapper(jest.fn, {
-                    samples: getSamplesTestAPIWrapper(jest.fn, {
-                        getSampleOperationConfirmationData: () => Promise.resolve(someAllowedStatus),
-                    }),
-                })}
-            />
-        );
-        await waitForLifecycle(wrapper);
-        validateText(wrapper, 'Create a New Picklist with This Sample', 'Create Picklist');
-        const alerts = wrapper.find(Alert);
-        expect(alerts).toHaveLength(2);
-        expect(alerts.at(1).text()).toBe(
-            'The current status of 2 selected samples prevents adding them to a picklist.'
-        );
-    });
-
-    test('Create picklist, all allowed', async () => {
-        const wrapper = mountWithAppServerContext(
-            <PicklistEditModal
-                sampleIds={['1', '2']}
-                onCancel={jest.fn()}
-                onFinish={jest.fn()}
-                api={getTestAPIWrapper(jest.fn, {
-                    samples: getSamplesTestAPIWrapper(jest.fn, {
-                        getSampleOperationConfirmationData: () => Promise.resolve(allAllowedStatus),
-                    }),
-                })}
-            />
-        );
-        await waitForLifecycle(wrapper);
-        validateText(wrapper, 'Create a New Picklist with These Samples', 'Create Picklist');
-        const alerts = wrapper.find(Alert);
-        expect(alerts).toHaveLength(2);
-        expect(alerts.at(0).text()).toBeFalsy();
-        expect(alerts.at(1).text()).toBeFalsy();
     });
 });

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -7,10 +7,6 @@ import { WizardNavButtons } from '../buttons/WizardNavButtons';
 
 import { Alert } from '../base/Alert';
 import { resolveErrorMessage } from '../../util/messaging';
-
-import { SampleOperation } from '../samples/constants';
-import { OperationConfirmationData } from '../entities/models';
-import { getOperationNotPermittedMessage } from '../samples/utils';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
@@ -22,18 +18,6 @@ import { setSnapshotSelections } from '../../actions';
 import { Picklist } from './models';
 import { createPicklist, getPicklistUrl, updatePicklist } from './actions';
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
-
-// TODO reconcile these properties. Do we need both selectionKey and queryModel.
-// Is selectedQuantity needed if we always have either the sampleIds or the queryModel?
-// SampleHeader usage passes in sampleIds, no queryModel
-// SampleActionsButton passes in the sample listing model and either a sampleFieldKey or the selectionKey for the sample listing model - don't need selection key; check for sampleFieldKey
-// PicklistButton passes in either the sampleIds or the model, its selectionKey, and the size of the selections from the model - use model's selection key and selections.length
-// MediaGridButtons passes in the listing model
-// SampleGridButtons passes in the listing model
-// WorkflowSamplesPageWrapper passes in the listing model
-// ItemSamplesActionMenu passes in the itemsModel and the selectedSampleIds as sampleIds
-//
-// PicklistListing passes in no queryModel, selectionKey or SampleIds (only for creating a picklist)
 
 export interface PicklistEditModalProps {
     sampleIds?: string[];

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -54,7 +54,6 @@ export function createPicklist(
     name: string,
     description: string,
     shared: boolean,
-    statusData: OperationConfirmationData,
     selectionKey: string,
     useSnapshotSelection: boolean,
     sampleIds: string[]
@@ -89,7 +88,7 @@ export function createPicklist(
             success: response => {
                 Promise.all([
                     getListIdFromDomainId(response.domainId),
-                    addSamplesToPicklist(name, statusData, useSnapshotSelection, selectionKey, sampleIds),
+                    addSamplesToPicklist(name, useSnapshotSelection, selectionKey, sampleIds),
                 ])
                     .then(responses => {
                         const [listId] = responses;
@@ -343,7 +342,6 @@ export async function getSamplesNotInList(
 
 export function addSamplesToPicklist(
     listName: string,
-    statusData: OperationConfirmationData,
     useSnapshotSelection?: boolean,
     selectionKey?: string,
     sampleIds?: string[]
@@ -353,9 +351,7 @@ export function addSamplesToPicklist(
             .then(sampleIdsToAdd => {
                 let rows = List<any>();
                 sampleIdsToAdd.forEach(id => {
-                    if (statusData.isIdAllowed(id)) {
-                        rows = rows.push({ SampleID: id });
-                    }
+                    rows = rows.push({ SampleID: id });
                 });
                 if (rows.size > 0) {
                     insertRows({

--- a/packages/components/src/internal/components/picklist/constants.ts
+++ b/packages/components/src/internal/components/picklist/constants.ts
@@ -1,2 +1,3 @@
 export const PRIVATE_PICKLIST_CATEGORY = 'PrivatePicklist';
 export const PUBLIC_PICKLIST_CATEGORY = 'PublicPicklist';
+export const MAX_SELECTIONS_PER_ADD = 1000;


### PR DESCRIPTION
#### Rationale
[Issue 48287](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48287): We have seen it happen sometimes that when trying to create a picklist from a very large selection of samples we get an error when checking the sample status values to see if all the samples can be added. There are currently no restrictions based on status for which samples can be added to a picklist, so this check is unnecessary and can be expensive. This PR removes that check (which was added only as a defensive check at the time statuses were introduced).  We also limit to 1000 the number of samples that can be added to a picklist at a time. The 1000 limit is somewhat arbitrary, but some limit seems prudent.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/209
- https://github.com/LabKey/inventory/pull/1048
- https://github.com/LabKey/sampleManagement/pull/2145
- https://github.com/LabKey/biologics/pull/2421

#### Changes
- Don't ask about sample status for picklists since there are no restrictions based on status for picklists
- Limit the number of samples that can be added at a time to 1000.
