### PR TITLE
Issue 48836: Resolve lineage item URL from queryName if available

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1-fb-lineage-url-48836.0",
+  "version": "2.390.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.1-fb-lineage-url-48836.0",
+      "version": "2.390.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.1-fb-lineage-url-48836.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.0",
+      "version": "2.390.1-fb-lineage-url-48836.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1-fb-lineage-url-48836.0",
+  "version": "2.390.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.1-fb-lineage-url-48836.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.390.1
+*Released*: 3 November 2023
+- Issue 48836: Update `URLResolver.resolveLineageItem` to resolve the name of the data type from the query name
+
 ### version 2.390.0
 *Released*: 31 October 2023
 * Issue 41677: Include single field uniqueness constraint option in field editor

--- a/packages/components/src/internal/url/URLResolver.spec.ts
+++ b/packages/components/src/internal/url/URLResolver.spec.ts
@@ -122,6 +122,7 @@ describe('resolveLineage', () => {
         let resolvedLinks = resolver.resolveLineageItem(
             lineageResult.nodes.get('urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3')
         );
+
         // test a sample type
         expect(resolvedLinks.list).toEqual('#/samples/Hemoglobin');
         expect(resolvedLinks.overview).toEqual('#/rd/samples/6814');
@@ -133,5 +134,13 @@ describe('resolveLineage', () => {
 
         expect(resolvedLinks.list).toEqual(undefined);
         expect(resolvedLinks.overview).toEqual('/labkey/testContainer/experiment-showRunGraph.view?rowId=794');
+
+        // Issue 48836: resolve list URL via queryName if available
+        // Note that the node "urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone" uses
+        // the new "cpasType" which does not include the name of the sample type.
+        resolvedLinks = resolver.resolveLineageItem(
+            lineageResult.nodes.get('urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone')
+        );
+        expect(resolvedLinks.list).toEqual('#/samples/shemoglobin');
     });
 });

--- a/packages/components/src/test/data/experiment-lineage.json
+++ b/packages/components/src/test/data/experiment-lineage.json
@@ -55,6 +55,35 @@
         "role" : "no role"
       } ]
     },
+    "urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone" : {
+      "created" : "2020-03-30 14:15:26.255",
+      "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-6:17",
+      "schemaName" : "samples",
+      "type" : "Sample",
+      "url" : "/labkey/testContainer/experiment-showMaterial.view?rowId=68144",
+      "lsid" : "urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone",
+      "createdBy" : "nickk@labkey.com",
+      "children" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-61:dbcee514-54f9-1038-9426-08c060dcd006",
+        "role" : "no role"
+      } ],
+      "pkFilters" : [ {
+        "fieldKey" : "RowId",
+        "value" : 68144
+      } ],
+      "name" : "Hgb3.3",
+      "queryName" : "shemoglobin",
+      "modified" : "2020-03-30 14:20:59.827",
+      "modifiedBy" : "nickk@labkey.com",
+      "id" : 68144,
+      "properties" : {
+        "name" : "Hgb3.3-clone"
+      },
+      "parents" : [ {
+        "lsid" : "urn:lsid:labkey.com:Run.Folder-61:83e2a187-54e9-1038-9426-08c060dcd006",
+        "role" : "no role"
+      } ]
+    },
     "urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3.1.2" : {
       "created" : "2020-03-30 14:22:19.979",
       "cpasType" : "urn:lsid:labkey.com:SampleSet.Folder-61:Hemoglobin",


### PR DESCRIPTION
#### Rationale
This addresses [Issue 48836](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48836) by updating how we parse/create an application URL from lineage node metadata. Formerly, we would parse the name from the  `cpasType`. Example: `urn:lsid:labkey.com:SampleSet.Folder-6:RawMaterials` (which would be "RawMaterials" in this case). At some point the `cpasType` has been updated to no longer include the name and now for newly created data types looks like `urn:lsid:labkey.com:SampleSet.Folder-6:17`. For reasons I don't quite understand I didn't just use the `item.queryName` which should suffice. Now we will use the `item.queryName` and fallback to the `cpasType` parsing if a query name is not available.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1338
- https://github.com/LabKey/biologics/pull/2497
- https://github.com/LabKey/sampleManagement/pull/2215
- https://github.com/LabKey/inventory/pull/1087

#### Changes
- Update `URLResolver.resolveLineageItem` to resolve the name of the data type from the query name if available and fallback to parsing from the cpasType.
