### PR TITLE
Replace formsy-react-components

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -18,7 +18,6 @@
         "enzyme": "~3.11.0",
         "font-awesome": "~4.7.0",
         "formsy-react": "~1.1.5",
-        "formsy-react-components": "~1.1.0",
         "history": "~4.7.2",
         "immer": "~10.0.2",
         "immutable": "~3.8.2",
@@ -9023,19 +9022,6 @@
       "peerDependencies": {
         "react": "^15.6.1 || ^16.0.0 || ^17.0.0",
         "react-dom": "^15.6.1 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/formsy-react-components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/formsy-react-components/-/formsy-react-components-1.1.0.tgz",
-      "integrity": "sha512-GUgnIqXbXNPf7auP4nwk5PF6477r5UhdQoO1aNCvQajLarUu/Jj8PaxTCHu56tNGSlewACqRV44m8MrYOMzdTQ==",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.5.10"
-      },
-      "peerDependencies": {
-        "formsy-react": "^1.1.0",
-        "react": "^15.6.1 || ^16.0.0"
       }
     },
     "node_modules/forwarded": {
@@ -24584,15 +24570,6 @@
       "integrity": "sha512-9IsV+XKQEcwvm7nZtyUTZBcl9SHgX2WKskVfvAKzQyJwMAqJ4E3Hf+6PM1E2dQo/MGYMM3pfECAbkDKwlKkp9g==",
       "requires": {
         "form-data-to-object": "^0.2.0",
-        "prop-types": "^15.5.10"
-      }
-    },
-    "formsy-react-components": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/formsy-react-components/-/formsy-react-components-1.1.0.tgz",
-      "integrity": "sha512-GUgnIqXbXNPf7auP4nwk5PF6477r5UhdQoO1aNCvQajLarUu/Jj8PaxTCHu56tNGSlewACqRV44m8MrYOMzdTQ==",
-      "requires": {
-        "classnames": "^2.2.5",
         "prop-types": "^15.5.10"
       }
     },

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.394.1",
+  "version": "2.395.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.394.1",
+      "version": "2.395.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,6 @@
     "enzyme": "~3.11.0",
     "font-awesome": "~4.7.0",
     "formsy-react": "~1.1.5",
-    "formsy-react-components": "~1.1.0",
     "history": "~4.7.2",
     "immer": "~10.0.2",
     "immutable": "~3.8.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.394.1",
+  "version": "2.395.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.395.0
+*Released*: 23 November 2023
+- Happy Thanksgiving!
+- Provide logically equivalent implementations for some `formsy-react-components` components. Only props that are used or are useful are supported (e.g. `changeDebounceInterval` is not supported).
+- Replace all usages of `formsy-react-components` components within the `@labkey/components` package with internal equivalent components.
+- Remove `formsy-react-components` dependency
+
+### version 2.394.1
+*Released*: 22 November 2023
 * Issue 48817: Update some wording in the NameIdSettings panel
 
 ### version 2.394.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -445,6 +445,7 @@ import { BreadcrumbCreate } from './internal/components/navigation/BreadcrumbCre
 import { MenuItemModel, MenuSectionModel, ProductMenuModel } from './internal/components/navigation/model';
 
 import { UserSelectInput } from './internal/components/forms/input/UserSelectInput';
+import { Input, TextArea } from './internal/components/forms/input/FormsyReactComponents';
 import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
