### PR TITLE
Plate Set: Listing, Create, & Details

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.5.5",
+      "version": "3.6.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.6.0
+*Released*: 15 January 2024
+- Publicly export `PlacementType`
+- Add `allowExport` prop on `EditableGridPanel`
+- Add `plate.PlateSet` to schema constants
+- `entity.getDeleteConfirmationData`: support containerPath
+
 ### version 3.5.5
 *Released*: 15 January 2024
 - Multi-Parent Matching in Sample Finder

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1798,6 +1798,7 @@ export type { ComponentsAPIWrapper } from './internal/APIWrapper';
 export type { GetParentTypeDataForLineage } from './internal/components/entities/actions';
 export type { URLMapper } from './internal/url/URLResolver';
 export type { EditableGridEvent } from './internal/components/editable/constants';
+export type { PlacementType } from './internal/components/editable/Controls';
 export type { EditableGridChange } from './internal/components/editable/EditableGrid';
 export type { GetAssayDefinitionsOptions, GetProtocolOptions } from './internal/components/assay/actions';
 export type {

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -19,6 +19,7 @@ import { EditableGrid, EditableGridChange, SharedEditableGridPanelProps } from '
 import { exportEditedData, getEditorExportData } from './utils';
 
 interface Props extends SharedEditableGridPanelProps {
+    allowExport?: boolean;
     editorModel: EditorModel | EditorModel[];
     getIsDirty?: () => boolean;
     model: QueryModel | QueryModel[];
@@ -60,6 +61,7 @@ const exportHandler = (
  */
 export const EditableGridPanel: FC<Props> = memo(props => {
     const {
+        allowExport = true,
         editorModel,
         model,
         onChange,
@@ -172,7 +174,7 @@ export const EditableGridPanel: FC<Props> = memo(props => {
             readonlyRows={activeReadOnlyRows}
             readOnlyColumns={readOnlyColumns}
             updateColumns={activeUpdateColumns}
-            exportHandler={exportHandlerCallback}
+            exportHandler={allowExport ? exportHandlerCallback : undefined}
             exportColFilter={exportColFilter}
             insertColumns={insertColumns}
             forUpdate={forUpdate}

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -29,7 +29,6 @@ import {
     IParentOption,
     OperationConfirmationData,
 } from './models';
-import { SchemaQuery } from '../../../public/SchemaQuery';
 
 export interface EntityAPIWrapper {
     getDataOperationConfirmationData: (
@@ -71,7 +70,7 @@ export interface EntityAPIWrapper {
         importParameters?: Record<string, any>,
         importFileController?: string,
         saveToPipeline?: boolean,
-        containerPath?: string,
+        containerPath?: string
     ) => Promise<any>;
     initParentOptionsSelects: (
         includeSampleTypes: boolean,

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -9,6 +9,7 @@ import { InsertOptions } from '../../query/api';
 
 import {
     getDataOperationConfirmationData,
+    GetDeleteConfirmationDataOptions,
     getDeleteConfirmationData,
     getMoveConfirmationData,
     getEntityTypeData,
@@ -37,13 +38,7 @@ export interface EntityAPIWrapper {
         selectionKey?: string,
         useSnapshotSelection?: boolean
     ) => Promise<OperationConfirmationData>;
-    getDeleteConfirmationData: (
-        dataType: EntityDataType,
-        rowIds: string[] | number[],
-        selectionKey?: string,
-        useSnapshotSelection?: boolean,
-        schemaQuery?: SchemaQuery,
-    ) => Promise<OperationConfirmationData>;
+    getDeleteConfirmationData: (options: GetDeleteConfirmationDataOptions) => Promise<OperationConfirmationData>;
     getEntityTypeData: (
         model: EntityIdCreationModel,
         entityDataType: EntityDataType,

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -33,7 +33,7 @@ import {
     isAssayDesignEntity,
     isAssayResultEntity,
     isDataClassEntity,
-    isSampleEntity
+    isSampleEntity,
 } from './utils';
 import {
     AssayRunOperation,
@@ -635,7 +635,7 @@ export function handleEntityFileImport(
     importParameters?: Record<string, any>,
     importFileController?: string,
     saveToPipeline?: boolean,
-    containerPath?: string,
+    containerPath?: string
 ): Promise<any> {
     return new Promise((resolve, reject) => {
         return importData({

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -147,6 +147,7 @@ export const AUDIT_TABLES = {
 const PLATE_SCHEMA = 'plate';
 const PLATE_TABLES = {
     PLATE: new SchemaQuery(PLATE_SCHEMA, 'Plate'),
+    PLATE_SET: new SchemaQuery(PLATE_SCHEMA, 'PlateSet'),
     SCHEMA: PLATE_SCHEMA,
     WELL: new SchemaQuery(PLATE_SCHEMA, 'Well'),
     WELL_GROUP: new SchemaQuery(PLATE_SCHEMA, 'WellGroup'),


### PR DESCRIPTION
#### Rationale
Introduces UX for creation, listing, and details for Plate Sets.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1390
- https://github.com/LabKey/labkey-ui-premium/pull/302
- https://github.com/LabKey/platform/pull/5118
- https://github.com/LabKey/biologics/pull/2636
- https://github.com/LabKey/sampleManagement/pull/2374
- https://github.com/LabKey/inventory/pull/1162

#### Changes
- Publicly export `PlacementType`
- Add `allowExport` prop on `EditableGridPanel`
- Add `plate.PlateSet` to schema constants
- `entity.getDeleteConfirmationData`: support containerPath
