### PR TITLE
Issue 49357: Fix error in editable grid when checking for values on undefined set

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.4",
+  "version": "3.2.5-hasDataEmptyValues.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.2.4",
+      "version": "3.2.5-hasDataEmptyValues.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.5-hasDataEmptyValues.0",
+  "version": "3.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.2.5-hasDataEmptyValues.0",
+      "version": "3.2.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.5-hasDataEmptyValues.0",
+  "version": "3.2.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.2.4",
+  "version": "3.2.5-hasDataEmptyValues.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 49357: Fix error in editable grid when checking for values on undefined set
+
 ### version 3.2.4
 *Released*: 29 December 2023
 - remove AliquotedFrom from samples grid export/editable grid export

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 3.2.5
+*Released*: 9 January 2024
 - Issue 49357: Fix error in editable grid when checking for values on undefined set
 
 ### version 3.2.4

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -510,7 +510,7 @@ export class EditorModel
     get hasData(): boolean {
         return (
             this.cellValues.find(valueList => {
-                return valueList.find(value => this.hasRawValue(value)) !== undefined;
+                return valueList?.find(value => this.hasRawValue(value)) !== undefined;
             }) !== undefined
         );
     }


### PR DESCRIPTION
#### Rationale
[Issue 49357](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49357)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/297
- https://github.com/LabKey/inventory/pull/1155
- https://github.com/LabKey/sampleManagement/pull/2365
- https://github.com/LabKey/biologics/pull/2627

#### Changes
- Add null check