### PR TITLE
Issue 49155: Get proper raw value for measurement units in grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.5-rawUnits.0",
+  "version": "2.390.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.5-rawUnits.0",
+      "version": "2.390.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.4",
+  "version": "2.390.5-rawUnits.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.4",
+      "version": "2.390.5-rawUnits.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.5-rawUnits.0",
+  "version": "2.390.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.4",
+  "version": "2.390.5-rawUnits.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.390.5
+*Released*: 27 November 2023
 * Issue 49155: Get proper raw value for measurement units in grid
 
 ### version 2.390.4

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+* Issue 49155: Get proper raw value for measurement units in grid
+
 ### version 2.390.4
 *Released*: 10 November 2023
 * Fix for reportId url param check in locationHasQueryParamSettings

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -282,7 +282,7 @@ export class EditorModel
                                 return arr;
                             }, [])
                         );
-                    } else if (col.lookup.displayColumn === col.lookup.keyColumn) {
+                    } else if (!col.isUnitsLookup() && col.lookup.displayColumn === col.lookup.keyColumn) {
                         row = row.set(
                             col.name,
                             values.size === 1 ? quoteValueWithDelimiters(values.first()?.display, ',') : undefined

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -262,6 +262,7 @@ export class QueryColumn implements IQueryColumn {
     static ALIQUOTED_FROM = 'AliquotedFrom';
     static ALIQUOTED_FROM_CAPTION = 'Aliquoted From';
     static ALIQUOTED_FROM_LSID = 'AliquotedFromLSID';
+    static MEASUREMENT_UNITS_QUERY = "MeasurementUnits";
 
     static isUserLookup(lookupInfo: Record<string, any>): boolean {
         if (!lookupInfo) return false;
@@ -316,6 +317,10 @@ export class QueryColumn implements IQueryColumn {
             this.name.toLowerCase().indexOf(QueryColumn.DATA_INPUTS.toLowerCase()) !== -1 &&
             (!checkLookup || this.isLookup())
         );
+    }
+
+    isUnitsLookup(): boolean {
+        return this.isLookup && this.lookup.queryName === QueryColumn.MEASUREMENT_UNITS_QUERY;
     }
 
     isAliquotParent(): boolean {


### PR DESCRIPTION
#### Rationale
Issue [49155](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49155)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/265
- https://github.com/LabKey/sampleManagement/pull/2257
- https://github.com/LabKey/biologics/pull/2537
- https://github.com/LabKey/inventory/pull/1109

#### Changes
- Update logic for getting raw values from editable grid to account for measurement unit lookups having a raw value that may be different than the display value, even though the lookup and display columns are the same.
