### PR TITLE
Issue 48804: Scroll error message at bottom of domain designer into view

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1-stickyFixes.1",
+  "version": "2.391.1-stickyFixes.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.1-stickyFixes.1",
+      "version": "2.391.1-stickyFixes.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.1-stickyFixes.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.0",
+      "version": "2.390.1-stickyFixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.391.1-stickyFixes.3",
+  "version": "2.391.1-stickyFixes.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.391.1-stickyFixes.3",
+      "version": "2.391.1-stickyFixes.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1-stickyFixes.0",
+  "version": "2.390.1-stickyFixes.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.1-stickyFixes.0",
+      "version": "2.390.1-stickyFixes.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.391.1-stickyFixes.4",
+  "version": "2.391.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.391.1-stickyFixes.4",
+      "version": "2.391.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.391.1-stickyFixes.2",
+  "version": "2.391.1-stickyFixes.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.391.1-stickyFixes.2",
+      "version": "2.391.1-stickyFixes.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.391.1-stickyFixes.2",
+  "version": "2.391.1-stickyFixes.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.1-stickyFixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.391.1-stickyFixes.1",
+  "version": "2.391.1-stickyFixes.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.391.1-stickyFixes.4",
+  "version": "2.391.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1-stickyFixes.0",
+  "version": "2.390.1-stickyFixes.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.391.1-stickyFixes.3",
+  "version": "2.391.1-stickyFixes.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.391.1
+*Released*: 2 November 2023
 * Issue 48804: Scroll error message at bottom of domain designer into view
 * fix `FormButtons` handling of single child case
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 48804: Scroll error message at bottom of domain designer into view
+* Issue 48896: Remove 'Cancel' button from Group and Permission management pages
+
 ### version 2.390.0
 *Released*: 31 October 2023
 * Issue 41677: Include single field uniqueness constraint option in field editor

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 * Issue 48804: Scroll error message at bottom of domain designer into view
-* Issue 48896: Remove 'Cancel' button from Group and Permission management pages
+* fix `FormButtons` handling of single child case
 
 ### version 2.391.0
 *Released*: 1 November 2023

