### PR TITLE
FormsyReactComponents.tsx fix for handling of rowClassName prop

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.2-formsyRowClassNameFix.0",
+  "version": "2.395.2-formsyRowClassNameFix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.395.2-formsyRowClassNameFix.0",
+      "version": "2.395.2-formsyRowClassNameFix.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.2",
+  "version": "2.395.2-formsyRowClassNameFix.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.395.2",
+      "version": "2.395.2-formsyRowClassNameFix.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.4",
+  "version": "2.396.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.395.4",
+      "version": "2.396.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.4",
+  "version": "2.396.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.2-formsyRowClassNameFix.0",
+  "version": "2.395.2-formsyRowClassNameFix.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.395.2",
+  "version": "2.395.2-formsyRowClassNameFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- FormsyReactComponents.tsx fix for handling of rowClassName prop
+
 ### version 2.395.2
 *Released*: 29 November 2023
 - Issue 49113: Better handling for ListDesignerPanels case where the only error is a form error for saveDomain()

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.396.0
+*Released*: 1 December 2023
 - FormsyReactComponents.tsx fix for handling of rowClassName prop
 
 ### version 2.395.4

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -170,12 +170,8 @@ const Control: FC<BaseControlProps & LabelProps> = memo(props => {
         return control;
     }
 
-    const rowClassNames = [];
-    if (rowClassName !== undefined) {
-        rowClassNames.push(rowClassName);
-    } else {
-        rowClassNames.push('form-group');
-
+    const rowClassNames = [rowClassName ?? 'form-group'];
+    if (rowClassName === undefined) {
         if (showErrors) {
             rowClassNames.push('has-error');
             rowClassNames.push('has-feedback');

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -170,18 +170,21 @@ const Control: FC<BaseControlProps & LabelProps> = memo(props => {
         return control;
     }
 
-    const rowClassNames = ['form-group'];
+    const rowClassNames = [];
+    if (rowClassName !== undefined) {
+        rowClassNames.push(rowClassName);
+    } else {
+        rowClassNames.push('form-group');
 
-    if (showErrors) {
-        rowClassNames.push('has-error');
-        rowClassNames.push('has-feedback');
+        if (showErrors) {
+            rowClassNames.push('has-error');
+            rowClassNames.push('has-feedback');
+        }
+
+        if (layout === 'horizontal') {
+            rowClassNames.push('row');
+        }
     }
-
-    if (layout === 'horizontal') {
-        rowClassNames.push('row');
-    }
-
-    rowClassNames.push(rowClassName);
 
     // We should render the label if there is label text defined, or if the
     // component is required (so a required symbol is displayed in the label tag)


### PR DESCRIPTION
#### Rationale
I noticed a layout issue with the freezer/storage designer properties panel:
<img width="807" alt="Screenshot 2023-11-29 at 8 51 52 AM" src="https://github.com/LabKey/labkey-ui-components/assets/6411206/c27b38ac-0cd2-45b2-9e1b-7138858f3058">

I believe this was a result of the change in the PR to replace formsy-react-components (https://github.com/LabKey/labkey-ui-components/pull/1352). I only found two usages that passed in this "rowClassName" prop: this one for LKFM and a second in LKB for the sequence annotation form checkbox input.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1352
- https://github.com/LabKey/labkey-ui-components/pull/1360
- https://github.com/LabKey/sampleManagement/pull/2267
- https://github.com/LabKey/biologics/pull/2549
- https://github.com/LabKey/inventory/pull/1115

#### Changes
- FormsyReactComponents.tsx fix to use rowClassName when provided 
