### PR TITLE
Remove react-redux dependency

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -32,7 +32,6 @@
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
         "react-dom": "~16.14.0",
-        "react-redux": "~5.1.0",
         "react-router": "~3.2.6",
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
@@ -14580,24 +14579,6 @@
         "react": ">=0.14.0"
       }
     },
-    "node_modules/react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
-      }
-    },
     "node_modules/react-router": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.6.tgz",
@@ -28655,20 +28636,6 @@
       "integrity": "sha512-IyjsJhDX9JkoOV9wlmLaS7z+oxYoIWhfzDcFy7inwoAKTu+VcVNrVpPmLeioJ94y6GeDRsnwarG1py5qofFQMg==",
       "requires": {
         "warning": "^3.0.0"
-      }
-    },
-    "react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
       }
     },
     "react-router": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.387.0",
+  "version": "2.388.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.387.0",
+      "version": "2.388.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -104,7 +104,6 @@
     "jest-cli": "~29.7.0",
     "jest-environment-jsdom": "~29.7.0",
     "jest-teamcity-reporter": "~0.9.0",
-    "react-redux": "~8.1.3",
     "react-test-renderer": "~16.14.0",
     "ts-jest": "~29.1.1",
     "webpack-merge": "~5.9.0"
@@ -113,8 +112,7 @@
     "immutable": "^3.8.2",
     "react": "^16.0",
     "react-bootstrap": "^0.33.1",
-    "react-dom": "^16.0",
-    "react-redux": "^8"
+    "react-dom": "^16.0"
   },
   "resolutions": {
     "**/@types/react-dom": "~16.9.19",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.387.0",
+  "version": "2.388.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -73,7 +73,6 @@
     "react-color": "~2.19.3",
     "react-datepicker": "~4.17.0",
     "react-dom": "~16.14.0",
-    "react-redux": "~5.1.0",
     "react-router": "~3.2.6",
     "react-select": "~5.7.0",
     "react-treebeard": "~3.2.4",
@@ -105,6 +104,7 @@
     "jest-cli": "~29.7.0",
     "jest-environment-jsdom": "~29.7.0",
     "jest-teamcity-reporter": "~0.9.0",
+    "react-redux": "~8.1.3",
     "react-test-renderer": "~16.14.0",
     "ts-jest": "~29.1.1",
     "webpack-merge": "~5.9.0"
@@ -113,7 +113,8 @@
     "immutable": "^3.8.2",
     "react": "^16.0",
     "react-bootstrap": "^0.33.1",
-    "react-dom": "^16.0"
+    "react-dom": "^16.0",
+    "react-redux": "^8"
   },
   "resolutions": {
     "**/@types/react-dom": "~16.9.19",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.388.0
+*Released*: 27 October 2023
+- Remove dependency on `react-redux`
+- Remove configuration of `Provider` and `Router` from `AppContexts`
+
 ### version 2.387.0
 *Released*: 27 October 2023
 - Issue 48969: add loadAllQueryInfos method to withQueryModels actions

--- a/packages/components/src/internal/AppContexts.tsx
+++ b/packages/components/src/internal/AppContexts.tsx
@@ -1,7 +1,5 @@
 import { getServerContext } from '@labkey/api';
 import React, { FC, useMemo } from 'react';
-import { Provider } from 'react-redux';
-import { Router } from 'react-router';
 
 import { AppContextProvider, ExtendableAppContext } from './AppContext';
 import { GlobalStateContextProvider } from './GlobalStateContext';
@@ -10,9 +8,7 @@ import { NotificationsContextProvider } from './components/notifications/Notific
 import { LabelPrintingContextProvider } from './components/labels/LabelPrintingContextProvider';
 
 interface Props<T = {}> {
-    history: any;
     initialAppContext?: ExtendableAppContext<T>;
-    store: any;
 }
 
 /**
@@ -21,7 +17,7 @@ interface Props<T = {}> {
  * at once, and reduce the level of nesting needed in our Route configurations.
  */
 export const AppContexts: FC<Props> = props => {
-    const { children, history, initialAppContext, store } = props;
+    const { children, initialAppContext } = props;
     const initialServerContext = useMemo(() => withAppUser(getServerContext()), []);
     return (
         <ServerContextProvider initialContext={initialServerContext}>
@@ -29,9 +25,7 @@ export const AppContexts: FC<Props> = props => {
                 <GlobalStateContextProvider>
                     <NotificationsContextProvider>
                         <LabelPrintingContextProvider>
-                            <Provider store={store}>
-                                <Router history={history}>{children}</Router>
-                            </Provider>
+                            {children}
                         </LabelPrintingContextProvider>
                     </NotificationsContextProvider>
                 </GlobalStateContextProvider>

--- a/packages/components/src/internal/AppContexts.tsx
+++ b/packages/components/src/internal/AppContexts.tsx
@@ -24,9 +24,7 @@ export const AppContexts: FC<Props> = props => {
             <AppContextProvider initialContext={initialAppContext}>
                 <GlobalStateContextProvider>
                     <NotificationsContextProvider>
-                        <LabelPrintingContextProvider>
-                            {children}
-                        </LabelPrintingContextProvider>
+                        <LabelPrintingContextProvider>{children}</LabelPrintingContextProvider>
                     </NotificationsContextProvider>
                 </GlobalStateContextProvider>
             </AppContextProvider>

--- a/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
@@ -1044,7 +1044,6 @@ exports[`Dataset Properties Panel New dataset 1`] = `
                         className="css-1f43avz-a11yText-A11yText"
                       />
                       <div
-                        aria-disabled={true}
                         className="select-input__control select-input__control--is-disabled css-1mgq1wa-control"
                         onMouseDown={[Function]}
                         onTouchEnd={[Function]}

--- a/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
@@ -1044,6 +1044,7 @@ exports[`Dataset Properties Panel New dataset 1`] = `
                         className="css-1f43avz-a11yText-A11yText"
                       />
                       <div
+                        aria-disabled={true}
                         className="select-input__control select-input__control--is-disabled css-1mgq1wa-control"
                         onMouseDown={[Function]}
                         onTouchEnd={[Function]}


### PR DESCRIPTION
#### Rationale
This removes `react-redux` as a dependency from `@labkey/components`. The `Provider` and `Router` components now must be specified by the applications directly.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1329
- https://github.com/LabKey/labkey-ui-premium/pull/236
- https://github.com/LabKey/biologics/pull/2476
- https://github.com/LabKey/sampleManagement/pull/2193
- https://github.com/LabKey/inventory/pull/1077

#### Changes
- Remove dependency on `react-redux`.
- Remove configuration of `Provider` and `Router` from `AppContexts`. Must be done by applications.