@@ -1137,6 +1138,8 @@ export {
     FieldEditProps,
     QuerySelect,
     UserSelectInput,
+    Input,
+    TextArea,
     DetailPanelHeader,
     handleInputTab,
     handleTabKeyOnTextArea,
@@ -1828,3 +1831,4 @@ export type { URLMapper } from './internal/url/URLResolver';
 export type { EditableGridEvent } from './internal/components/editable/constants';
 export type { EditableGridChange } from './internal/components/editable/EditableGrid';
 export type { GetAssayDefinitionsOptions, GetProtocolOptions } from './internal/components/assay/actions';
+import type { InputProps, TextAreaProps } from './internal/components/forms/input/FormsyReactComponents';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1831,4 +1831,4 @@ export type { URLMapper } from './internal/url/URLResolver';
 export type { EditableGridEvent } from './internal/components/editable/constants';
 export type { EditableGridChange } from './internal/components/editable/EditableGrid';
 export type { GetAssayDefinitionsOptions, GetProtocolOptions } from './internal/components/assay/actions';
-import type { InputProps, TextAreaProps } from './internal/components/forms/input/FormsyReactComponents';
+export type { InputProps, TextAreaProps } from './internal/components/forms/input/FormsyReactComponents';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -440,7 +440,12 @@ import { BreadcrumbCreate } from './internal/components/navigation/BreadcrumbCre
 import { MenuItemModel, MenuSectionModel, ProductMenuModel } from './internal/components/navigation/model';
 
 import { UserSelectInput } from './internal/components/forms/input/UserSelectInput';
-import { FormsyInput, FormsySelect, FormsyTextArea } from './internal/components/forms/input/FormsyReactComponents';
+import {
+    FormsyCheckbox,
+    FormsyInput,
+    FormsySelect,
+    FormsyTextArea,
+} from './internal/components/forms/input/FormsyReactComponents';
 import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
@@ -1133,6 +1138,7 @@ export {
     FieldEditProps,
     QuerySelect,
     UserSelectInput,
+    FormsyCheckbox,
     FormsyInput,
     FormsySelect,
     FormsyTextArea,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -242,12 +242,7 @@ import {
     PIPELINE_JOB_NOTIFICATION_EVENT_SUCCESS,
     SHARED_CONTAINER_PATH,
 } from './internal/constants';
-import {
-    pushParameters,
-    removeParameters,
-    replaceParameters,
-    resetParameters,
-} from './internal/util/URL';
+import { pushParameters, removeParameters, replaceParameters, resetParameters } from './internal/util/URL';
 import { ActionMapper, URL_MAPPERS, URLResolver, URLService } from './internal/url/URLResolver';
 import { DATA_IMPORT_TOPIC, getHelpLink, HELP_LINK_REFERRER, HelpLink } from './internal/util/helpLinks';
 import { ExperimentRunResolver, ListResolver } from './internal/url/AppURLResolver';
@@ -445,7 +440,7 @@ import { BreadcrumbCreate } from './internal/components/navigation/BreadcrumbCre
 import { MenuItemModel, MenuSectionModel, ProductMenuModel } from './internal/components/navigation/model';
 
 import { UserSelectInput } from './internal/components/forms/input/UserSelectInput';
-import { Input, TextArea } from './internal/components/forms/input/FormsyReactComponents';
+import { Input, Select, TextArea } from './internal/components/forms/input/FormsyReactComponents';
 import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
@@ -1139,6 +1134,7 @@ export {
     QuerySelect,
     UserSelectInput,
     Input,
+    Select,
     TextArea,
     DetailPanelHeader,
     handleInputTab,
@@ -1831,4 +1827,9 @@ export type { URLMapper } from './internal/url/URLResolver';
 export type { EditableGridEvent } from './internal/components/editable/constants';
 export type { EditableGridChange } from './internal/components/editable/EditableGrid';
 export type { GetAssayDefinitionsOptions, GetProtocolOptions } from './internal/components/assay/actions';
-export type { InputProps, TextAreaProps } from './internal/components/forms/input/FormsyReactComponents';
+export type {
+    FormsySelectOption,
+    InputProps,
+    SelectProps,
+    TextAreaProps,
+} from './internal/components/forms/input/FormsyReactComponents';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -440,7 +440,7 @@ import { BreadcrumbCreate } from './internal/components/navigation/BreadcrumbCre
 import { MenuItemModel, MenuSectionModel, ProductMenuModel } from './internal/components/navigation/model';
 
 import { UserSelectInput } from './internal/components/forms/input/UserSelectInput';
-import { Input, Select, TextArea } from './internal/components/forms/input/FormsyReactComponents';
+import { FormsyInput, FormsySelect, FormsyTextArea } from './internal/components/forms/input/FormsyReactComponents';
 import { UserDetailHeader } from './internal/components/user/UserDetailHeader';
 import { UserProfile } from './internal/components/user/UserProfile';
 import { ChangePasswordModal } from './internal/components/user/ChangePasswordModal';
@@ -1133,9 +1133,9 @@ export {
     FieldEditProps,
     QuerySelect,
     UserSelectInput,
-    Input,
-    Select,
-    TextArea,
+    FormsyInput,
+    FormsySelect,
+    FormsyTextArea,
     DetailPanelHeader,
     handleInputTab,
     handleTabKeyOnTextArea,
@@ -1829,7 +1829,7 @@ export type { EditableGridChange } from './internal/components/editable/Editable
 export type { GetAssayDefinitionsOptions, GetProtocolOptions } from './internal/components/assay/actions';
 export type {
     FormsySelectOption,
-    InputProps,
-    SelectProps,
-    TextAreaProps,
+    FormsyInputProps,
+    FormsySelectProps,
+    FormsyTextAreaProps,
 } from './internal/components/forms/input/FormsyReactComponents';

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { OrderedMap } from 'immutable';
-import { Input } from 'formsy-react-components';
 
 import { ASSAY_WIZARD_MODEL } from '../../../test/data/constants';
 
@@ -11,7 +10,7 @@ import { QueryFormInputs } from '../forms/QueryFormInputs';
 import { TextInput } from '../forms/input/TextInput';
 import { DatePickerInput } from '../forms/input/DatePickerInput';
 import { SelectInput } from '../forms/input/SelectInput';
-import { Textarea } from '../forms/input/FormsyReactComponents';
+import { Input, TextArea } from '../forms/input/FormsyReactComponents';
 
 import { mountWithServerContext } from '../../test/enzymeTestHelpers';
 
@@ -25,7 +24,7 @@ describe('RunPropertiesPanel', () => {
 
         expect(wrapper.find('.panel')).toHaveLength(1);
         expect(wrapper.find(Input)).toHaveLength(1); // assay id input always there for run props
-        expect(wrapper.find(Textarea)).toHaveLength(1); // comments input always there for run props
+        expect(wrapper.find(TextArea)).toHaveLength(1); // comments input always there for run props
         expect(wrapper.find(QueryFormInputs)).toHaveLength(0);
     });
 
@@ -34,7 +33,7 @@ describe('RunPropertiesPanel', () => {
 
         expect(wrapper.find('.panel')).toHaveLength(1);
         expect(wrapper.find(Input)).toHaveLength(4); // assay id plus 4 TextInputs
-        expect(wrapper.find(Textarea)).toHaveLength(2); // comments plus one other multi-line text input
+        expect(wrapper.find(TextArea)).toHaveLength(2); // comments plus one other multi-line text input
         expect(wrapper.find(QueryFormInputs)).toHaveLength(1);
         expect(wrapper.find(TextInput)).toHaveLength(3); // text, multi-line, integer, and decimal fields
         expect(wrapper.find(DatePickerInput)).toHaveLength(1);

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
@@ -10,7 +10,7 @@ import { QueryFormInputs } from '../forms/QueryFormInputs';
 import { TextInput } from '../forms/input/TextInput';
 import { DatePickerInput } from '../forms/input/DatePickerInput';
 import { SelectInput } from '../forms/input/SelectInput';
-import { Input, TextArea } from '../forms/input/FormsyReactComponents';
+import { FormsyInput, FormsyTextArea } from '../forms/input/FormsyReactComponents';
 
 import { mountWithServerContext } from '../../test/enzymeTestHelpers';
 
@@ -23,8 +23,8 @@ describe('RunPropertiesPanel', () => {
         const wrapper = mountWithServerContext(<RunPropertiesPanel model={model} onChange={jest.fn} />);
 
         expect(wrapper.find('.panel')).toHaveLength(1);
-        expect(wrapper.find(Input)).toHaveLength(1); // assay id input always there for run props
-        expect(wrapper.find(TextArea)).toHaveLength(1); // comments input always there for run props
+        expect(wrapper.find(FormsyInput)).toHaveLength(1); // assay id input always there for run props
+        expect(wrapper.find(FormsyTextArea)).toHaveLength(1); // comments input always there for run props
         expect(wrapper.find(QueryFormInputs)).toHaveLength(0);
     });
 
@@ -32,8 +32,8 @@ describe('RunPropertiesPanel', () => {
         const wrapper = mountWithServerContext(<RunPropertiesPanel model={ASSAY_WIZARD_MODEL} onChange={jest.fn} />);
 
         expect(wrapper.find('.panel')).toHaveLength(1);
-        expect(wrapper.find(Input)).toHaveLength(4); // assay id plus 4 TextInputs
-        expect(wrapper.find(TextArea)).toHaveLength(2); // comments plus one other multi-line text input
+        expect(wrapper.find(FormsyInput)).toHaveLength(4); // assay id plus 4 TextInputs
+        expect(wrapper.find(FormsyTextArea)).toHaveLength(2); // comments plus one other multi-line text input
         expect(wrapper.find(QueryFormInputs)).toHaveLength(1);
         expect(wrapper.find(TextInput)).toHaveLength(3); // text, multi-line, integer, and decimal fields
         expect(wrapper.find(DatePickerInput)).toHaveLength(1);

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { OrderedMap } from 'immutable';
-import { Input, Textarea } from 'formsy-react-components';
+import { Input } from 'formsy-react-components';
 
 import { ASSAY_WIZARD_MODEL } from '../../../test/data/constants';
 
@@ -11,6 +11,7 @@ import { QueryFormInputs } from '../forms/QueryFormInputs';
 import { TextInput } from '../forms/input/TextInput';
 import { DatePickerInput } from '../forms/input/DatePickerInput';
 import { SelectInput } from '../forms/input/SelectInput';
+import { Textarea } from '../forms/input/FormsyReactComponents';
 
 import { mountWithServerContext } from '../../test/enzymeTestHelpers';
 

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -15,7 +15,6 @@
  */
 import React, { FC, memo, useMemo } from 'react';
 import Formsy from 'formsy-react';
-import { Input } from 'formsy-react-components';
 import { ExtendedMap } from '../../../public/ExtendedMap';
 import { QueryColumn } from '../../../public/QueryColumn';
 
@@ -24,7 +23,7 @@ import { AssayTaskInput } from '../forms/input/AssayTaskInput';
 import { isWorkflowEnabled } from '../../app/utils';
 import { LabelOverlay } from '../forms/LabelOverlay';
 import { QueryFormInputs } from '../forms/QueryFormInputs';
-import { Textarea } from '../forms/input/FormsyReactComponents';
+import { Input, TextArea } from '../forms/input/FormsyReactComponents';
 
 import { getContainerFilterForLookups } from '../../query/api';
 
@@ -58,15 +57,13 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, 
             <div className="panel-body">
                 <Formsy className="form-horizontal" onChange={onChange}>
                     <Input
-                        changeDebounceInterval={0}
                         id="runname"
                         label={NAME_LABEL}
                         labelClassName="text-left"
                         name="runname"
-                        type="text"
                         value={model.runName}
                     />
-                    <Textarea
+                    <TextArea
                         cols={60}
                         id="comment"
                         label={COMMENT_LABEL}

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -15,6 +15,7 @@
  */
 import React, { FC, memo, useMemo } from 'react';
 import Formsy from 'formsy-react';
+
 import { ExtendedMap } from '../../../public/ExtendedMap';
 import { QueryColumn } from '../../../public/QueryColumn';
 

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -15,7 +15,7 @@
  */
 import React, { FC, memo, useMemo } from 'react';
 import Formsy from 'formsy-react';
-import { Input, Textarea } from 'formsy-react-components';
+import { Input } from 'formsy-react-components';
 import { ExtendedMap } from '../../../public/ExtendedMap';
 import { QueryColumn } from '../../../public/QueryColumn';
 
@@ -24,6 +24,7 @@ import { AssayTaskInput } from '../forms/input/AssayTaskInput';
 import { isWorkflowEnabled } from '../../app/utils';
 import { LabelOverlay } from '../forms/LabelOverlay';
 import { QueryFormInputs } from '../forms/QueryFormInputs';
+import { Textarea } from '../forms/input/FormsyReactComponents';
 
 import { getContainerFilterForLookups } from '../../query/api';
 
@@ -66,7 +67,6 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, 
                         value={model.runName}
                     />
                     <Textarea
-                        changeDebounceInterval={0}
                         cols={60}
                         id="comment"
                         label={COMMENT_LABEL}

--- a/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunPropertiesPanel.tsx
@@ -23,7 +23,7 @@ import { AssayTaskInput } from '../forms/input/AssayTaskInput';
 import { isWorkflowEnabled } from '../../app/utils';
 import { LabelOverlay } from '../forms/LabelOverlay';
 import { QueryFormInputs } from '../forms/QueryFormInputs';
-import { Input, TextArea } from '../forms/input/FormsyReactComponents';
+import { FormsyInput, FormsyTextArea } from '../forms/input/FormsyReactComponents';
 
 import { getContainerFilterForLookups } from '../../query/api';
 
@@ -56,14 +56,14 @@ export const RunPropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, 
             <div className="panel-heading">Run Details</div>
             <div className="panel-body">
                 <Formsy className="form-horizontal" onChange={onChange}>
-                    <Input
+                    <FormsyInput
                         id="runname"
                         label={NAME_LABEL}
                         labelClassName="text-left"
                         name="runname"
                         value={model.runName}
                     />
-                    <TextArea
+                    <FormsyTextArea
                         cols={60}
                         id="comment"
                         label={COMMENT_LABEL}

--- a/packages/components/src/internal/components/buttons/ToggleButtons.tsx
+++ b/packages/components/src/internal/components/buttons/ToggleButtons.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback } from 'react';
 import classNames from 'classnames';
 
-import { Input } from '../forms/input/FormsyReactComponents';
+import { FormsyInput } from '../forms/input/FormsyReactComponents';
 
 interface Props {
     active: string;
@@ -49,7 +49,7 @@ export const ToggleButtons: FC<Props> = memo(props => {
     return (
         <>
             {inputFieldName && (
-                <Input name={inputFieldName} type="hidden" value={active === first ? 'true' : 'false'} />
+                <FormsyInput name={inputFieldName} type="hidden" value={active === first ? 'true' : 'false'} />
             )}
             <div
                 className={classNames('toggle', 'btn-group', {
@@ -86,7 +86,7 @@ export const ToggleIcon: FC<Props> = memo(props => {
     return (
         <>
             {inputFieldName && (
-                <Input name={inputFieldName} type="hidden" value={active === first ? 'true' : 'false'} />
+                <FormsyInput name={inputFieldName} type="hidden" value={active === first ? 'true' : 'false'} />
             )}
             <div
                 className={classNames('toggle', 'toggle-group-icon', 'btn-group', {

--- a/packages/components/src/internal/components/buttons/ToggleButtons.tsx
+++ b/packages/components/src/internal/components/buttons/ToggleButtons.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo, useCallback } from 'react';
-import { Input } from 'formsy-react-components';
 import classNames from 'classnames';
+
+import { Input } from '../forms/input/FormsyReactComponents';
 
 interface Props {
     active: string;

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -24,7 +24,7 @@ import { QueryInfo } from '../../../public/QueryInfo';
 
 import { caseInsensitive } from '../../util/utils';
 
-import { Input } from './input/FormsyReactComponents';
+import { FormsyInput } from './input/FormsyReactComponents';
 import { resolveInputRenderer } from './input/InputRenderFactory';
 import { QuerySelect } from './QuerySelect';
 import { SelectInputChange } from './input/SelectInput';
@@ -144,7 +144,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
 
         if (includeLabelField) {
             const fieldName = getQueryFormLabelFieldName(col.name);
-            return <Input name={fieldName} type="hidden" value={this.state.labels[fieldName]} />;
+            return <FormsyInput name={fieldName} type="hidden" value={this.state.labels[fieldName]} />;
         }
 
         return null;

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -16,6 +16,7 @@
 import React, { ReactNode } from 'react';
 import { List, Map } from 'immutable';
 import { Filter, Query } from '@labkey/api';
+
 import { ExtendedMap } from '../../../public/ExtendedMap';
 
 import { insertColumnFilter, Operation, QueryColumn } from '../../../public/QueryColumn';

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 import React, { ReactNode } from 'react';
-import { List, Map, OrderedMap } from 'immutable';
-import { Input } from 'formsy-react-components';
+import { List, Map } from 'immutable';
 import { Filter, Query } from '@labkey/api';
 import { ExtendedMap } from '../../../public/ExtendedMap';
 
@@ -25,6 +24,7 @@ import { QueryInfo } from '../../../public/QueryInfo';
 
 import { caseInsensitive } from '../../util/utils';
 
+import { Input } from './input/FormsyReactComponents';
 import { resolveInputRenderer } from './input/InputRenderFactory';
 import { QuerySelect } from './QuerySelect';
 import { SelectInputChange } from './input/SelectInput';

--- a/packages/components/src/internal/components/forms/QueryInfoQuantity.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoQuantity.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Input } from 'formsy-react-components';
 import Formsy from 'formsy-react';
 
 import { mount, ReactWrapper } from 'enzyme';
@@ -7,6 +6,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import { DERIVATIVE_CREATION, POOLED_SAMPLE_CREATION } from '../samples/models';
 
 import { QueryInfoQuantity } from './QueryInfoQuantity';
+import { Input } from './input/FormsyReactComponents';
 import { RadioGroupInput } from './input/RadioGroupInput';
 
 describe('<QueryInfoQuantity>', () => {

--- a/packages/components/src/internal/components/forms/QueryInfoQuantity.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoQuantity.spec.tsx
@@ -9,8 +9,8 @@ import { QueryInfoQuantity } from './QueryInfoQuantity';
 import { FormsyInput } from './input/FormsyReactComponents';
 import { RadioGroupInput } from './input/RadioGroupInput';
 
-describe('<QueryInfoQuantity>', () => {
-    function validate(wrapper: ReactWrapper, optionCount: number, includeCount: boolean) {
+describe('QueryInfoQuantity', () => {
+    function validate(wrapper: ReactWrapper, optionCount: number, includeCount: boolean): void {
         expect(wrapper.find(RadioGroupInput)).toHaveLength(optionCount === 0 ? 0 : 1);
         expect(wrapper.find(FormsyInput)).toHaveLength(includeCount || optionCount > 0 ? 1 : 0);
     }
@@ -31,12 +31,7 @@ describe('<QueryInfoQuantity>', () => {
     test('no options, show quantity', () => {
         const wrapper = mount(
             <Formsy>
-                <QueryInfoQuantity
-                    creationTypeOptions={[]}
-                    includeCountField={true}
-                    maxCount={5}
-                    countText="Quantity"
-                />
+                <QueryInfoQuantity creationTypeOptions={[]} includeCountField maxCount={5} countText="Quantity" />
             </Formsy>
         );
         validate(wrapper, 0, true);
@@ -70,7 +65,7 @@ describe('<QueryInfoQuantity>', () => {
             <Formsy>
                 <QueryInfoQuantity
                     creationTypeOptions={[{ ...DERIVATIVE_CREATION, selected: true }, POOLED_SAMPLE_CREATION]}
-                    includeCountField={true}
+                    includeCountField
                     maxCount={5}
                     countText="Quantity"
                 />

--- a/packages/components/src/internal/components/forms/QueryInfoQuantity.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoQuantity.spec.tsx
@@ -6,13 +6,13 @@ import { mount, ReactWrapper } from 'enzyme';
 import { DERIVATIVE_CREATION, POOLED_SAMPLE_CREATION } from '../samples/models';
 
 import { QueryInfoQuantity } from './QueryInfoQuantity';
-import { Input } from './input/FormsyReactComponents';
+import { FormsyInput } from './input/FormsyReactComponents';
 import { RadioGroupInput } from './input/RadioGroupInput';
 
 describe('<QueryInfoQuantity>', () => {
     function validate(wrapper: ReactWrapper, optionCount: number, includeCount: boolean) {
         expect(wrapper.find(RadioGroupInput)).toHaveLength(optionCount === 0 ? 0 : 1);
-        expect(wrapper.find(Input)).toHaveLength(includeCount || optionCount > 0 ? 1 : 0);
+        expect(wrapper.find(FormsyInput)).toHaveLength(includeCount || optionCount > 0 ? 1 : 0);
     }
 
     test('no content', () => {
@@ -40,7 +40,7 @@ describe('<QueryInfoQuantity>', () => {
             </Formsy>
         );
         validate(wrapper, 0, true);
-        const input = wrapper.find(Input);
+        const input = wrapper.find(FormsyInput);
         expect(input.prop('max')).toBe(5);
         expect(input.prop('value')).toBe('1');
         wrapper.unmount();

--- a/packages/components/src/internal/components/forms/QueryInfoQuantity.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoQuantity.tsx
@@ -3,7 +3,7 @@ import { addValidationRule } from 'formsy-react';
 
 import { SampleCreationType, SampleCreationTypeModel } from '../samples/models';
 
-import { Input } from './input/FormsyReactComponents';
+import { FormsyInput } from './input/FormsyReactComponents';
 import { RadioGroupInput } from './input/RadioGroupInput';
 
 interface Props {
@@ -85,7 +85,7 @@ export class QueryInfoQuantity extends PureComponent<Props, State> {
                     </div>
                 )}
                 {(options.length > 0 || includeCountField) && (
-                    <Input
+                    <FormsyInput
                         id="numItems"
                         label={text}
                         labelClassName="control-label text-left"

--- a/packages/components/src/internal/components/forms/QueryInfoQuantity.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoQuantity.tsx
@@ -1,10 +1,9 @@
 import React, { PureComponent } from 'react';
-import { Input } from 'formsy-react-components';
-
 import { addValidationRule } from 'formsy-react';
 
 import { SampleCreationType, SampleCreationTypeModel } from '../samples/models';
 
+import { Input } from './input/FormsyReactComponents';
 import { RadioGroupInput } from './input/RadioGroupInput';
 
 interface Props {

--- a/packages/components/src/internal/components/forms/constants.ts
+++ b/packages/components/src/internal/components/forms/constants.ts
@@ -22,10 +22,19 @@ export interface WithFormsyProps {
     getErrorMessage?: Function;
     getErrorMessages?: Function;
     getValue?: Function;
+    hasValue?: Function;
+    isFormDisabled?: Function;
+    isFormSubmitted?: Function;
+    isPristine?: Function;
     isRequired?: () => boolean;
     isValid?: Function;
+    isValidValue?: Function;
+    resetValue?: Function;
+    setValidations?: Function;
     setValue?: Function;
     showError?: () => boolean;
     showRequired?: Function;
-    validations?: any;
+    validationError?: string;
+    validationErrors?: string;
+    validations?: any; // Record<string, any> | string;
 }

--- a/packages/components/src/internal/components/forms/constants.ts
+++ b/packages/components/src/internal/components/forms/constants.ts
@@ -23,6 +23,7 @@ export interface WithFormsyProps {
     getErrorMessages?: Function;
     getValue?: Function;
     hasValue?: Function;
+    innerRef?: any;
     isFormDisabled?: Function;
     isFormSubmitted?: Function;
     isPristine?: Function;

--- a/packages/components/src/internal/components/forms/constants.ts
+++ b/packages/components/src/internal/components/forms/constants.ts
@@ -20,8 +20,12 @@ export const DELIMITER = ',';
 // Interface for components that support the withFormsy() component wrapper.
 export interface WithFormsyProps {
     getErrorMessage?: Function;
+    getErrorMessages?: Function;
     getValue?: Function;
+    isRequired?: () => boolean;
+    isValid?: Function;
     setValue?: Function;
+    showError?: () => boolean;
     showRequired?: Function;
     validations?: any;
 }

--- a/packages/components/src/internal/components/forms/constants.ts
+++ b/packages/components/src/internal/components/forms/constants.ts
@@ -35,6 +35,6 @@ export interface WithFormsyProps {
     showError?: () => boolean;
     showRequired?: Function;
     validationError?: string;
-    validationErrors?: string;
+    validationErrors?: any; // Record<string, any> | string;
     validations?: any; // Record<string, any> | string;
 }

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -407,7 +407,7 @@ export function resolveDetailEditRenderer(
 
                 return (
                     <TextInput
-                        elementWrapperClassName={[{ 'col-sm-9': false }, 'col-sm-12']}
+                        elementWrapperClassName="col-sm-12"
                         queryColumn={col}
                         // Issue 43561: Support name expression fields
                         // NK: If a name expression is applied, then the server does not mark the field as required as

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -356,7 +356,7 @@ export function resolveDetailEditRenderer(
             return (
                 <TextAreaInput
                     cols={4}
-                    elementWrapperClassName={[{ 'col-sm-9': false }, 'col-sm-12']}
+                    elementWrapperClassName="col-sm-12"
                     queryColumn={col}
                     rows={4}
                     showLabel={showLabel}

--- a/packages/components/src/internal/components/forms/input/AppendUnitsInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/AppendUnitsInput.spec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Formsy from 'formsy-react';
-import { Input } from 'formsy-react-components';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
+
+import { Input } from './FormsyReactComponents';
 
 import { AppendUnitsInput } from './AppendUnitsInput';
 

--- a/packages/components/src/internal/components/forms/input/AppendUnitsInput.spec.tsx
+++ b/packages/components/src/internal/components/forms/input/AppendUnitsInput.spec.tsx
@@ -4,7 +4,7 @@ import Formsy from 'formsy-react';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
-import { Input } from './FormsyReactComponents';
+import { FormsyInput } from './FormsyReactComponents';
 
 import { AppendUnitsInput } from './AppendUnitsInput';
 
@@ -18,7 +18,7 @@ describe('AppendUnitsInput', () => {
     test('without formsy', () => {
         // Without Formsy it should not crash the page
         const wrapper = mount(<AppendUnitsInput col={column} data={undefined} value={undefined} />);
-        expect(wrapper.exists(Input)).toBeFalsy();
+        expect(wrapper.exists(FormsyInput)).toBeFalsy();
         wrapper.unmount();
     });
 
@@ -28,7 +28,7 @@ describe('AppendUnitsInput', () => {
                 <AppendUnitsInput col={column} data={undefined} formsy value={undefined} />
             </Formsy>
         );
-        expect(wrapper.exists(Input)).toBeTruthy();
+        expect(wrapper.exists(FormsyInput)).toBeTruthy();
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -19,6 +19,7 @@ import { WithFormsyProps } from '../constants';
 type LayoutType = 'elementOnly' | 'horizontal' | 'vertical';
 
 interface SharedFormsyProps {
+    innerRef?: any; // Maybe on WithFormsyProps instead?
     validationError?: string;
     validationErrors?: any; // Record<string, any> | string;
     validations?: any; // Record<string, any> | string;
@@ -225,6 +226,7 @@ const InputImpl: FC<FormsyInputProps & WithFormsyProps> = props => {
         getErrorMessages,
         getValue,
         hasValue,
+        innerRef,
         isFormDisabled,
         isFormSubmitted,
         isPristine,
@@ -235,6 +237,7 @@ const InputImpl: FC<FormsyInputProps & WithFormsyProps> = props => {
         setValidations,
         setValue,
         showError,
+        step,
         showRequired,
         validationError,
         validationErrors,
@@ -282,7 +285,7 @@ const InputImpl: FC<FormsyInputProps & WithFormsyProps> = props => {
             onBlur={handleBlur}
             onChange={handleChange}
             ref={componentRef}
-            value={getValue()}
+            value={getValue() ?? ''}
         />
     );
 
@@ -392,6 +395,7 @@ const SelectImpl: FC<FormsySelectProps> = props => {
         getErrorMessages,
         getValue,
         hasValue,
+        innerRef,
         isFormDisabled,
         isFormSubmitted,
         isPristine,
@@ -513,6 +517,7 @@ const TextAreaImpl: FC<FormsyTextAreaProps & WithFormsyProps> = props => {
         getErrorMessages,
         getValue,
         hasValue,
+        innerRef,
         isFormDisabled,
         isFormSubmitted,
         isPristine,

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -98,7 +98,7 @@ interface RequiredSymbolProps {
     symbol?: ReactNode;
 }
 
-const RequiredSymbol: FC<RequiredSymbolProps> = memo(({ required, symbol = '*' }) => {
+const RequiredSymbol: FC<RequiredSymbolProps> = memo(({ required, symbol = ' *' }) => {
     if (required === false) return null;
     return <span className="required-symbol">{symbol}</span>;
 });

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -190,7 +190,7 @@ InputGroup.displayName = 'InputGroup';
 
 type InputHTMLProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'onBlur' | 'onChange' | 'value'>;
 
-type InputProps = BaseComponentProps & InputGroupProps & InputHTMLProps;
+export type InputProps = BaseComponentProps & InputGroupProps & InputHTMLProps;
 
 const InputImpl: FC<InputProps & WithFormsyProps> = props => {
     // Extract InputGroupProps

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -263,7 +263,7 @@ const CheckboxImpl: FC<FormsyCheckboxProps & WithFormsyProps> = props => {
         value,
         ...inputHTMLProps
     } = formsyAndHTMLProps;
-    const { id } = inputHTMLProps;
+    const { disabled, id } = inputHTMLProps;
 
     const handleChange = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
@@ -279,6 +279,7 @@ const CheckboxImpl: FC<FormsyCheckboxProps & WithFormsyProps> = props => {
                 {...inputHTMLProps}
                 checked={getValue() === true}
                 className="custom-control-input"
+                disabled={isFormDisabled() || disabled || false}
                 id={id}
                 onChange={handleChange}
                 ref={componentRef}

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -404,7 +404,7 @@ const InputImpl: FC<FormsyInputProps & WithFormsyProps> = props => {
             classNames(
                 {
                     'custom-range': type === 'range',
-                    'form-control': type !== 'hidden' && type !== 'range', // TODO: Double check this logic
+                    'form-control': type !== 'hidden' && type !== 'range',
                     'is-invalid': markAsInvalid,
                 },
                 className

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -200,9 +200,9 @@ InputGroup.displayName = 'InputGroup';
 
 type InputHTMLProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'onBlur' | 'onChange' | 'value'>;
 
-export type InputProps = BaseComponentProps & InputGroupProps & InputHTMLProps;
+export type FormsyInputProps = BaseComponentProps & InputGroupProps & InputHTMLProps;
 
-const InputImpl: FC<InputProps & WithFormsyProps> = props => {
+const InputImpl: FC<FormsyInputProps & WithFormsyProps> = props => {
     // Extract InputGroupProps
     const { addonAfter, addonBefore, buttonAfter, buttonBefore, ...rest } = props;
     const {
@@ -350,14 +350,13 @@ InputImpl.defaultProps = {
 
 const InputWithFormsy = withFormsy(InputImpl);
 
-export const Input: FC<InputProps & WithFormsyProps> = props => <InputWithFormsy {...props} />;
+export const FormsyInput: FC<FormsyInputProps & WithFormsyProps> = props => <InputWithFormsy {...props} />;
 
-Input.displayName = 'Input';
+FormsyInput.displayName = 'FormsyInput';
 
 export interface FormsySelectOption {
     className?: string;
     disabled?: boolean;
-    group?: string;
     label: string;
     value: string;
 }
@@ -369,9 +368,9 @@ interface SelectBaseProps extends BaseComponentProps {
 
 type SelectHTMLProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'onBlur' | 'onChange'>;
 
-export type SelectProps = SelectBaseProps & SelectHTMLProps & WithFormsyProps;
+export type FormsySelectProps = SelectBaseProps & SelectHTMLProps & WithFormsyProps;
 
-const SelectImpl: FC<SelectProps> = props => {
+const SelectImpl: FC<FormsySelectProps> = props => {
     const {
         componentRef,
         elementWrapperClassName,
@@ -485,15 +484,15 @@ SelectImpl.defaultProps = {
 
 const SelectWithFormsy = withFormsy(SelectImpl);
 
-export const Select: FC<SelectProps> = props => <SelectWithFormsy {...props} />;
+export const FormsySelect: FC<FormsySelectProps> = props => <SelectWithFormsy {...props} />;
 
-Select.displayName = 'Select';
+FormsySelect.displayName = 'FormsySelect';
 
 type TextAreaHTMLProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onBlur' | 'onChange' | 'value'>;
 
-export type TextAreaProps = BaseComponentProps & TextAreaHTMLProps;
+export type FormsyTextAreaProps = BaseComponentProps & TextAreaHTMLProps;
 
-const TextAreaImpl: FC<TextAreaProps & WithFormsyProps> = props => {
+const TextAreaImpl: FC<FormsyTextAreaProps & WithFormsyProps> = props => {
     const {
         componentRef,
         elementWrapperClassName,
@@ -602,6 +601,6 @@ TextAreaImpl.defaultProps = {
 
 const TextAreaWithFormsy = withFormsy(TextAreaImpl);
 
-export const TextArea: FC<TextAreaProps & WithFormsyProps> = props => <TextAreaWithFormsy {...props} />;
+export const FormsyTextArea: FC<FormsyTextAreaProps & WithFormsyProps> = props => <TextAreaWithFormsy {...props} />;
 
-TextArea.displayName = 'TextArea';
+FormsyTextArea.displayName = 'FormsyTextArea';

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -1,0 +1,196 @@
+import React, { ChangeEvent, FC, FocusEvent, memo, ReactNode, useCallback } from 'react';
+import { withFormsy } from 'formsy-react';
+import classNames from 'classnames';
+
+import { WithFormsyProps } from '../constants';
+
+type LayoutType = 'elementOnly' | 'horizontal' | 'vertical';
+
+interface BaseComponentProps {
+    elementWrapperClassName?: string;
+    help?: ReactNode;
+    labelClassName?: string;
+    layout?: LayoutType;
+    onChange?: (name: string, value: any) => void;
+    required?: boolean;
+    rowClassName?: string;
+}
+
+const componentDefaultProps = {
+    layout: 'horizontal',
+};
+
+interface ErrorMessageProps {
+    messages: ReactNode[];
+}
+
+const ErrorMessages: FC<ErrorMessageProps> = memo(props => {
+    const { messages } = props;
+    if (!messages) return null;
+    return (
+        <div className="invalid-feedback">
+            {messages.map((message, key) => (
+                <div key={key}>{message}</div>
+            ))}
+        </div>
+    );
+});
+
+const Help: FC = ({ children }) => <small className="form-text text-muted">{children}</small>;
+
+interface RequiredSymbolProps {
+    required: boolean;
+    symbol?: ReactNode;
+}
+
+const RequiredSymbol: FC<RequiredSymbolProps> = memo(({ required, symbol = '*' }) => {
+    if (required === false) return null;
+    return <span className="required-symbol">{symbol}</span>;
+});
+
+interface LabelProps {
+    htmlFor: string;
+    labelClassName?: string;
+    layout?: LayoutType;
+    required?: boolean;
+}
+
+const Label: FC<LabelProps> = memo(props => {
+    const { children, htmlFor, labelClassName, layout, required = false } = props;
+
+    if (layout === 'elementOnly') return null;
+
+    const labelClassNames = classNames(['col-form-label', layout === 'horizontal' ? 'col-sm-3' : '', labelClassName]);
+
+    return (
+        <label className={labelClassNames} data-required={required} htmlFor={htmlFor}>
+            {children}
+            <RequiredSymbol required={required} />
+        </label>
+    );
+});
+
+interface RowProps extends BaseComponentProps, LabelProps {
+    label?: ReactNode;
+    showErrors?: boolean;
+}
+
+const Row: FC<RowProps> = memo(props => {
+    const { children, label, ...baseProps } = props;
+    const { elementWrapperClassName, layout, required, rowClassName, showErrors } = baseProps;
+
+    if (layout === 'elementOnly') {
+        return <span>{children}</span>;
+    }
+
+    const rowClassNames = ['form-group'];
+
+    if (showErrors) {
+        rowClassNames.push('has-error');
+        rowClassNames.push('has-feedback');
+    }
+
+    if (layout === 'horizontal') {
+        rowClassNames.push('row');
+    }
+
+    rowClassNames.push(rowClassName);
+
+    // We should render the label if there is label text defined, or if the
+    // component is required (so a required symbol is displayed in the label tag)
+    const renderLabel = label !== null || required;
+
+    return (
+        <div className={classNames(rowClassNames)}>
+            {renderLabel && (
+                <Label
+                    htmlFor={props.htmlFor}
+                    labelClassName={props.labelClassName}
+                    layout={layout}
+                    required={required}
+                >
+                    {label}
+                </Label>
+            )}
+            {layout === 'horizontal' && (
+                <div className={classNames('col-sm-9', elementWrapperClassName, { 'offset-sm-3': !renderLabel })}>
+                    {children}
+                </div>
+            )}
+            {layout !== 'horizontal' && children}
+        </div>
+    );
+});
+
+export interface TextareaProps extends BaseComponentProps {
+    className?: string;
+    cols?: number;
+    disabled?: boolean;
+    id?: string;
+    label?: ReactNode;
+    name?: string;
+    placeholder?: string;
+    rows?: number;
+    value?: any; // TODO: Move to WithFormsyProps?
+}
+
+const TextareaImpl: FC<TextareaProps & WithFormsyProps> = props => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { className, cols, disabled, id, label, name, placeholder, rows, value, ...baseProps } = props;
+    const { getErrorMessages, getValue, help, required, isValid, layout, onChange, setValue, showError } = baseProps;
+    const showErrors = !isValid() || showError();
+    const errorMessages = getErrorMessages();
+    const markAsInvalid = showErrors && (required || errorMessages?.length > 0);
+
+    const handleBlur = useCallback(
+        (event: FocusEvent<HTMLTextAreaElement>) => {
+            setValue(event.currentTarget.value);
+        },
+        [setValue]
+    );
+
+    const handleChange = useCallback(
+        (event: ChangeEvent<HTMLTextAreaElement>) => {
+            setValue(event.currentTarget.value);
+            onChange?.(event.currentTarget.name, event.currentTarget.value);
+        },
+        [onChange, setValue]
+    );
+
+    const element = (
+        <textarea
+            className={classNames('form-control', { 'is-invalid': markAsInvalid }, className)}
+            cols={cols}
+            disabled={disabled}
+            id={id}
+            name={name}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            placeholder={placeholder}
+            required={required}
+            rows={rows}
+            value={getValue()}
+        />
+    );
+
+    if (layout === 'elementOnly') {
+        return element;
+    }
+
+    return (
+        <Row {...baseProps} htmlFor={id} showErrors={showErrors}>
+            {element}
+            {help && <Help>{help}</Help>}
+            {showErrors && <ErrorMessages messages={errorMessages} />}
+        </Row>
+    );
+};
+
+TextareaImpl.defaultProps = {
+    ...componentDefaultProps,
+    cols: 0,
+    rows: 3,
+    value: '',
+} as any;
+
+export const Textarea = withFormsy(TextareaImpl);

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -1,3 +1,7 @@
+// The components declared in this file are intended to be functional equivalents for components
+// in the "formsy-react-components" package. That package is no longer maintained as of this writing (11/23)
+// and we needed to drop it as a dependency with our move to React 18.
+// Credit: https://github.com/twisty/formsy-react-components
 import React, {
     ChangeEvent,
     FC,

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -290,7 +290,7 @@ function useControlProps<H>(props: any): ControlProps<H> {
             label,
             labelClassName,
             layout,
-            markAsInvalid: (!isValid() || showError()) && (required || messages?.length > 0),
+            markAsInvalid: showError() && (required || messages?.length > 0),
             messages,
             onChange,
             required,

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -191,9 +191,7 @@ const Control: FC<BaseControlProps & LabelProps> = memo(props => {
                 </Label>
             )}
             {layout === 'horizontal' && (
-                <div className={classNames('col-sm-9', elementWrapperClassName, { 'offset-sm-3': !renderLabel })}>
-                    {control}
-                </div>
+                <div className={classNames(elementWrapperClassName, { 'offset-sm-3': !renderLabel })}>{control}</div>
             )}
             {layout !== 'horizontal' && control}
         </div>
@@ -201,6 +199,7 @@ const Control: FC<BaseControlProps & LabelProps> = memo(props => {
 });
 
 Control.defaultProps = {
+    elementWrapperClassName: 'col-sm-9',
     label: null,
     showErrors: true,
 };

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -89,7 +89,10 @@ const ErrorMessages: FC<ErrorMessageProps> = memo(props => {
     );
 });
 
-const Help: FC = ({ children }) => <small className="form-text text-muted">{children}</small>;
+const Help: FC = ({ children }) => {
+    if (!children) return null;
+    return <small className="form-text text-muted">{children}</small>;
+};
 
 interface RequiredSymbolProps {
     required: boolean;
@@ -143,8 +146,17 @@ interface RowProps extends BaseComponentProps, LabelProps {
 }
 
 const Row: FC<RowProps> = memo(props => {
-    const { children, elementWrapperClassName, label, labelClassName, layout, required, rowClassName, showErrors } =
-        props;
+    const {
+        children,
+        elementWrapperClassName,
+        help,
+        label,
+        labelClassName,
+        layout,
+        required,
+        rowClassName,
+        showErrors,
+    } = props;
 
     if (layout === 'elementOnly') {
         return <span>{children}</span>;
@@ -177,9 +189,15 @@ const Row: FC<RowProps> = memo(props => {
             {layout === 'horizontal' && (
                 <div className={classNames('col-sm-9', elementWrapperClassName, { 'offset-sm-3': !renderLabel })}>
                     {children}
+                    <Help>{help}</Help>
                 </div>
             )}
-            {layout !== 'horizontal' && children}
+            {layout !== 'horizontal' && (
+                <>
+                    {children}
+                    <Help>{help}</Help>
+                </>
+            )}
         </div>
     );
 });
@@ -307,16 +325,16 @@ const CheckboxImpl: FC<FormsyCheckboxProps & WithFormsyProps> = props => {
         <Row
             elementWrapperClassName={elementWrapperClassName}
             fakeLabel
+            help={help}
+            htmlFor={id}
             label={label}
             labelClassName={labelClassName}
             layout={layout}
-            htmlFor={id}
             required={required}
             rowClassName={rowClassName}
             showErrors={showErrors_}
         >
             {control}
-            {help && <Help>{help}</Help>}
             {showErrors_ && <ErrorMessages messages={getErrorMessages()} />}
         </Row>
     );
@@ -464,16 +482,16 @@ const InputImpl: FC<FormsyInputProps & WithFormsyProps> = props => {
     return (
         <Row
             elementWrapperClassName={elementWrapperClassName}
+            help={help}
+            htmlFor={id}
             label={label}
             labelClassName={labelClassName}
             layout={layout}
-            htmlFor={id}
             required={required}
             rowClassName={rowClassName}
             showErrors={showErrors_}
         >
             {control}
-            {help && <Help>{help}</Help>}
             {showErrors_ && <ErrorMessages messages={errorMessages} />}
         </Row>
     );
@@ -599,16 +617,16 @@ const SelectImpl: FC<FormsySelectProps> = props => {
     return (
         <Row
             elementWrapperClassName={elementWrapperClassName}
+            help={help}
+            htmlFor={id}
             label={label}
             labelClassName={labelClassName}
             layout={layout}
-            htmlFor={id}
             required={required}
             rowClassName={rowClassName}
             showErrors={showErrors_}
         >
             {control}
-            {help && <Help>{help}</Help>}
             {showErrors_ && <ErrorMessages messages={errorMessages} />}
         </Row>
     );
@@ -715,16 +733,16 @@ const TextAreaImpl: FC<FormsyTextAreaProps & WithFormsyProps> = props => {
     return (
         <Row
             elementWrapperClassName={elementWrapperClassName}
+            help={help}
+            htmlFor={id}
             label={label}
             labelClassName={labelClassName}
             layout={layout}
-            htmlFor={id}
             required={required}
             rowClassName={rowClassName}
             showErrors={showErrors_}
         >
             {control}
-            {help && <Help>{help}</Help>}
             {showErrors_ && <ErrorMessages messages={errorMessages} />}
         </Row>
     );

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import React, { ReactNode } from 'react';
-import { Textarea as OldTextarea } from 'formsy-react-components';
 
 import { FieldLabel } from '../FieldLabel';
 
@@ -100,42 +99,22 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
         } = this.props;
 
         return (
-            <>
-                <OldTextarea
-                    disabled={this.state.isDisabled}
-                    onChange={this.onChange}
-                    cols={cols}
-                    elementWrapperClassName={elementWrapperClassName}
-                    id={queryColumn.fieldKey}
-                    label={this.renderLabel()}
-                    labelClassName={showLabel ? labelClassName : 'hide-label'}
-                    placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
-                    name={name ?? queryColumn.fieldKey}
-                    rowClassName={rowClassName}
-                    rows={rows}
-                    required
-                    // required={required ?? queryColumn.required}
-                    validatePristine={validatePristine}
-                    value={this.getInputValue()}
-                />
-                <Textarea
-                    disabled={this.state.isDisabled}
-                    onChange={this.onChange}
-                    cols={cols}
-                    elementWrapperClassName={elementWrapperClassName}
-                    id={queryColumn.fieldKey}
-                    label={this.renderLabel()}
-                    labelClassName={showLabel ? labelClassName : 'hide-label'}
-                    placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
-                    name={name ?? queryColumn.fieldKey}
-                    rowClassName={rowClassName}
-                    rows={rows}
-                    required
-                    // required={required ?? queryColumn.required}
-                    validatePristine={validatePristine}
-                    value={this.getInputValue()}
-                />
-            </>
+            <Textarea
+                disabled={this.state.isDisabled}
+                onChange={this.onChange}
+                cols={cols}
+                elementWrapperClassName={elementWrapperClassName}
+                id={queryColumn.fieldKey}
+                label={this.renderLabel()}
+                labelClassName={showLabel ? labelClassName : 'hide-label'}
+                placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
+                name={name ?? queryColumn.fieldKey}
+                rowClassName={rowClassName}
+                rows={rows}
+                required={required ?? queryColumn.required}
+                validatePristine={validatePristine}
+                value={this.getInputValue()}
+            />
         );
     }
 }

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -20,15 +20,14 @@ import { FieldLabel } from '../FieldLabel';
 import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
-import { Textarea, TextareaProps } from './FormsyReactComponents';
+import { TextArea, TextAreaProps } from './FormsyReactComponents';
 
-interface TextAreaInputProps extends DisableableInputProps, Omit<TextareaProps, 'onChange'> {
+interface TextAreaInputProps extends DisableableInputProps, Omit<TextAreaProps, 'onChange'> {
     addLabelAsterisk?: boolean;
     onChange?: (value: any) => void;
     queryColumn: QueryColumn;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
     showLabel?: boolean;
-    validatePristine?: boolean;
 }
 
 export class TextAreaInput extends DisableableInput<TextAreaInputProps, DisableableInputState> {
@@ -86,33 +85,31 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
 
     render() {
         const {
-            cols,
-            elementWrapperClassName,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            addLabelAsterisk,
             labelClassName,
             name,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            onChange,
             queryColumn,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            renderFieldLabel,
             required,
-            rowClassName,
-            rows,
             showLabel,
-            validatePristine,
+            ...textAreaProps
         } = this.props;
 
         return (
-            <Textarea
+            <TextArea
+                id={queryColumn.fieldKey}
+                placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
+                {...textAreaProps}
                 disabled={this.state.isDisabled}
                 onChange={this.onChange}
-                cols={cols}
-                elementWrapperClassName={elementWrapperClassName}
-                id={queryColumn.fieldKey}
                 label={this.renderLabel()}
                 labelClassName={showLabel ? labelClassName : 'hide-label'}
-                placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
                 name={name ?? queryColumn.fieldKey}
-                rowClassName={rowClassName}
-                rows={rows}
                 required={required ?? queryColumn.required}
-                validatePristine={validatePristine}
                 value={this.getInputValue()}
             />
         );

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -14,32 +14,22 @@
  * limitations under the License.
  */
 import React, { ReactNode } from 'react';
-import { Textarea } from 'formsy-react-components';
+import { Textarea as OldTextarea } from 'formsy-react-components';
 
 import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
+import { Textarea, TextareaProps } from './FormsyReactComponents';
 
-interface TextAreaInputProps extends DisableableInputProps {
+interface TextAreaInputProps extends DisableableInputProps, Omit<TextareaProps, 'onChange'> {
     addLabelAsterisk?: boolean;
-    allowDisable?: boolean;
-    cols?: number;
-    elementWrapperClassName?: any[] | string;
-    initiallyDisabled?: boolean;
-    label?: any;
-    labelClassName?: any[] | string;
-    name?: string;
-    onChange?: any;
+    onChange?: (value: any) => void;
     queryColumn: QueryColumn;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
-    required?: boolean;
-    rowClassName?: any[] | string;
-    rows?: number;
     showLabel?: boolean;
     validatePristine?: boolean;
-    value?: any;
 }
 
 export class TextAreaInput extends DisableableInput<TextAreaInputProps, DisableableInputState> {
@@ -110,23 +100,42 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
         } = this.props;
 
         return (
-            <Textarea
-                changeDebounceInterval={0}
-                disabled={this.state.isDisabled}
-                onChange={this.onChange}
-                cols={cols}
-                elementWrapperClassName={elementWrapperClassName}
-                id={queryColumn.fieldKey}
-                label={this.renderLabel()}
-                labelClassName={showLabel ? labelClassName : 'hide-label'}
-                placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
-                name={name ?? queryColumn.fieldKey}
-                rowClassName={rowClassName}
-                rows={rows}
-                required={required ?? queryColumn.required}
-                validatePristine={validatePristine}
-                value={this.getInputValue()}
-            />
+            <>
+                <OldTextarea
+                    disabled={this.state.isDisabled}
+                    onChange={this.onChange}
+                    cols={cols}
+                    elementWrapperClassName={elementWrapperClassName}
+                    id={queryColumn.fieldKey}
+                    label={this.renderLabel()}
+                    labelClassName={showLabel ? labelClassName : 'hide-label'}
+                    placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
+                    name={name ?? queryColumn.fieldKey}
+                    rowClassName={rowClassName}
+                    rows={rows}
+                    required
+                    // required={required ?? queryColumn.required}
+                    validatePristine={validatePristine}
+                    value={this.getInputValue()}
+                />
+                <Textarea
+                    disabled={this.state.isDisabled}
+                    onChange={this.onChange}
+                    cols={cols}
+                    elementWrapperClassName={elementWrapperClassName}
+                    id={queryColumn.fieldKey}
+                    label={this.renderLabel()}
+                    labelClassName={showLabel ? labelClassName : 'hide-label'}
+                    placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
+                    name={name ?? queryColumn.fieldKey}
+                    rowClassName={rowClassName}
+                    rows={rows}
+                    required
+                    // required={required ?? queryColumn.required}
+                    validatePristine={validatePristine}
+                    value={this.getInputValue()}
+                />
+            </>
         );
     }
 }

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -84,32 +84,25 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
     };
 
     render() {
-        const {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            addLabelAsterisk,
-            labelClassName,
-            name,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onChange,
-            queryColumn,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            renderFieldLabel,
-            required,
-            showLabel,
-            ...textAreaProps
-        } = this.props;
+        // Extract DisableableInputProps
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { allowDisable, initiallyDisabled, onToggleDisable, ...rest } = this.props;
+        // Extract TextAreaInputProps
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { addLabelAsterisk, onChange, queryColumn, renderFieldLabel, showLabel, ...textAreaProps } = rest;
+        const { labelClassName } = textAreaProps;
 
         return (
             <TextArea
                 id={queryColumn.fieldKey}
+                name={queryColumn.fieldKey}
                 placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
+                required={queryColumn.required}
                 {...textAreaProps}
                 disabled={this.state.isDisabled}
                 onChange={this.onChange}
                 label={this.renderLabel()}
                 labelClassName={showLabel ? labelClassName : 'hide-label'}
-                name={name ?? queryColumn.fieldKey}
-                required={required ?? queryColumn.required}
                 value={this.getInputValue()}
             />
         );

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -20,9 +20,9 @@ import { FieldLabel } from '../FieldLabel';
 import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
-import { TextArea, TextAreaProps } from './FormsyReactComponents';
+import { FormsyTextArea, FormsyTextAreaProps } from './FormsyReactComponents';
 
-interface TextAreaInputProps extends DisableableInputProps, Omit<TextAreaProps, 'onChange'> {
+interface TextAreaInputProps extends DisableableInputProps, Omit<FormsyTextAreaProps, 'onChange'> {
     addLabelAsterisk?: boolean;
     onChange?: (value: any) => void;
     queryColumn: QueryColumn;
@@ -93,7 +93,7 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
         const { labelClassName } = textAreaProps;
 
         return (
-            <TextArea
+            <FormsyTextArea
                 id={queryColumn.fieldKey}
                 name={queryColumn.fieldKey}
                 placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -19,28 +19,16 @@ import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
-import { Input } from './FormsyReactComponents';
+import { Input, InputProps } from './FormsyReactComponents';
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 
-export interface TextInputProps extends DisableableInputProps {
+export interface TextInputProps extends DisableableInputProps, Omit<InputProps, 'onChange'> {
     addLabelAsterisk?: boolean;
-    addonAfter?: ReactNode;
-    elementWrapperClassName?: string;
-    label?: any;
-    labelClassName?: string;
-    name?: string;
-    onChange?: any;
-    placeholder?: string;
+    onChange?: (value: any) => void;
     queryColumn: QueryColumn;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
-    required?: boolean;
-    rowClassName?: string;
     showLabel?: boolean;
     startFocused?: boolean;
-    validatePristine?: boolean;
-    validationError?: string;
-    validations?: string;
-    value?: any;
 }
 
 interface TextInputState extends DisableableInputState {
@@ -119,20 +107,13 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
     };
 
     render() {
-        const {
-            addonAfter,
-            elementWrapperClassName,
-            labelClassName,
-            name,
-            placeholder,
-            queryColumn,
-            required,
-            rowClassName,
-            showLabel,
-            validatePristine,
-            validationError,
-        } = this.props;
-        let { validations } = this.props;
+        // Extract DisableableInputProps
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { allowDisable, initiallyDisabled, onToggleDisable, ...rest } = this.props;
+        // Extract TextInputProps
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { labelClassName, queryColumn, showLabel, startFocused, ...inputProps } = rest;
+        let { validations } = inputProps;
 
         let type = 'text';
         let step: string;
@@ -156,25 +137,21 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
 
         return (
             <Input
-                addonAfter={addonAfter}
-                disabled={this.state.isDisabled}
-                elementWrapperClassName={elementWrapperClassName}
-                help={help}
                 id={queryColumn.fieldKey}
+                name={queryColumn.fieldKey}
+                placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
+                required={queryColumn.required}
+                {...inputProps}
+                componentRef={this.textInput}
+                disabled={this.state.isDisabled}
+                help={help}
                 label={this.renderLabel()}
                 labelClassName={showLabel ? labelClassName : 'hide-label'}
-                name={name ?? queryColumn.fieldKey}
                 onChange={this.onChange}
-                placeholder={placeholder ?? `Enter ${queryColumn.caption.toLowerCase()}`}
-                required={required ?? queryColumn.required}
-                rowClassName={rowClassName}
                 step={step}
                 type={type}
-                validatePristine={validatePristine}
-                validationError={validationError}
                 validations={validations}
                 value={this.getInputValue()}
-                componentRef={this.textInput}
             />
         );
     }

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -111,8 +111,15 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { allowDisable, initiallyDisabled, onToggleDisable, ...rest } = this.props;
         // Extract TextInputProps
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { labelClassName, queryColumn, showLabel, startFocused, ...inputProps } = rest;
+        const {
+            addLabelAsterisk,
+            labelClassName,
+            renderFieldLabel,
+            queryColumn,
+            showLabel,
+            startFocused,
+            ...inputProps
+        } = rest;
         let { validations } = inputProps;
 
         let type = 'text';

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -19,10 +19,10 @@ import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
-import { Input, InputProps } from './FormsyReactComponents';
+import { FormsyInput, FormsyInputProps } from './FormsyReactComponents';
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 
-export interface TextInputProps extends DisableableInputProps, Omit<InputProps, 'onChange'> {
+export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputProps, 'onChange'> {
     addLabelAsterisk?: boolean;
     onChange?: (value: any) => void;
     queryColumn: QueryColumn;
@@ -136,7 +136,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
         }
 
         return (
-            <Input
+            <FormsyInput
                 id={queryColumn.fieldKey}
                 name={queryColumn.fieldKey}
                 placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -13,28 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
-import { Input } from 'formsy-react-components';
+import React, { ReactNode, RefObject } from 'react';
 
 import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
+import { Input } from './FormsyReactComponents';
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 
 export interface TextInputProps extends DisableableInputProps {
     addLabelAsterisk?: boolean;
     addonAfter?: ReactNode;
-    elementWrapperClassName?: any[] | string;
+    elementWrapperClassName?: string;
     label?: any;
-    labelClassName?: any[] | string;
+    labelClassName?: string;
     name?: string;
     onChange?: any;
     placeholder?: string;
     queryColumn: QueryColumn;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
     required?: boolean;
-    rowClassName?: any[] | string;
+    rowClassName?: string;
     showLabel?: boolean;
     startFocused?: boolean;
     validatePristine?: boolean;
@@ -58,7 +58,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
         },
     };
 
-    textInput: Input;
+    textInput: RefObject<any>;
 
     constructor(props: TextInputProps) {
         super(props);
@@ -69,6 +69,8 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
             didFocus: false,
             isDisabled: props.initiallyDisabled,
         };
+
+        this.textInput = React.createRef();
     }
 
     componentDidMount(): void {
@@ -76,8 +78,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
         const { didFocus } = this.state;
 
         if (startFocused && !didFocus && queryColumn && queryColumn.name) {
-            // https://github.com/twisty/formsy-react-components/blob/master/docs/refs.md
-            this.textInput.element.focus();
+            this.textInput.current?.focus();
             this.setState({ didFocus: true });
         }
     }
@@ -89,7 +90,6 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
     renderLabel() {
         const { label, queryColumn, showLabel, allowDisable, addLabelAsterisk, renderFieldLabel } = this.props;
         const { isDisabled } = this.state;
-
 
         if (renderFieldLabel) {
             return renderFieldLabel(queryColumn);
@@ -158,7 +158,6 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
             <Input
                 addonAfter={addonAfter}
                 disabled={this.state.isDisabled}
-                changeDebounceInterval={0}
                 elementWrapperClassName={elementWrapperClassName}
                 help={help}
                 id={queryColumn.fieldKey}
@@ -175,7 +174,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
                 validationError={validationError}
                 validations={validations}
                 value={this.getInputValue()}
-                componentRef={node => (this.textInput = node)}
+                componentRef={this.textInput}
             />
         );
     }

--- a/packages/components/src/internal/components/listing/QueriesListing.tsx
+++ b/packages/components/src/internal/components/listing/QueriesListing.tsx
@@ -15,11 +15,10 @@
  */
 import React, { Component, ReactNode } from 'react';
 import { Link } from 'react-router';
-import { fromJS, List } from 'immutable';
+import { fromJS, List, Map } from 'immutable';
 import { Query } from '@labkey/api';
 
 import { GridColumn } from '../base/models/GridColumn';
-import { QueryInfo } from '../../../public/QueryInfo';
 import { AppURL } from '../../url/AppURL';
 import { naturalSortByProperty } from '../../../public/sort';
 import { Grid } from '../base/Grid';
@@ -28,10 +27,7 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { SchemaListing } from './SchemaListing';
 
-// This should extend GetQueryResponse from @labkey/api but we don't export that type at the moment.
-interface QueryData {
-    description: string;
-    name: string;
+interface QueryData extends Query.GetQueryResponse {
     schemaName: string;
 }
 
@@ -39,9 +35,14 @@ const columns = List([
     new GridColumn({
         index: 'name',
         title: 'Name',
-        cell: (name: string, info: QueryInfo) => {
-            if (name && info) {
-                return <Link to={AppURL.create('q', info.schemaName, info.name).toString()}>{info.title}</Link>;
+        cell: (name: string, map: Map<string, any>) => {
+            if (name && map) {
+                const queryData: QueryData = map.toJS();
+                return (
+                    <Link to={AppURL.create('q', queryData.schemaName, queryData.name).toString()}>
+                        {queryData.title}
+                    </Link>
+                );
             }
             return name;
         },
@@ -125,7 +126,7 @@ export class QueriesListing extends Component<QueriesListingProps, QueriesListin
         if (queries) {
             return (
                 <>
-                    <SchemaListing schemaName={schemaName} hideEmpty={true} asPanel={true} title="Nested Schemas" />
+                    <SchemaListing schemaName={schemaName} hideEmpty asPanel title="Nested Schemas" />
                     {hideEmpty && queries.length === 0 ? null : asPanel ? (
                         <div className="panel panel-default">
                             <div className="panel-heading">{title}</div>


### PR DESCRIPTION
#### Rationale
As a part of our efforts to update to React 18 we're replacing our dependency on `formsy-react-components` (FRC) with an internal implementation. FRC is no longer maintained and does not support React 18. The internal implementation does not implement all the components provided by FRC but rather only the ones we've used. This provides implementations for:

- `Checkbox` (now called `FormsyCheckbox`)
- `Input` (now called `FormsyInput`)
- `Select` (now called `FormsySelect`)
- `Textarea` (now called `FormsyTextArea`)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1352
- https://github.com/LabKey/biologics/pull/2530
- https://github.com/LabKey/sampleManagement/pull/2253
- https://github.com/LabKey/inventory/pull/1106

#### Changes
- Provide logically equivalent implementations for some `formsy-react-components` components. Only props that are used or are useful are supported (e.g. `changeDebounceInterval` is not supported).
- Replace all usages of `formsy-react-components` components within the `@labkey/components` package with internal equivalent components.
- Remove `formsy-react-components` dependency.
