### PR TITLE
AssayImportPanels.tsx fix for grid cell updates to use applyEditableGridChangesToModels()

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.383.1-fb-assayImportPanelFix.0",
+  "version": "2.383.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.383.1-fb-assayImportPanelFix.0",
+      "version": "2.383.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.383.0",
+  "version": "2.383.0-fb-assayImportPanelFix.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.383.0",
+      "version": "2.383.0-fb-assayImportPanelFix.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.383.1",
+  "version": "2.383.1-fb-assayImportPanelFix.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.383.1",
+      "version": "2.383.1-fb-assayImportPanelFix.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.383.1",
+  "version": "2.383.1-fb-assayImportPanelFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.383.1-fb-assayImportPanelFix.0",
+  "version": "2.383.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.383.0",
+  "version": "2.383.0-fb-assayImportPanelFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD October 2023
+* AssayImportPanels.tsx fix for grid cell updates to use applyEditableGridChangesToModels()
+
 ### version 2.383.0
 *Released*: 19 October 2023
 * Issue 48347: Update field editor "User" data type to allow lookup validator option

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD October 2023
+### version 2.383.2
+*Released*: 23 October 2023
 * AssayImportPanels.tsx fix for grid cell updates to use applyEditableGridChangesToModels()
 
 ### version 2.383.1

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -81,6 +81,7 @@ import { AssayUploadResultModel } from './models';
 import { PlatePropertiesPanel } from './PlatePropertiesPanel';
 import { RunDataPanel } from './RunDataPanel';
 import { RunPropertiesPanel } from './RunPropertiesPanel';
+import { applyEditableGridChangesToModels } from '../editable/utils';
 
 const BASE_FILE_TYPES = ['.csv', '.tsv', '.txt', '.xlsx', '.xls'];
 const BATCH_PROPERTIES_GRID_ID = 'assay-batch-details';
@@ -671,18 +672,19 @@ class AssayImportPanelsBody extends Component<Props, State> {
 
     onGridChange: EditableGridChange = (event, editorModelChanges, dataKeys, data): void => {
         this.setState(state => {
-            const editorModel = state.editorModel.merge(editorModelChanges) as EditorModel;
-            let { dataModel } = state;
-            const orderedRows = dataKeys?.toJS();
-            const rows = data?.toJS();
-
-            if (orderedRows !== undefined && rows !== undefined) {
-                dataModel = dataModel.mutate({ orderedRows, rows });
-            }
+            const { dataModel, editorModel } = state;
+            const updatedModels = applyEditableGridChangesToModels(
+                [dataModel],
+                [editorModel],
+                editorModelChanges,
+                undefined,
+                dataKeys,
+                data
+            );
 
             this.props.setIsDirty?.(true);
 
-            return { dataModel, editorModel };
+            return { dataModel: updatedModels.dataModels[0], editorModel: updatedModels.editorModels[0] };
         });
     };
 

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -62,6 +62,8 @@ import { getOperationNotPermittedMessage } from '../samples/utils';
 
 import { EditableGridChange } from '../editable/EditableGrid';
 
+import { applyEditableGridChangesToModels } from '../editable/utils';
+
 import {
     allowReimportAssayRun,
     checkForDuplicateAssayFiles,
@@ -81,7 +83,6 @@ import { AssayUploadResultModel } from './models';
 import { PlatePropertiesPanel } from './PlatePropertiesPanel';
 import { RunDataPanel } from './RunDataPanel';
 import { RunPropertiesPanel } from './RunPropertiesPanel';
-import { applyEditableGridChangesToModels } from '../editable/utils';
 
 const BASE_FILE_TYPES = ['.csv', '.tsv', '.txt', '.xlsx', '.xls'];
 const BATCH_PROPERTIES_GRID_ID = 'assay-batch-details';


### PR DESCRIPTION
#### Rationale
When importing an assay run using the EditableGrid panel, the cell fillDown and other actions cause a JS error because the editorModel selectionCells is converted to an immutable List instead of a string array. The issue was that it was not using the expected helper for applyEditableGridChangesToModels() which handles this conversion.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1323
- https://github.com/LabKey/labkey-ui-premium/pull/229
- https://github.com/LabKey/inventory/pull/1069
- https://github.com/LabKey/biologics/pull/2462
- https://github.com/LabKey/sampleManagement/pull/2181

#### Changes
- AssayImportPanels.tsx fix for grid cell updates to use applyEditableGridChangesToModels()
