### PR TITLE
Remove feature flag for R report capabilities

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.7.2
+*Released*: 17 January 2024
+- Remove experimental feature flag for R report capabilities
+
 ### version 3.7.1
 *Released*: 17 January 2024
 * Update `EntityIdCreationModel.postEntityGrid` to accept optional `containerPath`

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -107,8 +107,6 @@ export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 
 export const EXPERIMENTAL_APP_PLATE_SUPPORT = 'experimental-app-plate-support';
 
-export const EXPERIMENTAL_APP_R_SUPPORT = 'experimental-app-r-support';
-
 export const EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = 'queryProductAllFolderLookups';
 export const EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED = 'queryProductProjectDataListingScoped';
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -21,7 +21,6 @@ import {
     ASSAYS_KEY,
     BIOLOGICS_APP_PROPERTIES,
     EXPERIMENTAL_APP_PLATE_SUPPORT,
-    EXPERIMENTAL_APP_R_SUPPORT,
     EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS,
     EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED,
     EXPERIMENTAL_REQUESTS_MENU,
@@ -350,10 +349,7 @@ export function isPlatesEnabled(moduleContext?: ModuleContext): boolean {
 }
 
 export function isRReportsEnabled(moduleContext?: ModuleContext): boolean {
-    return (
-        biologicsIsPrimaryApp(moduleContext) &&
-        resolveModuleContext(moduleContext)?.biologics?.[EXPERIMENTAL_APP_R_SUPPORT] === true
-    );
+    return biologicsIsPrimaryApp(moduleContext);
 }
 
 export function isELNEnabled(moduleContext?: ModuleContext): boolean {


### PR DESCRIPTION
#### Rationale
Remove the experimental flag for R report capabilities.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1394
- https://github.com/LabKey/biologics/pull/2647
- https://github.com/LabKey/sampleManagement/pull/2388
- https://github.com/LabKey/inventory/pull/1166

#### Changes
- Bump @labkey/components
- Update tests
