### PR TITLE
Improve cross-project actions: Import job notifications

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.393.0",
+  "version": "2.393.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.393.0",
+      "version": "2.393.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.392.2-fb-crossFolderNotifications.0",
+  "version": "2.392.2-fb-crossFolderNotifications.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.392.2-fb-crossFolderNotifications.0",
+      "version": "2.392.2-fb-crossFolderNotifications.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.392.2",
+  "version": "2.392.2-fb-crossFolderNotifications.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.392.2",
+      "version": "2.392.2-fb-crossFolderNotifications.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.392.2-fb-crossFolderNotifications.0",
+  "version": "2.392.2-fb-crossFolderNotifications.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.393.0",
+  "version": "2.393.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.392.2",
+  "version": "2.392.2-fb-crossFolderNotifications.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Improve cross-project actions: Import job notifications
+  * Use the Query.ContainerFilter.allInProject container filter in getUserNotifications API call and PipelineJobsPage queryConfig
+
 ### version 2.392.2
 *Released*: 8 November 2023
 * Issue 48999: Unable to "Select them in the grid" when created trigger script runs after samples are added

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.393.1
+*Released*: 10 November 2023
 * Improve cross-project actions: Import job notifications
   * Use the Query.ContainerFilter.allInProject container filter in getUserNotifications API call and PipelineJobsPage queryConfig
 

--- a/packages/components/src/internal/components/navigation/ProductMenu.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.tsx
@@ -121,6 +121,7 @@ const ProductMenuButtonImpl: FC<ProductMenuButtonProps & WithRouterProps> = memo
             if (
                 !nodeName ||
                 (nodeName.toLowerCase() === 'a' && className !== 'menu-folder-item') ||
+                (nodeName.toLowerCase() === 'span' && className?.indexOf('product-menu-item') > -1) ||
                 (nodeName.toLowerCase() === 'i' && className?.toLowerCase().startsWith('fa'))
             ) {
                 toggleMenu();

--- a/packages/components/src/internal/components/notifications/actions.ts
+++ b/packages/components/src/internal/components/notifications/actions.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Ajax, Filter, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Filter, Query, Utils } from '@labkey/api';
 
 import { buildURL } from '../../url/AppURL';
 import { resolveErrorMessage } from '../../util/messaging';
@@ -38,7 +38,15 @@ export function getServerNotifications(typeLabels?: string[], maxRows?: number):
         Ajax.request({
             url: ActionURL.buildURL('notification', 'getUserNotifications.api'),
             method: 'GET',
-            params: { byContainer: true, containerFilter: getContainerFilter(), typeLabels, maxRows },
+            params: {
+                byContainer: true,
+                // per cross-folder action improvements, we always want to default to using the allInProject
+                // containerFilter for this API call so users can see all of their pipeline job details regardless of
+                // which project container they are in
+                containerFilter: Query.ContainerFilter.allInProject,
+                typeLabels,
+                maxRows,
+            },
             success: Utils.getCallbackWrapper(response => {
                 if (response.success) {
                     const notifications = response.notifications.map(

--- a/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
+++ b/packages/components/src/internal/components/pipeline/PipelineJobsPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Checkbox } from 'react-bootstrap';
 
-import { Filter } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 import { SchemaQuery } from '../../../public/SchemaQuery';
@@ -49,6 +49,7 @@ export class PipelineJobsPageImpl extends React.PureComponent<Props & InjectedQu
 
         const queryConfig = {
             id: gridId,
+            containerFilter: Query.ContainerFilter.allInProject, // use AllInProject for this grid to match getServerNotifications()
             schemaQuery: new SchemaQuery('pipeline', 'job'),
             baseFilters,
             sorts: [new QuerySort({ fieldKey: 'Created', dir: '-' })],

--- a/packages/components/src/theme/notification.scss
+++ b/packages/components/src/theme/notification.scss
@@ -125,3 +125,7 @@
         width: 18px;
     }
 }
+
+.page-detail-header-title-padding {
+    padding-left: 10px;
+}


### PR DESCRIPTION
#### Rationale
Currently the job notifications for active background imports (the spinners that show up in the megamenu and the entity type headers) default to using the current container as a container filter. We are updating this so it indicates if there are imports running for any of the visible projects for the user. We are also updating the containerFilter on the API call to get the user notifications for the notifications header panel so that it includes info from all projects as well.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1347
- https://github.com/LabKey/labkey-ui-premium/pull/253
- https://github.com/LabKey/platform/pull/4943
- https://github.com/LabKey/sampleManagement/pull/2232
- https://github.com/LabKey/biologics/pull/2515
- https://github.com/LabKey/inventory/pull/1094

#### Changes
- Use the Query.ContainerFilter.allInProject container filter in getUserNotifications API call and PipelineJobsPage queryConfig
