### PR TITLE
GridPanel, EditableGrid: support shift-select of multiple rows

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.3",
+  "version": "2.395.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.395.3",
+      "version": "2.395.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.3",
+  "version": "2.395.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.395.4
+*Released*: 30 November 2023
+- Adds support for shift-select across multiple rows in any components that leverage `GridPanel` or `EditableGrid`
+
 ### version 2.395.3
 *Released*: 30 November 2023
 - Issue 49148: use LabelOverlay as label for TextChoiceInput fields

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -266,7 +266,6 @@ class GridBody extends PureComponent<GridBodyProps> {
         const { columns, rowKey } = this.props;
         const key = rowKey ? row.get(rowKey) : r;
 
-        // CONSIDER: Could implement row selector at a table level instead and pass the data from the clicked row using data-index
         // style cast to "any" type due to @types/react@16.3.14 switch to csstype package usage which does not declare
         // "textAlign" property correctly for <td> elements.
         return (
@@ -278,7 +277,7 @@ class GridBody extends PureComponent<GridBodyProps> {
                     'grid-row': r % 2 === 1,
                 })}
             >
-                {columns.map((column, c) =>
+                {columns.map((column: GridColumn, c: number) =>
                     column.tableCell ? (
                         <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, r, c)}</Fragment>
                     ) : (

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -240,6 +240,7 @@ interface GridBodyProps {
     highlightRowIndexes?: List<number>;
     isLoading: boolean;
     loadingText: ReactNode;
+    onRowClick?: (row: Map<string, any>, event) => void;
     rowKey: any;
     transpose: boolean;
 }
@@ -262,10 +263,11 @@ class GridBody extends PureComponent<GridBodyProps> {
         );
     }
 
-    renderRow(row: any, r: number, highlight?: boolean): any {
-        const { columns, rowKey } = this.props;
-        const key = rowKey ? row.get(rowKey) : r;
+    renderRow(row: any, rowIndex: number, highlight?: boolean): any {
+        const { columns, onRowClick, rowKey } = this.props;
+        const key = rowKey ? row.get(rowKey) : rowIndex;
 
+        // CONSIDER: Could implement row selector at a table level instead and pass the data from the clicked row using data-index
         // style cast to "any" type due to @types/react@16.3.14 switch to csstype package usage which does not declare
         // "textAlign" property correctly for <td> elements.
         return (
@@ -273,16 +275,17 @@ class GridBody extends PureComponent<GridBodyProps> {
                 key={key}
                 className={classNames({
                     'grid-row-highlight': highlight,
-                    'grid-row-alternate': r % 2 === 0,
-                    'grid-row': r % 2 === 1,
+                    'grid-row-alternate': rowIndex % 2 === 0,
+                    'grid-row': rowIndex % 2 === 1,
                 })}
+                onClick={onRowClick?.bind(this, row)}
             >
-                {columns.map((column: GridColumn, c: number) =>
+                {columns.map((column, colIdx) =>
                     column.tableCell ? (
-                        <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, r, c)}</Fragment>
+                        <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, rowIndex, colIdx)}</Fragment>
                     ) : (
                         <td key={column.index} style={{ textAlign: column.align || 'left' } as any}>
-                            {column.cell(row.get(column.index), row, column, r, c)}
+                            {column.cell(row.get(column.index), row, column, rowIndex, colIdx)}
                         </td>
                     )
                 )}
@@ -341,6 +344,7 @@ export interface GridProps {
     loadingText?: ReactNode;
     messages?: List<Map<string, string>>;
     onColumnDrop?: (sourceIndex: string, targetIndex: string) => void;
+    onRowClick?: (row: Map<string, any>, event) => void;
     responsive?: boolean;
     /**
      * If a rowKey is specified the <Grid> will use it as a lookup key into each row. The associated value
@@ -373,6 +377,7 @@ export const Grid: FC<GridProps> = memo(props => {
         columns,
         headerCell,
         onColumnDrop,
+        onRowClick,
         rowKey,
         highlightRowIndexes,
         gridId,
@@ -403,6 +408,7 @@ export const Grid: FC<GridProps> = memo(props => {
         emptyText,
         isLoading,
         loadingText,
+        onRowClick,
         rowKey,
         transpose,
         highlightRowIndexes,

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -240,7 +240,6 @@ interface GridBodyProps {
     highlightRowIndexes?: List<number>;
     isLoading: boolean;
     loadingText: ReactNode;
-    onRowClick?: (row: Map<string, any>, event) => void;
     rowKey: any;
     transpose: boolean;
 }
@@ -263,9 +262,9 @@ class GridBody extends PureComponent<GridBodyProps> {
         );
     }
 
-    renderRow(row: any, rowIndex: number, highlight?: boolean): any {
-        const { columns, onRowClick, rowKey } = this.props;
-        const key = rowKey ? row.get(rowKey) : rowIndex;
+    renderRow(row: any, r: number, highlight?: boolean): any {
+        const { columns, rowKey } = this.props;
+        const key = rowKey ? row.get(rowKey) : r;
 
         // CONSIDER: Could implement row selector at a table level instead and pass the data from the clicked row using data-index
         // style cast to "any" type due to @types/react@16.3.14 switch to csstype package usage which does not declare
@@ -275,17 +274,16 @@ class GridBody extends PureComponent<GridBodyProps> {
                 key={key}
                 className={classNames({
                     'grid-row-highlight': highlight,
-                    'grid-row-alternate': rowIndex % 2 === 0,
-                    'grid-row': rowIndex % 2 === 1,
+                    'grid-row-alternate': r % 2 === 0,
+                    'grid-row': r % 2 === 1,
                 })}
-                onClick={onRowClick?.bind(this, row)}
             >
-                {columns.map((column, colIdx) =>
+                {columns.map((column, c) =>
                     column.tableCell ? (
-                        <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, rowIndex, colIdx)}</Fragment>
+                        <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, r, c)}</Fragment>
                     ) : (
                         <td key={column.index} style={{ textAlign: column.align || 'left' } as any}>
-                            {column.cell(row.get(column.index), row, column, rowIndex, colIdx)}
+                            {column.cell(row.get(column.index), row, column, r, c)}
                         </td>
                     )
                 )}
@@ -344,7 +342,6 @@ export interface GridProps {
     loadingText?: ReactNode;
     messages?: List<Map<string, string>>;
     onColumnDrop?: (sourceIndex: string, targetIndex: string) => void;
-    onRowClick?: (row: Map<string, any>, event) => void;
     responsive?: boolean;
     /**
      * If a rowKey is specified the <Grid> will use it as a lookup key into each row. The associated value
@@ -377,7 +374,6 @@ export const Grid: FC<GridProps> = memo(props => {
         columns,
         headerCell,
         onColumnDrop,
-        onRowClick,
         rowKey,
         highlightRowIndexes,
         gridId,
@@ -408,7 +404,6 @@ export const Grid: FC<GridProps> = memo(props => {
         emptyText,
         isLoading,
         loadingText,
-        onRowClick,
         rowKey,
         transpose,
         highlightRowIndexes,

--- a/packages/components/src/public/QueryModel/GridPanel.spec.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.spec.tsx
@@ -338,7 +338,7 @@ describe('GridPanel', () => {
         let checkbox = getCheckbox(wrapper, index + 1);
         const event = { target: { checked: expectedState } };
         checkbox.simulate('change', event);
-        expect(actions.selectRow).toHaveBeenCalledWith(model.id, expectedState, row);
+        expect(actions.selectRow).toHaveBeenCalledWith(model.id, expectedState, row, false);
         const newSelections = new Set(model.selections);
 
         if (expectedState) {

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -440,17 +440,6 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         view: ViewAction;
     };
 
-    onRowClick = (row: Map<string, any>, event): void => {
-        const { actions, model } = this.props;
-        const nodeName = event.target.nodeName?.toLowerCase();
-
-        if (nodeName === 'td' || nodeName === 'tr') {
-            const checked = row.get(GRID_SELECTION_INDEX) === true;
-            actions.selectRow(model.id, !checked, row.toJS(), event.shiftKey);
-            document.getSelection().removeAllRanges();
-        }
-    };
-
     createGridActionValues = (): ActionValue[] => {
         const { model } = this.props;
         const { filterArray, sorts } = model;
@@ -1137,7 +1126,6 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                                     columns={this.getGridColumns()}
                                     data={model.gridData}
                                     highlightRowIndexes={this.getHighlightRowIndexes()}
-                                    onRowClick={allowSelections ? this.onRowClick : undefined}
                                 />
                             )}
                         </div>

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType, FC, memo, PureComponent, ReactNode, useCallback, useMemo, useState } from 'react';
 import classNames from 'classnames';
-import { fromJS, List, Set } from 'immutable';
+import { fromJS, List, Map, Set } from 'immutable';
 import { Filter, getServerContext, Query } from '@labkey/api';
 
 import { MenuItem, SplitButton } from 'react-bootstrap';
@@ -438,6 +438,16 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         search: SearchAction;
         sort: SortAction;
         view: ViewAction;
+    };
+
+    onRowClick = (row: Map<string, any>, event): void => {
+        const { actions, model } = this.props;
+        const nodeName = event.target.nodeName?.toLowerCase();
+
+        if (nodeName === 'td' || nodeName === 'tr') {
+            const checked = row.get(GRID_SELECTION_INDEX) === true;
+            actions.selectRow(model.id, !checked, row.toJS());
+        }
     };
 
     createGridActionValues = (): ActionValue[] => {
@@ -1130,6 +1140,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                                     columns={this.getGridColumns()}
                                     data={model.gridData}
                                     highlightRowIndexes={this.getHighlightRowIndexes()}
+                                    onRowClick={allowSelections ? this.onRowClick : undefined}
                                 />
                             )}
                         </div>

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -446,7 +446,8 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
         if (nodeName === 'td' || nodeName === 'tr') {
             const checked = row.get(GRID_SELECTION_INDEX) === true;
-            actions.selectRow(model.id, !checked, row.toJS());
+            actions.selectRow(model.id, !checked, row.toJS(), event.shiftKey);
+            document.getSelection().removeAllRanges();
         }
     };
 
@@ -511,11 +512,11 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         }
     };
 
-    selectRow = (row, event): void => {
+    selectRow = (row: Map<string, any>, event): void => {
         const { model, actions } = this.props;
         const checked = event.target.checked === true;
         // Have to call toJS() on the row because <Grid /> converts rows to Immutable objects.
-        actions.selectRow(model.id, checked, row.toJS());
+        actions.selectRow(model.id, checked, row.toJS(), event.shiftKey);
     };
 
     selectPage = (event): void => {
@@ -924,18 +925,14 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 index: GRID_SELECTION_INDEX,
                 title: '',
                 showHeader: true,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                cell: (selected: boolean, row: any): ReactNode => {
-                    const onChange = (event): void => this.selectRow(row, event);
-                    const disabled = isLoading || isLoadingSelections;
+                cell: (selected: boolean, row: Map<string, any>): ReactNode => {
                     return (
-                        // eslint-disable-next-line react/jsx-no-bind
                         <input
-                            className="grid-panel__row-checkbox"
-                            type="checkbox"
-                            disabled={disabled}
                             checked={selected === true}
-                            onChange={onChange} // eslint-disable-line
+                            className="grid-panel__row-checkbox"
+                            disabled={isLoading || isLoadingSelections}
+                            onClick={this.selectRow.bind(this, row)} // eslint-disable-line
+                            type="checkbox"
                         />
                     );
                 },

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -1,4 +1,14 @@
-import React, { ComponentType, FC, memo, PureComponent, ReactNode, useCallback, useMemo, useState } from 'react';
+import React, {
+    ChangeEvent,
+    ComponentType,
+    FC,
+    memo,
+    PureComponent,
+    ReactNode,
+    useCallback,
+    useMemo,
+    useState,
+} from 'react';
 import classNames from 'classnames';
 import { fromJS, List, Map, Set } from 'immutable';
 import { Filter, getServerContext, Query } from '@labkey/api';
@@ -35,6 +45,10 @@ import { Grid } from '../../internal/components/base/Grid';
 
 import { Alert } from '../../internal/components/base/Alert';
 
+import { userCanEditSharedViews } from '../../internal/app/utils';
+
+import { User } from '../../internal/components/base/models/User';
+
 import { ActionValue } from './grid/actions/Action';
 import { FilterAction } from './grid/actions/Filter';
 import { SearchAction } from './grid/actions/Search';
@@ -59,8 +73,6 @@ import { CustomizeGridViewModal } from './CustomizeGridViewModal';
 import { ManageViewsModal } from './ManageViewsModal';
 import { Actions, InjectedQueryModels, RequiresModelAndActions, withQueryModels } from './withQueryModels';
 import { ChartPanel } from './ChartPanel';
-import { userCanEditSharedViews } from '../../internal/app/utils';
-import { User } from '../../internal/components/base/models/User';
 
 export interface GridPanelProps<ButtonsComponentProps> {
     ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
@@ -476,8 +488,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                     actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
                 } else if (filter.getColumnName().indexOf('/') > -1) {
                     const lookupCol = model.getColumn(filter.getColumnName().split('/')[0]);
-                    if (lookupCol)
-                        actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
+                    if (lookupCol) actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
                 }
             }
         });
@@ -501,11 +512,11 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         }
     };
 
-    selectRow = (row: Map<string, any>, event): void => {
+    selectRow = (row: Map<string, any>, event: ChangeEvent<HTMLInputElement>): void => {
         const { model, actions } = this.props;
         const checked = event.target.checked === true;
-        // Have to call toJS() on the row because <Grid /> converts rows to Immutable objects.
-        actions.selectRow(model.id, checked, row.toJS(), event.shiftKey);
+        // Look through to the nativeEvent to determine if the shift key is engaged.
+        actions.selectRow(model.id, checked, row.toJS(), (event.nativeEvent as any).shiftKey ?? false);
     };
 
     selectPage = (event): void => {
@@ -920,7 +931,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                             checked={selected === true}
                             className="grid-panel__row-checkbox"
                             disabled={isLoading || isLoadingSelections}
-                            onClick={this.selectRow.bind(this, row)} // eslint-disable-line
+                            onChange={this.selectRow.bind(this, row)} // eslint-disable-line
                             type="checkbox"
                         />
                     );

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -215,6 +215,16 @@ const DEFAULT_OFFSET = 0;
 const DEFAULT_MAX_ROWS = 20;
 
 /**
+ * An object that describes the current selection pivot row for shift-select behavior. When a single row is selected
+ * it becomes the "pivot" row for shift-select behavior. Subsequently, if a user selects another row while holding
+ * the shift key then all rows between the pivot row and the newly selected row will be selected/deselected.
+ */
+interface SelectionPivot {
+    checked: boolean;
+    selection: string;
+}
+
+/**
  * This is the base model used to store all the data for a query. At a high level the QueryModel API is a wrapper around
  * the [selectRows](https://labkey.github.io/labkey-api-js/modules/Query.html#selectRows) API.
  * If you need to retrieve data from a LabKey table or query, so you can render it in a React
@@ -386,6 +396,10 @@ export class QueryModel {
      */
     readonly selectedReportId: string;
     /**
+     * [[SelectionPivot]] object that describes the current selection pivot row for shift-select behavior.
+     */
+    readonly selectionPivot?: SelectionPivot;
+    /**
      * Array of row keys for row selections in the QueryModel.
      */
     readonly selections?: Set<string>; // Note: ES6 Set is being used here, not Immutable Set.
@@ -471,6 +485,7 @@ export class QueryModel {
         this.rowCount = undefined;
         this.rowsLoadingState = LoadingState.INITIALIZED;
         this.selectedReportId = undefined;
+        this.selectionPivot = undefined;
         this.selections = undefined;
         this.selectionsError = undefined;
         this.selectionsLoadingState = LoadingState.INITIALIZED;

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -219,7 +219,7 @@ const DEFAULT_MAX_ROWS = 20;
  * it becomes the "pivot" row for shift-select behavior. Subsequently, if a user selects another row while holding
  * the shift key then all rows between the pivot row and the newly selected row will be selected/deselected.
  */
-interface SelectionPivot {
+export interface SelectionPivot {
     checked: boolean;
     selection: string;
 }

--- a/packages/components/src/public/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/public/QueryModel/QueryModelLoader.ts
@@ -105,7 +105,7 @@ export interface QueryModelLoader {
      * @param checked: boolean, the checked status of the ids
      * @param selections: A list of stringified RowIds.
      */
-    setSelections: (model: QueryModel, checked, selections: string[]) => Promise<SelectResponse>;
+    setSelections: (model: QueryModel, checked: boolean, selections: string[]) => Promise<SelectResponse>;
 }
 
 export const DefaultQueryModelLoader: QueryModelLoader = {

--- a/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
@@ -3,8 +3,6 @@ import { mount } from 'enzyme';
 import { createMemoryHistory, InjectedRouter, Route, Router } from 'react-router';
 import { Filter } from '@labkey/api';
 
-import { enableMapSet } from 'immer';
-
 import { makeQueryInfo, makeTestData, sleep } from '../../internal/test/testHelpers';
 import { MockQueryModelLoader } from '../../test/MockQueryModelLoader';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
@@ -42,7 +40,6 @@ let AMINO_ACIDS_QUERY_INFO: QueryInfo;
 let AMINO_ACIDS_DATA: RowsResponse;
 
 beforeAll(() => {
-    enableMapSet();
     MIXTURES_QUERY_INFO = makeQueryInfo(mixturesQueryInfo);
     AMINO_ACIDS_QUERY_INFO = makeQueryInfo(aminoAcidsQueryInfo);
     AMINO_ACIDS_DATA = makeTestData(aminoAcidsQuery);

--- a/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
@@ -3,6 +3,8 @@ import { mount } from 'enzyme';
 import { createMemoryHistory, InjectedRouter, Route, Router } from 'react-router';
 import { Filter } from '@labkey/api';
 
+import { enableMapSet } from 'immer';
+
 import { makeQueryInfo, makeTestData, sleep } from '../../internal/test/testHelpers';
 import { MockQueryModelLoader } from '../../test/MockQueryModelLoader';
 import mixturesQueryInfo from '../../test/data/mixtures-getQueryDetails.json';
@@ -17,12 +19,12 @@ import { LoadingState } from '../LoadingState';
 
 import { QuerySort } from '../QuerySort';
 
+import { waitForLifecycle } from '../../internal/test/enzymeTestHelpers';
+
 import { Actions, QueryModelMap, withQueryModels } from './withQueryModels';
 import { QueryModel } from './QueryModel';
 
 import { RowsResponse } from './QueryModelLoader';
-import {enableMapSet} from "immer";
-import {waitForLifecycle} from "../../internal/test/enzymeTestHelpers";
 
 /**
  * Note: All of the tests in this file look a tad weird. We create a component that resets local variables on render

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -435,6 +435,12 @@ export function withQueryModels<Props>(
                 this.setState(
                     produce<State>(draft => {
                         const model = draft.queryModels[id];
+
+                        // If there are selections made, then ensure the model.selections is initialized
+                        if (!model.selections && selections.length > 0) {
+                            model.selections = new Set();
+                        }
+
                         selections.forEach(selection => {
                             if (checked) {
                                 model.selections.add(selection);

--- a/packages/components/src/test/MockQueryModelLoader.ts
+++ b/packages/components/src/test/MockQueryModelLoader.ts
@@ -1,6 +1,7 @@
 import { QueryModelLoader, RowsResponse } from '../public/QueryModel/QueryModelLoader';
 import { QueryInfo } from '../public/QueryInfo';
 import { QueryModel } from '../public/QueryModel/QueryModel';
+import { SelectResponse } from '../internal/actions';
 
 export class MockQueryModelLoader implements QueryModelLoader {
     queryInfo: QueryInfo;
@@ -52,8 +53,12 @@ export class MockQueryModelLoader implements QueryModelLoader {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    setSelections = (model: QueryModel, selections): Promise<never> => {
-        return Promise.reject('Not implemented!');
+    setSelections = (model: QueryModel, checked: boolean, selections: string[]): Promise<SelectResponse> => {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve({ count: selections.length });
+            }, 0);
+        });
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -67,8 +72,12 @@ export class MockQueryModelLoader implements QueryModelLoader {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    clearSelections = (model: QueryModel): Promise<never> => {
-        return Promise.reject('Not implemented!');
+    clearSelections = (model: QueryModel): Promise<SelectResponse> => {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve({ count: 0 });
+            }, 0);
+        });
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/components/src/test/jest.setup.react.ts
+++ b/packages/components/src/test/jest.setup.react.ts
@@ -1,4 +1,9 @@
 import '@testing-library/jest-dom'; // add custom jest matchers from jest-dom
 require('blob-polyfill');
+import { enableMapSet, enablePatches } from 'immer';
+
+// See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
+enableMapSet();
+enablePatches();
 
 Object.defineProperty(window, '__react-beautiful-dnd-disable-dev-warnings', { value: true, writable: false });

--- a/packages/components/src/test/jest.setup.ts
+++ b/packages/components/src/test/jest.setup.ts
@@ -15,10 +15,15 @@
  */
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { enableMapSet, enablePatches } from 'immer';
 
 // Enzyme expects an adapter to be configured
 // http://airbnb.io/enzyme/docs/installation/react-16.html
 configure({ adapter: new Adapter() });
+
+// See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
+enableMapSet();
+enablePatches();
 
 // This silences errors related to our Page component using window.scrollTo. JSDom doesn't implement scrollTo, but that
 // is ok, we aren't testing that behavior.


### PR DESCRIPTION
#### Rationale
This adds support for shift-select across multiple rows in any components that leverage `GridPanel` or `EditableGrid`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1359
- https://github.com/LabKey/biologics/pull/2545
- https://github.com/LabKey/sampleManagement/pull/2264
- https://github.com/LabKey/inventory/pull/1113

#### Changes
- Add a `selectionPivot` to keep track of selection state for pivoting shift-selection around
- Interrogate change events for `shiftKey`
- unit tests for `selectRow` action on `QueryModel`
