### PR TITLE
Add moveRows to Query module in @labkey/api

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0",
+  "version": "2.399.0-fb-moveRowsJSAPI.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.399.0",
+      "version": "2.399.0-fb-moveRowsJSAPI.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.27.0",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.0.tgz",
-      "integrity": "sha512-Hs1TahaNp1K3JrvdpGCB0m8as1JidJImxyRD6NG5UK897z90tK1L3o3PihjyoU3oJ11nV/iePXJbG31c4C44gQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.0.tgz",
+      "integrity": "sha512-KhCQzww5wRKGO0v8Uflzj874n0Dz61e8TH3lvpC0RZIAAQC2V92bX9jjErZYKVA70WFWZMBB3ConTi3KtQYSMQ=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -20223,9 +20223,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.0.tgz",
-      "integrity": "sha512-Hs1TahaNp1K3JrvdpGCB0m8as1JidJImxyRD6NG5UK897z90tK1L3o3PihjyoU3oJ11nV/iePXJbG31c4C44gQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.0.tgz",
+      "integrity": "sha512-KhCQzww5wRKGO0v8Uflzj874n0Dz61e8TH3lvpC0RZIAAQC2V92bX9jjErZYKVA70WFWZMBB3ConTi3KtQYSMQ=="
     },
     "@labkey/build": {
       "version": "6.16.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.0",
+  "version": "2.399.0-fb-moveRowsJSAPI.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.399.0-fb-moveRowsJSAPI.0",
+      "version": "2.399.0-fb-moveRowsJSAPI.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.0",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.2",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.0.tgz",
-      "integrity": "sha512-KhCQzww5wRKGO0v8Uflzj874n0Dz61e8TH3lvpC0RZIAAQC2V92bX9jjErZYKVA70WFWZMBB3ConTi3KtQYSMQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.2.tgz",
+      "integrity": "sha512-JpZbWSROGn0SkEQ9gAOZwb2iNBzEZ+2e8cIof3f5lR0CNz2tIje2lyYRcNa0U3wGqRAcEbhfsAb2khXz+x2WoQ=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -20223,9 +20223,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.0.tgz",
-      "integrity": "sha512-KhCQzww5wRKGO0v8Uflzj874n0Dz61e8TH3lvpC0RZIAAQC2V92bX9jjErZYKVA70WFWZMBB3ConTi3KtQYSMQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.2.tgz",
+      "integrity": "sha512-JpZbWSROGn0SkEQ9gAOZwb2iNBzEZ+2e8cIof3f5lR0CNz2tIje2lyYRcNa0U3wGqRAcEbhfsAb2khXz+x2WoQ=="
     },
     "@labkey/build": {
       "version": "6.16.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.1",
+  "version": "2.399.0-fb-moveRowsJSAPI.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.399.0-fb-moveRowsJSAPI.1",
+      "version": "2.399.0-fb-moveRowsJSAPI.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.2",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.2.tgz",
-      "integrity": "sha512-JpZbWSROGn0SkEQ9gAOZwb2iNBzEZ+2e8cIof3f5lR0CNz2tIje2lyYRcNa0U3wGqRAcEbhfsAb2khXz+x2WoQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
+      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -20223,9 +20223,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.2.tgz",
-      "integrity": "sha512-JpZbWSROGn0SkEQ9gAOZwb2iNBzEZ+2e8cIof3f5lR0CNz2tIje2lyYRcNa0U3wGqRAcEbhfsAb2khXz+x2WoQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
+      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
     },
     "@labkey/build": {
       "version": "6.16.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.3",
+  "version": "2.399.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.399.0-fb-moveRowsJSAPI.3",
+      "version": "2.399.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
+        "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
-      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
+      "version": "1.28.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
+      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -20223,9 +20223,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
-      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
+      "version": "1.28.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
+      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
       "version": "6.16.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.2",
+  "version": "2.399.0-fb-moveRowsJSAPI.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.399.0-fb-moveRowsJSAPI.2",
+      "version": "2.399.0-fb-moveRowsJSAPI.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3336,9 +3336,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
-      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
+      "version": "1.27.1-fb-moveRowsJSAPI.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
+      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -20223,9 +20223,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
-      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
+      "version": "1.27.1-fb-moveRowsJSAPI.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
+      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
     },
     "@labkey/build": {
       "version": "6.16.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.3",
+  "version": "2.399.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
+    "@labkey/api": "1.28.0",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.2",
+  "version": "2.399.0-fb-moveRowsJSAPI.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
+    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.1",
+  "version": "2.399.0-fb-moveRowsJSAPI.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.2",
+    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0-fb-moveRowsJSAPI.0",
+  "version": "2.399.0-fb-moveRowsJSAPI.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.0",
+    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.2",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.399.0",
+  "version": "2.399.0-fb-moveRowsJSAPI.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.27.0",
+    "@labkey/api": "1.27.1-fb-moveRowsJSAPI.0",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 2.399.1
+*Released*: 19 December 2023
 - Update @labkey/api and use moveRows() function
 - Include fix for Issue 49164: Datepicker in editable grid needs to account for the sticky footer when at the bottom of the grid
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Update @labkey/api and use moveRows() function
+
 ### version 2.399.0
 *Released*: 15 December 2023
 - Consolidate move entities to MoveRowsAction in query controller

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - Update @labkey/api and use moveRows() function
+- Include fix for Issue 49164: Datepicker in editable grid needs to account for the sticky footer when at the bottom of the grid
 
 ### version 2.399.0
 *Released*: 15 December 2023

--- a/packages/components/src/internal/components/chart/configs.test.ts
+++ b/packages/components/src/internal/components/chart/configs.test.ts
@@ -4,7 +4,7 @@ import { ChartData } from './types';
 describe('CHART_GROUPS', () => {
     test('getAppURL', () => {
         let row = { x: 'x', xSub: 'xSub' } as ChartData;
-        expect(CHART_GROUPS.Assays.getAppURL(row).toHref()).toBe('#/assays/general/x/overview');
+        expect(CHART_GROUPS.Assays.getAppURL(row).toHref()).toBe('#/assays/general/x/runs');
         expect(CHART_GROUPS.Samples.getAppURL(row).toHref()).toBe('#/samples/x');
         expect(CHART_GROUPS.SampleStatuses.getAppURL(row, { target: { tagName: 'title' } }).toHref()).toBe(
             '#/samples/xSub'

--- a/packages/components/src/internal/components/chart/configs.ts
+++ b/packages/components/src/internal/components/chart/configs.ts
@@ -32,8 +32,8 @@ export const CHART_GROUPS: Record<string, BarChartConfig> = {
             CHART_SELECTORS.Week,
             CHART_SELECTORS.Today,
         ],
-        // TODO: Use redirect AppURL.create('assays', row.id, 'overview')
-        getAppURL: row => AppURL.create(ASSAYS_KEY, 'general', row.x || row['label'], 'overview'),
+        // TODO: Use redirect AppURL.create('assays', row.id, 'runs')
+        getAppURL: row => AppURL.create(ASSAYS_KEY, 'general', row.x || row['label'], 'runs'),
         filterDataRegionName: 'Runs',
         itemCountSQ: SCHEMAS.ASSAY_TABLES.ASSAY_LIST,
         key: ASSAYS_KEY,

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -1,4 +1,5 @@
 import { List, Map } from 'immutable';
+import { Query } from '@labkey/api';
 
 import { GetNameExpressionOptionsResponse, loadNameExpressionOptions } from '../settings/actions';
 
@@ -26,7 +27,6 @@ import {
     IEntityTypeOption,
     IParentAlias,
     IParentOption,
-    MoveEntitiesResult,
     OperationConfirmationData,
 } from './models';
 
@@ -100,7 +100,7 @@ export interface EntityAPIWrapper {
         selectionKey?: string,
         useSnapshotSelection?: boolean,
         auditUserComment?: string
-    ) => Promise<MoveEntitiesResult>;
+    ) => Promise<Query.MoveRowsResponse>;
 }
 
 export class EntityServerAPIWrapper implements EntityAPIWrapper {

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -7,8 +7,6 @@ import { QueryInfo } from '../../../public/QueryInfo';
 
 import { InsertOptions } from '../../query/api';
 
-import { Container } from '../base/models/Container';
-
 import {
     getDataOperationConfirmationData,
     getDeleteConfirmationData,
@@ -18,6 +16,7 @@ import {
     handleEntityFileImport,
     moveEntities,
     initParentOptionsSelects,
+    MoveEntitiesOptions,
 } from './actions';
 import { DataOperation } from './constants';
 import {
@@ -90,17 +89,7 @@ export interface EntityAPIWrapper {
         parentOptions: IParentOption[];
     }>;
     loadNameExpressionOptions: (containerPath?: string) => Promise<GetNameExpressionOptionsResponse>;
-    moveEntities: (
-        sourceContainer: Container,
-        targetContainer: string,
-        entityDataType: EntityDataType,
-        schemaName: string,
-        queryName: string,
-        rowIds?: number[],
-        selectionKey?: string,
-        useSnapshotSelection?: boolean,
-        auditUserComment?: string
-    ) => Promise<Query.MoveRowsResponse>;
+    moveEntities: (options: MoveEntitiesOptions) => Promise<Query.MoveRowsResponse>;
 }
 
 export class EntityServerAPIWrapper implements EntityAPIWrapper {

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
 
-import { ActionURL } from '@labkey/api';
+import { ActionURL, AuditBehaviorTypes } from '@labkey/api';
 
 import { Progress } from '../base/Progress';
 import { ConfirmModal } from '../base/ConfirmModal';
@@ -117,17 +117,18 @@ export const EntityMoveModal: FC<EntityMoveModalProps> = memo(props => {
             const useSnapshotSelection = useSelected && movingAll && queryModel.filterArray.length > 0;
 
             try {
-                await api.entity.moveEntities(
-                    currentContainer,
+                await api.entity.moveEntities({
+                    containerPath: currentContainer?.path,
                     targetContainerPath,
                     entityDataType,
-                    queryModel.schemaName,
-                    queryModel.queryName,
-                    rowIds_,
-                    selectionKey,
+                    schemaName: queryModel.schemaName,
+                    queryName: queryModel.queryName,
+                    rowIds: rowIds_,
+                    dataRegionSelectionKey: selectionKey,
                     useSnapshotSelection,
-                    auditUserComment
-                );
+                    auditBehavior: AuditBehaviorTypes.DETAILED,
+                    auditUserComment,
+                });
 
                 let projectUrl = buildURL(
                     getPrimaryAppProperties()?.productId,

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1,4 +1,4 @@
-import { ActionURL, Ajax, AuditBehaviorTypes, Filter, getServerContext, Query, Utils } from '@labkey/api';
+import { ActionURL, Ajax, Filter, getServerContext, Query, Utils } from '@labkey/api';
 import { List, Map } from 'immutable';
 
 import { getSelectedData, getSelected, setSnapshotSelections } from '../../actions';
@@ -19,8 +19,6 @@ import { SCHEMAS } from '../../schemas';
 import { Row, selectRows, SelectRowsResponse } from '../../query/selectRows';
 
 import { ViewInfo } from '../../ViewInfo';
-
-import { Container } from '../base/models/Container';
 
 import { getProjectDataExclusion, hasModule } from '../../app/utils';
 
@@ -817,35 +815,20 @@ export function getMoveConfirmationData(
     );
 }
 
-export function moveEntities(
-    sourceContainer: Container,
-    targetContainer: string,
-    entityDataType: EntityDataType,
-    schemaName: string,
-    queryName: string,
-    rowIds?: number[],
-    selectionKey?: string,
-    useSnapshotSelection?: boolean,
-    userComment?: string
-): Promise<Query.MoveRowsResponse> {
+export interface MoveEntitiesOptions extends Omit<Query.MoveRowsOptions, 'rows' | 'success' | 'failure' | 'scope'> {
+    entityDataType: EntityDataType;
+    rowIds?: number[];
+}
+
+export function moveEntities(options: MoveEntitiesOptions): Promise<Query.MoveRowsResponse> {
     return new Promise((resolve, reject) => {
-        const params = {
-            containerPath: sourceContainer?.path,
-            auditBehavior: AuditBehaviorTypes.DETAILED,
-            auditUserComment: userComment,
-            targetContainerPath: targetContainer,
-            schemaName,
-            queryName,
-        };
+        const { entityDataType, rowIds, ...rest} = options;
+        const params = Object.assign({}, rest);
         if (rowIds) {
             params['rows'] = rowIds.reduce((prev, curr) => {
                 prev.push({ rowId: curr });
                 return prev;
             }, []);
-        }
-        if (selectionKey) {
-            params['dataRegionSelectionKey'] = selectionKey;
-            params['useSnapshotSelection'] = useSnapshotSelection;
         }
 
         Query.moveRows({

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -822,7 +822,7 @@ export interface MoveEntitiesOptions extends Omit<Query.MoveRowsOptions, 'rows' 
 
 export function moveEntities(options: MoveEntitiesOptions): Promise<Query.MoveRowsResponse> {
     return new Promise((resolve, reject) => {
-        const { entityDataType, rowIds, ...rest} = options;
+        const { entityDataType, rowIds, ...rest } = options;
         const params = Object.assign({}, rest);
         if (rowIds) {
             params['rows'] = rowIds.reduce((prev, curr) => {

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -586,12 +586,6 @@ export interface IParentAlias {
     parentValue: IParentOption;
 }
 
-export interface MoveEntitiesResult {
-    containerPath: string;
-    success: boolean;
-    updateCounts: Record<string, number>;
-}
-
 export interface DataTypeEntity {
     description?: string;
     label: string;

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -195,7 +195,8 @@ div.react-datepicker__current-month {
 .react-datepicker-popper {
     // The default z-index is 1, but bootstrap sets the z-index for form inputs to 2, which means all form inputs render
     // on top of the date-picker by default, which makes it hard to use in some situations.
-    z-index: 10;
+    // Issue 49164: set z-index greater than the sticky footer (which is 10)
+    z-index: 11;
 }
 .add-control--error-message {
     padding-top: 5px;

--- a/packages/themes/package-lock.json
+++ b/packages/themes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/themes",
-  "version": "1.3.2",
+  "version": "1.3.2-fb-moveRowsJSAPI.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/themes",
-      "version": "1.3.2",
+      "version": "1.3.2-fb-moveRowsJSAPI.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "bootstrap-sass": "3.4.3",

--- a/packages/themes/package-lock.json
+++ b/packages/themes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/themes",
-  "version": "1.3.2-fb-moveRowsJSAPI.1",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/themes",
-      "version": "1.3.2-fb-moveRowsJSAPI.1",
+      "version": "1.3.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "bootstrap-sass": "3.4.3",

--- a/packages/themes/package-lock.json
+++ b/packages/themes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/themes",
-  "version": "1.3.2-fb-moveRowsJSAPI.0",
+  "version": "1.3.2-fb-moveRowsJSAPI.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/themes",
-      "version": "1.3.2-fb-moveRowsJSAPI.0",
+      "version": "1.3.2-fb-moveRowsJSAPI.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "bootstrap-sass": "3.4.3",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.3.2-fb-moveRowsJSAPI.1",
+  "version": "1.3.3",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.3.2-fb-moveRowsJSAPI.0",
+  "version": "1.3.2-fb-moveRowsJSAPI.1",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/themes",
-  "version": "1.3.2",
+  "version": "1.3.2-fb-moveRowsJSAPI.0",
   "description": "Themes that come bundled with LabKey Server",
   "files": [
     "dist/"

--- a/packages/themes/styles/js/navigation.js
+++ b/packages/themes/styles/js/navigation.js
@@ -203,9 +203,9 @@
                             document.getElementById(id).innerHTML = '<div style="padding: 5px">You do not have permission to view this data. You have likely been logged out.'
                                     + (this.loginUrl != null ? ' Please <a href="' + this.loginUrl + '">log in</a> again.' : ' Please <a href="#" id="' + id + '-reload">reload</a> the page.') + "</div>";
 
-                            document.getElementById(id + '-reload')['onclick'] = function() {
+                            document.getElementById(id + '-reload').addEventListener('click', function() {
                                 location.reload();
-                            }
+                            });
                         }
                         else {
                             if (window.console && window.console.log) {

--- a/packages/themes/styles/js/navigation.js
+++ b/packages/themes/styles/js/navigation.js
@@ -201,7 +201,11 @@
                         // Show a better error to the user than just a generic Unauthorized dialog
                         if (response.status === 401) {
                             document.getElementById(id).innerHTML = '<div style="padding: 5px">You do not have permission to view this data. You have likely been logged out.'
-                                    + (this.loginUrl != null ? ' Please <a href="' + this.loginUrl + '">log in</a> again.' : ' Please <a href="#" onclick="location.reload();">reload</a> the page.') + "</div>";
+                                    + (this.loginUrl != null ? ' Please <a href="' + this.loginUrl + '">log in</a> again.' : ' Please <a href="#" id="' + id + '-reload">reload</a> the page.') + "</div>";
+
+                            document.getElementById(id + '-reload')['onclick'] = function() {
+                                location.reload();
+                            }
                         }
                         else {
                             if (window.console && window.console.log) {
@@ -364,7 +368,7 @@
         if (menu.length === 0) {
             return;
         }
-        
+
         var offset = menu.offset();
         var win = $(window);
 


### PR DESCRIPTION
#### Rationale
Related PR added a query-moveRows.api to the QueryController so that we could consolidate the various move entities actions to a single action. This PR bumps the @labkey/api package version and uses Query.moveRows().

Include fix for Issue [49164](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49164): LKSM: Datepicker in editable grid needs to account for the sticky footer when at the bottom of the grid

Include @labkey/theme fix for Issue [49304](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49304): Remove inline handler from navigation.js

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1369
- https://github.com/LabKey/labkey-api-js/pull/167
- https://github.com/LabKey/labkey-ui-components/pull/1372
- https://github.com/LabKey/platform/pull/5064
- https://github.com/LabKey/inventory/pull/1131
- https://github.com/LabKey/biologics/pull/2587
- https://github.com/LabKey/sampleManagement/pull/2310
- https://github.com/LabKey/testAutomation/pull/1761 

#### Changes
- update @labkey/api package version
- use Query.moveRows() in moveEntities()
- date picker css z-index update
- @labkey/theme package update to remove inline event handler
