### PR TITLE
AbDisc: Polish, v1

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.381.3",
+  "version": "2.382.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.381.3",
+      "version": "2.382.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.381.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.25.0",
+        "@labkey/api": "1.25.1-fb-plate-polish.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.25.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.25.0.tgz",
-      "integrity": "sha512-ZOkAp2hBDxT4me/tejlKLVBzY2IRP1bt9ueBhVUipNnowaoscIpVZz+iGYmEM3A1V8pQj4QJdTbwXqWdIIHM2g=="
+      "version": "1.25.1-fb-plate-polish.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.25.1-fb-plate-polish.0.tgz",
+      "integrity": "sha512-aSR2mHIXLlcJjl1mZUZTUECCyke33DPG6dCDIsJVpjOJ2z2bEdby6N6zVloqEfuMU+ecWt69skLFoEH/xoPh1g=="
     },
     "node_modules/@labkey/build": {
       "version": "6.15.0",
@@ -20276,9 +20276,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.25.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.25.0.tgz",
-      "integrity": "sha512-ZOkAp2hBDxT4me/tejlKLVBzY2IRP1bt9ueBhVUipNnowaoscIpVZz+iGYmEM3A1V8pQj4QJdTbwXqWdIIHM2g=="
+      "version": "1.25.1-fb-plate-polish.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.25.1-fb-plate-polish.0.tgz",
+      "integrity": "sha512-aSR2mHIXLlcJjl1mZUZTUECCyke33DPG6dCDIsJVpjOJ2z2bEdby6N6zVloqEfuMU+ecWt69skLFoEH/xoPh1g=="
     },
     "@labkey/build": {
       "version": "6.15.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.381.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.25.1-fb-plate-polish.0",
+        "@labkey/api": "1.26.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.25.1-fb-plate-polish.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.25.1-fb-plate-polish.0.tgz",
-      "integrity": "sha512-aSR2mHIXLlcJjl1mZUZTUECCyke33DPG6dCDIsJVpjOJ2z2bEdby6N6zVloqEfuMU+ecWt69skLFoEH/xoPh1g=="
+      "version": "1.26.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.0.tgz",
+      "integrity": "sha512-Nq4PK013hQS0/WR11niaTkHGe1VMcuRvcLR060H6a7hD4T5acwtnMmC2cid81j4ni4U6cJGMi7XaADgb9r44uA=="
     },
     "node_modules/@labkey/build": {
       "version": "6.15.0",
@@ -20276,9 +20276,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.25.1-fb-plate-polish.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.25.1-fb-plate-polish.0.tgz",
-      "integrity": "sha512-aSR2mHIXLlcJjl1mZUZTUECCyke33DPG6dCDIsJVpjOJ2z2bEdby6N6zVloqEfuMU+ecWt69skLFoEH/xoPh1g=="
+      "version": "1.26.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.0.tgz",
+      "integrity": "sha512-Nq4PK013hQS0/WR11niaTkHGe1VMcuRvcLR060H6a7hD4T5acwtnMmC2cid81j4ni4U6cJGMi7XaADgb9r44uA=="
     },
     "@labkey/build": {
       "version": "6.15.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.25.1-fb-plate-polish.0",
+    "@labkey/api": "1.26.0",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.381.3",
+  "version": "2.382.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.25.0",
+    "@labkey/api": "1.25.1-fb-plate-polish.0",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.382.0
+Released*: 18 October 2023
+- Introduce `AssayAPIWrapper` to better support calls to assay endpoints from within components.
+- Rename `fetchAllAssays` and `fetchProtocol` to `getAssayDefinitions and `getProtocol` respectively.
+- Update `getAssayDefinitions` (formerly `fetchAllAssays`) to utilize the newly exposed `Assay.getAssays` endpoint wrapper.
+- Update `withAssayModels` component to use `api.assay` in place of the `AssayLoader` pattern.
+- Add `SchemaQuery.hasSchemaQuery` for more succinct comparison of `SchemaQuery` objects where it only matters if the `schemaName` and `queryName` match.
+- Recognize the `plateLsid` URL parameter in `AssayImportPanels` to support selection of a plate.
+
 ### version 2.381.3
 Released*: 18 October 2023
 - Issue 48854: Trim leading spaces for field values in domain forms

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -410,7 +410,12 @@ import {
 } from './internal/components/assay/withAssayModels';
 import { AssayPicker, AssayPickerTabs } from './internal/components/assay/AssayPicker';
 import { AssayStateModel, AssayUploadResultModel } from './internal/components/assay/models';
-import { allowReimportAssayRun, clearAssayDefinitionCache, fetchAllAssays } from './internal/components/assay/actions';
+import {
+    allowReimportAssayRun,
+    clearAssayDefinitionCache,
+    getAssayDefinitions,
+    getProtocol,
+} from './internal/components/assay/actions';
 import { BaseBarChart } from './internal/components/chart/BaseBarChart';
 import {
     createHorizontalBarLegendData,
@@ -551,7 +556,7 @@ import { SAMPLE_TYPE } from './internal/components/domainproperties/PropDescType
 import DomainForm from './internal/components/domainproperties/DomainForm';
 import { BasePropertiesPanel } from './internal/components/domainproperties/BasePropertiesPanel';
 import { DomainFieldsDisplay } from './internal/components/domainproperties/DomainFieldsDisplay';
-import { fetchProtocol, saveAssayDesign } from './internal/components/domainproperties/assay/actions';
+import { saveAssayDesign } from './internal/components/domainproperties/assay/actions';
 import { AssayProtocolModel } from './internal/components/domainproperties/assay/models';
 import { AssayDesignerPanels } from './internal/components/domainproperties/assay/AssayDesignerPanels';
 import { ListModel } from './internal/components/domainproperties/list/models';
@@ -1328,7 +1333,7 @@ export {
     AssayDesignEmptyAlert,
     allowReimportAssayRun,
     clearAssayDefinitionCache,
-    fetchAllAssays,
+    getAssayDefinitions,
     WORKFLOW_TASK_PROPERTIES_REQUIRED_COLUMNS,
     RUN_PROPERTIES_REQUIRED_COLUMNS,
     GENERAL_ASSAY_PROVIDER_NAME,
@@ -1415,7 +1420,7 @@ export {
     BasePropertiesPanel,
     AssayDesignerPanels,
     saveAssayDesign,
-    fetchProtocol,
+    getProtocol,
     AssayProtocolModel,
     SAMPLE_TYPE,
     DOMAIN_FIELD_REQUIRED,
@@ -1815,3 +1820,4 @@ export type { GetParentTypeDataForLineage } from './internal/components/entities
 export type { URLMapper } from './internal/url/URLResolver';
 export type { EditableGridEvent } from './internal/components/editable/constants';
 export type { EditableGridChange } from './internal/components/editable/EditableGrid';
+export type { GetAssayDefinitionsOptions, GetProtocolOptions } from './internal/components/assay/actions';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -78,11 +78,7 @@ import {
 } from './internal/util/utils';
 import { AutoForm } from './internal/components/AutoForm';
 import { HelpIcon } from './internal/components/HelpIcon';
-import {
-    getUserProperties,
-    getUserRoleDisplay,
-    getUserSharedContainerPermissions,
-} from './internal/components/user/actions';
+import { getUserProperties, getUserRoleDisplay } from './internal/components/user/actions';
 import { BeforeUnload } from './internal/util/BeforeUnload';
 import { withWindowFocusCheckExpiredSession } from './internal/util/WindowFocusCheckExpiredSession';
 import {
@@ -1152,7 +1148,6 @@ export {
     useUsersWithPermissions,
     getUserProperties,
     getUserRoleDisplay,
-    getUserSharedContainerPermissions,
     UserDetailHeader,
     UserProfile,
     UserLink,

--- a/packages/components/src/internal/APIWrapper.ts
+++ b/packages/components/src/internal/APIWrapper.ts
@@ -1,3 +1,4 @@
+import { AssayAPIWrapper, AssayServerAPIWrapper, getAssayTestAPIWrapper } from './components/assay/APIWrapper';
 import { SamplesAPIWrapper, SamplesServerAPIWrapper, getSamplesTestAPIWrapper } from './components/samples/APIWrapper';
 import {
     PicklistAPIWrapper,
@@ -33,6 +34,7 @@ import {
 import { getSearchTestAPIWrapper, SearchAPIWrapper, SearchServerAPIWrapper } from './components/search/APIWrapper';
 
 export interface ComponentsAPIWrapper {
+    assay: AssayAPIWrapper;
     domain: DomainPropertiesAPIWrapper;
     entity: EntityAPIWrapper;
     folder: FolderAPIWrapper;
@@ -50,6 +52,7 @@ let DEFAULT_WRAPPER: ComponentsAPIWrapper;
 export function getDefaultAPIWrapper(): ComponentsAPIWrapper {
     if (!DEFAULT_WRAPPER) {
         DEFAULT_WRAPPER = {
+            assay: new AssayServerAPIWrapper(),
             domain: new DomainPropertiesAPIWrapper(),
             entity: new EntityServerAPIWrapper(),
             folder: new ServerFolderAPIWrapper(),
@@ -74,6 +77,7 @@ export function getTestAPIWrapper(
     overrides: Partial<ComponentsAPIWrapper> = {}
 ): ComponentsAPIWrapper {
     return {
+        assay: getAssayTestAPIWrapper(mockFn, overrides.assay),
         domain: getDomainPropertiesTestAPIWrapper(mockFn, overrides.domain),
         entity: getEntityTestAPIWrapper(mockFn, overrides.entity),
         folder: getFolderTestAPIWrapper(mockFn, overrides.folder),

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -1,4 +1,4 @@
-import { fromJS, List, Map, OrderedMap, Record } from 'immutable';
+import { fromJS, List, Map, OrderedMap, Record as ImmutableRecord } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { QueryColumn } from '../public/QueryColumn';
@@ -34,7 +34,7 @@ interface ScopedSampleColumn {
     domain: AssayDomainTypes;
 }
 
-export class AssayDefinitionModel extends Record({
+export class AssayDefinitionModel extends ImmutableRecord({
     containerPath: undefined,
     description: undefined,
     domains: Map<string, List<QueryColumn>>(),
@@ -115,26 +115,23 @@ export class AssayDefinitionModel extends Record({
         targetProductId?: string,
         ignoreFilter?: boolean
     ): string {
-        let url,
-            params = {};
+        let url: AppURL | string;
         // Note, will need to handle the re-import run case separately. Possibly introduce another URL via links
         if (this.name !== undefined && this.importAction === 'uploadWizard' && this.importController === 'assay') {
-            params['rowId'] = this.id;
-            if (dataTab) params['dataTab'] = dataTab;
+            const params: Record<string, any> = { rowId: this.id };
+            if (dataTab) params.dataTab = dataTab;
             if (!ignoreFilter) {
-                if (filterList && !filterList.isEmpty()) {
-                    filterList.forEach(filter => {
-                        // if the filter has a URL suffix and is not registered as one recognized for URL filters, we ignore it here
-                        // CONSIDER:  Applications might want to be able to register their own filter types
-                        const urlSuffix = filter.getFilterType().getURLSuffix();
-                        if (!urlSuffix || Filter.getFilterTypeForURLSuffix(urlSuffix)) {
-                            params[filter.getURLParameterName()] = filter.getURLParameterValue();
-                        }
-                    });
-                }
+                filterList?.forEach(filter => {
+                    // if the filter has a URL suffix and is not registered as one recognized for URL filters, we ignore it here
+                    // CONSIDER:  Applications might want to be able to register their own filter types
+                    const urlSuffix = filter.getFilterType().getURLSuffix();
+                    if (!urlSuffix || Filter.getFilterTypeForURLSuffix(urlSuffix)) {
+                        params[filter.getURLParameterName()] = filter.getURLParameterValue();
+                    }
+                });
             }
-            if (selectionKey) params['selectionKey'] = selectionKey;
-            if (isPicklist) params['isPicklist'] = true;
+            if (selectionKey) params.selectionKey = selectionKey;
+            if (isPicklist) params.isPicklist = true;
             url = createProductUrlFromParts(
                 targetProductId,
                 currentProductId,

--- a/packages/components/src/internal/components/assay/APIWrapper.ts
+++ b/packages/components/src/internal/components/assay/APIWrapper.ts
@@ -1,0 +1,44 @@
+import { AssayDefinitionModel } from '../../AssayDefinitionModel';
+
+import { AssayProtocolModel } from '../domainproperties/assay/models';
+
+import {
+    clearAssayDefinitionCache,
+    GetAssayDefinitionsOptions,
+    getAssayDefinitions,
+    GetProtocolOptions,
+    getProtocol,
+    ImportAssayRunOptions,
+    importAssayRun,
+} from './actions';
+import { AssayUploadResultModel } from './models';
+
+export interface AssayAPIWrapper {
+    clearAssayDefinitionCache: () => void;
+    getAssayDefinitions: (options: GetAssayDefinitionsOptions) => Promise<AssayDefinitionModel[]>;
+    getProtocol: (options: GetProtocolOptions) => Promise<AssayProtocolModel>;
+    importAssayRun: (options: ImportAssayRunOptions) => Promise<AssayUploadResultModel>;
+}
+
+export class AssayServerAPIWrapper implements AssayAPIWrapper {
+    clearAssayDefinitionCache = clearAssayDefinitionCache;
+    getAssayDefinitions = getAssayDefinitions;
+    getProtocol = getProtocol;
+    importAssayRun = importAssayRun;
+}
+
+/**
+ * Note: Intentionally does not use jest.fn() to avoid jest becoming an implicit external package dependency.
+ */
+export function getAssayTestAPIWrapper(
+    mockFn = (): any => () => {},
+    overrides: Partial<AssayAPIWrapper> = {}
+): AssayAPIWrapper {
+    return {
+        clearAssayDefinitionCache: mockFn(),
+        getAssayDefinitions: mockFn(),
+        getProtocol: mockFn(),
+        importAssayRun: mockFn(),
+        ...overrides,
+    };
+}

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -237,6 +237,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
     initModel = async (): Promise<void> => {
         const { assayDefinition, location, runId } = this.props;
         const { schemaQuery } = this.state;
+        let plateProperties = Map<string, any>();
         let workflowTask: number;
 
         if (location?.query?.workflowTaskId) {
@@ -250,6 +251,12 @@ class AssayImportPanelsBody extends Component<Props, State> {
 
         const { plateColumns, runColumns } = this.getRunColumns(runQueryInfo);
 
+        if (this.plateSupportEnabled) {
+            if (location?.query?.plateLsid) {
+                plateProperties = plateProperties.set(PLATE_TEMPLATE_COLUMN, location.query.plateLsid);
+            }
+        }
+
         this.setState(
             {
                 model: new AssayWizardModel({
@@ -259,6 +266,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                     assayDef: assayDefinition,
                     batchColumns: this.getDomainColumns(AssayDomainTypes.BATCH, batchQueryInfo),
                     plateColumns,
+                    plateProperties,
                     runColumns,
                     runId,
                     usePreviousRunFile: this.isReimport(),
@@ -790,7 +798,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 </FormButtons>
                 <Progress
                     estimate={this.getProgressSizeEstimate()}
-                    modal={true}
+                    modal
                     title={isReimport ? 'Re-importing assay run' : 'Importing assay run'}
                     toggle={model.isSubmitting}
                 />

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -58,7 +58,8 @@ export function getAssayDefinitions(options: GetAssayDefinitionsOptions): Promis
     if (!assayDefinitionCache[key]) {
         assayDefinitionCache[key] = new Promise((resolve, reject) => {
             Assay.getAssays({
-                ...options,
+                // TODO: Fix this so "parameters" does not have to be specified
+                parameters: options,
                 success: rawModels => {
                     resolve(rawModels.map(raw => AssayDefinitionModel.create(raw)) ?? []);
                 },

--- a/packages/components/src/internal/components/assay/actions.ts
+++ b/packages/components/src/internal/components/assay/actions.ts
@@ -58,8 +58,7 @@ export function getAssayDefinitions(options: GetAssayDefinitionsOptions): Promis
     if (!assayDefinitionCache[key]) {
         assayDefinitionCache[key] = new Promise((resolve, reject) => {
             Assay.getAssays({
-                // TODO: Fix this so "parameters" does not have to be specified
-                parameters: options,
+                ...options,
                 success: rawModels => {
                     resolve(rawModels.map(raw => AssayDefinitionModel.create(raw)) ?? []);
                 },

--- a/packages/components/src/internal/components/assay/withAssayModels.spec.tsx
+++ b/packages/components/src/internal/components/assay/withAssayModels.spec.tsx
@@ -142,7 +142,9 @@ describe('withAssayModels', () => {
         const expectedError = 'load protocol failed!';
         const assayName = 'SomeAssayDefinition';
         const api = createAPIWrapper({
-            getAssayDefinitions: jest.fn().mockResolvedValue([AssayDefinitionModel.create({ id: 123, name: assayName })]),
+            getAssayDefinitions: jest
+                .fn()
+                .mockResolvedValue([AssayDefinitionModel.create({ id: 123, name: assayName })]),
             getProtocol: jest.fn().mockRejectedValue(expectedError),
         });
         let injectedAssayModel: AssayStateModel;

--- a/packages/components/src/internal/components/domainproperties/assay/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/assay/actions.ts
@@ -21,39 +21,11 @@ import { DomainException } from '../models';
 
 import { setDomainException } from '../actions';
 
-import { AssayProtocolModel } from './models';
 import { buildURL } from '../../../url/AppURL';
 import { Container } from '../../base/models/Container';
 import { isAssayEnabled } from '../../../app/utils';
 
-export function fetchProtocol(
-    protocolId?: number,
-    providerName?: string,
-    copy?: boolean,
-    containerPath?: string
-): Promise<AssayProtocolModel> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: buildURL(
-                'assay',
-                'getProtocol.api',
-                {
-                    // give precedence to the protocolId if both are provided
-                    protocolId,
-                    providerName: protocolId !== undefined ? undefined : providerName,
-                    copy: copy || false,
-                },
-                { container: containerPath }
-            ),
-            success: Utils.getCallbackWrapper(data => {
-                resolve(AssayProtocolModel.create(data.data));
-            }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
-        });
-    });
-}
+import { AssayProtocolModel } from './models';
 
 export function saveAssayDesign(model: AssayProtocolModel): Promise<AssayProtocolModel> {
     return new Promise((resolve, reject) => {

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -1,11 +1,10 @@
 import moment from 'moment';
 import { OrderedMap } from 'immutable';
-import { Ajax, PermissionRoles, PermissionTypes, Security, Utils } from '@labkey/api';
+import { Ajax, PermissionRoles, PermissionTypes, Utils } from '@labkey/api';
 
 import { buildURL } from '../../url/AppURL';
 import { hasAllPermissions, User } from '../base/models/User';
 import { caseInsensitive } from '../../util/utils';
-import { SHARED_CONTAINER_PATH } from '../../constants';
 
 import { APPLICATION_SECURITY_ROLES, SITE_SECURITY_ROLES } from '../administration/constants';
 
@@ -191,21 +190,6 @@ export function resetPassword(email: string): Promise<any> {
             failure: Utils.getCallbackWrapper(response => {
                 reject(response);
             }),
-        });
-    });
-}
-
-export function getUserSharedContainerPermissions(): Promise<string[]> {
-    return new Promise((resolve, reject) => {
-        Security.getUserPermissions({
-            containerPath: SHARED_CONTAINER_PATH,
-            success: response => {
-                const { container } = response;
-                resolve(container.effectivePermissions);
-            },
-            failure: error => {
-                reject(error);
-            },
         });
     });
 }

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -555,7 +555,10 @@ export class URLResolver {
         }
 
         if (mapper.url !== undefined && _url !== false && getServerContext().devMode) {
-            console.warn('Unable to map URL:', mapper.url);
+            // Don't bother logging the default server URL
+            if (!mapper.url.indexOf('project-begin')) {
+                console.warn('Unable to map URL:', mapper.url);
+            }
         }
 
         return mapper.url;

--- a/packages/components/src/public/SchemaQuery.ts
+++ b/packages/components/src/public/SchemaQuery.ts
@@ -85,6 +85,11 @@ export class SchemaQuery {
         return false;
     }
 
+    hasSchemaQuery(sq: SchemaQuery): boolean {
+        if (!sq) return false;
+        return this.toString(false).toLowerCase() === sq.toString(false).toLowerCase();
+    }
+
     getKey(includeViewName = true): string {
         return resolveKey(this.schemaName, this.queryName, includeViewName ? this.viewName : undefined);
     }
@@ -102,8 +107,12 @@ export class SchemaQuery {
         return [APP_SELECTION_PREFIX, targetSQ.getKey(), keys.join(';')].join('|');
     }
 
-    toString(): string {
-        return [this.schemaName, this.queryName, this.viewName].join('|');
+    toString(includeViewName = true): string {
+        const parts = [this.schemaName, this.queryName];
+        if (includeViewName) {
+            parts.push(this.viewName);
+        }
+        return parts.join('|');
     }
 }
 


### PR DESCRIPTION
#### Rationale
This introduces the `AssayAPIWrapper` in support of new plating scenarios.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/162
* https://github.com/LabKey/labkey-ui-components/pull/1314
* https://github.com/LabKey/labkey-ui-premium/pull/219
* https://github.com/LabKey/platform/pull/4820
* https://github.com/LabKey/biologics/pull/2444
* https://github.com/LabKey/sampleManagement/pull/2165
* https://github.com/LabKey/inventory/pull/1059

#### Changes
- Introduce `AssayAPIWrapper` to better support calls to assay endpoints from within components.
- Rename `fetchAllAssays` and `fetchProtocol` to `getAssayDefinitions and `getProtocol` respectively.
- Update `getAssayDefinitions` (formerly `fetchAllAssays`) to utilize the newly exposed `Assay.getAssays` endpoint wrapper.
- Update `withAssayModels` component to use `api.assay` in place of the `AssayLoader` pattern.
- Add `SchemaQuery.hasSchemaQuery` for more succinct comparison of `SchemaQuery` objects where it only matters if the `schemaName` and `queryName` match.
- Recognize the `plateLsid` URL parameter in `AssayImportPanels` to support selection of a plate.