### PR TITLE
Issue 48969: Load queryInfos even if not autoloading and polish of ExportModal display

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.386.1-tabbedExportQueryInfo.1",
+  "version": "2.386.1-tabbedExportQueryInfo.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.386.1-tabbedExportQueryInfo.1",
+      "version": "2.386.1-tabbedExportQueryInfo.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.386.1-tabbedExportQueryInfo.2",
+  "version": "2.387.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.386.1-tabbedExportQueryInfo.2",
+      "version": "2.387.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.385.0",
+  "version": "2.385.1-tabbedExportQueryInfo.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.385.0",
+      "version": "2.385.1-tabbedExportQueryInfo.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.386.1-tabbedExportQueryInfo.1",
+  "version": "2.386.1-tabbedExportQueryInfo.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.386.1-tabbedExportQueryInfo.2",
+  "version": "2.387.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.385.0",
+  "version": "2.385.1-tabbedExportQueryInfo.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48969: add loadAllQueryInfos method to withQueryModels actions
+- Update ExportModal to show all system views (prefixed by ~~) as 'Default'
+- Update ExportModal to pre-select models with counts > 0 when using `tabRowCounts`
+
 ### version 2.385.0
 *Released*: 25 October 2023
 - EditableGrid: Add more specific classNames to button bar buttons

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.387.0
+*Released*: 27 October 2023
 - Issue 48969: add loadAllQueryInfos method to withQueryModels actions
 - Update ExportModal to show all system views (prefixed by ~~) as 'Default'
 - Update ExportModal to pre-select models with counts > 0 when using `tabRowCounts`

