### PR TITLE
Issue 48828: Don't show sample insights panel while editing in the grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1-noInsightsForEdit.0",
+  "version": "2.391.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.1-noInsightsForEdit.0",
+      "version": "2.391.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.1-noInsightsForEdit.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.0",
+      "version": "2.390.1-noInsightsForEdit.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.1-noInsightsForEdit.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1-noInsightsForEdit.0",
+  "version": "2.391.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 48828: Don't show sample insights panel while editing in the grid
+  -  add `onEditToggle` optional prop for `SampleTabbedGridPanel`
+
 ### version 2.390.0
 *Released*: 31 October 2023
 * Issue 41677: Include single field uniqueness constraint option in field editor

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.391.0
+*Released*: 1 November 2023
 * Issue 48828: Don't show sample insights panel while editing in the grid
   -  add `onEditToggle` optional prop for `SampleTabbedGridPanel`
 

--- a/packages/components/src/internal/sampleModels.ts
+++ b/packages/components/src/internal/sampleModels.ts
@@ -27,6 +27,7 @@ export interface SamplesTabbedGridPanelComponentProps {
     initialTabId?: string; // use if you have multiple tabs but want to start on something other than the first one
     isAllSamplesTab?: (QuerySchema) => boolean;
     modelId?: string; // if a usage wants to just show a single GridPanel, they should provide a modelId prop
+    onEditToggle?: (isEditing: boolean) => void;
     onSampleTabSelect?: (modelId: string) => void;
     sampleAliquotType?: ALIQUOT_FILTER_MODE; // the init sampleAliquotType, requires all query models to have completed loading queryInfo prior to rendering of the component
     samplesEditableGridProps?: Partial<SamplesEditableGridProps>;


### PR DESCRIPTION
#### Rationale
Issue [48828](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48828) - The insights panel contains links that filter the samples grid. If a user is in the process of editing the samples in the grid and clicks on one of these filtering URLs, it may cause the samples they are editing to be filtered out of the grid.  With this PR and its relatives, we remove the temptation by removing the insights panel altogether when in edit mode.

#### Related Pull Requests

- https://github.com/LabKey/biologics/pull/2489
- https://github.com/LabKey/sampleManagement/pull/2208
- https://github.com/LabKey/inventory/pull/1084
- https://github.com/LabKey/labkey-ui-premium/pull/242

#### Changes
- add `onEditToggle` optional prop for `SampleTabbedGridPanel`
