### PR TITLE
Replace usages of Query.selectRows

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,17 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.1.0
+*Released*: 21 December 2023
+- Change `domain` and `security` API wrappers to use `selectRows`
+- Update `api.security.getAuditLogDate` to not need to specify additional columns
+- Update `GroupDetailsPanel` to use API wrapper from context
+- Improve typings of `SecurityAPIWrapper`
+
+### version 3.0.1
+*Released*: 21 December 2023
+- Rehydrate the package-lock.json for the components package
+
 ### version 3.0.0
 *Released*: 20 December 2023
 * Breaking Changes:

--- a/packages/components/src/internal/components/administration/GroupAssignments.spec.tsx
+++ b/packages/components/src/internal/components/administration/GroupAssignments.spec.tsx
@@ -20,7 +20,7 @@ import { TEST_USER_APP_ADMIN } from '../../userFixtures';
 import { MemberType } from './models';
 import { GroupAssignments } from './GroupAssignments';
 
-describe('<GroupAssignments/>', () => {
+describe('GroupAssignments', () => {
     const GROUP_MEMBERSHIP = {
         '1035': {
             groupName: 'NewSiteGroup',
@@ -114,7 +114,6 @@ describe('<GroupAssignments/>', () => {
         save: jest.fn(),
         setErrorMsg: jest.fn(),
         setIsDirty: jest.fn(),
-        getAuditLogData: jest.fn(),
     };
 
     test('without members', async () => {

--- a/packages/components/src/internal/components/administration/GroupAssignments.tsx
+++ b/packages/components/src/internal/components/administration/GroupAssignments.tsx
@@ -23,7 +23,6 @@ export interface GroupAssignmentsProps {
     createGroup: (name: string) => void;
     deleteGroup: (id: string) => void;
     errorMsg: string;
-    getAuditLogData: (columns: string, filterCol: string, filterVal: string | number) => Promise<string>;
     getIsDirty: () => boolean;
     groupMembership: GroupMembership;
     policy: SecurityPolicy;
@@ -40,7 +39,6 @@ export interface GroupAssignmentsProps {
 export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
     const {
         errorMsg,
-        getAuditLogData,
         getIsDirty,
         groupMembership,
         policy,
@@ -211,7 +209,6 @@ export const GroupAssignments: FC<GroupAssignmentsProps> = memo(props => {
                         rolesByUniqueName={rolesByUniqueName}
                         members={groupMembership[selectedPrincipal?.userId]?.members}
                         isSiteGroup={groupMembership[selectedPrincipal?.userId]?.type === MemberType.siteGroup}
-                        getAuditLogData={getAuditLogData}
                         displayCounts={userIsAppAdmin}
                     />
                 ) : (

--- a/packages/components/src/internal/components/administration/GroupAssignments.tsx
+++ b/packages/components/src/internal/components/administration/GroupAssignments.tsx
@@ -16,7 +16,7 @@ import { naturalSort } from '../../../public/sort';
 import { useServerContext } from '../base/ServerContext';
 
 import { Group } from './Group';
-import { GroupMembership, MemberType } from './models';
+import { Groups, MemberType } from './models';
 
 export interface GroupAssignmentsProps {
     addMembers: (groupId: string, principalId: number, principalName: string, principalType: string) => void;
@@ -24,7 +24,7 @@ export interface GroupAssignmentsProps {
     deleteGroup: (id: string) => void;
     errorMsg: string;
     getIsDirty: () => boolean;
-    groupMembership: GroupMembership;
+    groupMembership: Groups;
     policy: SecurityPolicy;
     principalsById: Map<number, Principal>;
     removeMember: (groupId: string, memberId: number) => void;

--- a/packages/components/src/internal/components/administration/GroupManagementPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.spec.tsx
@@ -39,7 +39,7 @@ describe('GroupManagementPage', () => {
                     fetchPolicy: jest.fn().mockResolvedValue(TEST_POLICY),
                     fetchGroups: jest.fn().mockResolvedValue([]),
                     getGroupMemberships: jest.fn().mockResolvedValue([]),
-                    getAuditLogData: jest.fn().mockResolvedValue('Modified a day ago'),
+                    getAuditLogDate: jest.fn().mockResolvedValue('Modified a day ago'),
                     ...overrides,
                 }),
             }),

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -67,8 +67,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
         setLoadingState(LoadingState.LOADING);
         try {
             // Used in renderButtons()
-            const lastModifiedState = await api.security.getAuditLogData('ProjectId/Name', projectPath.slice(0, -1));
-
+            const lastModifiedState = await api.security.getAuditLogDate('ProjectId/Name', projectPath.slice(0, -1));
             setLastModified(lastModifiedState);
 
             // Used in DetailsPanels
@@ -173,7 +172,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
 
         return (
             <>
-                <CreatedModified row={row} />
+                <CreatedModified row={row} useServerDate={false} />
                 <ManageDropdownButton collapsed id="admin-page-manage" pullRight>
                     <MenuItem
                         href={AppURL.create(AUDIT_KEY)

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -36,7 +36,7 @@ import { useAdministrationSubNav } from './useAdministrationSubNav';
 import { GroupAssignments } from './GroupAssignments';
 
 import { showPremiumFeatures } from './utils';
-import { GroupMembership, MemberType } from './models';
+import { Groups, MemberType } from './models';
 import { fetchGroupMembership } from './actions';
 
 export type GroupManagementPageProps = InjectedPermissionsPage;
@@ -47,8 +47,8 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
     const [getIsDirty, setIsDirty] = useRouteLeave();
     const [error, setError] = useState<string>();
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
-    const [savedGroupMembership, setSavedGroupMembership] = useState<GroupMembership>();
-    const [groupMembership, setGroupMembership] = useState<GroupMembership>();
+    const [savedGroupMembership, setSavedGroupMembership] = useState<Groups>();
+    const [groupMembership, setGroupMembership] = useState<Groups>();
     const [updatedPrincipals, setUpdatedPrincipals] = useState<List<Principal>>(principals);
     const [lastModified, setLastModified] = useState<string>();
     const [policy, setPolicy] = useState<SecurityPolicy>();

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -67,11 +67,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
         setLoadingState(LoadingState.LOADING);
         try {
             // Used in renderButtons()
-            const lastModifiedState = await api.security.getAuditLogData(
-                'Date,Project',
-                'ProjectId/Name',
-                projectPath.slice(0, -1)
-            );
+            const lastModifiedState = await api.security.getAuditLogData('ProjectId/Name', projectPath.slice(0, -1));
 
             setLastModified(lastModifiedState);
 
@@ -101,6 +97,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
 
     const save = useCallback(async () => {
         try {
+            // TODO: This should all be done server-side and transacted
             // Delete members
             const newGroupMembership = { ...groupMembership };
             for (const groupId of Object.keys(newGroupMembership)) {
@@ -147,10 +144,10 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
                     await api.security.addGroupMembers(parseInt(groupId, 10), addedMembers, projectPath);
             }
 
-            const principals = await getPrincipals();
+            const principals_ = await getPrincipals();
 
             // Save updated state
-            setUpdatedPrincipals(principals);
+            setUpdatedPrincipals(principals_);
             setSavedGroupMembership(newGroupMembership);
             setGroupMembership(newGroupMembership);
 
@@ -255,7 +252,7 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
         return showPremiumFeatures(moduleContext) ? container.path : undefined;
     }, [container, moduleContext]);
 
-    if (isProductProjectsEnabled() && !container.isProject) return <NotFound />;
+    if (isProductProjectsEnabled(moduleContext) && !container.isProject) return <NotFound />;
 
     return (
         <BasePermissionsCheckPage
@@ -283,7 +280,6 @@ export const GroupManagementPageImpl: FC<GroupManagementPageProps> = memo(props 
                     setErrorMsg={onSetErrorMsg}
                     setIsDirty={setIsDirty}
                     getIsDirty={getIsDirty}
-                    getAuditLogData={api.security.getAuditLogData}
                 />
             )}
         </BasePermissionsCheckPage>

--- a/packages/components/src/internal/components/administration/GroupManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/GroupManagementPage.tsx
@@ -31,6 +31,7 @@ import { AUDIT_EVENT_TYPE_PARAM, GROUP_AUDIT_QUERY } from '../auditlog/constants
 import { AUDIT_KEY } from '../../app/constants';
 
 import { NotFound } from '../base/NotFound';
+
 import { useAdministrationSubNav } from './useAdministrationSubNav';
 
 import { GroupAssignments } from './GroupAssignments';

--- a/packages/components/src/internal/components/administration/PermissionManagementPage.spec.tsx
+++ b/packages/components/src/internal/components/administration/PermissionManagementPage.spec.tsx
@@ -23,7 +23,7 @@ import { createMockWithRouteLeave } from '../../mockUtils';
 import { BasePermissionsCheckPage } from '../permissions/BasePermissionsCheckPage';
 
 import { MemberType } from './models';
-import { PermissionManagementPage, PermissionManagementPageImpl } from './PermissionManagementPage';
+import { PermissionManagementPageImpl } from './PermissionManagementPage';
 
 const USER = Principal.createFromSelectRow(
     fromJS({

--- a/packages/components/src/internal/components/administration/PermissionManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/PermissionManagementPage.tsx
@@ -17,6 +17,7 @@ import { BasePermissionsCheckPage } from '../permissions/BasePermissionsCheckPag
 import { PermissionAssignments } from '../permissions/PermissionAssignments';
 import { useRouteLeave } from '../../util/RouteLeave';
 import { InjectedPermissionsPage, withPermissionsPage } from '../permissions/withPermissionsPage';
+
 import { useAdministrationSubNav } from './useAdministrationSubNav';
 
 import { useAdminAppContext } from './useAdminAppContext';

--- a/packages/components/src/internal/components/administration/PermissionManagementPage.tsx
+++ b/packages/components/src/internal/components/administration/PermissionManagementPage.tsx
@@ -32,7 +32,7 @@ export const PermissionManagementPageImpl: FC<Props> = memo(props => {
     const { roles } = props;
     useAdministrationSubNav();
     const [getIsDirty, setIsDirty] = useRouteLeave();
-    const [policyLastModified, setPolicyLastModified] = useState<string>(undefined);
+    const [policyLastModified, setPolicyLastModified] = useState<string>();
     const [hidePageDescription, setHidePageDescription] = useState<boolean>(false);
     const { dismissNotifications, createNotification } = useNotificationsContext();
     const { extraPermissionRoles } = useAdminAppContext();

--- a/packages/components/src/internal/components/administration/actions.test.ts
+++ b/packages/components/src/internal/components/administration/actions.test.ts
@@ -2,13 +2,15 @@ import { fromJS, List, Map } from 'immutable';
 
 import { SecurityRole } from '../permissions/models';
 
+import { Row } from '../../query/selectRows';
+
 import {
     getGroupMembership,
     getUpdatedPolicyRoles,
     getUpdatedPolicyRolesByUniqueName,
     getUserGridFilterURL,
 } from './actions';
-import { MemberType } from './models';
+import { GroupMembership, MemberType } from './models';
 
 describe('Administration actions', () => {
     test('getUpdatedPolicyRoles', () => {
@@ -81,45 +83,45 @@ describe('Administration actions', () => {
             },
         ];
 
-        const groupMemberships = [
+        const groupMemberships: Row[] = [
             {
-                'UserId/Email': 'rosalinep@labkey.com',
-                'UserId/DisplayName': 'rosalinep',
-                'GroupId/Name': 'Administrators',
-                UserId: 1005,
-                GroupId: -1,
+                GroupId: { displayValue: 'Administrators', value: -1 },
+                'GroupId/Name': { value: 'Administrators' },
+                UserId: { displayValue: 'rosalinep', value: 1005 },
+                'UserId/DisplayName': { value: 'rosalinep' },
+                'UserId/Email': { value: 'rosalinep@labkey.com' },
             },
             {
-                'UserId/Email': 'rosalinep@labkey.com',
-                'UserId/DisplayName': 'rosalinep',
-                'GroupId/Name': 'NewSiteGroup',
-                UserId: 1005,
-                GroupId: 1035,
+                GroupId: { displayValue: 'NewSiteGroup', value: 1035 },
+                'GroupId/Name': { value: 'NewSiteGroup' },
+                UserId: { displayValue: 'rosalinep', value: 1005 },
+                'UserId/DisplayName': { value: 'rosalinep' },
+                'UserId/Email': { value: 'rosalinep@labkey.com' },
             },
             {
-                'UserId/Email': 'rosalinep@labkey.com',
-                'UserId/DisplayName': 'rosalinep',
-                'GroupId/Name': 'group1',
-                UserId: 1005,
-                GroupId: 1064,
+                GroupId: { displayValue: 'group1', value: 1064 },
+                'GroupId/Name': { value: 'group1' },
+                UserId: { displayValue: 'rosalinep', value: 1005 },
+                'UserId/DisplayName': { value: 'rosalinep' },
+                'UserId/Email': { value: 'rosalinep@labkey.com' },
             },
             {
-                'UserId/Email': null,
-                'UserId/DisplayName': null,
-                'GroupId/Name': 'group1',
-                UserId: 1066,
-                GroupId: 1064,
+                GroupId: { displayValue: 'group1', value: 1064 },
+                'GroupId/Name': { value: 'group1' },
+                UserId: { value: 1066 },
+                'UserId/DisplayName': { value: null },
+                'UserId/Email': { value: null },
             },
             {
-                'UserId/Email': null,
-                'UserId/DisplayName': null,
-                'GroupId/Name': 'group1',
-                UserId: 1000,
-                GroupId: 1064,
+                GroupId: { displayValue: 'group1', value: 1064 },
+                'GroupId/Name': { value: 'group1' },
+                UserId: { value: 1000 },
+                'UserId/DisplayName': { value: null },
+                'UserId/Email': { value: null },
             },
         ];
 
-        const expected = {
+        const expected: GroupMembership = {
             '1035': {
                 groupName: 'NewSiteGroup',
                 members: [

--- a/packages/components/src/internal/components/administration/actions.test.ts
+++ b/packages/components/src/internal/components/administration/actions.test.ts
@@ -2,15 +2,13 @@ import { fromJS, List, Map } from 'immutable';
 
 import { SecurityRole } from '../permissions/models';
 
-import { Row } from '../../query/selectRows';
-
 import {
     getGroupMembership,
     getUpdatedPolicyRoles,
     getUpdatedPolicyRolesByUniqueName,
     getUserGridFilterURL,
 } from './actions';
-import { GroupMembership, MemberType } from './models';
+import { GroupMembership, Groups, MemberType } from './models';
 
 describe('Administration actions', () => {
     test('getUpdatedPolicyRoles', () => {
@@ -83,45 +81,45 @@ describe('Administration actions', () => {
             },
         ];
 
-        const groupMemberships: Row[] = [
+        const groupMemberships: GroupMembership[] = [
             {
-                GroupId: { displayValue: 'Administrators', value: -1 },
-                'GroupId/Name': { value: 'Administrators' },
-                UserId: { displayValue: 'rosalinep', value: 1005 },
-                'UserId/DisplayName': { value: 'rosalinep' },
-                'UserId/Email': { value: 'rosalinep@labkey.com' },
+                groupId: -1,
+                groupName: 'Administrators',
+                userDisplayName: 'rosalinep',
+                userEmail: 'rosalinep@labkey.com',
+                userId: 1005,
             },
             {
-                GroupId: { displayValue: 'NewSiteGroup', value: 1035 },
-                'GroupId/Name': { value: 'NewSiteGroup' },
-                UserId: { displayValue: 'rosalinep', value: 1005 },
-                'UserId/DisplayName': { value: 'rosalinep' },
-                'UserId/Email': { value: 'rosalinep@labkey.com' },
+                groupId: 1035,
+                groupName: 'NewSiteGroup',
+                userDisplayName: 'rosalinep',
+                userEmail: 'rosalinep@labkey.com',
+                userId: 1005,
             },
             {
-                GroupId: { displayValue: 'group1', value: 1064 },
-                'GroupId/Name': { value: 'group1' },
-                UserId: { displayValue: 'rosalinep', value: 1005 },
-                'UserId/DisplayName': { value: 'rosalinep' },
-                'UserId/Email': { value: 'rosalinep@labkey.com' },
+                groupId: 1064,
+                groupName: 'group1',
+                userDisplayName: 'rosalinep',
+                userEmail: 'rosalinep@labkey.com',
+                userId: 1005,
             },
             {
-                GroupId: { displayValue: 'group1', value: 1064 },
-                'GroupId/Name': { value: 'group1' },
-                UserId: { value: 1066 },
-                'UserId/DisplayName': { value: null },
-                'UserId/Email': { value: null },
+                groupId: 1064,
+                groupName: 'group1',
+                userDisplayName: null,
+                userEmail: null,
+                userId: 1066,
             },
             {
-                GroupId: { displayValue: 'group1', value: 1064 },
-                'GroupId/Name': { value: 'group1' },
-                UserId: { value: 1000 },
-                'UserId/DisplayName': { value: null },
-                'UserId/Email': { value: null },
+                groupId: 1064,
+                groupName: 'group1',
+                userDisplayName: null,
+                userEmail: null,
+                userId: 1000,
             },
         ];
 
-        const expected: GroupMembership = {
+        const expected: Groups = {
             '1035': {
                 groupName: 'NewSiteGroup',
                 members: [

--- a/packages/components/src/internal/components/administration/actions.ts
+++ b/packages/components/src/internal/components/administration/actions.ts
@@ -5,7 +5,7 @@ import { Security } from '@labkey/api';
 import { AppURL } from '../../url/AppURL';
 import { SecurityPolicy, SecurityRole } from '../permissions/models';
 
-import { naturalSort } from '../../../public/sort';
+import { naturalSortByProperty } from '../../../public/sort';
 
 import { FetchedGroup, SecurityAPIWrapper } from '../security/APIWrapper';
 
@@ -13,7 +13,11 @@ import { getProjectPath } from '../../app/utils';
 
 import { Container } from '../base/models/Container';
 
-import { GroupMembership, MemberType } from './models';
+import { Row } from '../../query/selectRows';
+
+import { caseInsensitive } from '../../util/utils';
+
+import { GroupMembership, Member, MemberType } from './models';
 import { SECURITY_ROLE_DESCRIPTIONS } from './constants';
 
 export function getUpdatedPolicyRoles(
@@ -104,43 +108,46 @@ export function updateSecurityPolicy(
 //       ...
 // }
 // Where the members array is sorted by type, and then by name. The types stand for 'group,' 'site group,' and 'user'
-export const getGroupMembership = (groups: FetchedGroup[], groupMemberships): GroupMembership => {
-    const groupsWithMembers = groupMemberships.reduce((prev, curr) => {
-        const groupId = curr['GroupId'];
-        const isProjectGroup = groups.find(group => group.id === groupId)?.isProjectGroup;
-
+export const getGroupMembership = (groups: FetchedGroup[], groupMemberships: Row[]): GroupMembership => {
+    const groupsWithMembers = groupMemberships.reduce<GroupMembership>((membership, row) => {
+        const groupId = caseInsensitive(row, 'GroupId').value;
         if (groupId === -1) {
-            return prev;
+            return membership;
         }
-        const userDisplayName = curr['UserId/DisplayName'];
-        const userDisplayValue = `${curr['UserId/Email']} (${userDisplayName})`;
-        const memberIsGroup = !userDisplayName;
-        const foundGroup = groups.find(group => group.id === curr.UserId);
 
-        // Issue47306: When a member is not resolvable, do not accumulate the member into any groups.
+        const userDisplayName = caseInsensitive(row, 'UserId/DisplayName').value;
+        const userEmail = caseInsensitive(row, 'UserId/Email').value;
+        const userId: number = caseInsensitive(row, 'UserId').value;
+        const memberIsGroup = !userDisplayName;
+        const foundGroup = groups.find(group => group.id === userId);
+
+        // Issue 47306: When a member is not resolvable, do not accumulate the member into any groups.
         // For example, if you are a Project Admin, a groupMembership row associating a site group with a user possessing no
         // permissions in the project will result in your inability to resolve data on the permission-less user.
         // That user will not be visible to you, and so should be excluded from the GroupMembership return value.
         if (memberIsGroup && !foundGroup) {
-            return prev;
+            return membership;
         }
-        const member = {
-            name: memberIsGroup ? foundGroup.name : userDisplayValue,
-            id: curr.UserId,
+
+        const member: Member = {
+            name: memberIsGroup ? foundGroup.name : `${userEmail} (${userDisplayName})`,
+            id: userId,
             type: memberIsGroup ? MemberType.group : MemberType.user,
         };
-        if (curr.GroupId in prev) {
-            prev[groupId].members.push(member);
-            prev[groupId].members.sort((member1, member2) => naturalSort(member1.name, member2.name));
-            return prev;
+
+        if (groupId in membership) {
+            membership[groupId].members.push(member);
+            membership[groupId].members.sort(naturalSortByProperty('name'));
         } else {
-            prev[groupId] = {
-                groupName: curr['GroupId/Name'],
+            const isProjectGroup = groups.find(group => group.id === groupId)?.isProjectGroup;
+            membership[groupId] = {
+                groupName: caseInsensitive(row, 'GroupId/Name').value,
                 members: [member],
                 type: isProjectGroup ? MemberType.group : MemberType.siteGroup,
             };
-            return prev;
         }
+
+        return membership;
     }, {});
 
     // If a group has no members—is in groupsData but not groupRows—add it as well, unless it is a site group

--- a/packages/components/src/internal/components/administration/models.ts
+++ b/packages/components/src/internal/components/administration/models.ts
@@ -10,9 +10,15 @@ interface Group {
     type?: string;
 }
 
-export interface GroupMembership {
-    [key: string]: Group;
-}
+export type GroupMembership = {
+    groupId: number;
+    groupName: string;
+    userDisplayName: string;
+    userEmail: string;
+    userId: number;
+};
+
+export type Groups = Record<string, Group>;
 
 export enum MemberType {
     group = 'g',

--- a/packages/components/src/internal/components/assay/utils.ts
+++ b/packages/components/src/internal/components/assay/utils.ts
@@ -40,7 +40,7 @@ export function inferDomainFromFile(
  * This is used for retrieving preview data for a file already on the server side
  * @param file This can be a rowId for the file, or a path to the file
  * @param fileName The file name to be used to check the extension
- * @param numLinesToInclude: the number of lines of data to include (excludes the header)
+ * @param numLinesToInclude the number of lines of data to include (excludes the header)
  */
 export function getServerFilePreview(
     file: string,

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -1164,7 +1164,7 @@ export async function getTextChoiceInUseValues(
     queryName: string,
     lockedSqlFragment: string
 ): Promise<Record<string, any>> {
-    const containerFilter = Query.ContainerFilter.allFolders; // to account for a shared domain at project or /Shared
+    const containerFilter = Query.ContainerFilter.allInProjectPlusShared; // to account for a shared domain at project or /Shared
     const fieldName = field.original?.name ?? field.name;
 
     // If the field is set as PHI, we need the query to include the RowId for logging, so we have to do the aggregate client side
@@ -1187,7 +1187,6 @@ export async function getTextChoiceInUseValues(
                 values[value].count++;
                 values[value].locked =
                     values[value].locked || caseInsensitive(row, 'SampleState/StatusType').value === 'Locked';
-                // TODO: Double check displayValue vs value of 'SampleState/StatusType'
             }
         });
         return values;

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -33,7 +33,7 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { SCHEMAS } from '../../schemas';
 
-import {caseInsensitive, handleRequestFailure} from '../../util/utils';
+import { caseInsensitive, handleRequestFailure } from '../../util/utils';
 
 import { getExcludedDataTypeNames } from '../entities/actions';
 

--- a/packages/components/src/internal/components/permissions/GroupDetailsPanel.spec.tsx
+++ b/packages/components/src/internal/components/permissions/GroupDetailsPanel.spec.tsx
@@ -29,7 +29,7 @@ const POLICY = SecurityPolicy.create(policyJSON);
 const ROLES = processGetRolesResponse(rolesJSON.roles);
 const ROLES_BY_NAME = getRolesByUniqueName(ROLES);
 
-describe('<GroupDetailsPanel/>', () => {
+describe('GroupDetailsPanel', () => {
     test('no principal', () => {
         const component = mountWithAppServerContext(
             <GroupDetailsPanel
@@ -38,7 +38,6 @@ describe('<GroupDetailsPanel/>', () => {
                 rolesByUniqueName={ROLES_BY_NAME}
                 members={[]}
                 isSiteGroup={false}
-                getAuditLogData={jest.fn()}
             />,
             {},
             { user: TEST_USER_APP_ADMIN }
@@ -63,7 +62,6 @@ describe('<GroupDetailsPanel/>', () => {
                     { id: 3, name: 'group1', type: MemberType.group },
                 ]}
                 isSiteGroup={false}
-                getAuditLogData={jest.fn()}
             />,
             {},
             { user: TEST_USER_APP_ADMIN }
@@ -95,7 +93,6 @@ describe('<GroupDetailsPanel/>', () => {
                     { id: 3, name: 'group1', type: MemberType.group },
                 ]}
                 isSiteGroup={true}
-                getAuditLogData={jest.fn()}
             />,
             {},
             { user: TEST_USER_APP_ADMIN }
@@ -127,7 +124,6 @@ describe('<GroupDetailsPanel/>', () => {
                     { id: 3, name: 'group1', type: MemberType.group },
                 ]}
                 isSiteGroup={true}
-                getAuditLogData={jest.fn()}
                 displayCounts={false}
             />,
             {},

--- a/packages/components/src/internal/components/permissions/GroupDetailsPanel.spec.tsx
+++ b/packages/components/src/internal/components/permissions/GroupDetailsPanel.spec.tsx
@@ -32,13 +32,7 @@ const ROLES_BY_NAME = getRolesByUniqueName(ROLES);
 describe('GroupDetailsPanel', () => {
     test('no principal', () => {
         const component = mountWithAppServerContext(
-            <GroupDetailsPanel
-                principal={undefined}
-                policy={POLICY}
-                rolesByUniqueName={ROLES_BY_NAME}
-                members={[]}
-                isSiteGroup={false}
-            />,
+            <GroupDetailsPanel policy={POLICY} rolesByUniqueName={ROLES_BY_NAME} members={[]} isSiteGroup={false} />,
             {},
             { user: TEST_USER_APP_ADMIN }
         );
@@ -92,7 +86,7 @@ describe('GroupDetailsPanel', () => {
                     { id: 1, name: 'user1', type: MemberType.user },
                     { id: 3, name: 'group1', type: MemberType.group },
                 ]}
-                isSiteGroup={true}
+                isSiteGroup
             />,
             {},
             { user: TEST_USER_APP_ADMIN }
@@ -123,7 +117,7 @@ describe('GroupDetailsPanel', () => {
                     { id: 1, name: 'user1', type: MemberType.user },
                     { id: 3, name: 'group1', type: MemberType.group },
                 ]}
-                isSiteGroup={true}
+                isSiteGroup
                 displayCounts={false}
             />,
             {},

--- a/packages/components/src/internal/components/permissions/GroupDetailsPanel.tsx
+++ b/packages/components/src/internal/components/permissions/GroupDetailsPanel.tsx
@@ -13,6 +13,8 @@ import { UserProperties } from '../user/UserProperties';
 
 import { useServerContext } from '../base/ServerContext';
 
+import { useAppContext } from '../../AppContext';
+
 import { EffectiveRolesList } from './EffectiveRolesList';
 
 import { Principal, SecurityPolicy, SecurityRole } from './models';
@@ -20,51 +22,43 @@ import { MembersList } from './MembersList';
 
 interface Props {
     displayCounts?: boolean;
-    getAuditLogData: (columns: string, filterCol: string, filterVal: string | number) => Promise<string>;
     isSiteGroup: boolean;
     members?: Member[];
     policy: SecurityPolicy;
-    principal: Principal;
+    principal: Principal; // TODO: Is "principal" required or not? The code seems confused about this
     rolesByUniqueName: Map<string, SecurityRole>;
     showPermissionListLinks?: boolean;
 }
 
 export const GroupDetailsPanel: FC<Props> = memo(props => {
-    const {
-        getAuditLogData,
-        principal,
-        members,
-        isSiteGroup,
-        displayCounts = true,
-        showPermissionListLinks = true,
-    } = props;
+    const { principal, members, isSiteGroup, displayCounts = true, showPermissionListLinks = true } = props;
     const [created, setCreated] = useState<string>('');
+    const { api } = useAppContext();
     const { user } = useServerContext();
 
     const loadWhenCreated = useCallback(async () => {
         try {
-            const createdState = await getAuditLogData('Date,group/UserId', 'group/UserId', principal.userId);
-
+            const createdState = await api.security.getAuditLogData('group/UserId', principal.userId);
+            // TODO: Surely need a comment about -7
             setCreated(createdState.slice(0, -7));
         } catch (e) {
             console.error(resolveErrorMessage(e) ?? 'Failed to load when group created');
         }
-    }, [getAuditLogData, principal]);
+    }, [api, principal]);
 
     useEffect(() => {
         loadWhenCreated();
     }, [loadWhenCreated]);
 
     const { usersCount, groupsCount } = useMemo(() => {
-        const usersCount = members.filter(member => member.type === MemberType.user).length;
-        const groupsCount = (members.length - usersCount).toString();
+        const usersCount_ = members.filter(member => member.type === MemberType.user).length;
 
-        return { usersCount, groupsCount };
+        return { usersCount: usersCount_, groupsCount: (members.length - usersCount_).toString() };
     }, [members]);
 
     return (
         <Panel className="group-details-panel">
-            <Panel.Heading>{principal ? principal.displayName : 'Group Details'}</Panel.Heading>
+            <Panel.Heading>{principal?.displayName ?? 'Group Details'}</Panel.Heading>
             <Panel.Body>
                 {principal ? (
                     <>

--- a/packages/components/src/internal/components/permissions/GroupsList.tsx
+++ b/packages/components/src/internal/components/permissions/GroupsList.tsx
@@ -6,7 +6,7 @@ import { User } from '../base/models/User';
 import { fetchGroupMembership } from '../administration/actions';
 import { useAppContext } from '../../AppContext';
 import { useServerContext } from '../base/ServerContext';
-import { GroupMembership, MemberType } from '../administration/models';
+import { Groups, MemberType } from '../administration/models';
 import { getCurrentAppProperties, getPrimaryAppProperties } from '../../app/utils';
 
 interface Props {
@@ -18,7 +18,7 @@ interface Props {
 
 export const GroupsList: FC<Props> = memo(props => {
     const { groups, currentUser, asRow = true, showLinks = true } = props;
-    const [groupMembership, setGroupMembership] = useState<GroupMembership>();
+    const [groupMembership, setGroupMembership] = useState<Groups>();
     const { api } = useAppContext();
     const { container } = useServerContext();
     const currentProductId = getCurrentAppProperties()?.productId;

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -27,7 +27,7 @@ import { resolveErrorMessage } from '../../util/messaging';
 
 import { Alert } from '../base/Alert';
 
-import { GroupMembership, MemberType } from '../administration/models';
+import { Groups, MemberType } from '../administration/models';
 
 import { fetchGroupMembership } from '../administration/actions';
 
@@ -81,7 +81,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
     const [rootPolicy, setRootPolicy] = useState<SecurityPolicy>();
     const [saveErrorMsg, setSaveErrorMsg] = useState<string>();
     const [selectedUserId, setSelectedUserId] = useState<number>();
-    const [groupMembership, setGroupMembership] = useState<GroupMembership>();
+    const [groupMembership, setGroupMembership] = useState<Groups>();
     const [error, setError] = useState<string>();
     const [submitting, setSubmitting] = useState<boolean>(false);
     const [hasPolicyChange, setHasPolicyChange] = useState<boolean>(false);

--- a/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionAssignments.tsx
@@ -86,29 +86,41 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
     const [submitting, setSubmitting] = useState<boolean>(false);
     const [hasPolicyChange, setHasPolicyChange] = useState<boolean>(false);
     const [hasRootPolicyChange, setHasRootPolicyChange] = useState<boolean>(false);
-    const [policy, setPolicy] = useState<SecurityPolicy>(undefined);
-
-    const [projects, setProjects] = useState<Container[]>(undefined);
-    const [appHomeContainer, setAppHomeContainer] = useState<Container>(undefined);
-    const [selectedProject, setSelectedProject] = useState<Container>(undefined);
+    const [policy, setPolicy] = useState<SecurityPolicy>();
+    const [projects, setProjects] = useState<Container[]>();
+    const [appHomeContainer, setAppHomeContainer] = useState<Container>();
+    const [selectedProject, setSelectedProject] = useState<Container>();
     const [loaded, setLoaded] = useState<boolean>(false);
-    const [inheritedProjects, setInheritedProjects] = useState<string[]>(undefined);
+    const [inheritedProjects, setInheritedProjects] = useState<string[]>();
 
     const { api } = useAppContext<AppContext>();
     const { container, project, user, moduleContext } = useServerContext();
 
     const isAppHome = isAppHomeFolder(container, moduleContext);
     const homeFolderPath = isAppHome ? container.path : container.parentPath;
-
     const selectedPrincipal = principalsById?.get(selectedUserId);
     const [searchParams] = useSearchParams();
     const initExpandedRole = searchParams.get('expand');
     const projectUser = useContainerUser(getProjectPath(container?.path));
+    const projectsEnabled = isProductProjectsEnabled(moduleContext);
+
+    const loadContainerTree = useCallback(
+        async (homeContainer?: Container) => {
+            if (!projectsEnabled) return;
+            try {
+                const _inherited = await api.security.getInheritedProjects(homeContainer ?? appHomeContainer);
+                setInheritedProjects(_inherited);
+            } catch (e) {
+                setError(resolveErrorMessage(e) ?? 'Failed to load container tree');
+            }
+        },
+        [api, appHomeContainer, projectsEnabled]
+    );
 
     const loadGroupMembership = useCallback(async () => {
         // Issue 47641: since groups are defined at the project container level,
         // check permissions there before requesting group membership info
-        if (!selectedProject || projectUser.error || !userCanReadGroupDetails(projectUser?.user)) return;
+        if (!selectedProject || projectUser.error || !userCanReadGroupDetails(projectUser.user)) return;
 
         try {
             const groupMembershipState = await fetchGroupMembership(selectedProject, api.security);
@@ -116,13 +128,10 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         } catch (e) {
             setError(resolveErrorMessage(e) ?? 'Failed to load group membership data.');
         }
-    }, [api.security, selectedProject, projectUser.error, projectUser?.user]);
+    }, [api, selectedProject, projectUser.error, projectUser.user]);
 
     useEffect(() => {
         (async () => {
-            setLoaded(false);
-            setError(undefined);
-
             if (user.isRootAdmin) {
                 try {
                     const rootPolicy_ = await api.security.fetchPolicy(
@@ -136,7 +145,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                 }
             }
 
-            if (!isProductProjectsEnabled(moduleContext)) {
+            if (!projectsEnabled) {
                 setSelectedProject(container);
                 setLoaded(true);
                 return;
@@ -168,20 +177,9 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                 setLoaded(true);
             }
         })();
-    }, [moduleContext]);
+    }, []);
 
-    const loadContainerTree = useCallback(
-        async (homeContainer?: Container) => {
-            if (!isProductProjectsEnabled(moduleContext)) return;
-
-            const _inherited = await api.security.getInheritedProjects(homeContainer ?? appHomeContainer);
-
-            setInheritedProjects(_inherited);
-        },
-        [projects, moduleContext, container, appHomeContainer]
-    );
-
-    const sortedProjects = useMemo(() => {
+    const sortedProjects = useMemo<Container[]>(() => {
         if (!inheritedProjects || inheritedProjects.length === 0) return projects;
 
         if (!project || projects.length <= 2) return projects;
@@ -198,11 +196,11 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         _inheritedProjects.sort(naturalSortByProperty('title'));
         _nonInheritedProjects.sort(naturalSortByProperty('title'));
         return [home, ..._inheritedProjects, ..._nonInheritedProjects];
-    }, [projects, inheritedProjects]);
+    }, [inheritedProjects, projects, project]);
 
     const loadPolicy = useCallback(async () => {
+        if (!selectedProject) return;
         try {
-            if (!selectedProject) return;
             const policy_ = await api.security.fetchPolicy(selectedProject.id, principalsById, inactiveUsersById);
             setPolicy(policy_);
             setInherited(policy_.isInheritFromParent());
@@ -211,7 +209,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         } catch (e) {
             setError(resolveErrorMessage(e) ?? 'Failed to load security policy');
         }
-    }, [selectedProject?.id, principalsById, inactiveUsersById, setLastModified, loadGroupMembership]);
+    }, [selectedProject, api, principalsById, inactiveUsersById, setLastModified, loadGroupMembership]);
 
     useEffect(() => {
         (async () => {
@@ -267,7 +265,7 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         await loadPolicy();
 
         if (projects.length > 1) await loadContainerTree();
-    }, [loadPolicy, projects]);
+    }, [loadContainerTree, loadPolicy, projects]);
 
     const onSavePolicy = useCallback(async () => {
         const wasInherited = policy.isInheritFromParent();
@@ -356,7 +354,19 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
         setHasPolicyChange(false);
         setIsDirty(false);
         setSubmitting(false);
-    }, [project, selectedProject, inherited, _onSuccess, policy, hasRootPolicyChange, hasPolicyChange]);
+    }, [
+        policy,
+        hasRootPolicyChange,
+        hasPolicyChange,
+        inherited,
+        _onSuccess,
+        onSaveSuccess,
+        setIsDirty,
+        api,
+        rootPolicy,
+        project.rootId,
+        selectedProject,
+    ]);
 
     const _removeAssignment = useCallback(
         (isRootPolicy: boolean, userId: number, role: SecurityRole) => {
@@ -366,31 +376,31 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
             setIsDirty(true);
             isRootPolicy ? setHasRootPolicyChange(true) : setHasPolicyChange(true);
         },
-        [policy, rootPolicy]
+        [policy, rootPolicy, setIsDirty]
     );
 
     const removeAssignment = useCallback(
         (userId: number, role: SecurityRole) => {
             _removeAssignment(false, userId, role);
         },
-        [_removeAssignment, policy, rootPolicy]
+        [_removeAssignment]
     );
 
     const removeRootAssignment = useCallback(
         (userId: number, role: SecurityRole) => {
             _removeAssignment(true, userId, role);
         },
-        [policy, _removeAssignment, rootPolicy]
+        [_removeAssignment]
     );
 
     const showDetails = useCallback((selectedUserId_: number) => {
         setSelectedUserId(selectedUserId_);
     }, []);
 
-    const handleSelectProject = useCallback((project: Container) => {
+    const handleSelectProject = useCallback((selectedProject_: Container) => {
         setHasPolicyChange(false);
         setHasRootPolicyChange(false);
-        setSelectedProject(project);
+        setSelectedProject(selectedProject_);
         setSelectedUserId(undefined);
     }, []);
 
@@ -423,7 +433,6 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
 
     const isSubfolder = !isProjectContainer(selectedProject.path);
     const canInherit = project.rootId !== selectedProject.id;
-    const projectsEnabled = isProductProjectsEnabled(moduleContext);
 
     const _panelContent = (
         <div className="panel panel-default">
@@ -493,8 +502,8 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
             {error && <Alert>{error}</Alert>}
             <div className="row">
                 <div className="col-md-8 col-xs-12">
-                    {(!isProductProjectsEnabled(moduleContext) || projects?.length <= 1) && <>{_panelContent}</>}
-                    {isProductProjectsEnabled(moduleContext) && projects?.length > 1 && (
+                    {(!projectsEnabled || projects?.length <= 1) && <>{_panelContent}</>}
+                    {projectsEnabled && projects?.length > 1 && (
                         <div className="side-panels-container">
                             <ProjectListing
                                 projects={sortedProjects}
@@ -523,7 +532,6 @@ export const PermissionAssignments: FC<PermissionAssignmentsProps> = memo(props 
                             rolesByUniqueName={rolesByUniqueName}
                             members={groupMembership[selectedPrincipal?.userId].members}
                             isSiteGroup={groupMembership[selectedPrincipal?.userId]?.type === MemberType.siteGroup}
-                            getAuditLogData={api.security.getAuditLogData}
                             showPermissionListLinks={false}
                         />
                     ) : (

--- a/packages/components/src/internal/components/permissions/PermissionsRole.tsx
+++ b/packages/components/src/internal/components/permissions/PermissionsRole.tsx
@@ -10,7 +10,7 @@ import { ExpandableContainer } from '../ExpandableContainer';
 
 import { naturalSort } from '../../../public/sort';
 
-import { GroupMembership, MemberType } from '../administration/models';
+import { Groups, MemberType } from '../administration/models';
 
 import { Principal, SecurityAssignment, SecurityRole } from './models';
 import { RemovableButton } from './RemovableButton';
@@ -19,7 +19,7 @@ import { AddRoleAssignmentInput } from './AddRoleAssignmentInput';
 interface Props {
     assignments: List<SecurityAssignment>;
     disabledId?: number;
-    groupMembership: GroupMembership;
+    groupMembership: Groups;
     initExpanded?: boolean;
     onAddAssignment?: (principal: Principal, role: SecurityRole) => any;
     onClickAssignment: (userId: number) => any;

--- a/packages/components/src/internal/components/permissions/models.tsx
+++ b/packages/components/src/internal/components/permissions/models.tsx
@@ -7,7 +7,7 @@ import { Record, List, Map } from 'immutable';
 import React from 'react';
 
 import { naturalSort } from '../../../public/sort';
-import { GroupMembership, MemberType } from '../administration/models';
+import { Groups, MemberType } from '../administration/models';
 
 export class Principal extends Record({
     userId: undefined,
@@ -41,7 +41,7 @@ export class Principal extends Record({
 
     static filterAndSort(
         principals: List<Principal>,
-        groupMembership: GroupMembership,
+        groupMembership: Groups,
         excludeUserIds?: List<number>
     ): List<Principal> {
         return (

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -63,7 +63,7 @@ export interface SecurityAPIWrapper {
         inactiveUsersById?: Map<number, Principal>
     ) => Promise<SecurityPolicy>;
     fetchRoles: () => Promise<List<SecurityRole>>;
-    getAuditLogData: (filterCol: string, filterVal: string | number) => Promise<string>;
+    getAuditLogDate: (filterCol: string, filterVal: string | number) => Promise<string>;
     getDeletionSummaries: () => Promise<Summary[]>;
     getGroupMemberships: () => Promise<GroupMembership[]>;
     getInheritedProjects: (container: Container) => Promise<string[]>;
@@ -183,7 +183,7 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         });
     };
 
-    getAuditLogData = async (filterCol: string, filterVal: string | number): Promise<string> => {
+    getAuditLogDate = async (filterCol: string, filterVal: string | number): Promise<string> => {
         const result = await selectRows({
             columns: ['Date'],
             containerFilter: Query.ContainerFilter.allFolders,
@@ -193,7 +193,12 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
             sort: '-Date',
         });
 
-        return result.rows.length > 0 ? caseInsensitive(result.rows[0], 'Date').value : '';
+        if (result.rows.length === 0) {
+            return '';
+        }
+
+        const dateRow = caseInsensitive(result.rows[0], 'Date');
+        return dateRow.formattedValue ?? dateRow.value;
     };
 
     getDeletionSummaries = (): Promise<Summary[]> => {
@@ -375,7 +380,7 @@ export function getSecurityTestAPIWrapper(
         fetchGroups: mockFn(),
         fetchPolicy: mockFn(),
         fetchRoles: mockFn(),
-        getAuditLogData: mockFn(),
+        getAuditLogDate: mockFn(),
         getDeletionSummaries: mockFn(),
         getGroupMemberships: mockFn(),
         getUserLimitSettings: mockFn(),

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -153,7 +153,7 @@ export class UserProfile extends PureComponent<Props, State> {
             this.setState(() => ({ reloadRequired: true }));
         }
 
-        return api.security.updateUserDetails(SCHEMAS.CORE_TABLES.USERS, getUserDetailsRowData(user, data, avatar));
+        return api.security.updateUserDetails(getUserDetailsRowData(user, data, avatar));
     };
 
     onSuccess = (result: {}): void => {


### PR DESCRIPTION
#### Rationale
This replaces all direct usages of `Query.selectRows`, outside of our explicit wrappers `selectRows` and `selectRowsDeprecated`, with `selectRows`. This ensures application metadata is applied in all cases.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1374
- https://github.com/LabKey/labkey-ui-premium/pull/286
- https://github.com/LabKey/biologics/pull/2593
- https://github.com/LabKey/sampleManagement/pull/2321
- https://github.com/LabKey/inventory/pull/1136

#### Changes
- Change `api.domain.fetchOntologies`, `api.security.getAuditLogData`, `api.security.getGroupMemberships` and `api.security.getUserPropertiesForOther` to use `selectRows`
- Refactor `getGroupMemberships` processing to define more explicit type `GroupMembership` instead of generic `Row`
- Update `api.security.getAuditLogData` to not need to specify additional columns
- Update `GroupDetailsPanel` to use API wrapper from context
- Improve typings of `SecurityAPIWrapper`