--- a/packages/components/src/internal/FormButtons.tsx
+++ b/packages/components/src/internal/FormButtons.tsx
@@ -19,7 +19,7 @@ export const FormButtons: FC<Props> = memo(({ children, sticky = true }) => {
     if (childCount === 0) {
         return null;
     } else if (childCount === 1) {
-        submit = children[0];
+        submit = children;
     } else if (childCount === 2) {
         cancel = children[0];
         submit = children[1];

--- a/packages/components/src/internal/components/administration/GroupAssignments.tsx
+++ b/packages/components/src/internal/components/administration/GroupAssignments.tsx
@@ -32,7 +32,6 @@ export interface GroupAssignmentsProps {
     principalsById: Map<number, Principal>;
     removeMember: (groupId: string, memberId: number) => void;
     rolesByUniqueName: Map<string, SecurityRole>;
-    router?: InjectedRouter;
     save: () => Promise<void>;
     setErrorMsg: (e: string) => void;
     setIsDirty: (isDirty: boolean) => void;
@@ -57,18 +56,12 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
         save,
         setErrorMsg,
         setIsDirty,
-        router,
     } = props;
     const { user } = useServerContext();
     const [submitting, setSubmitting] = useState<boolean>(false);
     const [selectedPrincipalId, setSelectedPrincipalId] = useState<number>();
     const [newGroupName, setNewGroupName] = useState<string>('');
     const initExpandedGroup = getLocation().query?.get('expand');
-
-    const onCancel = useCallback(() => {
-        setIsDirty(false);
-        router.goBack();
-    }, [router, setIsDirty]);
 
     const onSave = useCallback(async () => {
         setSubmitting(true);
@@ -188,12 +181,6 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
                         <div className="group-assignment-panel__footer">{errorMsg && <Alert>{errorMsg}</Alert>}</div>
 
                         <FormButtons>
-                            {router && (
-                                <button className="btn btn-default" onClick={onCancel} type="button">
-                                    Cancel
-                                </button>
-                            )}
-
                             <button
                                 className="btn btn-success alert-button group-management-save-btn"
                                 disabled={submitting || !getIsDirty()}

--- a/packages/components/src/internal/components/administration/GroupAssignments.tsx
+++ b/packages/components/src/internal/components/administration/GroupAssignments.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, FC, memo, useCallback, useMemo, useState } from 'react';
-import { Button, Col, Panel, Row } from 'react-bootstrap';
+import { Button, Panel } from 'react-bootstrap';
 import { List, Map } from 'immutable';
 import { InjectedRouter } from 'react-router';
 
@@ -32,6 +32,7 @@ export interface GroupAssignmentsProps {
     principalsById: Map<number, Principal>;
     removeMember: (groupId: string, memberId: number) => void;
     rolesByUniqueName: Map<string, SecurityRole>;
+    router?: InjectedRouter;
     save: () => Promise<void>;
     setErrorMsg: (e: string) => void;
     setIsDirty: (isDirty: boolean) => void;
@@ -56,12 +57,18 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
         save,
         setErrorMsg,
         setIsDirty,
+        router,
     } = props;
     const { user } = useServerContext();
     const [submitting, setSubmitting] = useState<boolean>(false);
     const [selectedPrincipalId, setSelectedPrincipalId] = useState<number>();
     const [newGroupName, setNewGroupName] = useState<string>('');
     const initExpandedGroup = getLocation().query?.get('expand');
+
+    const onCancel = useCallback(() => {
+        setIsDirty(false);
+        router.goBack();
+    }, [router, setIsDirty]);
 
     const onSave = useCallback(async () => {
         setSubmitting(true);
@@ -140,8 +147,8 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
     const userIsAppAdmin = user.isAppAdmin();
 
     return (
-        <Row>
-            <Col xs={12} md={8}>
+        <div className="row">
+            <div className="col-xs-12 col-md-8">
                 <Panel>
                     <Panel.Heading> Application Groups and Assignments </Panel.Heading>
                     <Panel.Body className="permissions-groups-assignment-panel group-assignment-panel">
@@ -181,6 +188,11 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
                         <div className="group-assignment-panel__footer">{errorMsg && <Alert>{errorMsg}</Alert>}</div>
 
                         <FormButtons>
+                            {router && (
+                                <button className="btn btn-default" onClick={onCancel} type="button">
+                                    Cancel
+                                </button>
+                            )}
                             <button
                                 className="btn btn-success alert-button group-management-save-btn"
                                 disabled={submitting || !getIsDirty()}
@@ -192,9 +204,9 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
                         </FormButtons>
                     </Panel.Body>
                 </Panel>
-            </Col>
+            </div>
 
-            <Col xs={12} md={4}>
+            <div className="col-xs-12 col-md-4">
                 {selectedPrincipal?.type === MemberType.group ? (
                     <GroupDetailsPanel
                         principal={selectedPrincipal}
@@ -214,7 +226,7 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
                         showGroupListLinks={false}
                     />
                 )}
-            </Col>
-        </Row>
+            </div>
+        </div>
     );
 });

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -42,7 +42,7 @@ import { fetchGroupMembership } from './actions';
 export type GroupManagementPageProps = InjectedRouteLeaveProps & InjectedPermissionsPage & WithRouterProps;
 
 export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props => {
-    const { setIsDirty, getIsDirty, inactiveUsersById, principalsById, rolesByUniqueName, principals } = props;
+    const { setIsDirty, getIsDirty, inactiveUsersById, principalsById, rolesByUniqueName, principals, router } = props;
     const [error, setError] = useState<string>();
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [savedGroupMembership, setSavedGroupMembership] = useState<GroupMembership>();
@@ -283,6 +283,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
                     setIsDirty={setIsDirty}
                     getIsDirty={getIsDirty}
                     getAuditLogData={api.security.getAuditLogData}
+                    router={router}
                 />
             )}
         </BasePermissionsCheckPage>

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -42,7 +42,7 @@ import { fetchGroupMembership } from './actions';
 export type GroupManagementPageProps = InjectedRouteLeaveProps & InjectedPermissionsPage & WithRouterProps;
 
 export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props => {
-    const { setIsDirty, getIsDirty, inactiveUsersById, principalsById, rolesByUniqueName, principals, router } = props;
+    const { setIsDirty, getIsDirty, inactiveUsersById, principalsById, rolesByUniqueName, principals } = props;
     const [error, setError] = useState<string>();
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
     const [savedGroupMembership, setSavedGroupMembership] = useState<GroupMembership>();
@@ -283,7 +283,6 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
                     setIsDirty={setIsDirty}
                     getIsDirty={getIsDirty}
                     getAuditLogData={api.security.getAuditLogData}
-                    router={router}
                 />
             )}
         </BasePermissionsCheckPage>

--- a/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
@@ -7,7 +7,7 @@ import { FormButtons } from '../../FormButtons';
 import { Alert } from '../base/Alert';
 
 import { getDomainBottomErrorMessage, getDomainHeaderName, getUpdatedVisitedPanelsList } from './actions';
-import { SEVERITY_LEVEL_ERROR } from './constants';
+import { DOMAIN_ERROR_ID, SEVERITY_LEVEL_ERROR } from './constants';
 
 import { DomainDesign } from './models';
 
@@ -151,7 +151,7 @@ export const BaseDomainDesigner: FC<BaseDomainDesignerProps> = memo(props => {
         <div className="domain-designer">
             {children}
             {bottomErrorMsg && (
-                <div className="domain-form-panel" id="domain-error">
+                <div className="domain-form-panel" id={DOMAIN_ERROR_ID}>
                     <Alert bsStyle="danger">{bottomErrorMsg}</Alert>
                 </div>
             )}

--- a/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
@@ -150,13 +150,11 @@ export const BaseDomainDesigner: FC<BaseDomainDesignerProps> = memo(props => {
     return (
         <div className="domain-designer">
             {children}
-            <div id="domain-bottom">
             {bottomErrorMsg && (
-                <div className="domain-form-panel">
+                <div className="domain-form-panel" id="domain-error">
                     <Alert bsStyle="danger">{bottomErrorMsg}</Alert>
                 </div>
             )}
-            </div>
             <FormButtons sticky={isApp()}>
                 <button className="cancel-button btn btn-default" onClick={onCancel} type="button">
                     Cancel

--- a/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/BaseDomainDesigner.tsx
@@ -150,11 +150,13 @@ export const BaseDomainDesigner: FC<BaseDomainDesignerProps> = memo(props => {
     return (
         <div className="domain-designer">
             {children}
+            <div id="domain-bottom">
             {bottomErrorMsg && (
                 <div className="domain-form-panel">
                     <Alert bsStyle="danger">{bottomErrorMsg}</Alert>
                 </div>
             )}
+            </div>
             <FormButtons sticky={isApp()}>
                 <button className="cancel-button btn btn-default" onClick={onCancel} type="button">
                     Cancel

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -40,6 +40,7 @@ import { getExcludedDataTypeNames } from '../entities/actions';
 import { getQueryDetails } from '../../query/api';
 
 import {
+    DOMAIN_ERROR_ID,
     DOMAIN_FIELD_CLIENT_SIDE_ERROR,
     DOMAIN_FIELD_LOOKUP_CONTAINER,
     DOMAIN_FIELD_LOOKUP_QUERY,
@@ -1318,4 +1319,8 @@ export function setGenId(
             },
         });
     });
+}
+
+export function scrollDomainErrorIntoView(): void {
+    document.querySelector('#' + DOMAIN_ERROR_ID).scrollIntoView();
 }

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -5,7 +5,7 @@ import { DomainPropertiesAPIWrapper } from '../APIWrapper';
 
 import { DomainDesign, HeaderRenderer, IDomainFormDisplayOptions } from '../models';
 
-import { getDomainPanelStatus } from '../actions';
+import { getDomainPanelStatus, scrollDomainErrorIntoView } from '../actions';
 
 import DomainForm from '../DomainForm';
 import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesigner } from '../BaseDomainDesigner';
@@ -119,7 +119,7 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                 this.setState(
                     () => ({ protocolModel: updatedModel }),
                     () => {
-                        document.querySelector('#domain-error').scrollIntoView();
+                        scrollDomainErrorIntoView();
                     }
                 );
             });

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -119,7 +119,7 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                 this.setState(
                     () => ({ protocolModel: updatedModel }),
                     () => {
-                        document.querySelector('#domain-bottom').scrollIntoView();
+                        document.querySelector('#domain-error').scrollIntoView();
                     }
                 );
             });

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -116,7 +116,12 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                     : textChoiceValidMsg ?? protocolModel.getFirstDomainFieldError();
             const updatedModel = protocolModel.set('exception', exception) as AssayProtocolModel;
             setSubmitting(false, () => {
-                this.setState(() => ({ protocolModel: updatedModel }));
+                this.setState(
+                    () => ({ protocolModel: updatedModel }),
+                    () => {
+                        document.querySelector('#domain-bottom').scrollIntoView();
+                    }
+                );
             });
         }
     };

