### PR TITLE
Fix issue with withQueryModels outside of react router

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.1.1
+*Released*: 21 December 2023
+* withQueryModels: fix issue when operating outside of a React Router context
+
 ### version 3.1.0
 *Released*: 21 December 2023
 - Change `domain` and `security` API wrappers to use `selectRows`


### PR DESCRIPTION
#### Rationale
There is an issue where withQueryModels throws an error if used outside of a react-router context, this fixes the issu.e

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1376
* https://github.com/LabKey/labkey-ui-premium/pull/289
* https://github.com/LabKey/platform/pull/5074
* https://github.com/LabKey/tutorialModules/pull/173
* https://github.com/LabKey/puppeteer/pull/55
* https://github.com/LabKey/ontology/pull/133
* https://github.com/LabKey/niaidElisa/pull/39
* https://github.com/LabKey/moduleEditor/pull/91
* https://github.com/LabKey/commonAssays/pull/710
* https://github.com/LabKey/provenance/pull/162
* https://github.com/LabKey/sampleManagement/pull/2323
* https://github.com/LabKey/inventory/pull/1138
* https://github.com/LabKey/biologics/pull/2597

#### Changes
- withQueryModels: don't throw error if rendering outside of a react-router context
