### PR TITLE
bug fixes: Issue 49144, Issue 49082

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.1",
+  "version": "3.2.2-fb-smBugFix24.1X.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.2.1",
+      "version": "3.2.2-fb-smBugFix24.1X.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.1",
+  "version": "3.2.2-fb-smBugFix24.1X.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.X
+*Released*: X December 2023
+- TODO
+
 ### version 3.2.1
 *Released*: 27 December 2023
 - Support cross-folder sample import

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -205,13 +205,13 @@ export const SAMPLE_INSERT_EXTRA_COLUMNS = [...AMOUNT_AND_UNITS_COLUMNS, ...SAMP
 export const SAMPLE_EXPORT_CONFIG = {
     'exportAlias.name': DEFAULT_SAMPLE_FIELD_CONFIG.label,
     'exportAlias.aliquotedFromLSID': ALIQUOTED_FROM_COL,
+    'exportAlias.aliquotedFromLSID/name': ALIQUOTED_FROM_COL,
     'exportAlias.sampleState': STATUS_COL,
     'exportAlias.storedAmount': 'Amount',
 };
 
 export const SAMPLE_DATA_EXPORT_CONFIG = {
     ...SAMPLE_EXPORT_CONFIG,
-    includeColumn: ['AliquotedFromLSID'],
 };
 
 // Issue 46037: Some plate-based assays (e.g., NAB) create samples with a bogus 'Material' sample type, which should get excluded everywhere in the application

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -1220,3 +1220,7 @@ export function saveSettingsToLocalStorage(model: QueryModel): void {
     // a single model.
     localStorage.setItem(localStorageKey(model.id, model.containerPath), JSON.stringify(settings));
 }
+
+export function removeSettingsFromLocalStorage(model: QueryModel): void {
+    localStorage.removeItem(localStorageKey(model.id, model.containerPath));
+}

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -22,6 +22,7 @@ import {
     locationHasQueryParamSettings,
     QueryConfig,
     QueryModel,
+    removeSettingsFromLocalStorage,
     saveSettingsToLocalStorage,
 } from './QueryModel';
 
@@ -391,6 +392,7 @@ export function withQueryModels<Props>(
 
                     console.error(`Error setting selections for model ${id}:`, selectionsError);
                     model.selectionsError = selectionsError;
+                    removeSettingsFromLocalStorage(this.state.queryModels[id]);
                 })
             );
         };
@@ -647,6 +649,7 @@ export function withQueryModels<Props>(
                         }
 
                         console.error(`Error loading rows for model ${id}: `, rowsError);
+                        removeSettingsFromLocalStorage(this.state.queryModels[id]);
                         model.rowsLoadingState = LoadingState.LOADED;
                         model.rowsError = rowsError;
                         model.selectionPivot = undefined;
@@ -720,6 +723,7 @@ export function withQueryModels<Props>(
                         }
 
                         console.error(`Error loading rows for model ${id}: `, rowsError);
+                        removeSettingsFromLocalStorage(this.state.queryModels[id]);
                         model.totalCountLoadingState = LoadingState.LOADED;
                         model.totalCountError = rowsError;
                     })
@@ -763,7 +767,7 @@ export function withQueryModels<Props>(
                         }
 
                         console.error(`Error loading QueryInfo for model ${id}:`, queryInfoError);
-
+                        removeSettingsFromLocalStorage(this.state.queryModels[id]);
                         model.queryInfoLoadingState = LoadingState.LOADED;
                         model.queryInfoError = queryInfoError;
                     })
@@ -909,6 +913,7 @@ export function withQueryModels<Props>(
                         }
 
                         console.error(`Error loading charts for model ${id}`, chartsError);
+                        removeSettingsFromLocalStorage(this.state.queryModels[id]);
                         model.chartsLoadingState = LoadingState.LOADED;
                         model.chartsError = chartsError;
                     })


### PR DESCRIPTION
#### Rationale
Issue [49144](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49144): LKSM/LKB: “AliquotedFrom” column unexpectedly included in all sample downloads
Issue [49082](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49082): LKSM/LKB: query.view is remembered by samples grid

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1380
- https://github.com/LabKey/labkey-ui-premium/pull/291
- https://github.com/LabKey/sampleManagement/pull/2332
- https://github.com/LabKey/biologics/pull/2603
- https://github.com/LabKey/inventory/pull/1142

#### Changes
- remove AliquotedFrom from samples grid export/template/editable grid export
- remove QueryModel from localStorage on error