--- a/packages/components/src/internal/components/domainproperties/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/constants.ts
@@ -227,3 +227,5 @@ export const DERIVATION_DATA_SCOPES = {
 export const MAX_VALID_TEXT_CHOICES = 200;
 
 export const LOOKUP_VALIDATOR_VALUES = { type: 'Lookup', name: 'Lookup Validator' };
+
+export const DOMAIN_ERROR_ID = "domain-error";

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -175,7 +175,9 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
             }
 
             setSubmitting(false, () => {
-                this.saveModel({ exception });
+                this.saveModel({ exception }, () => {
+                    document.querySelector("#domain-bottom").scrollIntoView();
+                });
             });
         }
     };
@@ -323,7 +325,7 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
         );
     };
 
-    onNameFieldHover = () => {
+    onNameFieldHover = (): void => {
         const { api } = this.props;
         const { model, namePreviewsLoading } = this.state;
 

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -6,7 +6,7 @@ import { Domain, getServerContext } from '@labkey/api';
 
 import { DomainDesign, IDomainField, IDomainFormDisplayOptions } from '../models';
 import DomainForm from '../DomainForm';
-import { getDomainPanelStatus, saveDomain } from '../actions';
+import { getDomainPanelStatus, saveDomain, scrollDomainErrorIntoView } from '../actions';
 import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesigner } from '../BaseDomainDesigner';
 
 import { getAppHomeFolderPath, isSampleManagerEnabled } from '../../../app/utils';
@@ -176,7 +176,7 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
 
             setSubmitting(false, () => {
                 this.saveModel({ exception }, () => {
-                    document.querySelector("#domain-error").scrollIntoView();
+                    scrollDomainErrorIntoView();
                 });
             });
         }

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -176,7 +176,7 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
 
             setSubmitting(false, () => {
                 this.saveModel({ exception }, () => {
-                    document.querySelector("#domain-bottom").scrollIntoView();
+                    document.querySelector("#domain-error").scrollIntoView();
                 });
             });
         }

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -382,7 +382,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
             const updatedModel = model.set('exception', exception) as SampleTypeModel;
             setSubmitting(false, () => {
                 this.setState(() => ({ model: updatedModel }), () => {
-                    document.querySelector("#domain-bottom").scrollIntoView();
+                    document.querySelector("#domain-error").scrollIntoView();
                 });
             });
         }
