### PR TITLE
@labkey/build: Update to ES2019

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.2-fb-ts-lib.0",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.0.2-fb-ts-lib.0",
+      "version": "7.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.22.20",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.1",
+  "version": "7.0.2-fb-ts-lib.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.0.1",
+      "version": "7.0.2-fb-ts-lib.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.22.20",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.2-fb-ts-lib.0",
+  "version": "7.0.2",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.0.1",
+  "version": "7.0.2-fb-ts-lib.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,9 @@
 # @labkey/build
 
+### version 7.0.2
+*Released*: 27 December  2023
+- Update TypeScript compiler `lib` option to `["es2019", "dom", "dom.iterable"]`
+
 ### version 7.0.1
 *Released*: 26 December  2023
 - Issue 49331: Include `nonce` in `app.template.xml` to support CSP in `appDev.view`

--- a/packages/build/webpack/tsconfig.json
+++ b/packages/build/webpack/tsconfig.json
@@ -10,7 +10,7 @@
     // compile times
     "sourceMap": true,
     "target": "es6",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom", "dom.iterable"],
     "types": ["jest"],
   }
 }

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -36,7 +36,7 @@
         "vis-network": "~6.5.2"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.0",
+        "@labkey/build": "7.0.2-fb-ts-lib.0",
         "@labkey/eslint-config-react": "0.0.13",
         "@types/enzyme": "3.10.13",
         "@types/history": "4.7.9",
@@ -3340,9 +3340,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.0.tgz",
-      "integrity": "sha512-GnYnIfh+yKP9exJwEgbMciMpwkBHIKvDbZEeqf9ZLL6jydmPkJSMXeFTc372dqAXHaltEMPVwfiGZLCy/FpFhw==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -20316,9 +20316,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.0.tgz",
-      "integrity": "sha512-GnYnIfh+yKP9exJwEgbMciMpwkBHIKvDbZEeqf9ZLL6jydmPkJSMXeFTc372dqAXHaltEMPVwfiGZLCy/FpFhw==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -36,7 +36,7 @@
         "vis-network": "~6.5.2"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.2-fb-ts-lib.0",
+        "@labkey/build": "7.0.2",
         "@labkey/eslint-config-react": "0.0.13",
         "@types/enzyme": "3.10.13",
         "@types/history": "4.7.9",
@@ -3340,9 +3340,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -20316,9 +20316,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "vis-network": "~6.5.2"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.0",
+    "@labkey/build": "7.0.2-fb-ts-lib.0",
     "@labkey/eslint-config-react": "0.0.13",
     "@types/enzyme": "3.10.13",
     "@types/history": "4.7.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "vis-network": "~6.5.2"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.2-fb-ts-lib.0",
+    "@labkey/build": "7.0.2",
     "@labkey/eslint-config-react": "0.0.13",
     "@types/enzyme": "3.10.13",
     "@types/history": "4.7.9",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.2.2
+*Released*: 27 December 2023
+- Bump @labkey/build
+- Replace Immer `Draft<Type>` with `produce<Type>` as the former declaration pattern can cause compilation problems.
+
 ### version 3.2.1
 *Released*: 27 December 2023
 - Support cross-folder sample import

--- a/packages/components/src/internal/components/assay/models.ts
+++ b/packages/components/src/internal/components/assay/models.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 import { immerable, produce } from 'immer';
+
 import { Operation } from '../../../public/QueryColumn';
 
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
 import { LoadingState } from '../../../public/LoadingState';
 
-import { AssayWizardModel } from './AssayWizardModel';
 import { SelectInputChange } from '../forms/input/SelectInput';
