### PR TITLE
Issue 49019: LKSM: Grid filter persists in Starter edition but not in Pro

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.0-fb-gridSessionState49019.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.0",
+      "version": "2.390.0-fb-gridSessionState49019.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1",
+  "version": "2.390.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.1",
+      "version": "2.390.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.0",
+  "version": "2.390.0-fb-gridSessionState49019.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.1",
+  "version": "2.390.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 2.390.TBD
-*Released*: 3 November 2023
+### version 2.390.2
+*Released*: 6 November 2023
 * Issue 49019: Grid session filters/sorts/etc. are not applied as expected when model loads queryInfo from API instead of cache
   * the additional render cycle from the query details API call causes the withQueryModels componentDidUpdate to detect a URL param change and then remove the filters/sorts/etc. that were just applied from the session state
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.390.TBD
+*Released*: 3 November 2023
+* Issue 49019: Grid session filters/sorts/etc. are not applied as expected when model loads queryInfo from API instead of cache
+  * the additional render cycle from the query details API call causes the withQueryModels componentDidUpdate to detect a URL param change and then remove the filters/sorts/etc. that were just applied from the session state
+
 ### version 2.390.0
 *Released*: 31 October 2023
 * Issue 41677: Include single field uniqueness constraint option in field editor

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -281,7 +281,15 @@ export function withQueryModels<Props>(
                             return result;
                         }, {});
 
-                        if (!paramsEqual(modelParamsFromURL, model.urlQueryParams)) {
+                        // Issue 49019: Grid session filters/sorts/etc. are not applied as expected when model loads
+                        // queryInfo from API instead of cache the additional render cycle from the query details API
+                        // call causes the withQueryModels componentDidUpdate to detect a URL param change and then
+                        // remove the filters/sorts/etc. that were just applied from the session state. So add a check
+                        // for the queryInfo loading state in the if statement here.
+                        if (
+                            !isLoading(model.queryInfoLoadingState) &&
+                            !paramsEqual(modelParamsFromURL, model.urlQueryParams)
+                        ) {
                             // The params for the model have changed on the URL, so update the model.
                             this.updateModelFromURL(model.id);
                         }


### PR DESCRIPTION
#### Rationale
Issue [49019](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49019): Grid session filters/sorts/etc. are not applied as expected when model loads queryInfo from API instead of cache

The additional render cycle from the query details API call causes the withQueryModels componentDidUpdate to detect a URL param change and then remove the filters/sorts/etc. that were just applied from the session state.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1339
- https://github.com/LabKey/labkey-ui-premium/pull/245
- https://github.com/LabKey/sampleManagement/pull/2216
- https://github.com/LabKey/biologics/pull/2498
- https://github.com/LabKey/inventory/pull/1088

#### Changes
- withQueryModels componentDidUpdate to check for queryInfo loading state before calling updateModelFromURL