@@ -492,7 +492,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
             setSubmitting(false, () => {
                 this.setState(() => ({ model: updatedModel, showUniqueIdConfirmation: false }),
                      () => {
-                        document.querySelector("#domain-bottom").scrollIntoView();
+                        document.querySelector("#domain-error").scrollIntoView();
                     });
             });
         }

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -392,7 +392,6 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         const { beforeFinish, setSubmitting, api } = this.props;
         const { model } = this.state;
         const { name, domain, description } = model;
-        console.log("saveDomain");
         if (beforeFinish && !hasConfirmedNameExpression) {
             beforeFinish(model);
         }

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -381,7 +381,9 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
 
             const updatedModel = model.set('exception', exception) as SampleTypeModel;
             setSubmitting(false, () => {
-                this.setState(() => ({ model: updatedModel }));
+                this.setState(() => ({ model: updatedModel }), () => {
+                    document.querySelector("#domain-bottom").scrollIntoView();
+                });
             });
         }
     };
@@ -390,7 +392,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         const { beforeFinish, setSubmitting, api } = this.props;
         const { model } = this.state;
         const { name, domain, description } = model;
-
+        console.log("saveDomain");
         if (beforeFinish && !hasConfirmedNameExpression) {
             beforeFinish(model);
         }
@@ -489,7 +491,10 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                   }) as SampleTypeModel);
 
             setSubmitting(false, () => {
-                this.setState(() => ({ model: updatedModel, showUniqueIdConfirmation: false }));
+                this.setState(() => ({ model: updatedModel, showUniqueIdConfirmation: false }),
+                     () => {
+                        document.querySelector("#domain-bottom").scrollIntoView();
+                    });
             });
         }
     };

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -6,7 +6,7 @@ import { DomainDesign, DomainDetails, IAppDomainHeader, IDomainField, IDomainFor
 import DomainForm from '../DomainForm';
 
 import { DEFAULT_DOMAIN_FORM_DISPLAY_OPTIONS, DERIVATION_DATA_SCOPES } from '../constants';
-import { addDomainField, getDomainPanelStatus, saveDomain } from '../actions';
+import { addDomainField, getDomainPanelStatus, saveDomain, scrollDomainErrorIntoView } from '../actions';
 import { DEFAULT_SAMPLE_FIELD_CONFIG, SAMPLE_TYPE_NAME_EXPRESSION_TOPIC } from '../../samples/constants';
 import { SAMPLE_SET_DISPLAY_TEXT } from '../../../constants';
 import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesigner } from '../BaseDomainDesigner';
