### PR TITLE
Use FormButtons with DetailPanel

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.384.0",
+  "version": "2.385.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.384.0",
+      "version": "2.385.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.384.0",
+  "version": "2.385.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.38?.0
-*Released*: ?? October 2023
+### version 2.385.0
+*Released*: 25 October 2023
 - EditableGrid: Add more specific classNames to button bar buttons
 - EditableDetailPanel: Use FormButtons
 - DetailPanel/EditableDetailPanel: Remove actions prop

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.38?.0
+*Released*: ?? October 2023
+- EditableGrid: Add more specific classNames to button bar buttons
+- EditableDetailPanel: Use FormButtons
+- DetailPanel/EditableDetailPanel: Remove actions prop
+- DetailPanelHeader: convert to FC, simplify props, render panel-heading div
+
 ### version 2.384.0
 *Released*: 25 October 2023
 * remove react-bootstrap-toggle dependency from @labkey/components

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1345,34 +1345,37 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             : 'The grid contains the maximum number of ' + nounPlural + '.';
 
         const allowExport = !!exportHandler;
+        const actionButtonClassNames = classNames('editable-grid-buttons__action-buttons', {
+            'col-sm-9': showAddOnTop,
+            'col-sm-12': !showAddOnTop,
+        });
 
         return (
-            <div className="row QueryGrid-bottom-spacing">
+            <div className="row editable-grid-buttons">
                 {showAddOnTop && <div className="col-sm-3">{this.renderAddRowsControl('top')}</div>}
-                <div className={showAddOnTop ? 'col-sm-9' : 'col-sm-12'}>
+                <div className={actionButtonClassNames}>
                     {!showAsTab && allowBulkAdd && (
-                        <span className="control-right">
-                            <Button title={addTitle} disabled={!canAddRows} onClick={this.toggleBulkAdd}>
-                                {bulkAddText}
-                            </Button>
-                        </span>
+                        <Button
+                            className="bulk-add-button"
+                            title={addTitle}
+                            disabled={!canAddRows}
+                            onClick={this.toggleBulkAdd}
+                        >
+                            {bulkAddText}
+                        </Button>
                     )}
                     {!showAsTab && allowBulkUpdate && (
-                        <span className="control-right">
-                            <Button className="control-right" disabled={invalidSel} onClick={this.toggleBulkUpdate}>
-                                {bulkUpdateText}
-                            </Button>
-                        </span>
+                        <Button className="bulk-update-button" disabled={invalidSel} onClick={this.toggleBulkUpdate}>
+                            {bulkUpdateText}
+                        </Button>
                     )}
                     {allowBulkRemove && (
-                        <span className="control-right">
-                            <Button className="control-right" disabled={invalidSel} onClick={this.removeSelected}>
-                                {bulkRemoveText}
-                            </Button>
-                        </span>
+                        <Button className="bulk-remove-button" disabled={invalidSel} onClick={this.removeSelected}>
+                            {bulkRemoveText}
+                        </Button>
                     )}
                     {allowExport && (
-                        <span className="control-right pull-right">
+                        <span className="pull-right">
                             <EditableGridExportMenu id={editorModel.id} hasData exportHandler={exportHandler} />
                         </span>
                     )}

--- a/packages/components/src/internal/components/forms/detail/DetailPanelHeader.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailPanelHeader.tsx
@@ -13,59 +13,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { FC, memo } from 'react';
 
 interface DetailPanelHeaderProps {
-    canUpdate: boolean;
     editing?: boolean;
     isEditable: boolean;
-    onClickFn?: () => void;
+    onClick?: () => void;
     title?: string;
-    useEditIcon: boolean;
     verb?: string;
     warning?: string;
 }
 
-export class DetailPanelHeader extends React.Component<DetailPanelHeaderProps, any> {
-    static defaultProps = {
-        title: 'Details',
-        useEditIcon: true,
-        verb: 'Editing',
-    };
+export const DetailPanelHeader: FC<DetailPanelHeaderProps> = memo(props => {
+    const { isEditable, editing, onClick, warning, title = 'Details', verb = 'Editing' } = props;
 
-    render() {
-        const { isEditable, canUpdate, editing, onClickFn, warning, title, useEditIcon, verb } = this.props;
-
-        if (editing) {
-            return (
-                <>
-                    {verb} {title}
-                    <span className="detail__edit--heading">
-                        {warning !== undefined && (
-                            <span>
-                                <span> - </span>
-                                <span className="edit__warning">{warning}</span>
-                            </span>
-                        )}
-                    </span>
-                </>
-            );
-        }
-
+    if (editing) {
         return (
-            <>
-                {title}
+            <div className="panel-heading">
+                {verb} {title}
                 <span className="detail__edit--heading">
-                    {isEditable && canUpdate && (
-                        <>
-                            <div className="detail__edit-button" onClick={onClickFn}>
-                                {useEditIcon ? <i className="fa fa-pencil-square-o" /> : 'Edit'}
-                            </div>
-                            <div className="clearfix" />
-                        </>
+                    {warning !== undefined && (
+                        <span>
+                            <span> - </span>
+                            <span className="edit__warning">{warning}</span>
+                        </span>
                     )}
                 </span>
-            </>
+            </div>
         );
     }
-}
+
+    return (
+        <div className="panel-heading">
+            {title}
+            <span className="detail__edit--heading">
+                {isEditable && (
+                    <>
+                        <div className="detail__edit-button" onClick={onClick}>
+                            <i className="fa fa-pencil-square-o" />
+                        </div>
+                        <div className="clearfix" />
+                    </>
+                )}
+            </span>
+        </div>
+    );
+});
+DetailPanelHeader.displayName = 'DetailPanelHeader';

--- a/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
@@ -18,7 +18,7 @@ export interface LineageDetailProps {
 }
 
 const LineageDetailImpl: FC<LineageDetailProps & InjectedQueryModels> = memo(props => {
-    const { actions, queryModels } = props;
+    const { queryModels } = props;
     if (queryModels.model.isLoading) return <LoadingSpinner />;
     if (queryModels.model.hasLoadErrors) return <Alert>{queryModels.model.loadErrors[0]}</Alert>;
 
@@ -28,12 +28,7 @@ const LineageDetailImpl: FC<LineageDetailProps & InjectedQueryModels> = memo(pro
     const detailColumns = [...queryModels.model.detailColumns, ...additionalCols];
 
     return (
-        <DetailPanel
-            model={queryModels.model}
-            actions={actions}
-            queryColumns={detailColumns}
-            detailRenderer={_resolveDetailRenderer}
-        />
+        <DetailPanel model={queryModels.model} queryColumns={detailColumns} detailRenderer={_resolveDetailRenderer} />
     );
 });
 

--- a/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
+++ b/packages/components/src/internal/components/listing/pages/QueryDetailPage.tsx
@@ -48,7 +48,7 @@ class DetailBodyImpl extends PureComponent<BodyProps & InjectedQueryModels> {
     }
 
     render(): ReactNode {
-        const { actions, id, queryModels } = this.props;
+        const { id, queryModels } = this.props;
         const model = queryModels[id];
 
         if (model.isLoading) {
@@ -69,7 +69,7 @@ class DetailBodyImpl extends PureComponent<BodyProps & InjectedQueryModels> {
                     <Link to={AppURL.create('q', schemaName, name).toString()}>{plural}</Link>
                 </BreadcrumbCreate>
                 {title && <PageHeader title={title} />}
-                <DetailPanel actions={actions} asPanel model={model} />
+                <DetailPanel asPanel model={model} />
             </Page>
         );
     }

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -30,13 +30,15 @@ interface DetailPanelProps extends DetailDisplaySharedProps {
     queryColumns?: QueryColumn[];
 }
 
+type RequiresModel = Pick<RequiresModelAndActions, 'model'>;
+
 /**
  * Render a QueryModel with a single row of a data. For in-depth documentation and examples see
  * components/docs/QueryModel.md.
  */
-export const DetailPanel: FC<DetailPanelProps & RequiresModelAndActions> = memo(props => {
+export const DetailPanel: FC<DetailPanelProps & RequiresModel> = memo(props => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { actions, editColumns, model, queryColumns, ...detailDisplayProps } = props;
+    const { editColumns, model, queryColumns, ...detailDisplayProps } = props;
     const { editingMode } = detailDisplayProps;
     const error = model.queryInfoError ?? model.rowsError;
     let displayColumns: List<QueryColumn>;

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -23,7 +23,6 @@ export interface EditableDetailPanelProps {
     appEditable?: boolean;
     asSubPanel?: boolean;
     canUpdate: boolean;
-    cancelText?: string;
     containerFilter?: Query.ContainerFilter;
     containerPath?: string;
     detailEditRenderer?: DetailRenderer;
@@ -37,7 +36,6 @@ export interface EditableDetailPanelProps {
     queryColumns?: QueryColumn[];
     submitText?: string;
     title?: string;
-    useEditIcon?: boolean;
 }
 
 interface State {
@@ -50,8 +48,6 @@ interface State {
 export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps, State> {
     static defaultProps = {
         api: getDefaultAPIWrapper(),
-        useEditIcon: true,
-        cancelText: 'Cancel',
         submitText: 'Save',
     };
 
@@ -144,14 +140,12 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
             detailHeader,
             detailRenderer,
             asSubPanel,
-            cancelText,
             canUpdate,
             editColumns,
             model,
             queryColumns,
             submitText,
             title,
-            useEditIcon,
             onAdditionalFormDataChange,
         } = this.props;
         const { canSubmit, editing, error, warning } = this.state;
@@ -159,17 +153,13 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
         const panel = (
             <div className={`panel ${editing ? 'panel-info' : 'panel-default'}`}>
-                <div className="panel-heading">
-                    <DetailPanelHeader
-                        useEditIcon={useEditIcon}
-                        isEditable={isEditable}
-                        canUpdate={canUpdate}
-                        editing={editing}
-                        title={title}
-                        onClickFn={this.toggleEditing}
-                        warning={warning}
-                    />
-                </div>
+                <DetailPanelHeader
+                    isEditable={isEditable && canUpdate}
+                    editing={editing}
+                    title={title}
+                    onClick={this.toggleEditing}
+                    warning={warning}
+                />
 
                 <div className="panel-body">
                     <div className="detail__editing">
@@ -225,7 +215,7 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
                     <div className="full-width bottom-spacing">
                         <Button className="pull-left" onClick={this.toggleEditing}>
-                            {cancelText}
+                            Cancel
                         </Button>
                         <Button className="pull-right" bsStyle="success" type="submit" disabled={!canSubmit}>
                             {submitText}

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -7,6 +7,7 @@ import { AuditBehaviorTypes, Query } from '@labkey/api';
 import { DetailPanelHeader } from '../../internal/components/forms/detail/DetailPanelHeader';
 import { DetailRenderer } from '../../internal/components/forms/detail/DetailDisplay';
 import { extractChanges } from '../../internal/components/forms/detail/utils';
+import { FormButtons } from '../../internal/FormButtons';
 
 import { QueryColumn } from '../QueryColumn';
 import { FileInput } from '../../internal/components/forms/input/FileInput';
@@ -213,14 +214,14 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
                 >
                     {panel}
 
-                    <div className="full-width bottom-spacing">
-                        <Button className="pull-left" onClick={this.toggleEditing}>
+                    <FormButtons>
+                        <button className="btn btn-default" type="button" onClick={this.toggleEditing}>
                             Cancel
-                        </Button>
-                        <Button className="pull-right" bsStyle="success" type="submit" disabled={!canSubmit}>
+                        </button>
+                        <button className="btn btn-success" type="submit" disabled={!canSubmit}>
                             {submitText}
-                        </Button>
-                    </div>
+                        </button>
+                    </FormButtons>
 
                     {asSubPanel && <div className="panel-divider-spacing" />}
                 </Formsy>

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -14,11 +14,11 @@ import { resolveErrorMessage } from '../../internal/util/messaging';
 import { Alert } from '../../internal/components/base/Alert';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../internal/APIWrapper';
+import { QueryModel } from './QueryModel';
 
-import { RequiresModelAndActions } from './withQueryModels';
 import { DetailPanel, DetailPanelWithModel } from './DetailPanel';
 
-export interface EditableDetailPanelProps extends RequiresModelAndActions {
+export interface EditableDetailPanelProps {
     api?: ComponentsAPIWrapper;
     appEditable?: boolean;
     asSubPanel?: boolean;
@@ -30,6 +30,7 @@ export interface EditableDetailPanelProps extends RequiresModelAndActions {
     detailHeader?: ReactNode;
     detailRenderer?: DetailRenderer;
     editColumns?: QueryColumn[];
+    model: QueryModel;
     onAdditionalFormDataChange?: (name: string, value: any) => any;
     onEditToggle?: (editing: boolean) => void;
     onUpdate: () => void;
@@ -136,7 +137,6 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
     render(): ReactNode {
         const {
-            actions,
             appEditable,
             containerFilter,
             containerPath,
@@ -179,7 +179,6 @@ export class EditableDetailPanel extends PureComponent<EditableDetailPanelProps,
 
                         {!editing && (
                             <DetailPanel
-                                actions={actions}
                                 containerFilter={containerFilter}
                                 containerPath={containerPath}
                                 detailRenderer={detailRenderer}

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -189,6 +189,14 @@
   padding-bottom: 12px;
 }
 
+.editable-grid-buttons {
+    margin-bottom: 15px;
+}
+
+.editable-grid-buttons__action-buttons button {
+    margin-right: 10px;
+}
+
 .edit-grid-container {
   width: 100%;
 }
@@ -445,11 +453,6 @@ $table-cell-selection-bg-color: #EDF3FF;
 
 .loading-mask {
   @include loading($mask: true);
-}
-
-// Grid bar
-.QueryGrid-bottom-spacing {
-  padding-bottom: 15px;
 }
 
 // Add rows controls


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1327
- https://github.com/LabKey/labkey-ui-premium/pull/233
- https://github.com/LabKey/biologics/pull/2470
- https://github.com/LabKey/sampleManagement/pull/2188
- https://github.com/LabKey/inventory/pull/1074
- https://github.com/LabKey/testAutomation/pull/1691

#### Changes
- EditableGrid: Add more specific classNames to button bar buttons
- EditableDetailPanel: Use FormButtons
- DetailPanel/EditableDetailPanel: Remove actions prop
- DetailPanelHeader: convert to FC, simplify props, render panel-heading div
