### PR TITLE
Issue 48854: Trim spaces from names of domains

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.381.2-nameTrimming.2",
+  "version": "2.381.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.381.2-nameTrimming.2",
+      "version": "2.381.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.25.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.380.1",
+  "version": "2.380.2-nameTrimming.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.380.1",
+      "version": "2.380.2-nameTrimming.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.25.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.381.2-nameTrimming.1",
+  "version": "2.381.2-nameTrimming.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.381.2-nameTrimming.1",
+      "version": "2.381.2-nameTrimming.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.25.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.381.2-nameTrimming.1",
+  "version": "2.381.2-nameTrimming.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.381.3-nameTrimming.2",
+  "version": "2.381.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.380.1",
+  "version": "2.380.2-nameTrimming.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48854: Trim leading spaces for field values in domain forms
+
 ### version 2.380.1
 *Released*: 13 October 2023
 - Add UI for making non-default views sharable

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -50,7 +50,7 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
     const onValueChange = useCallback(
         (id, value): void => {
             const newModel = model.merge({
-                [id.replace(FORM_ID_PREFIX, '')]: value?.trimStart(),
+                [id.replace(FORM_ID_PREFIX, '')]: Utils.isString(value) ? value.trimStart() : value,
             }) as AssayProtocolModel;
 
             onChange(newModel);

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -50,7 +50,7 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
     const onValueChange = useCallback(
         (id, value): void => {
             const newModel = model.merge({
-                [id.replace(FORM_ID_PREFIX, '')]: value,
+                [id.replace(FORM_ID_PREFIX, '')]: value?.trimStart(),
             }) as AssayProtocolModel;
 
             onChange(newModel);
@@ -69,7 +69,7 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
             }
 
             // special case for empty string, set as null instead
-            if (Utils.isString(value) && value.length === 0) {
+            if (Utils.isString(value) && value?.trimStart().length === 0) {
                 value = null;
             }
 

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassPropertiesPanel.tsx
@@ -119,7 +119,7 @@ export class DataClassPropertiesPanelImpl extends PureComponent<Props, State> {
 
     onFormChange = (evt: any): void => {
         const { id, value } = evt.target;
-        this.onChange(id, value);
+        this.onChange(id, value?.trimStart());
     };
 
     onChange = (id: string, value: any): void => {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -181,7 +181,7 @@ class SampleTypePropertiesPanelImpl extends React.PureComponent<
     onFormChange = (evt: any): void => {
         const id = evt.target.id;
         const value = evt.target.value;
-        this.onFieldChange(getFormNameFromId(id), value);
+        this.onFieldChange(getFormNameFromId(id), value?.trimStart());
     };
 
     onFieldChange = (key: string, value: any): void => {


### PR DESCRIPTION
#### Rationale
[Issue 48854](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48854): Leading and trailing spaces in the names of domains are problematic.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4827
- https://github.com/LabKey/inventory/pull/1061
- https://github.com/LabKey/sampleManagement/pull/2170
- https://github.com/LabKey/biologics/pull/2448
- https://github.com/LabKey/testAutomation/pull/1679
- https://github.com/LabKey/labkey-ui-premium/pull/221

#### Changes
- Trim leading spaces from form input values (leave the tailing spaces to the server side)
