### PR TITLE
Impove error handling when BarTender Service endpoint is set

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.1-fb-49250-btCSP.0",
+  "version": "2.396.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.396.1-fb-49250-btCSP.0",
+      "version": "2.396.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.1",
+  "version": "2.396.1-fb-49250-btCSP.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.396.1",
+      "version": "2.396.1-fb-49250-btCSP.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.1",
+  "version": "2.396.1-fb-49250-btCSP.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.1-fb-49250-btCSP.0",
+  "version": "2.396.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.396.2
+*Released*: 11 December 2023
+- Secure Issue 49250: BarTender: CSP parsing of the Service URL fails for relative and partial URIs
+
 ### version 2.396.1
 *Released*: 7 December 2023
 - Issue 49005: Field editor assigning a lookup to exp.Materials then switching to Samples type should retain schema/query for lookup

--- a/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
+++ b/packages/components/src/internal/components/labels/BarTenderSettingsForm.tsx
@@ -158,7 +158,8 @@ export const BarTenderSettingsForm: FC<Props> = memo(props => {
             setDirty(false);
             onSuccess?.();
         } catch (e) {
-            setFailureMessage(FAILED_TO_SAVE_MESSAGE);
+            setFailureMessage(resolveErrorMessage(e) ?? FAILED_TO_SAVE_MESSAGE);
+            setConnectionValidated(false);
         } finally {
             setSubmitting(false);
         }


### PR DESCRIPTION
#### Rationale
Recent change to add BT service URL to the CSP caused an error with some existing test data

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/2288
- https://github.com/LabKey/biologics/pull/2568
- https://github.com/LabKey/labkey-ui-components/pull/1366


#### Changes
- Show returned error message
- Fix error message not being displayed