### PR TITLE
Issue 49005: Field editor assigning a lookup to exp.Materials then switching to Samples type should retain schema/query for lookup

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.0-fb-assayLookupSample49005.0",
+  "version": "2.396.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.396.0-fb-assayLookupSample49005.0",
+      "version": "2.396.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.0",
+  "version": "2.396.0-fb-assayLookupSample49005.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.396.0",
+      "version": "2.396.0-fb-assayLookupSample49005.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.0",
+  "version": "2.396.0-fb-assayLookupSample49005.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.0-fb-assayLookupSample49005.0",
+  "version": "2.396.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD December 2023
+### version 2.396.1
+*Released*: 7 December 2023
 - Issue 49005: Field editor assigning a lookup to exp.Materials then switching to Samples type should retain schema/query for lookup
 
 ### version 2.396.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD December 2023
+- Issue 49005: Field editor assigning a lookup to exp.Materials then switching to Samples type should retain schema/query for lookup
+
 ### version 2.396.0
 *Released*: 1 December 2023
 - FormsyReactComponents.tsx fix for handling of rowClassName prop

--- a/packages/components/src/internal/components/domainproperties/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.test.ts
@@ -739,6 +739,33 @@ describe('domain properties actions', () => {
         expect(field.dimension).toBe(false);
     });
 
+    test('updateDataType Sample data type, new field', () => {
+        let field = DomainField.create({});
+        field = updateDataType(field, 'sample');
+        expect(field.dataType).toBe(SAMPLE_TYPE);
+        expect(field.lookupSchema).toBe('exp');
+        expect(field.lookupQuery).toBe('Materials');
+        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|Materials');
+    });
+
+    test('updateDataType Sample data type, saved field', () => {
+        let field = DomainField.create({ propertyId: 1 });
+        field = updateDataType(field, 'sample');
+        expect(field.dataType).toBe(SAMPLE_TYPE);
+        expect(field.lookupSchema).toBe('exp');
+        expect(field.lookupQuery).toBe('Materials');
+        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|Materials');
+    });
+
+    test('updateDataType Sample data type, saved lookup field', () => {
+        let field = DomainField.create({ propertyId: 1, lookupSchema: 'exp', lookupQuery: 'Materials' });
+        field = updateDataType(field, 'sample');
+        expect(field.dataType).toBe(SAMPLE_TYPE);
+        expect(field.lookupSchema).toBe('exp');
+        expect(field.lookupQuery).toBe('Materials');
+        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|Materials');
+    });
+
     test('updateDomainField principalConceptCode', () => {
         let domainDesign = DomainDesign.create({
             fields: [{ name: 'field1', principalConceptCode: undefined }],

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -710,6 +710,9 @@ export function updateDataType(field: DomainField, value: any): DomainField {
 
         if (field.isNew()) {
             field = DomainField.updateDefaultValues(field);
+        } else if (dataType === SAMPLE_TYPE) {
+            // Issue 49005: set default lookup schema/query for change to Sample data type
+            field = field.merge(DomainField.resolveLookupConfig(field, dataType)) as DomainField;
         }
 
         if (field.isTextChoiceField()) {

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1006,7 +1006,7 @@ export class DomainField
         return field;
     }
 
-    private static resolveLookupConfig(rawField: Partial<IDomainField>, dataType: PropDescType): ILookupConfig {
+    static resolveLookupConfig(rawField: Partial<IDomainField>, dataType: PropDescType): ILookupConfig {
         const lookupType = LOOKUP_TYPE.set('rangeURI', rawField.rangeURI) as PropDescType;
         const lookupContainer = rawField.lookupContainer === null ? undefined : rawField.lookupContainer;
         const lookupSchema = resolveLookupSchema(rawField, dataType);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49005

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1363
- https://github.com/LabKey/sampleManagement/pull/2280
- https://github.com/LabKey/biologics/pull/2563

#### Changes
- domainproperties/actions updateDataType() should resolve lookup config after changing type to Sample for an existing field (similar to what it does for new fields)