@@ -382,7 +382,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
             const updatedModel = model.set('exception', exception) as SampleTypeModel;
             setSubmitting(false, () => {
                 this.setState(() => ({ model: updatedModel }), () => {
-                    document.querySelector("#domain-error").scrollIntoView();
+                    scrollDomainErrorIntoView();
                 });
             });
         }
@@ -492,7 +492,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
             setSubmitting(false, () => {
                 this.setState(() => ({ model: updatedModel, showUniqueIdConfirmation: false }),
                      () => {
-                        document.querySelector("#domain-error").scrollIntoView();
+                         scrollDomainErrorIntoView();
                     });
             });
         }

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.spec.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.spec.tsx
@@ -216,7 +216,7 @@ describe('PermissionAssignments', () => {
         expect(projectList.prop('inheritedProjects')).toEqual([TEST_FOLDER_OTHER_CONTAINER_ADMIN.name]);
 
         // Displays inherit checkbox
-        const inheritCheckbox = wrapper.find('.permissions-assignment-inherit');
+        const inheritCheckbox = wrapper.find('.permissions-assignment-inherit input');
         expect(inheritCheckbox.exists()).toEqual(true);
         expect(inheritCheckbox.at(0).prop('checked')).toEqual(true);
 

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -3,20 +3,19 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Checkbox, Col, Row } from 'react-bootstrap';
 import { List } from 'immutable';
-import { InjectedRouter } from 'react-router';
-import { Security } from '@labkey/api';
-import { FormButtons } from '../../FormButtons';
 
+import { Security } from '@labkey/api';
+
+import { FormButtons } from '../../FormButtons';
 import { UserDetailsPanel } from '../user/UserDetailsPanel';
 
 import {
     getProjectPath,
-    isProjectContainer,
-    isProductProjectsEnabled,
-    userCanReadGroupDetails,
     isAppHomeFolder,
+    isProductProjectsEnabled,
+    isProjectContainer,
+    userCanReadGroupDetails,
 } from '../../app/utils';
 
 import { useServerContext } from '../base/ServerContext';
@@ -57,7 +56,6 @@ export interface PermissionAssignmentsProps extends InjectedPermissionsPage, Inj
     /** Subset list of role uniqueNames to show in this component usage */
     rolesToShow?: List<string>;
     rootRolesToShow?: List<string>;
-    router?: InjectedRouter;
     setLastModified?: (modified: string) => void;
     setProjectCount?: (count: number) => void;
     /** Specific principal type (i.e. 'u' for users and 'g' for groups) to show in this component usage */
@@ -79,7 +77,6 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         rolesByUniqueName,
         rolesToShow,
         setIsDirty,
-        router,
         rootRolesToShow,
         setLastModified,
         setProjectCount,
@@ -265,11 +262,6 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         loadGroupMembership();
     }, [onSuccess, loadGroupMembership]);
 
