### PR TITLE
Issue 48961: Editable grids should always show ID fields as read-only fields

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.386.0",
+  "version": "2.386.1-EditableGridRONames.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.386.0",
+      "version": "2.386.1-EditableGridRONames.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.388.1-EditableGridRONames.1",
+  "version": "2.388.2-EditableGridRONames.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.388.1-EditableGridRONames.1",
+      "version": "2.388.2-EditableGridRONames.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.388.2-EditableGridRONames.2",
+  "version": "2.388.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.388.2-EditableGridRONames.2",
+      "version": "2.388.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.26.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.386.0",
+  "version": "2.386.1-EditableGridRONames.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.388.2-EditableGridRONames.1",
+  "version": "2.388.2-EditableGridRONames.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.388.2-EditableGridRONames.2",
+  "version": "2.388.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 48961: Make sure Name (id) fields are shown, but read-only, in editable grids for update
+
 ### version 2.386.0
 *Released*: 26 October 2023
 - Add ability to create, edit, and delete sample, source, and assay domains from subfolders

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.388.2
+*Released*: 31 October 2023
 - Issue 48961: Make sure Name (id) fields are shown, but read-only, in editable grids for update
 
 ### version 2.388.1

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -422,19 +422,21 @@ export async function addRows(
  * @param queryColumns the ordered map of columns to be added
  * @param fieldKey the fieldKey of the existing column after which the new columns should be inserted.  If undefined
  * or the column is not found, columns will be added at the beginning.
+ * @param readOnlyColumns set of columns that are in the grid but may be designated not as showInInsertView (e.g., 'Name')
  */
 export function addColumns(
     editorModel: EditorModel,
     queryInfo: QueryInfo,
     originalData: Map<any, Map<string, any>>,
     queryColumns: ExtendedMap<string, QueryColumn>,
-    fieldKey?: string
+    fieldKey?: string,
+    readOnlyColumns?: string[]
 ): EditorModelUpdates {
     if (queryColumns.size === 0) return {};
 
     // add one to these because we insert after the given field (or at the
     // beginning if there is no such field)
-    const editorColIndex = queryInfo.getInsertColumnIndex(fieldKey) + 1;
+    const editorColIndex = queryInfo.getInsertColumnIndex(fieldKey, readOnlyColumns) + 1;
     const queryColIndex = queryInfo.getColumnIndex(fieldKey) + 1;
 
     if (editorColIndex < 0 || editorColIndex > queryInfo.columns.size) return {};

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -273,16 +273,24 @@ export class QueryInfo {
 
     // @param isIncludedColumn can be used to filter out columns that should not be designate as insertColumns
     // (e.g., if creating samples that are not aliquots, the aliquot-only fields should never be included)
-    getInsertColumns(isIncludedColumn?: (col: QueryColumn) => boolean): QueryColumn[] {
+    getInsertColumns(isIncludedColumn?: (col: QueryColumn) => boolean, readOnlyColumns?: string[]): QueryColumn[] {
+        const lowerReadOnlyColumnsSet = readOnlyColumns?.reduce((result, value) => {
+            result.add(value.toLowerCase());
+            return result;
+        }, new Set());
         // CONSIDER: use the columns in ~~INSERT~~ view to determine this set
-        return this.columns.valueArray.filter(col => insertColumnFilter(col, false, isIncludedColumn));
+        return this.columns.valueArray.filter(
+            col =>
+                lowerReadOnlyColumnsSet?.has(col.fieldKey.toLowerCase()) ||
+                insertColumnFilter(col, false, isIncludedColumn)
+        );
     }
 
-    getInsertColumnIndex(fieldKey: string): number {
+    getInsertColumnIndex(fieldKey: string, readOnlyColumns?: string[]): number {
         if (!fieldKey) return -1;
 
         const lcFieldKey = fieldKey.toLowerCase();
-        return this.getInsertColumns().findIndex(column => column.fieldKey.toLowerCase() === lcFieldKey);
+        return this.getInsertColumns(undefined, readOnlyColumns).findIndex(column => column.fieldKey.toLowerCase() === lcFieldKey);
     }
 
     getUpdateColumns(readOnlyColumns?: string[]): QueryColumn[] {


### PR DESCRIPTION
#### Rationale
Issue [48961](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48961): When an application is configured to not allow users to supply ids for entities, we are currently not showing the ids as read-only fields in the editable grids, making it difficult to know which entities are being edited.  This PR assures the id columns (or, generally, designated read-only columns) are included in the grid, even when designated as not to be included in the insert view.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/240
- https://github.com/LabKey/inventory/pull/1082
- https://github.com/LabKey/sampleManagement/pull/2199
- https://github.com/LabKey/biologics/pull/2482

#### Changes
- Add optional readOnlyColumns parameter to `editable/acitons` `getColumns` method and `queryInfo`'s `getInsertColumns`