### PR TITLE
Issue 49237: From app settings page, set defaultDateFormat whenever defaultDateTimeFormat is changed

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.397.1",
+  "version": "2.397.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.397.1",
+      "version": "2.397.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.2",
+  "version": "2.396.2-fb-appDateFormat49237.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.396.2",
+      "version": "2.396.2-fb-appDateFormat49237.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.396.2",
+  "version": "2.396.2-fb-appDateFormat49237.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.397.1",
+  "version": "2.397.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD December 2023
+### version 2.397.2
+*Released*: 13 December 2023
 - Issue 49237: From app settings page, set defaultDateFormat whenever defaultDateTimeFormat is changed
 
 ### version 2.397.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD December 2023
+- Issue 49237: From app settings page, set defaultDateFormat whenever defaultDateTimeFormat is changed
+
 ### version 2.396.2
 *Released*: 11 December 2023
 - Secure Issue 49250: BarTender: CSP parsing of the Service URL fails for relative and partial URIs

--- a/packages/components/src/internal/components/container/FolderAPIWrapper.ts
+++ b/packages/components/src/internal/components/container/FolderAPIWrapper.ts
@@ -24,6 +24,7 @@ export interface ProjectSettingsOptions {
 }
 
 export interface UpdateProjectSettingsOptions {
+    defaultDateFormat?: string;
     defaultDateTimeFormat?: string;
 }
 

--- a/packages/components/src/internal/components/project/ProjectLookAndFeelForm.test.tsx
+++ b/packages/components/src/internal/components/project/ProjectLookAndFeelForm.test.tsx
@@ -39,6 +39,7 @@ describe('ProjectLookAndFeelForm', () => {
 
         expect(api.updateProjectLookAndFeelSettings).toHaveBeenCalledWith(
             {
+                defaultDateFormat: 'yyyy-MM-dd HH:mmaa',
                 defaultDateTimeFormat: 'yyyy-MM-dd HH:mmaa',
             },
             TEST_PROJECT_CONTAINER.path
@@ -73,6 +74,7 @@ describe('ProjectLookAndFeelForm', () => {
 
         expect(api.updateProjectLookAndFeelSettings).toHaveBeenCalledWith(
             {
+                defaultDateFormat: 'yyyy-MM-dd HH:mmb',
                 defaultDateTimeFormat: 'yyyy-MM-dd HH:mmb',
             },
             TEST_PROJECT_CONTAINER.path

--- a/packages/components/src/internal/components/project/ProjectLookAndFeelForm.tsx
+++ b/packages/components/src/internal/components/project/ProjectLookAndFeelForm.tsx
@@ -79,6 +79,7 @@ export const ProjectLookAndFeelForm: FC<Props> = memo(props => {
 
         try {
             const options: UpdateProjectSettingsOptions = {
+                defaultDateFormat: dateTimeFormat, // Issue 49237: when defaultDateTimeFormat is set from app, use the same format value for defaultDateFormat
                 defaultDateTimeFormat: dateTimeFormat,
             };
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49237
A previous story added the ability to set the Date/Time format for the app via the app settings page. This PR extends that so that we use that same date format as the Date format for the project/container as well when edited via the app.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1238
- https://github.com/LabKey/labkey-ui-components/pull/1367
- https://github.com/LabKey/sampleManagement/pull/2291
- https://github.com/LabKey/biologics/pull/2570
- https://github.com/LabKey/inventory/pull/1124

#### Changes
- set defaultDateFormat from app whenever defaultDateTimeFormat is changed
