### PR TITLE
UserSelectInput: use APIWrapper

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.8.1",
+      "version": "3.9.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.8.2
+*Released*: 23 January 2024
+- Add `api.security.getUsersWithPermissions` to `SecurityAPIWrapper`
+- Display internal component request errors via placeholder in `UserSelectInput`. Disable on error.
+- Use `async` pattern for requests from `UserDetailsPanel`
+
 ### version 3.8.1
 *Released*: 23 January 2024
 - Add optional `onBeforeUpdate` to `EditableDetailPanel`

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.8.2
+### version 3.9.0
 *Released*: 23 January 2024
 - Add `api.security.getUsersWithPermissions` to `SecurityAPIWrapper`
 - Display internal component request errors via placeholder in `UserSelectInput`. Disable on error.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -463,7 +463,7 @@ import {
 import { ExpandableContainer } from './internal/components/ExpandableContainer';
 import { withPermissionsPage } from './internal/components/permissions/withPermissionsPage';
 import { Principal, SecurityPolicy, SecurityRole } from './internal/components/permissions/models';
-import { fetchContainerSecurityPolicy, getUserLimitSettings } from './internal/components/permissions/actions';
+import { fetchContainerSecurityPolicy } from './internal/components/permissions/actions';
 import {
     getCrossFolderSelectionResult,
     getDataDeleteConfirmationData,
@@ -1167,7 +1167,6 @@ export {
     hasAnyPermissions,
     hasPermissions,
     fetchContainerSecurityPolicy,
-    getUserLimitSettings,
     withPermissionsPage,
     SecurityPolicy,
     SecurityRole,

--- a/packages/components/src/internal/components/administration/UserManagement.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.tsx
@@ -317,7 +317,9 @@ export const UserManagementPageImpl: FC<InjectedPermissionsPage> = props => {
     const { container, moduleContext, project, user } = useServerContext();
     const { extraPermissionRoles } = useAdminAppContext();
 
-    if (isProductProjectsEnabled() && !container.isProject) return <NotFound />;
+    if (isProductProjectsEnabled(moduleContext) && !container.isProject) {
+        return <NotFound />;
+    }
 
     return (
         <UserManagement

--- a/packages/components/src/internal/components/administration/UserManagement.tsx
+++ b/packages/components/src/internal/components/administration/UserManagement.tsx
@@ -35,6 +35,7 @@ import { AUDIT_KEY } from '../../app/constants';
 import { NotFound } from '../base/NotFound';
 
 import { isProductProjectsEnabled } from '../../app/utils';
+
 import { useAdministrationSubNav } from './useAdministrationSubNav';
 
 import { isLoginAutoRedirectEnabled, showPremiumFeatures } from './utils';

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -59,14 +59,14 @@ export function handleTabKeyOnTextArea(evt: ITargetElementEvent): void {
  * @param includeInactive flag to optionally return inactive users
  */
 export function getUsersWithPermissions(
-    permissions: string | string[] = PermissionTypes.Read,
+    permissions?: string | string[],
     containerPath?: string,
     includeInactive?: boolean
 ): Promise<User[]> {
     return new Promise((resolve, reject) => {
         return Security.getUsersWithPermissions({
             containerPath,
-            permissions,
+            permissions: permissions ?? PermissionTypes.Read,
             includeInactive,
             requiredVersion: 23.11,
             success: ({ users }) => {
@@ -94,9 +94,9 @@ export function useUsersWithPermissions(
     containerPath?: string,
     loader: UsersLoader = getUsersWithPermissions
 ): UsersState {
-    const [users, setUsers_] = useState<User[]>(undefined);
+    const [users, setUsers_] = useState<User[]>();
     const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.INITIALIZED);
-    const [error, setError] = useState<string>(undefined);
+    const [error, setError] = useState<string>();
     const load = useCallback(async () => {
         setLoadingState(LoadingState.LOADING);
 

--- a/packages/components/src/internal/components/permissions/actions.ts
+++ b/packages/components/src/internal/components/permissions/actions.ts
@@ -172,9 +172,7 @@ export type UserLimitSettings = {
 export function getUserLimitSettings(containerPath?: string): Promise<UserLimitSettings> {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: ActionURL.buildURL('user', 'getuserLimitSettings.api', containerPath),
-            method: 'GET',
-            scope: this,
+            url: ActionURL.buildURL('user', 'getUserLimitSettings.api', containerPath),
             success: Utils.getCallbackWrapper(settings => {
                 resolve(settings as UserLimitSettings);
             }),

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.spec.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.spec.tsx
@@ -16,7 +16,7 @@ import { ActiveUserLimit, ActiveUserLimitMessage } from './ActiveUserLimit';
 describe('ActiveUserLimitMessage', () => {
     test('without message', () => {
         const wrapper = mountWithAppServerContext(
-            <ActiveUserLimitMessage settings={{} as UserLimitSettings} />,
+            <ActiveUserLimitMessage />,
             { api: getTestAPIWrapper(jest.fn) },
             { user: TEST_USER_APP_ADMIN }
         );
@@ -26,7 +26,7 @@ describe('ActiveUserLimitMessage', () => {
 
     test('with message', () => {
         const wrapper = mountWithAppServerContext(
-            <ActiveUserLimitMessage settings={{ messageHtml: 'test' } as UserLimitSettings} />,
+            <ActiveUserLimitMessage settings={{ messageHtml: 'test' }} />,
             { api: getTestAPIWrapper(jest.fn) },
             { user: TEST_USER_APP_ADMIN }
         );
@@ -37,7 +37,7 @@ describe('ActiveUserLimitMessage', () => {
 
     test('with html message', () => {
         const wrapper = mountWithAppServerContext(
-            <ActiveUserLimitMessage settings={{ messageHtml: '<b>test</b>' } as UserLimitSettings} />,
+            <ActiveUserLimitMessage settings={{ messageHtml: '<b>test</b>' }} />,
             { api: getTestAPIWrapper(jest.fn) },
             { user: TEST_USER_APP_ADMIN }
         );
@@ -48,16 +48,16 @@ describe('ActiveUserLimitMessage', () => {
 });
 
 describe('ActiveUserLimit', () => {
-    const USER_LIMIT_ENABLED = {
+    const USER_LIMIT_ENABLED: Partial<UserLimitSettings> = {
         userLimit: true,
         userLimitLevel: 10,
         remainingUsers: 1,
-    } as UserLimitSettings;
-    const USER_LIMIT_DISABLED = {
+    };
+    const USER_LIMIT_DISABLED: Partial<UserLimitSettings> = {
         userLimit: false,
         userLimitLevel: 10,
         remainingUsers: 1,
-    } as UserLimitSettings;
+    };
     const DEFAULT_PROPS = {
         user: TEST_USER_PROJECT_ADMIN,
         container: TEST_PROJECT_CONTAINER,

--- a/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
+++ b/packages/components/src/internal/components/settings/ActiveUserLimit.tsx
@@ -8,7 +8,20 @@ import { UserLimitSettings } from '../permissions/actions';
 import { User } from '../base/models/User';
 import { Container } from '../base/models/Container';
 
-const TITLE = 'Active Users';
+interface ActiveUserLimitMessageProps {
+    settings?: Partial<UserLimitSettings>;
+}
+
+export const ActiveUserLimitMessage: FC<ActiveUserLimitMessageProps> = memo(({ settings }) => {
+    if (!settings?.messageHtml) return null;
+
+    return (
+        <Alert bsStyle="warning">
+            {/* eslint-disable-next-line react/no-danger */}
+            <div dangerouslySetInnerHTML={{ __html: settings.messageHtml }} />
+        </Alert>
+    );
+});
 
 interface Props {
     container: Container;
@@ -40,7 +53,7 @@ export const ActiveUserLimit: FC<Props> = memo(props => {
 
     return (
         <div className="active-user-limit-panel panel panel-default">
-            <div className="panel-heading">{TITLE}</div>
+            <div className="panel-heading">Active Users</div>
             <div className="panel-body">
                 <Alert>{error}</Alert>
                 {settings && (
@@ -56,21 +69,5 @@ export const ActiveUserLimit: FC<Props> = memo(props => {
                 )}
             </div>
         </div>
-    );
-});
-
-interface ActiveUserLimitMessageProps {
-    settings: UserLimitSettings;
-}
-
-export const ActiveUserLimitMessage: FC<ActiveUserLimitMessageProps> = memo(({ settings }) => {
-    return (
-        <>
-            {settings?.messageHtml && (
-                <Alert bsStyle="warning">
-                    <div dangerouslySetInnerHTML={{ __html: settings.messageHtml }} />
-                </Alert>
-            )}
-        </>
     );
 });

--- a/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.spec.tsx
@@ -18,8 +18,6 @@ import { mount } from 'enzyme';
 
 import { SECURITY_ROLE_AUTHOR, SECURITY_ROLE_EDITOR, SECURITY_ROLE_READER } from '../../../test/data/constants';
 
-import { UserLimitSettings } from '../permissions/actions';
-
 import { CreateUsersModal } from './CreateUsersModal';
 
 const ROLE_OPTIONS = [
@@ -110,7 +108,7 @@ describe('CreateUsersModal', () => {
         const component = (
             <CreateUsersModal
                 show
-                userLimitSettings={{ userLimit: true, remainingUsers: 2 } as UserLimitSettings}
+                userLimitSettings={{ userLimit: true, remainingUsers: 2 }}
                 onCancel={jest.fn()}
                 onComplete={jest.fn()}
             />

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { FormControl, Modal } from 'react-bootstrap';
 import { Security } from '@labkey/api';
+
 import { ModalButtons } from '../../ModalButtons';
 
 import { UserLimitSettings } from '../permissions/actions';

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -11,7 +11,7 @@ interface Props {
     onCancel: () => void;
     onComplete: (response: any, roles: string[]) => void;
     show: boolean;
-    userLimitSettings?: UserLimitSettings;
+    userLimitSettings?: Partial<UserLimitSettings>;
 
     // optional array of role options, objects with id and label values (i.e. [{id: "org.labkey.api.security.roles.ReaderRole", label: "Reader (default)"}])
     // note that the createNewUser action will not use this value but it will be passed back to the onComplete

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -55,7 +55,7 @@ interface Props {
     container?: Container;
     currentUser: User;
     isSelf?: boolean;
-    onUsersStateChangeComplete?: (response: any, resetSelection: boolean) => any;
+    onUsersStateChangeComplete?: (response: any, resetSelection: boolean) => void;
     policy?: SecurityPolicy;
     rolesByUniqueName?: Map<string, SecurityRole>;
     rootPolicy?: SecurityPolicy;
@@ -78,7 +78,6 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
         allowDelete: true,
         allowResetPassword: true,
         api: getDefaultAPIWrapper().security,
-        onUsersStateChangeComplete: undefined,
         showGroupListLinks: true,
         showPermissionListLinks: true,
     };
@@ -95,12 +94,12 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.loadUserDetails();
         this.loadPolicyAndRoles();
     }
 
-    componentDidUpdate(prevProps: Readonly<Props>) {
+    componentDidUpdate(prevProps: Readonly<Props>): void {
         if (this.props.userId !== prevProps.userId) {
             this.loadUserDetails();
         }
@@ -113,59 +112,49 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
             try {
                 const policy_ = await api.fetchPolicy(container.id);
                 const roles = await api.fetchRoles();
-                const rolesByUniqueName_ = getRolesByUniqueName(roles);
-
-                this.setState(() => ({
-                    policy: policy_,
-                    rolesByUniqueName: rolesByUniqueName_,
-                }));
+                this.setState({ policy: policy_, rolesByUniqueName: getRolesByUniqueName(roles) });
             } catch (e) {
                 console.error(e);
             }
         }
     };
 
-    loadUserDetails = (): void => {
+    loadUserDetails = async (): Promise<void> => {
         const { userId, isSelf, api } = this.props;
 
-        if (userId) {
-            this.setState(() => ({ loading: true }));
-
-            if (isSelf) {
-                api.getUserProperties(userId)
-                    .then(response => {
-                        this.setState(() => ({ userProperties: response.props, loading: false }));
-                    })
-                    .catch(() => {
-                        this.setState(() => ({ userProperties: undefined, loading: false }));
-                    });
-            } else {
-                api.getUserPropertiesForOther(userId)
-                    .then(response => {
-                        this.setState(() => ({ userProperties: response, loading: false }));
-                    })
-                    .catch(() => {
-                        this.setState(() => ({ userProperties: undefined, loading: false }));
-                    });
-            }
-        } else {
-            this.setState(() => ({ userProperties: undefined }));
+        if (!userId) {
+            this.setState({ userProperties: undefined });
+            return;
         }
+
+        this.setState({ loading: true });
+
+        try {
+            if (isSelf) {
+                const response = await api.getUserProperties(userId);
+                this.setState({ userProperties: response.props });
+            } else {
+                const response = await api.getUserPropertiesForOther(userId);
+                this.setState({ userProperties: response });
+            }
+        } catch (e) {
+            this.setState({ userProperties: undefined });
+        }
+
+        this.setState({ loading: false });
     };
 
-    toggleDialog = (name: string) => {
-        this.setState(() => ({ showDialog: name }));
+    toggleDialog = (name: string): void => {
+        this.setState({ showDialog: name });
     };
 
-    onUsersStateChangeComplete = (response: any, isDelete: boolean) => {
+    onUsersStateChangeComplete = (response: any, isDelete: boolean): void => {
         this.toggleDialog(undefined); // close dialog
         if (!isDelete) {
             this.loadUserDetails(); // reload to pickup new user state
         }
 
-        if (this.props.onUsersStateChangeComplete) {
-            this.props.onUsersStateChangeComplete(response, isDelete);
-        }
+        this.props.onUsersStateChangeComplete?.(response, isDelete);
     };
 
     renderUserProp(label: string, prop: string, formatDate = false) {
@@ -317,7 +306,7 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
 
         if (toggleDetailsModal) {
             return (
-                <Modal onHide={toggleDetailsModal} show={true} className="user-detail-modal">
+                <Modal onHide={toggleDetailsModal} show className="user-detail-modal">
                     <Modal.Header closeButton>
                         <Modal.Title>{this.renderHeader()}</Modal.Title>
                     </Modal.Header>

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -178,7 +178,9 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
             <>
                 <hr className="principal-hr" />
                 {allowResetPassword && isActive && (
-                    <button className="btn btn-default" onClick={() => this.toggleDialog('reset')} type="button">Reset Password</button>
+                    <button className="btn btn-default" onClick={() => this.toggleDialog('reset')} type="button">
+                        Reset Password
+                    </button>
                 )}
                 {allowDelete && (
                     <button

--- a/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.spec.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { getRolesByUniqueName, processGetRolesResponse, UserLimitSettings } from '../permissions/actions';
+import { getRolesByUniqueName, processGetRolesResponse } from '../permissions/actions';
 import policyJSON from '../../../test/data/security-getPolicy.json';
 import rolesJSON from '../../../test/data/security-getRoles.json';
 import { TEST_USER_APP_ADMIN, TEST_USER_FOLDER_ADMIN, TEST_USER_PROJECT_ADMIN } from '../../userFixtures';
@@ -174,10 +174,7 @@ describe('<UsersGridPanel/>', () => {
 
     test('active user limit reached', () => {
         const component = (
-            <UsersGridPanelImpl
-                {...DEFAULT_PROPS}
-                userLimitSettings={{ userLimit: true, remainingUsers: 0 } as UserLimitSettings}
-            />
+            <UsersGridPanelImpl {...DEFAULT_PROPS} userLimitSettings={{ userLimit: true, remainingUsers: 0 }} />
         );
         const wrapper = mount(component);
         wrapper.setState({ usersView: 'inactive' });
@@ -192,10 +189,7 @@ describe('<UsersGridPanel/>', () => {
 
     test('active user limit not reached', () => {
         const component = (
-            <UsersGridPanelImpl
-                {...DEFAULT_PROPS}
-                userLimitSettings={{ userLimit: true, remainingUsers: 2 } as UserLimitSettings}
-            />
+            <UsersGridPanelImpl {...DEFAULT_PROPS} userLimitSettings={{ userLimit: true, remainingUsers: 2 }} />
         );
         const wrapper = mount(component);
         wrapper.setState({ usersView: 'inactive' });
@@ -210,10 +204,7 @@ describe('<UsersGridPanel/>', () => {
 
     test('active user limit disabled', () => {
         const component = (
-            <UsersGridPanelImpl
-                {...DEFAULT_PROPS}
-                userLimitSettings={{ userLimit: false, remainingUsers: 0 } as UserLimitSettings}
-            />
+            <UsersGridPanelImpl {...DEFAULT_PROPS} userLimitSettings={{ userLimit: false, remainingUsers: 0 }} />
         );
         const wrapper = mount(component);
         expect(wrapper.find(DisableableButton)).toHaveLength(1); // create button

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -51,8 +51,8 @@ interface OwnProps {
     // optional array of role options, objects with id and label values (i.e. [{id: "org.labkey.api.security.roles.ReaderRole", label: "Reader (default)"}])
     // note that the createNewUser action will not use this value but it will be passed back to the onCreateComplete
     newUserRoleOptions?: any[];
-    onCreateComplete: (response: any, roles: string[]) => any;
-    onUsersStateChangeComplete: (response: any) => any;
+    onCreateComplete: (response: any, roles: string[]) => void;
+    onUsersStateChangeComplete: (response: any) => void;
     policy: SecurityPolicy;
     rolesByUniqueName?: Map<string, SecurityRole>;
     // searchParams/setSearchParams can be removed as props if we convert to an FC and use the useSearchParams hook
@@ -60,7 +60,7 @@ interface OwnProps {
     setSearchParams: SetURLSearchParams;
     showDetailsPanel?: boolean;
     user: User;
-    userLimitSettings?: UserLimitSettings;
+    userLimitSettings?: Partial<UserLimitSettings>;
 }
 
 type Props = OwnProps & InjectedQueryModels;
@@ -91,12 +91,12 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
         };
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.setLastSelectedId();
         this.initQueryModel(this.state.usersView);
     }
 
-    componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot?: any) {
+    componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>): void {
         this.setLastSelectedId();
         if (this.state.usersView !== prevState.usersView) {
             this.initQueryModel(this.state.usersView);
@@ -113,7 +113,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
         }
     }
 
-    initQueryModel(usersView: string) {
+    initQueryModel = (usersView: string): void => {
         const { actions } = this.props;
         const baseFilters = usersView === 'all' ? [] : [Filter.create('active', usersView === 'active')];
 
@@ -131,7 +131,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
             true,
             true
         );
-    }
+    };
 
     getUsersView(paramVal: string): string {
         return paramVal === 'inactive' || paramVal === 'all' ? paramVal : 'active'; // default to view active users
@@ -146,7 +146,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
     }
 
     toggleViewActive = (viewName: string): void => {
-        this.setState(() => ({ usersView: viewName }));
+        this.setState({ usersView: viewName });
     };
 
     closeDialog = (): void => {
@@ -155,9 +155,9 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
 
     toggleDialog = (name: string, requiresSelection = false): void => {
         if (requiresSelection && !this.getUsersModel().hasSelections) {
-            this.setState(() => ({ showDialog: undefined }));
+            this.setState({ showDialog: undefined });
         } else {
-            this.setState(() => ({ showDialog: name }));
+            this.setState({ showDialog: name });
         }
     };
 
@@ -370,7 +370,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
     }
 }
 
-const UsersGridPanelWithModels = withQueryModels(UsersGridPanelImpl);
+const UsersGridPanelWithModels = withQueryModels<OwnProps>(UsersGridPanelImpl);
 
 type PanelProps = Omit<OwnProps, 'searchParams' | 'setSearchParams'>;
 


### PR DESCRIPTION
#### Rationale
This updates the `UserSelectInput` to use the `SecurityAPIWrapper` to fetch user options. This reduces the number of requests being made from tests. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1398
- https://github.com/LabKey/labkey-ui-premium/pull/310
- https://github.com/LabKey/biologics/pull/2660
- https://github.com/LabKey/sampleManagement/pull/2398
- https://github.com/LabKey/inventory/pull/1170

#### Changes
- Add `api.security.getUsersWithPermissions` to `SecurityAPIWrapper`
- Display internal component request errors via placeholder in `UserSelectInput`. Disable on error.
- Use `async` pattern for requests from `UserDetailsPanel`