+
+import { AssayWizardModel } from './AssayWizardModel';
 
 export interface AssayPropertiesPanelProps {
     operation: Operation;

--- a/packages/components/src/internal/components/assay/models.ts
+++ b/packages/components/src/internal/components/assay/models.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 import { Operation } from '../../../public/QueryColumn';
 
 import { AssayDefinitionModel } from '../../AssayDefinitionModel';
@@ -89,7 +89,7 @@ export class AssayStateModel {
     }
 
     mutate(props: Partial<AssayStateModel>): AssayStateModel {
-        return produce(this, (draft: Draft<AssayStateModel>) => {
+        return produce<AssayStateModel>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent, ReactNode } from 'react';
-import { Draft, produce } from 'immer';
+import { produce } from 'immer';
 import { List, Map } from 'immutable';
 
 import { Domain, getServerContext } from '@labkey/api';
@@ -125,7 +125,7 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
             );
 
             this.setState(
-                produce((draft: Draft<State>) => {
+                produce<State>(draft => {
                     draft.model.parentAliases = parentAliases;
                     draft.parentOptions = parentOptions;
                 })
@@ -137,7 +137,7 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
 
             if (response.prefix) {
                 this.setState(
-                    produce((draft: Draft<State>) => {
+                    produce<State>(draft => {
                         draft.model.nameExpression =
                             response.prefix + (draft.model.nameExpression ? draft.model.nameExpression : '');
                     })
@@ -283,7 +283,7 @@ export class DataClassDesignerImpl extends PureComponent<Props & InjectedBaseDom
 
     saveModel = (modelOrProps: DataClassModel | Partial<DataClassModelConfig>, callback?: () => void): void => {
         this.setState(
-            produce((draft: Draft<State>) => {
+            produce<State>(draft => {
                 if (modelOrProps instanceof DataClassModel) {
                     draft.model = modelOrProps;
                 } else {

--- a/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/models.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 import { Map, fromJS, OrderedMap } from 'immutable';
 
 import { DomainDesign, IDomainField, SystemField } from '../models';
@@ -71,7 +71,7 @@ export class DataClassModel implements DataClassModelConfig {
 
         const model = new DataClassModel({ ...(raw.options ? raw.options : raw), domain });
 
-        return produce(model, (draft: Draft<DataClassModel>) => {
+        return produce<DataClassModel>(model, draft => {
             if (raw.options && model.category === null) {
                 draft.category = undefined;
             }

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetDesignerPanels.tsx
@@ -20,7 +20,7 @@ import { List } from 'immutable';
 
 import { Domain, getServerContext } from '@labkey/api';
 
-import { Draft, produce } from 'immer';
+import { produce } from 'immer';
 
 import { getDefaultAPIWrapper } from '../../../APIWrapper';
 import { DomainPropertiesAPIWrapper } from '../APIWrapper';
@@ -113,7 +113,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
                     .toList(),
             }) as DomainDesign;
 
-            const updatedModel = produce(model, (draft: Draft<DatasetModel>) => {
+            const updatedModel = produce<DatasetModel>(model, draft => {
                 draft.domain = updatedDomain;
             });
 
@@ -159,14 +159,14 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         if (file && (this._participantId || this._sequenceNum)) {
             const error = this.checkFieldsInColumnMapping(model);
             if (model.exception !== error) {
-                updatedModel = produce(model, (draft: Draft<DatasetModel>) => {
+                updatedModel = produce<DatasetModel>(model, draft => {
                     draft.exception = error;
                 });
             }
         }
 
         if (!model.hasValidAdditionalKey() && model.exception !== ADDITIONAL_KEY_ERROR) {
-            updatedModel = produce(model, (draft: Draft<DatasetModel>) => {
+            updatedModel = produce<DatasetModel>(model, draft => {
                 draft.exception = ADDITIONAL_KEY_ERROR;
             });
         }
@@ -192,7 +192,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
 
         if (shouldImportData && (!this._participantId || missingRequiredTimepointMapping)) {
             this.setState(
-                produce((draft: Draft<State>) => {
+                produce<State>(draft => {
                     draft.model.exception =
                         'You must select a column mapping field for ' +
                         getStudySubjectProp('nounPlural') +
@@ -218,7 +218,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         const { keyPropertyIndex, visitDatePropertyIndex } = this.state;
 
         this.setState(
-            produce((draft: Draft<State>) => {
+            produce<State>(draft => {
                 draft.model.domain = domain;
 
                 // if we are back to the no fields state, reset the file related items
@@ -314,7 +314,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         }) as DomainDesign;
 
         this.setState(
-            produce((draft: Draft<State>) => {
+            produce<State>(draft => {
                 draft.model.domain = updatedDomain;
                 draft.model.exception = this.checkFieldsInColumnMapping(draft.model);
             })
@@ -347,7 +347,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
             queryName: savedModel.name,
             failure: error => {
                 this.setState(
-                    produce((draft: Draft<State>) => {
+                    produce<State>(draft => {
                         draft.model.exception = error;
                         draft.savedModel = undefined;
                         draft.importError = undefined;
@@ -356,7 +356,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
             },
             success: () => {
                 this.setState(
-                    produce((draft: Draft<State>) => {
+                    produce<State>(draft => {
                         draft.savedModel = undefined;
                         draft.importError = undefined;
                     })
@@ -435,13 +435,13 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
         })
             .then(response => {
                 this.setState(
-                    produce((draftState: Draft<State>) => {
+                    produce<State>(draftState => {
                         draftState.keyPropertyIndex = keyPropIndex;
                         draftState.visitDatePropertyIndex = visitPropIndex;
                         draftState.model.exception = undefined;
 
                         // the savedModel will be used for dropping the domain on file import failure or for onComplete
-                        draftState.savedModel = produce(draftState.model, (draftModel: Draft<DatasetModel>) => {
+                        draftState.savedModel = produce<DatasetModel>(draftState.model, draftModel => {
                             draftModel.domain = response;
                         });
                     }),
@@ -462,7 +462,7 @@ export class DatasetDesignerPanelImpl extends React.PureComponent<Props & Inject
 
                 setSubmitting(false, () => {
                     this.setState(
-                        produce((draft: Draft<State>) => {
+                        produce<State>(draft => {
                             if (exception) {
                                 draft.model.exception = exception;
                             } else {

--- a/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataset/DatasetPropertiesPanel.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 
-import { Draft, produce } from 'immer';
+import { produce } from 'immer';
 
 import { List } from 'immutable';
 
@@ -84,14 +84,14 @@ export class DatasetPropertiesPanelImpl extends React.PureComponent<
     onChange = (identifier, value): void => {
         const { model } = this.props;
 
-        const newModel = produce(model, (draft: Draft<DatasetModel>) => {
+        const newModel = produce<DatasetModel>(model, draft => {
             draft[identifier] = value;
         });
 
         this.updateValidStatus(newModel);
     };
 
-    onInputChange = (evt: any) => {
+    onInputChange = (evt: any): void => {
         const id = evt.target.id;
         let value = evt.target.value;
 
@@ -104,7 +104,7 @@ export class DatasetPropertiesPanelImpl extends React.PureComponent<
 
     onCategoryChange = (_, category): void => {
         const { model } = this.props;
-        const newModel = produce(model, (draft: Draft<DatasetModel>) => {
+        const newModel = produce<DatasetModel>(model, draft => {
             draft.category = category ?? undefined;
         });
 
@@ -120,7 +120,7 @@ export class DatasetPropertiesPanelImpl extends React.PureComponent<
             fields: this.getUpdatedFieldsWithoutDisablePhi(),
         }) as DomainDesign;
 
-        const newModel = produce(model, (draft: Draft<DatasetModel>) => {
+        const newModel = produce<DatasetModel>(model, draft => {
             draft.domain = updatedDomain;
             draft.useTimeKeyField = false;
             draft.keyPropertyManaged = false;
@@ -166,7 +166,7 @@ export class DatasetPropertiesPanelImpl extends React.PureComponent<
                 .toList(),
         }) as DomainDesign;
 
-        const newModel = produce(model, (draft: Draft<DatasetModel>) => {
+        const newModel = produce<DatasetModel>(model, draft => {
             draft.domain = updatedDomain;
             draft.useTimeKeyField = formValue === TIME_KEY_FIELD_KEY;
             draft.keyPropertyName = formValue;
@@ -185,7 +185,7 @@ export class DatasetPropertiesPanelImpl extends React.PureComponent<
         const { model, onIndexChange, keyPropertyIndex } = this.props;
 
         let visitDatePropIndex;
-        const newModel = produce(model, (draft: Draft<DatasetModel>) => {
+        const newModel = produce<DatasetModel>(model, draft => {
             Object.assign(draft, model, advancedSettingsForm);
         });
 

--- a/packages/components/src/internal/components/domainproperties/dataset/models.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/models.ts
@@ -18,7 +18,7 @@ import { Record } from 'immutable';
 
 import { getServerContext } from '@labkey/api';
 
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 
 import { DomainDesign, DomainField } from '../models';
 
@@ -107,7 +107,7 @@ export class DatasetModel implements IDatasetModel {
                         .toList(),
                 }) as DomainDesign;
 
-                model = produce(model, (draft: Draft<DatasetModel>) => {
+                model = produce<DatasetModel>(model, draft => {
                     draft.domain = newDomain;
                 });
             }
@@ -178,7 +178,7 @@ export class DatasetModel implements IDatasetModel {
     }
 
     getOptions(): Record<string, any> {
-        return produce(this, (draft: Draft<IDatasetModel>) => {
+        return produce<IDatasetModel>(this, draft => {
             delete draft.exception;
             delete draft.domain;
         });

--- a/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/issues/IssuesListDefDesignerPanels.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { List } from 'immutable';
-import { Draft, produce } from 'immer';
+import { produce } from 'immer';
 
 import { BaseDomainDesigner, InjectedBaseDomainDesignerProps, withBaseDomainDesigner } from '../BaseDomainDesigner';
 import { getDomainPanelStatus, saveDomain } from '../actions';
@@ -47,7 +47,7 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
         const { onChange } = this.props;
 
         this.setState(
-            produce((draft: Draft<State>) => {
+            produce<State>(draft => {
                 draft.model = model;
             }),
             () => {
@@ -62,7 +62,7 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
         const { onChange } = this.props;
 
         this.setState(
-            produce((draft: Draft<State>) => {
+            produce<State>(draft => {
                 draft.model.domain = domain;
             }),
             () => {
@@ -87,7 +87,7 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
             .catch(response => {
                 setSubmitting(false, () => {
                     this.setState(
-                        produce((draft: Draft<State>) => {
+                        produce<State>(draft => {
                             draft.model.exception = response.exception;
                         })
                     );
@@ -111,7 +111,7 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
 
                 setSubmitting(false, () => {
                     this.setState(
-                        produce((draft: Draft<State>) => {
+                        produce<State>(draft => {
                             if (exception) {
                                 draft.model.exception = exception;
                             } else {
@@ -128,7 +128,7 @@ export class IssuesDesignerPanelsImpl extends React.PureComponent<Props & Inject
         const { setSubmitting } = this.props;
 
         this.setState(
-            produce((draft: Draft<State>) => {
+            produce<State>(draft => {
                 draft.model.exception = undefined;
                 if (response) {
                     draft.model.domain = response;

--- a/packages/components/src/internal/components/labels/models.ts
+++ b/packages/components/src/internal/components/labels/models.ts
@@ -1,4 +1,4 @@
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 
 import { flattenValuesFromRow } from '../../../public/QueryModel/QueryModel';
 
@@ -128,7 +128,7 @@ export class LabelTemplate {
     }
 
     mutate(props: Partial<LabelTemplate>): LabelTemplate {
-        return produce(this, (draft: Draft<LabelTemplate>) => {
+        return produce<LabelTemplate>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/internal/components/lineage/actions.ts
+++ b/packages/components/src/internal/components/lineage/actions.ts
@@ -3,7 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { createContext } from 'react';
-import { Draft, produce } from 'immer';
+import { produce } from 'immer';
 import { fromJS, Map, OrderedSet } from 'immutable';
 import { Experiment, Filter, getServerContext, Query } from '@labkey/api';
 
@@ -74,7 +74,7 @@ function applyLineageMetadata(
         const config = {
             ...applyItemMetadata(node, iconURLByLsid, urlResolver, lineage.seed === node.lsid),
             steps: node.steps.map(
-                produce((draft: Draft<LineageRunStep>) => {
+                produce<LineageRunStep>(draft => {
                     Object.assign(draft, applyItemMetadata(draft, iconURLByLsid, urlResolver));
                 })
             ),
@@ -111,7 +111,7 @@ function applyLineageIOMetadata(
     iconURLByLsid: Record<string /* LSID */, string>,
     urlResolver: LineageURLResolver
 ): LineageIOWithMetadata {
-    const _applyItem = produce((draft: Draft<LineageItemWithMetadata>) => {
+    const _applyItem = produce<LineageItemWithMetadata>(draft => {
         draft.iconProps = resolveIconAndShapeForNode(draft, iconURLByLsid[draft.lsid]);
         draft.links = urlResolver.resolveItem(draft);
     });

--- a/packages/components/src/internal/components/lineage/grid/LineageGrid.tsx
+++ b/packages/components/src/internal/components/lineage/grid/LineageGrid.tsx
@@ -5,6 +5,7 @@
 import React, { FC, memo, PureComponent, ReactNode, useMemo } from 'react';
 import { produce } from 'immer';
 import { useSearchParams } from 'react-router-dom';
+
 import { Page } from '../../base/Page';
 import { PageHeader } from '../../base/PageHeader';
 

--- a/packages/components/src/internal/components/lineage/grid/LineageGrid.tsx
+++ b/packages/components/src/internal/components/lineage/grid/LineageGrid.tsx
@@ -3,7 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import React, { FC, memo, PureComponent, ReactNode, useMemo } from 'react';
-import { Draft, produce } from 'immer';
+import { produce } from 'immer';
 import { useSearchParams } from 'react-router-dom';
 import { Page } from '../../base/Page';
 import { PageHeader } from '../../base/PageHeader';
@@ -33,7 +33,7 @@ class LineageGridImpl extends PureComponent<LineageGridProps, LineageGridState> 
         const { distance, lineage, members, pageNumber } = nextProps;
 
         return {
-            model: produce(prevState.model, (draft: Draft<LineageGridModel>) => {
+            model: produce<LineageGridModel>(prevState.model, draft => {
                 if (lineage?.error) {
                     draft.isError = true;
                     draft.isLoaded = false;

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 import { List, Map, Record as ImmutableRecord } from 'immutable';
 import { Experiment, Utils } from '@labkey/api';
 import { DataSet, Edge, IdType, Node } from 'vis-network';
@@ -613,7 +613,7 @@ export class Lineage {
      * @param props
      */
     mutate(props: Partial<Lineage>): Lineage {
-        return produce(this, (draft: Draft<Lineage>) => {
+        return produce<Lineage>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/internal/components/notifications/model.ts
+++ b/packages/components/src/internal/components/notifications/model.ts
@@ -16,7 +16,7 @@
 import React from 'react';
 import { Record } from 'immutable';
 
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 
 import { generateId } from '../../util/utils';
 
@@ -109,7 +109,7 @@ export class ServerActivityData {
     }
 
     mutate(props: Partial<ServerActivityData>): ServerActivityData {
-        return produce(this, (draft: Draft<ServerActivityData>) => {
+        return produce<ServerActivityData>(this, draft => {
             Object.assign(draft, props);
         });
     }
@@ -180,7 +180,7 @@ export class ServerNotificationModel implements IServerNotificationModel {
     }
 
     mutate(props: Partial<ServerNotificationModel>): ServerNotificationModel {
-        return produce(this, (draft: Draft<ServerNotificationModel>) => {
+        return produce<ServerNotificationModel>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/internal/components/picklist/models.ts
+++ b/packages/components/src/internal/components/picklist/models.ts
@@ -1,4 +1,4 @@
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 
 import { Filter } from '@labkey/api';
 
@@ -63,7 +63,7 @@ export class Picklist {
     }
 
     mutate(props: Partial<Picklist>): Picklist {
-        return produce(this, (draft: Draft<Picklist>) => {
+        return produce<Picklist>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/internal/components/pipeline/model.ts
+++ b/packages/components/src/internal/components/pipeline/model.ts
@@ -1,4 +1,4 @@
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 
 export interface PipelineLogEntry {
     dateTime: string;
@@ -45,7 +45,7 @@ export class PipelineStatusDetailModel {
     }
 
     mutate(props: Partial<PipelineStatusDetailModel>): PipelineStatusDetailModel {
-        return produce(this, (draft: Draft<PipelineStatusDetailModel>) => {
+        return produce<PipelineStatusDetailModel>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react';
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 import { Filter, Query } from '@labkey/api';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
@@ -176,7 +176,7 @@ export class SampleState {
     }
 
     mutate(props: Partial<SampleState>): SampleState {
-        return produce(this, (draft: Draft<SampleState>) => {
+        return produce<SampleState>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -1,4 +1,4 @@
-import { Draft, immerable, produce } from 'immer';
+import { immerable, produce } from 'immer';
 import { Filter, Query } from '@labkey/api';
 
 import { GRID_CHECKBOX_OPTIONS, GRID_SELECTION_INDEX } from '../../internal/constants';
@@ -1154,7 +1154,7 @@ export class QueryModel {
      * @param props
      */
     mutate(props: Partial<QueryModel>): QueryModel {
-        return produce(this, (draft: Draft<QueryModel>) => {
+        return produce<QueryModel>(this, draft => {
             Object.assign(draft, props);
         });
     }

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, FC, PureComponent, ReactNode, useMemo, useCallback } from 'react';
+import React, { ComponentType, FC, PureComponent, ReactNode } from 'react';
 import { Filter } from '@labkey/api';
 // eslint cannot find Draft for some reason, but Intellij can.
 // eslint-disable-next-line import/named
@@ -105,7 +105,7 @@ interface State {
 /**
  * Resets queryInfo state to initialized state. Use this when you need to load/reload QueryInfo.
  * Note: This method intentionally has side effects, it is only to be used inside of an Immer produce() callback.
- * @param model: Draft<QueryModel> the model to reset queryInfo state on.
+ * @param model The model to reset queryInfo state on.
  */
 const resetQueryInfoState = (model: Draft<QueryModel>): void => {
     model.queryInfo = undefined;
@@ -116,7 +116,7 @@ const resetQueryInfoState = (model: Draft<QueryModel>): void => {
 /**
  * Resets totalCount state to initialized state. Use this when you need to load/reload QueryInfo.
  * Note: This method intentionally has side effects, it is only to be used inside of an Immer produce() callback.
- * @param model: Draft<QueryModel> the model to reset queryInfo state on.
+ * @param model The model to reset queryInfo state on.
  */
 const resetTotalCountState = (model: Draft<QueryModel>): void => {
     model.rowCount = undefined;
@@ -127,7 +127,7 @@ const resetTotalCountState = (model: Draft<QueryModel>): void => {
 /**
  * Resets rows state to initialized state. Use this when you need to load/reload selections.
  * Note: This method intentionally has side effects, it is only to be used inside of an Immer produce() callback.
- * @param model: Draft<QueryModel> the model to reset selection state on.
+ * @param model The model to reset selection state on.
  */
 const resetRowsState = (model: Draft<QueryModel>): void => {
     model.messages = undefined;
@@ -142,7 +142,7 @@ const resetRowsState = (model: Draft<QueryModel>): void => {
 /**
  * Resets selection state to initialized state. Use this when you need to load/reload selections.
  * Note: This method intentionally has side effects, it is only to be used inside of an Immer produce() callback.
- * @param model: Draft<QueryModel> the model to reset selection state on.
+ * @param model The model to reset selection state on.
  */
 const resetSelectionState = (model: Draft<QueryModel>): void => {
     model.selections = undefined;
@@ -177,7 +177,7 @@ const paramsEqual = (oldParams, newParams): boolean => {
 
 /**
  * A wrapper for LabKey selectRows API. For in-depth documentation and examples see components/docs/QueryModel.md.
- * @param ComponentToWrap: A component that implements generic Props and InjectedQueryModels.
+ * @param ComponentToWrap A component that implements generic Props and InjectedQueryModels.
  * @returns A react ComponentType that implements generic Props and MakeQueryModels.
  */
 export function withQueryModels<Props>(


### PR DESCRIPTION
#### Rationale
This updates the `"lib"` property of the TypeScript `compilerOptions` declared by `@labkey/build` to include typings for more recently available ECMA Script features. Some of these features are already in use by our applications so we want to be sure to include the correct typings.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1379
- https://github.com/LabKey/labkey-ui-premium/pull/290
- https://github.com/LabKey/biologics/pull/2602
- https://github.com/LabKey/sampleManagement/pull/2330
- https://github.com/LabKey/inventory/pull/1141
- https://github.com/LabKey/platform/pull/5083

#### Changes
- **@labkey/build**
  -  Update `"lib"` declarations `es2017` to `es2019` and add `dom.iterable`. See [TypeScript Docs](https://www.typescriptlang.org/tsconfig#lib).
- **@labkey/components** 
  - Replace Immer `Draft<Type>` with `produce<Type>` as the former declaration pattern can cause compilation problems.