### PR TITLE
Fix Issue 48901

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.382.1",
+  "version": "2.382.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.382.1",
+      "version": "2.382.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.382.1",
+  "version": "2.382.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.382.2
+### version 2.382.2
 *Released*: 18 October 2023
 - Issue 48901: R Reports not filtering runs in assay
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.382.2
+*Released*: 18 October 2023
+- Issue 48901: R Reports not filtering runs in assay
+
 ### version 2.382.1
 *Released*: 18 October 2023
 - Issue 48855: Update @labkey/api for better parsing of Content-Disposition header

--- a/packages/components/src/internal/components/chart/api.ts
+++ b/packages/components/src/internal/components/chart/api.ts
@@ -30,7 +30,9 @@ function fetchRReport(
         // The getWebPart API honors containerFilterName, not containerFilter.
         const containerFilterPrefix = `${urlPrefix}.containerFilterName`;
         const params = { reportId, 'webpart.name': 'report', [containerFilterPrefix]: getContainerFilter(container) };
-        if (filters) filters.forEach(filter => (params[filter.getURLParameterName()] = filter.getURLParameterValue()));
+        if (filters) {
+            filters.forEach(filter => (params[filter.getURLParameterName(urlPrefix)] = filter.getURLParameterValue()));
+        }
         Ajax.request({
             url: buildURL('project', 'getWebPart.view', params, { container }),
             success: Utils.getCallbackWrapper(response => {


### PR DESCRIPTION
#### Rationale
R Reports aren't using the URL prefix for the grid, which is causing filters to not work in some situations (assay runs in particular).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1322
- https://github.com/LabKey/labkey-ui-premium/pull/228
- https://github.com/LabKey/biologics/pull/2460
- https://github.com/LabKey/inventory/pull/1068
- https://github.com/LabKey/sampleManagement/pull/2180

#### Changes
- Use URL prefix when appending filters to webpart URL for R Reports
