### PR TITLE
SampleStatusTag: use APIWrapper

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.9.0",
+  "version": "3.9.1-fb-toc-metrics.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.9.0",
+      "version": "3.9.1-fb-toc-metrics.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.9.1-fb-toc-metrics.0",
+  "version": "3.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.9.1-fb-toc-metrics.0",
+      "version": "3.9.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.9.0",
+  "version": "3.9.1-fb-toc-metrics.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.9.1-fb-toc-metrics.0",
+  "version": "3.9.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.9.1
+*Released*: 26 January 2024
+- Add metric for shift-select usage.
+- Update the `SampleStatusTag` component to use app/server context.
+
 ### version 3.9.0
 *Released*: 23 January 2024
 - Add `api.security.getUsersWithPermissions` to `SecurityAPIWrapper`

--- a/packages/components/src/internal/components/samples/SampleStatusLegend.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusLegend.spec.tsx
@@ -7,12 +7,14 @@ import { QueryInfo } from '../../../public/QueryInfo';
 import { LoadingState } from '../../../public/LoadingState';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
+import { mountWithAppServerContext } from '../../test/enzymeTestHelpers';
+
 import { SampleStatusLegendImpl } from './SampleStatusLegend';
 import { SampleStatusTag } from './SampleStatusTag';
 
 describe('SampleStatusLegend', () => {
     const SQ = new SchemaQuery('schema', 'query');
-    const MODEL_NO_ROWS = makeTestQueryModel(SQ, new QueryInfo(), {}, [], 0).mutate({
+    const MODEL_NO_ROWS = makeTestQueryModel(SQ, new QueryInfo({}), {}, [], 0).mutate({
         queryInfoLoadingState: LoadingState.LOADED,
         rowsLoadingState: LoadingState.LOADED,
     });
@@ -22,7 +24,7 @@ describe('SampleStatusLegend', () => {
     });
     const MODEL_WITH_ROWS = makeTestQueryModel(
         SQ,
-        new QueryInfo(),
+        new QueryInfo({}),
         {
             1: {
                 Label: { value: 'Available' },
@@ -70,7 +72,9 @@ describe('SampleStatusLegend', () => {
     });
 
     test('with rows', () => {
-        const wrapper = mount(<SampleStatusLegendImpl {...DEFAULT_PROPS} queryModels={{ model: MODEL_WITH_ROWS }} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusLegendImpl {...DEFAULT_PROPS} queryModels={{ model: MODEL_WITH_ROWS }} />
+        );
         validate(wrapper, false, 3);
         expect(wrapper.find('.sample-status-legend--description').at(0).text()).toBe('');
         expect(wrapper.find('.sample-status-legend--description').at(1).text()).toBe('');

--- a/packages/components/src/internal/components/samples/SampleStatusTag.spec.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusTag.spec.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 
-import { mount, ReactWrapper } from 'enzyme';
+import { ReactWrapper } from 'enzyme';
+
+import { mountWithAppServerContext } from '../../test/enzymeTestHelpers';
 
 import { LabelHelpTip } from '../base/LabelHelpTip';
+
+import { TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT } from '../../productFixtures';
 
 import { SampleStatusTag } from './SampleStatusTag';
 import { SampleStateType } from './constants';
 
-beforeEach(() => {
-    LABKEY.moduleContext = { api: { moduleNames: ['samplemanagement'] } };
-});
-
 describe('SampleStatusTag', () => {
+    const serverContext = { moduleContext: TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
+
     const lockedStatus = {
         label: 'Locked for testing',
         statusType: SampleStateType.Locked,
@@ -35,7 +37,7 @@ describe('SampleStatusTag', () => {
         statusType: SampleStateType.Available,
     };
 
-    function validateIconOnly(wrapper: ReactWrapper, expectedClass: string) {
+    function validateIconOnly(wrapper: ReactWrapper, expectedClass: string): void {
         const helpTip = wrapper.find(LabelHelpTip);
         expect(helpTip.exists()).toBeTruthy();
         const icon = helpTip.find('i');
@@ -49,7 +51,7 @@ describe('SampleStatusTag', () => {
         expectedClass: string,
         expectedText: string,
         hasHelpTip = true
-    ) {
+    ): void {
         const spans = wrapper.find('span');
         expect(spans).toHaveLength(hasHelpTip ? 3 : 1);
         expect(spans.at(0).prop('className')).toContain(expectedClass);
@@ -62,53 +64,84 @@ describe('SampleStatusTag', () => {
     }
 
     test('not enabled', () => {
-        LABKEY.moduleContext = {};
-        const wrapper = mount(<SampleStatusTag status={lockedStatus} />);
+        const wrapper = mountWithAppServerContext(<SampleStatusTag status={lockedStatus} />);
         expect(wrapper.find('span').exists()).toBeFalsy();
     });
 
     test('enabled, no label', () => {
-        const wrapper = mount(<SampleStatusTag status={{ label: undefined, statusType: SampleStateType.Locked }} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={{ label: undefined, statusType: SampleStateType.Locked }} />,
+            undefined,
+            serverContext
+        );
         expect(wrapper.find('span').exists()).toBeFalsy();
     });
 
     test('iconOnly, locked', () => {
-        const wrapper = mount(<SampleStatusTag status={lockedStatus} iconOnly={true} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={lockedStatus} iconOnly />,
+            undefined,
+            serverContext
+        );
         validateIconOnly(wrapper, 'danger');
     });
 
     test('iconOnly, consumed', () => {
-        const wrapper = mount(<SampleStatusTag status={consumedStatus} iconOnly={true} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={consumedStatus} iconOnly />,
+            undefined,
+            serverContext
+        );
         validateIconOnly(wrapper, 'warning');
     });
 
     test('iconOnly, available', () => {
-        const wrapper = mount(<SampleStatusTag status={availableStatus} iconOnly={true} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={availableStatus} iconOnly />,
+            undefined,
+            serverContext
+        );
         validateIconOnly(wrapper, 'success');
     });
 
     test('iconOnly, no description', () => {
-        const wrapper = mount(<SampleStatusTag status={availableNoDescription} iconOnly={true} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={availableNoDescription} iconOnly />,
+            undefined,
+            serverContext
+        );
         validateIconOnly(wrapper, 'success');
     });
 
     test('not iconOnly, locked status type', () => {
-        const wrapper = mount(<SampleStatusTag status={lockedStatus} />);
+        const wrapper = mountWithAppServerContext(<SampleStatusTag status={lockedStatus} />, undefined, serverContext);
         validateNotIconOnly(wrapper, 'danger', lockedStatus.label);
     });
 
     test('consumed status type', () => {
-        const wrapper = mount(<SampleStatusTag status={consumedStatus} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={consumedStatus} />,
+            undefined,
+            serverContext
+        );
         validateNotIconOnly(wrapper, 'warning', consumedStatus.label);
     });
 
     test('available status type with description', () => {
-        const wrapper = mount(<SampleStatusTag status={availableStatus} />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={availableStatus} />,
+            undefined,
+            serverContext
+        );
         validateNotIconOnly(wrapper, 'success', availableStatus.label);
     });
 
     test('available status, hide description', () => {
-        const wrapper = mount(<SampleStatusTag status={availableStatus} hideDescription />);
+        const wrapper = mountWithAppServerContext(
+            <SampleStatusTag status={availableStatus} hideDescription />,
+            undefined,
+            serverContext
+        );
         validateNotIconOnly(wrapper, 'success', availableStatus.label, false);
     });
 
@@ -117,7 +150,7 @@ describe('SampleStatusTag', () => {
             label: 'Also available',
             statusType: SampleStateType.Available,
         };
-        const wrapper = mount(<SampleStatusTag status={status} />);
+        const wrapper = mountWithAppServerContext(<SampleStatusTag status={status} />, undefined, serverContext);
         validateNotIconOnly(wrapper, 'success', status.label, false);
     });
 });

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -84,6 +84,10 @@ export class QueryLookup {
 
         return undefined;
     }
+
+    mutate(partial: Partial<QueryLookup>): QueryLookup {
+        return new QueryLookup(Object.assign({}, this, partial));
+    }
 }
 
 const defaultQueryColumn = {

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -145,7 +145,7 @@ export interface IQueryColumn {
     nameExpression: string;
     // nullable: boolean;
     phiProtected: boolean;
-    'protected': boolean;
+    protected: boolean;
     rangeURI: string;
     readOnly: boolean;
     // recommendedVariable: boolean;
@@ -266,7 +266,7 @@ export class QueryColumn implements IQueryColumn {
     static ALIQUOTED_FROM = 'AliquotedFrom';
     static ALIQUOTED_FROM_CAPTION = 'Aliquoted From';
     static ALIQUOTED_FROM_LSID = 'AliquotedFromLSID';
-    static MEASUREMENT_UNITS_QUERY = "MeasurementUnits";
+    static MEASUREMENT_UNITS_QUERY = 'MeasurementUnits';
 
     static isUserLookup(lookupInfo: Record<string, any>): boolean {
         if (!lookupInfo) return false;

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -516,7 +516,11 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         const { model, actions } = this.props;
         const checked = event.target.checked === true;
         // Look through to the nativeEvent to determine if the shift key is engaged.
-        actions.selectRow(model.id, checked, row.toJS(), (event.nativeEvent as any).shiftKey ?? false);
+        const useSelectionPivot = (event.nativeEvent as any).shiftKey ?? false;
+        actions.selectRow(model.id, checked, row.toJS(), useSelectionPivot);
+        if (useSelectionPivot) {
+            incrementClientSideMetricCount('grid', 'shiftSelect');
+        }
     };
 
     selectPage = (event): void => {


### PR DESCRIPTION
#### Rationale
This updates the `SampleStatusTag` component to use app/server context for ease of testing.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1400
- https://github.com/LabKey/labkey-ui-premium/pull/312

#### Changes
- Update the `SampleStatusTag` component to use app/server context.