-    const onCancel = useCallback(() => {
-        setIsDirty(false);
-        router.goBack();
-    }, [router, setIsDirty]);
-
     const onSaveSuccess = useCallback(async () => {
         await loadPolicy();
 
@@ -439,13 +431,12 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                 {isSubfolder && canInherit && (
                     <div>
                         <form>
-                            <Checkbox
-                                checked={inherited}
-                                className="permissions-assignment-inherit"
-                                onChange={onInheritChange}
-                            >
-                                Inherit permissions from the application
-                            </Checkbox>
+                            <div className="permissions-assignment-inherit checkbox">
+                                <label>
+                                    <input type="checkbox" checked={inherited} onChange={onInheritChange} />
+                                    Inherit permissions from the application
+                                </label>
+                            </div>
                         </form>
                         <hr />
                     </div>
@@ -499,10 +490,10 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
     return (
         <div className="permission-assignments-panel">
             {error && <Alert>{error}</Alert>}
-            <Row>
+            <div className="row">
                 {(!isProductProjectsEnabled(moduleContext) || projects?.length <= 1) && <>{_panelContent}</>}
                 {isProductProjectsEnabled(moduleContext) && projects?.length > 1 && (
-                    <Col xs={12} md={8}>
+                    <div className="col-md-8 col-xs-12">
                         <div className="side-panels-container">
                             <ProjectListing
                                 projects={sortedProjects}
@@ -521,9 +512,9 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                                 {_panelContent}
                             </VerticalScrollPanel>
                         </div>
-                    </Col>
+                    </div>
                 )}
-                <Col xs={12} md={4}>
+                <div className="col-md-4 col-xs-12">
                     {selectedPrincipal?.type === MemberType.group && groupMembership ? (
                         <GroupDetailsPanel
                             principal={selectedPrincipal}
@@ -545,12 +536,10 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                             showGroupListLinks={!projectsEnabled || !isSubfolder}
                         />
                     )}
-                </Col>
-            </Row>
+                </div>
+            </div>
 
             <FormButtons>
-                {router && <button className="btn btn-default" onClick={onCancel} type="button">Cancel</button>}
-
                 <button
                     className="pull-right alert-button permissions-assignment-save-btn btn btn-success"
                     disabled={submitting || !getIsDirty()}

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -49,6 +49,7 @@ import { Principal, SecurityPolicy, SecurityRole } from './models';
 import { PermissionsRole } from './PermissionsRole';
 import { GroupDetailsPanel } from './GroupDetailsPanel';
 import { InjectedPermissionsPage } from './withPermissionsPage';
+import { InjectedRouter } from 'react-router';
 
 // exported for testing
 export interface PermissionAssignmentsProps extends InjectedPermissionsPage, InjectedRouteLeaveProps {
@@ -56,6 +57,7 @@ export interface PermissionAssignmentsProps extends InjectedPermissionsPage, Inj
     /** Subset list of role uniqueNames to show in this component usage */
     rolesToShow?: List<string>;
     rootRolesToShow?: List<string>;
+    router?: InjectedRouter;
     setLastModified?: (modified: string) => void;
     setProjectCount?: (count: number) => void;
     /** Specific principal type (i.e. 'u' for users and 'g' for groups) to show in this component usage */
@@ -77,6 +79,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         rolesByUniqueName,
         rolesToShow,
         setIsDirty,
+        router,
         rootRolesToShow,
         setLastModified,
         setProjectCount,
@@ -261,6 +264,11 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         onSuccess();
         loadGroupMembership();
     }, [onSuccess, loadGroupMembership]);
+
+    const onCancel = useCallback(() => {
+        setIsDirty(false);
+        router.goBack();
+    }, [router, setIsDirty]);
 
     const onSaveSuccess = useCallback(async () => {
         await loadPolicy();
@@ -540,6 +548,8 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
             </div>
 
             <FormButtons>
+                {router && <button className="btn btn-default" onClick={onCancel} type="button">Cancel</button>}
+
                 <button
                     className="pull-right alert-button permissions-assignment-save-btn btn btn-success"
                     disabled={submitting || !getIsDirty()}


### PR DESCRIPTION
#### Rationale
Issue [48804:](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48804)  - Since we introduced the sticky form buttons at the bottom of the domain designers, users will no longer necessarily be scrolled to the bottom of the page when submitting the form and thus may miss the error message that is displayed at the bottom. Here, we introduce some `scrollIntoView` calls after detecting errors on saving domains.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Add id for error display in domain designer and some `scrollIntoView` callbacks
- Fix `FormButtons` to also work when there is a single child (which is not an array)
