### PR TITLE
Sample Types: Add RootMaterialRowId

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.392.2",
+  "version": "2.393.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.392.2",
+      "version": "2.393.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.392.2",
+  "version": "2.393.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.393.0
+*Released*: 10 November 2023
+- Replace all usages of `RootMaterialLSID` with `RootMaterialRowId`
+
 ### version 2.392.2
 *Released*: 8 November 2023
 * Issue 48999: Unable to "Select them in the grid" when created trigger script runs after samples are added

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -175,9 +175,9 @@ export const ParentEntityRequiredColumns = SCHEMAS.CBMB.concat(
     'RowId',
     'Description',
     'AliquotedFromLSID/Name',
-    'RootMaterialLSID',
-    'RootMaterialLSID/Name',
-    'RootMaterialLSID/Description'
+    'RootMaterialRowId',
+    'RootMaterialRowId/Name',
+    'RootMaterialRowId/Description'
 ).concat(ParentEntityLineageColumns);
 
 export enum DataOperation {

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -434,12 +434,7 @@ export function getSampleAliquotRows(sampleId: number | string): Promise<Array<R
     return new Promise((resolve, reject) => {
         Query.executeSql({
             containerFilter: getContainerFilter(),
-            sql:
-                'SELECT m.RowId, m.Name\n' +
-                'FROM exp.materials m \n' +
-                'WHERE m.lsid <> m.RootMaterialLSID AND m.RootMaterialLSID = (SELECT lsid FROM exp.materials mi WHERE mi.RowId = ' +
-                sampleId +
-                ')',
+            sql: `SELECT RowId, Name FROM materials WHERE RowId <> RootMaterialRowId AND RootMaterialRowId = ${sampleId}`,
             schemaName: SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
             requiredVersion: 17.1,
             success: result => {
@@ -698,8 +693,8 @@ export function hasExistingSamples(isRoot?: boolean, containerPath?: string): Pr
         '\n' +
         'FROM materials m WHERE EXISTS ' +
         '\n' +
-        '( SELECT * FROM materials mi WHERE mi.rowId = m.rowId';
-    if (isRoot) dataCountSql += ' AND mi.rootMaterialLSID = mi.lsid';
+        '( SELECT * FROM materials mi WHERE mi.RowId = m.RowId';
+    if (isRoot) dataCountSql += ' AND mi.RootMaterialRowId = mi.RowId';
     dataCountSql += ')';
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
#### Rationale
Replaces usages of `RootMaterialLSID` with `RootMaterialRowId`. See https://github.com/LabKey/platform/pull/4844 for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4844
* https://github.com/LabKey/labkey-ui-components/pull/1324
* https://github.com/LabKey/labkey-ui-premium/pull/230
* https://github.com/LabKey/biologics/pull/2464
* https://github.com/LabKey/sampleManagement/pull/2182
* https://github.com/LabKey/inventory/pull/1070

#### Changes
- Replace all usages of `RootMaterialLSID` with `RootMaterialRowId`
