### PR TITLE
@labkey/build: include nonce in appDev view

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.1-fb-build-nonce.1",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.0.1-fb-build-nonce.1",
+      "version": "7.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.22.20",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.0",
+  "version": "7.0.1-fb-build-nonce.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.0.0",
+      "version": "7.0.1-fb-build-nonce.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.22.20",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.1-fb-build-nonce.0",
+  "version": "7.0.1-fb-build-nonce.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.0.1-fb-build-nonce.0",
+      "version": "7.0.1-fb-build-nonce.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.22.20",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.0",
+  "version": "7.0.1-fb-build-nonce.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.1-fb-build-nonce.0",
+  "version": "7.0.1-fb-build-nonce.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.1-fb-build-nonce.1",
+  "version": "7.0.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,15 @@
 # @labkey/build
 
+### version 7.0.1
+*Released*: 26 December  2023
+- Issue 49331: Include `nonce` in `app.template.xml` to support CSP in `appDev.view`
+
+### version 7.0.0
+*Released*: 20 December  2023
+- Replace `react-hot-loader` with `react-refresh`
+- Add dependency on `@pmmmwh/react-refresh-webpack-plugin` for `ReactRefreshWebpackPlugin`
+- Add `@remix-run/router`, `normalizr` and `react-router-dom` to externals
+
 ### version 6.16.1
 *Released*: 20 October  2023
 * Export @labkey/api path in link mode

--- a/packages/build/webpack/app.template.html
+++ b/packages/build/webpack/app.template.html
@@ -1,4 +1,4 @@
 <div id="app"></div>
 <% if (htmlWebpackPlugin.options.mode === 'dev') { %>
-<script src="http://localhost:<%= htmlWebpackPlugin.options.port %>/<%= htmlWebpackPlugin.options.name %>.js"></script>
+<script src="http://localhost:<%= htmlWebpackPlugin.options.port %>/<%= htmlWebpackPlugin.options.name %>.js" nonce="<%- <%=scriptNonce%> %>"></script>
 <% } %>

--- a/packages/build/webpack/app.template.html
+++ b/packages/build/webpack/app.template.html
@@ -1,4 +1,4 @@
 <div id="app"></div>
 <% if (htmlWebpackPlugin.options.mode === 'dev') { %>
-<script src="http://localhost:<%= htmlWebpackPlugin.options.port %>/<%= htmlWebpackPlugin.options.name %>.js" nonce="<%- <%=scriptNonce%> %>"></script>
+<script src="http://localhost:<%= htmlWebpackPlugin.options.port %>/<%= htmlWebpackPlugin.options.name %>.js" nonce="<%= htmlWebpackPlugin.options.nonce %>"></script>
 <% } %>

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -345,6 +345,7 @@ module.exports = {
                         mode: 'dev',
                         port: watchPort,
                         name: app.name,
+                        nonce: '<%=scriptNonce%>',
                         filename: '../../views/gen/' + app.name + 'Dev.html',
                         template: 'node_modules/@labkey/build/webpack/app.template.html',
                         minify: minifyTemplateOptions


### PR DESCRIPTION
#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/2599

#### Changes
- Addresses [Issue 49331](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49331) by adding `nonce` attribute to development script tag generated in `app.template.xml` to satisfy CSP.