--- a/packages/components/src/internal/components/gridbar/ExportModal.tsx
+++ b/packages/components/src/internal/components/gridbar/ExportModal.tsx
@@ -20,6 +20,7 @@ export const ExportModal: FC<ExportModalProperties> = memo(props => {
     const [selected, setSelected] = useState<Set<string>>(() => {
         let selected = new Set<string>();
         tabOrder.forEach(modelId => {
+            if (tabRowCounts?.[modelId] > 0) selected = selected.add(modelId);
             if (queryModels[modelId].rowCount > 0) selected = selected.add(modelId);
         });
         return selected;
@@ -82,7 +83,7 @@ export const ExportModal: FC<ExportModalProperties> = memo(props => {
                                     </td>
                                     <td className="pull-right">{rowCountDisplay}</td>
                                     <td className="view-name">
-                                        {model.viewName || 'Default'}{' '}
+                                        { !model.viewName || model.viewName?.startsWith("~~") ? 'Default' : model.viewName}{' '}
                                         {model.currentView?.session && <span className="text-muted">(edited)</span>}
                                     </td>
                                 </tr>

--- a/packages/components/src/internal/components/gridbar/ExportModal.tsx
+++ b/packages/components/src/internal/components/gridbar/ExportModal.tsx
@@ -83,7 +83,7 @@ export const ExportModal: FC<ExportModalProperties> = memo(props => {
                                     </td>
                                     <td className="pull-right">{rowCountDisplay}</td>
                                     <td className="view-name">
-                                        { !model.viewName || model.viewName?.startsWith("~~") ? 'Default' : model.viewName}{' '}
+                                        { !model.viewName || model.viewName.startsWith("~~") ? 'Default' : model.viewName}{' '}
                                         {model.currentView?.session && <span className="text-muted">(edited)</span>}
                                     </td>
                                 </tr>

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -200,6 +200,7 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
                 await exportTabsXlsx(filename, models);
                 onExport?.[EXPORT_TYPES.EXCEL]?.();
             } catch (e) {
+                console.error(e);
                 // Set export error
                 _createNotification?.({ message: 'Export failed: ' + e, alertClass: 'danger' });
             } finally {

--- a/packages/components/src/public/QueryModel/testUtils.ts
+++ b/packages/components/src/public/QueryModel/testUtils.ts
@@ -63,6 +63,7 @@ export const makeTestActions = (mockFn = (): any => () => {}, overrides: Partial
         clearSelections: mockFn(),
         loadModel: mockFn(),
         loadAllModels: mockFn(),
+        loadAllQueryInfos: mockFn(),
         loadRows: mockFn(),
         loadNextPage: mockFn(),
         loadPreviousPage: mockFn(),

--- a/packages/components/src/public/QueryModel/testUtils.ts
+++ b/packages/components/src/public/QueryModel/testUtils.ts
@@ -63,7 +63,6 @@ export const makeTestActions = (mockFn = (): any => () => {}, overrides: Partial
         clearSelections: mockFn(),
         loadModel: mockFn(),
         loadAllModels: mockFn(),
-        loadAllQueryInfos: mockFn(),
         loadRows: mockFn(),
         loadNextPage: mockFn(),
         loadPreviousPage: mockFn(),

--- a/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
@@ -64,13 +64,13 @@ describe('withQueryModels', () => {
         // When we first mount a component we initialize rows and queryInfo to undefined with loading states set to
         // loading.
         expect(injectedModel.queryInfo).toEqual(undefined);
-        expect(injectedModel.queryInfoLoadingState).toEqual(LoadingState.INITIALIZED);
+        expect(injectedModel.queryInfoLoadingState).toEqual(LoadingState.LOADING);
         expect(injectedModel.rows).toEqual(undefined);
         expect(injectedModel.rowsLoadingState).toEqual(LoadingState.INITIALIZED);
 
         // Trigger load model like a consuming component would in componentDidMount.
         injectedActions.loadModel(injectedModel.id);
-        // We can expect that LoadingState for QueryInfo should be LOADING, but rows shoudl still be INITIALIZED
+        // We can expect that LoadingState for QueryInfo should be LOADING, but rows should still be INITIALIZED
         // because we can't even try until we have a QueryInfo.
         expect(injectedModel.queryInfoLoadingState).toEqual(LoadingState.LOADING);
         expect(injectedModel.rowsLoadingState).toEqual(LoadingState.INITIALIZED);

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -241,6 +241,10 @@ export function withQueryModels<Props>(
                 // for now. Attempts to coordinate better between these two settings have thus far not been successful
                 // (or have seemed too invasive to be attractive). See Issue 48758.
                 this.loadAllModels(!!this.props.modelLoader.loadSelections);
+            } else {
+                // Issue 48969: For purposes of export, at least, we want to know the queryInfo data for all models
+                // without having to visit each model.
+                this.loadAllQueryInfos();
             }
         }
 

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -30,7 +30,6 @@ export interface Actions {
     addModel: (queryConfig: QueryConfig, load?: boolean, loadSelections?: boolean) => void;
     clearSelections: (id: string) => void;
     loadAllModels: (loadSelections?: boolean, reloadTotalCount?: boolean) => void;
-    loadAllQueryInfos: () => void;
     loadCharts: (id: string) => void;
     loadFirstPage: (id: string) => void;
     loadLastPage: (id: string) => void;
@@ -207,7 +206,6 @@ export function withQueryModels<Props>(
                 clearSelections: this.clearSelections,
                 loadModel: this.loadModel,
                 loadAllModels: this.loadAllModels,
-                loadAllQueryInfos: this.loadAllQueryInfos,
                 loadRows: this.loadRows,
                 loadNextPage: this.loadNextPage,
                 loadPreviousPage: this.loadPreviousPage,

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -30,6 +30,7 @@ export interface Actions {
     addModel: (queryConfig: QueryConfig, load?: boolean, loadSelections?: boolean) => void;
     clearSelections: (id: string) => void;
     loadAllModels: (loadSelections?: boolean, reloadTotalCount?: boolean) => void;
+    loadAllQueryInfos: () => void;
     loadCharts: (id: string) => void;
     loadFirstPage: (id: string) => void;
     loadLastPage: (id: string) => void;
@@ -206,6 +207,7 @@ export function withQueryModels<Props>(
                 clearSelections: this.clearSelections,
                 loadModel: this.loadModel,
                 loadAllModels: this.loadAllModels,
+                loadAllQueryInfos: this.loadAllQueryInfos,
                 loadRows: this.loadRows,
                 loadNextPage: this.loadNextPage,
                 loadPreviousPage: this.loadPreviousPage,
@@ -730,6 +732,10 @@ export function withQueryModels<Props>(
 
         loadAllModels = (loadSelections = false, reloadTotalCount = true): void => {
             Object.keys(this.state.queryModels).forEach(id => this.loadModel(id, loadSelections, reloadTotalCount));
+        };
+
+        loadAllQueryInfos = (): void => {
+            Object.keys(this.state.queryModels).forEach(id => this.loadQueryInfo(id));
         };
 
         loadNextPage = (id: string): void => {


### PR DESCRIPTION
#### Rationale
Issue [48969](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48969): For efficiency in Sample Finder, we load the queryModel for only the first tab that is shown when more than one sample type is involved. If you choose to export data to Excel from Sample Finder without visiting the individual sample type tabs, an error occurs because we will not have loaded the QueryInfo data for the sample type and thus won't know what columns to include in the export.  This same error also occurs on he all samples listing page.  The change here is to update `withQueryModels` to load the queryInfos when autoLoad is false so we avoid this issue. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/237
- https://github.com/LabKey/inventory/pull/1078
- https://github.com/LabKey/sampleManagement/pull/2195
- https://github.com/LabKey/biologics/pull/2477

#### Changes
- Issue 48969: add loadAllQueryInfos method in withQueryModels and call this when autoLoad is false
- Update ExportModal to show all system views (prefixed by ~~) as 'Default'
- Update ExportModal to pre-select models with counts > 0 when using `tabRowCounts`
