### PR TITLE
Refactor all UNSAFE_ usages

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.5.3",
+  "version": "3.5.4-fb-make-safe.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.5.3",
+      "version": "3.5.4-fb-make-safe.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.5.4-fb-make-safe.0",
+  "version": "3.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.5.4-fb-make-safe.0",
+      "version": "3.5.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.5.4-fb-make-safe.0",
+  "version": "3.5.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.5.3",
+  "version": "3.5.4-fb-make-safe.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,12 +1,16 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.5.4
+*Released*: 11 January 2024
+- Refactor all UNSAFE_ usages
+
 ### version 3.5.3
 *Released*: 11 January 2024
 - Language Consistency: 'My' vs. 'Your' and 'Shared' vs. 'Public'
 
 ### version 3.5.2
-*Released*: 10 January 2024
+*Released*: 11 January 2024
 * Make menuReload action actually reload the menu
 * Use menuReload action in registerWebsocketListeners
 

--- a/packages/components/src/internal/components/base/Progress.tsx
+++ b/packages/components/src/internal/components/base/Progress.tsx
@@ -26,9 +26,9 @@ interface Props {
 }
 
 interface State {
-    duration?: number;
-    percent?: number;
-    show?: boolean;
+    duration: number;
+    percent: number;
+    show: boolean;
 }
 
 export class Progress extends React.Component<Props, State> {
@@ -42,39 +42,29 @@ export class Progress extends React.Component<Props, State> {
     delayTimer: number;
     timer: number;
 
-    constructor(props: Props) {
-        super(props);
+    state: Readonly<State> = { duration: 0, percent: 0, show: false };
 
-        this.end = this.end.bind(this);
-        this.start = this.start.bind(this);
-
-        this.state = {
-            duration: 0,
-            percent: 0,
-            show: false,
-        };
-    }
-
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         this.end(true);
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: Props): void {
-        if (!this.props.toggle && nextProps.toggle) {
-            if (this.props.delay) {
+    componentDidUpdate(prevProps: Props): void {
+        const { delay, toggle } = this.props;
+        if (!prevProps.toggle && toggle) {
+            if (delay) {
                 this.delayTimer = window.setTimeout(() => {
                     this.cycle(true);
                     this.start();
-                }, this.props.delay);
+                }, delay);
             } else {
                 this.start();
             }
-        } else if (this.props.toggle && !nextProps.toggle) {
+        } else if (prevProps.toggle && !toggle) {
             this.end();
         }
     }
 
-    cycle(fromDelay?: boolean) {
+    cycle = (fromDelay?: boolean): void => {
         const newDuration = this.state.duration + (fromDelay ? this.props.delay : this.props.updateIncrement);
         const newPercent = Math.ceil((newDuration / this.props.estimate) * 100);
 
@@ -83,39 +73,36 @@ export class Progress extends React.Component<Props, State> {
             percent: newPercent > 100 ? 100 : newPercent,
             show: true,
         });
-    }
+    };
 
-    end(fromUnmount?: boolean) {
+    end = (fromUnmount?: boolean): void => {
         clearTimeout(this.delayTimer);
         clearTimeout(this.timer);
 
         if (fromUnmount !== true) {
-            this.setState({
-                percent: 0,
-                show: false,
-            });
+            this.setState({ percent: 0, show: false });
         }
-    }
+    };
 
-    start() {
+    start = (): void => {
         clearTimeout(this.timer);
         this.timer = window.setTimeout(() => {
             this.timer = null;
             this.cycle();
             this.start();
         }, this.props.updateIncrement);
-    }
+    };
 
     render() {
         const { children, modal, title } = this.props;
-        const { show } = this.state;
-        let element = null;
+        const { percent, show } = this.state;
+
         const indicator = show && (
-            <ProgressBar active now={this.state.percent} bsStyle={this.state.percent === 100 ? 'success' : undefined} />
+            <ProgressBar active now={percent} bsStyle={percent === 100 ? 'success' : undefined} />
         );
 
         if (modal) {
-            element = (
+            return (
                 <Modal bsSize="large" show={show} onHide={() => {}}>
                     {title && (
                         <Modal.Header>
@@ -129,9 +116,9 @@ export class Progress extends React.Component<Props, State> {
                 </Modal>
             );
         } else if (show) {
-            element = indicator;
+            return indicator;
         }
 
-        return element;
+        return null;
     }
 }

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -246,16 +246,16 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
         this.setState({ isLoading: false });
     };
 
-    UNSAFE_componentWillReceiveProps(nextProps: Readonly<IDomainFormInput>): void {
-        const { controlledCollapse, initCollapsed, validate, onChange } = this.props;
+    componentDidUpdate(prevProps: IDomainFormInput): void {
+        const { controlledCollapse, domain, initCollapsed, validate, onChange } = this.props;
 
         // if controlled collapsible, allow the prop change to update the collapsed state
-        if (controlledCollapse && nextProps.initCollapsed !== initCollapsed) {
-            this.toggleLocalPanel(nextProps.initCollapsed);
+        if (controlledCollapse && prevProps.initCollapsed !== initCollapsed) {
+            this.toggleLocalPanel(initCollapsed);
         }
 
-        if (nextProps.validate && validate !== nextProps.validate) {
-            onChange?.(this.validateDomain(nextProps.domain), false);
+        if (validate && validate !== prevProps.validate) {
+            onChange?.(this.validateDomain(domain), false);
         }
     }
 

--- a/packages/components/src/internal/components/domainproperties/DomainPropertiesPanelCollapse.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainPropertiesPanelCollapse.tsx
@@ -11,7 +11,7 @@ export interface MakeDomainPropertiesPanelCollapseProps {
     collapsible?: boolean;
     controlledCollapse: boolean;
     initCollapsed: boolean;
-    onToggle?: (collapsed: boolean, callback: () => any) => any;
+    onToggle?: (collapsed: boolean, callback: () => any) => void;
 }
 
 interface State {
@@ -33,22 +33,22 @@ export function withDomainPropertiesPanelCollapse<Props>(
             };
         }
 
-        UNSAFE_componentWillReceiveProps(nextProps: Readonly<Props & MakeDomainPropertiesPanelCollapseProps>): void {
+        componentDidUpdate(prevProps: Props & MakeDomainPropertiesPanelCollapseProps): void {
             const { controlledCollapse, initCollapsed } = this.props;
 
             // if controlled collapse, allow the prop change to update the collapsed state
-            if (controlledCollapse && nextProps.initCollapsed !== initCollapsed) {
-                this.toggleLocalPanel(nextProps.initCollapsed);
+            if (controlledCollapse && prevProps.initCollapsed !== initCollapsed) {
+                this.toggleLocalPanel(initCollapsed);
             }
         }
 
-        toggleLocalPanel = (collapsed?: boolean) => {
+        toggleLocalPanel = (collapsed?: boolean): void => {
             this.setState(state => ({
                 collapsed: collapsed !== undefined ? collapsed : !state.collapsed,
             }));
         };
 
-        togglePanel = (evt: any, collapsed?: boolean) => {
+        togglePanel = (evt: any, collapsed?: boolean): void => {
             const { onToggle, collapsible, controlledCollapse } = this.props;
 
             if (collapsible || controlledCollapse) {
@@ -62,6 +62,7 @@ export function withDomainPropertiesPanelCollapse<Props>(
 
         render() {
             // pull out MakeDomainPropertiesPanelCollapseProps as we don't want to pass that to children
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { initCollapsed, onToggle, controlledCollapse, collapsible, ...props } = this.props;
             const { collapsed } = this.state;
 

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -135,10 +135,10 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
         this.ref.current.scrollIntoView({ behavior: 'smooth' });
     };
 
-    UNSAFE_componentWillReceiveProps(nextProps: DomainRowProps): void {
+    componentDidUpdate(prevProps: DomainRowProps): void {
         // if there was a prop change to isDragDisabled, need to call setDragDisabled
-        if (nextProps.isDragDisabled !== this.props.isDragDisabled) {
-            this.setDragDisabled(nextProps.isDragDisabled, false);
+        if (prevProps.isDragDisabled !== this.props.isDragDisabled) {
+            this.setDragDisabled(this.props.isDragDisabled, false);
         }
     }
 

--- a/packages/components/src/internal/components/forms/FormStep.spec.tsx
+++ b/packages/components/src/internal/components/forms/FormStep.spec.tsx
@@ -25,8 +25,8 @@ interface OwnProps {
 }
 type Props = OwnProps & WithFormStepsProps;
 
-class FormStepTestImpl extends React.Component<Props, any> {
-    UNSAFE_componentWillMount(): void {
+class FormStepTestImpl extends React.Component<Props> {
+    componentDidMount(): void {
         if (this.props.step !== undefined) {
             this.props.selectStep(this.props.step);
         }


### PR DESCRIPTION
#### Rationale
This replaces all usages of `UNSAFE_` prefixed component methods with an appropriate alternative.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1383
- https://github.com/LabKey/biologics/pull/2616
- https://github.com/LabKey/sampleManagement/pull/2349
- https://github.com/LabKey/inventory/pull/1150

#### Changes
- Replaces usages of `UNSAFE_componentWillReceiveProps` and `UNSAFE_componentWillMount`
