### PR TITLE
Issue 49507: add `convertUnitsForInput` to avoid commas in editable grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.11.0",
+  "version": "3.11.1-amountDisplayIssues.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.11.0",
+      "version": "3.11.1-amountDisplayIssues.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.11.1-amountDisplayIssues.1",
+  "version": "3.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.11.1-amountDisplayIssues.1",
+      "version": "3.12.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.11.1-amountDisplayIssues.0",
+  "version": "3.11.1-amountDisplayIssues.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.11.1-amountDisplayIssues.0",
+      "version": "3.11.1-amountDisplayIssues.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.28.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.11.2-amountDisplayIssues.1",
+  "version": "3.12.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.11.1-amountDisplayIssues.0",
+  "version": "3.11.1-amountDisplayIssues.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.11.0",
+  "version": "3.11.1-amountDisplayIssues.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 49507: add `convertUnitsForInput` to avoid commas in editable grid
+
 ### version 3.11.0
 *Released*: 29 January 2024
 - Remove MultiMenuButton

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -813,6 +813,7 @@ import { GlobalStateContextProvider } from './internal/GlobalStateContext';
 import {
     areUnitsCompatible,
     convertUnitDisplay,
+    convertUnitsForInput,
     getAltMetricUnitOptions,
     getAltUnitKeys,
     getMetricUnitOptions,
@@ -1291,6 +1292,7 @@ export {
     UnitModel,
     MEASUREMENT_UNITS,
     areUnitsCompatible,
+    convertUnitsForInput,
     convertUnitDisplay,
     getAltMetricUnitOptions,
     getAltUnitKeys,

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -1,15 +1,17 @@
 import {
     convertUnitDisplay,
+    convertUnitsForInput,
     getAltMetricUnitOptions,
     getAltUnitKeys,
     getMetricUnitOptions,
-    getMultiAltUnitKeys, getStoredAmountDisplay, isValuePrecisionValid,
-    UnitModel
+    getMultiAltUnitKeys,
+    getStoredAmountDisplay,
+    isValuePrecisionValid,
+    UnitModel,
 } from './measurement';
 
-describe("UnitModel", () => {
-
-    test("constructor and operators", () => {
+describe('UnitModel', () => {
+    test('constructor and operators', () => {
         expect(new UnitModel(10, null).toString()).toBe('10');
         expect(new UnitModel(10, 'mL').toString()).toBe('10 mL');
 
@@ -17,7 +19,7 @@ describe("UnitModel", () => {
         expect(new UnitModel(99999.133, 'uL').as('L').toString()).toBe('0.099999 L');
         expect(new UnitModel(10, 'mL').as('L').toString()).toBe('0.01 L');
         expect(new UnitModel(10, 'mL').add(10, 'uL').toString()).toBe('10.01 mL');
-        expect(new UnitModel(undefined, 'mL').as('L').toString()).toBe("0 L");
+        expect(new UnitModel(undefined, 'mL').as('L').toString()).toBe('0 L');
 
         expect(new UnitModel(10, 'mL').compareTo(new UnitModel(9, 'mL')) > 0).toBeTruthy();
         expect(new UnitModel(10, 'mL').compareTo(new UnitModel(9, 'L')) > 0).toBeFalsy();
@@ -25,20 +27,18 @@ describe("UnitModel", () => {
         expect(new UnitModel(undefined, 'mL').compareTo(new UnitModel(9, 'L')) > 0).toBeFalsy();
         expect(new UnitModel(undefined, 'mL').compareTo(new UnitModel(undefined, 'L')) > 0).toBeFalsy();
     });
-
 });
 
-describe("MetricUnit utils", () => {
-
-    test("getMetricUnitOptions", () => {
+describe('MetricUnit utils', () => {
+    test('getMetricUnitOptions', () => {
         const expectedMetricUnitOptions = [
-            {"label": "unit", "value": "unit"},
-            {"label": "g (grams)", "value": "g"},
-            {"label": "kg (kilograms)", "value": "kg"},
-            {"label": "mg (milligrams)", "value": "mg"},
-            {"label": "mL (milliliters)", "value": "mL"},
-            {"label": "uL (microliters)", "value": "uL"},
-            {"label": "L (liters)", "value": "L"}
+            { label: 'unit', value: 'unit' },
+            { label: 'g (grams)', value: 'g' },
+            { label: 'kg (kilograms)', value: 'kg' },
+            { label: 'mg (milligrams)', value: 'mg' },
+            { label: 'mL (milliliters)', value: 'mL' },
+            { label: 'uL (microliters)', value: 'uL' },
+            { label: 'L (liters)', value: 'L' },
         ];
 
         const options = getMetricUnitOptions().sort((a, b) => {
@@ -52,15 +52,17 @@ describe("MetricUnit utils", () => {
                 expect.objectContaining(expectedMetricUnitOptions[3]),
                 expect.objectContaining(expectedMetricUnitOptions[4]),
                 expect.objectContaining(expectedMetricUnitOptions[5]),
-                expect.objectContaining(expectedMetricUnitOptions[6])
+                expect.objectContaining(expectedMetricUnitOptions[6]),
             ])
         );
-
     });
 
-    test("getAltMetricUnitOptions", () => {
-
-        const expectedUlOptions = [{"label": "L", "value": "L"}, {"label": "mL", "value": "mL"}, {"label": "uL", "value": "uL"}];
+    test('getAltMetricUnitOptions', () => {
+        const expectedUlOptions = [
+            { label: 'L', value: 'L' },
+            { label: 'mL', value: 'mL' },
+            { label: 'uL', value: 'uL' },
+        ];
         const ulOptions = getAltMetricUnitOptions('uL').sort((a, b) => {
             return a.label.localeCompare(b.label);
         });
@@ -72,7 +74,11 @@ describe("MetricUnit utils", () => {
             ])
         );
 
-        const expectedUlLongLabelOptions = [{"label": "L (liters)", "value": "L"}, {"label": "mL (milliliters)", "value": "mL"}, {"label": "uL (microliters)", "value": "uL"}]
+        const expectedUlLongLabelOptions = [
+            { label: 'L (liters)', value: 'L' },
+            { label: 'mL (milliliters)', value: 'mL' },
+            { label: 'uL (microliters)', value: 'uL' },
+        ];
         const ulLongLabelOptions = getAltMetricUnitOptions('uL', true).sort((a, b) => {
             return a.label.localeCompare(b.label);
         });
@@ -84,7 +90,11 @@ describe("MetricUnit utils", () => {
             ])
         );
 
-        const expectedKgOptions = [{"label": "g", "value": "g"}, {"label": "kg", "value": "kg"}, {"label": "mg", "value": "mg"}];
+        const expectedKgOptions = [
+            { label: 'g', value: 'g' },
+            { label: 'kg', value: 'kg' },
+            { label: 'mg', value: 'mg' },
+        ];
         const kgOptions = getAltMetricUnitOptions('kg').sort((a, b) => {
             return a.label.localeCompare(b.label);
         });
@@ -101,13 +111,12 @@ describe("MetricUnit utils", () => {
         expect(getAltMetricUnitOptions('bad').length).toBe(0);
     });
 
-    test("getAltUnitKeys", () => {
-
-        const expectedUlOptions = ["mL", "uL", "L"];
+    test('getAltUnitKeys', () => {
+        const expectedUlOptions = ['mL', 'uL', 'L'];
         expect(getAltUnitKeys('uL')).toEqual(expectedUlOptions);
         expect(getAltUnitKeys('mL')).toEqual(expectedUlOptions);
 
-        const expectedGOptions = ["g", "mg", "kg"];
+        const expectedGOptions = ['g', 'mg', 'kg'];
         expect(getAltUnitKeys('g')).toEqual(expectedGOptions);
         expect(getAltUnitKeys('kg')).toEqual(expectedGOptions);
 
@@ -116,17 +125,15 @@ describe("MetricUnit utils", () => {
         expect(getAltUnitKeys(null).length).toBe(0);
         expect(getAltUnitKeys('').length).toBe(0);
         expect(getAltUnitKeys('bad').length).toBe(0);
-
     });
 
-    test("getMultiAltUnitKeys", () => {
-
-        const expectedUlOptions = ["mL", "uL", "L"];
+    test('getMultiAltUnitKeys', () => {
+        const expectedUlOptions = ['mL', 'uL', 'L'];
         expect(getMultiAltUnitKeys(['uL'])).toEqual(expectedUlOptions);
         expect(getMultiAltUnitKeys(['mL', 'mL'])).toEqual(expectedUlOptions);
         expect(getMultiAltUnitKeys(['uL', 'mL'])).toEqual(expectedUlOptions);
 
-        const expectedGOptions = ["g", "mg", "kg"];
+        const expectedGOptions = ['g', 'mg', 'kg'];
         expect(getMultiAltUnitKeys(['g'])).toEqual(expectedGOptions);
         expect(getMultiAltUnitKeys(['kg', 'g', 'mg'])).toEqual(expectedGOptions);
 
@@ -140,11 +147,23 @@ describe("MetricUnit utils", () => {
         expect(getMultiAltUnitKeys(['', null])).toEqual(allOptions);
     });
 
+    test('convertUnitsForInput', () => {
+        expect(convertUnitsForInput(null, null, null)).toBeNull();
+        expect(convertUnitsForInput(1000, null, null)).toBe(1000);
+        expect(convertUnitsForInput(1000, 'mL', null)).toBe(1000);
+        expect(convertUnitsForInput(1000, 'mL', null)).toBe(1000);
+        expect(convertUnitsForInput(1000, 'mL', 'mL')).toBe(1000);
+        expect(convertUnitsForInput(1234, 'mL', 'L')).toBe(1.234);
+        expect(convertUnitsForInput(12.34, 'L', 'mL')).toBe(12340);
+        expect(convertUnitsForInput(12, 'g', 'kg')).toBe(0.012);
+    });
+
     test('convertUnitDisplay', () => {
         expect(convertUnitDisplay(null, null, null, false)).toBe('');
         expect(convertUnitDisplay(null, null, null, false, 'empty')).toBe('empty');
 
         expect(convertUnitDisplay(10, null, null, false)).toBe('10');
+        expect(convertUnitDisplay(10000, null, null, false)).toBe('10,000');
         expect(convertUnitDisplay(10, 'mL', null, false)).toBe('10');
         expect(convertUnitDisplay(10, 'mL', null, true)).toBe('10 mL');
         expect(convertUnitDisplay(10, null, 'kg', false)).toBe('10');
@@ -161,10 +180,10 @@ describe("MetricUnit utils", () => {
         expect(convertUnitDisplay(10, 'g', 'kg', false)).toBe('0.01');
 
         expect(convertUnitDisplay(10, 'unit', 'unit', true)).toBe('10 unit');
+        expect(convertUnitDisplay(10000, 'unit', 'unit', true)).toBe('10,000 unit');
     });
 
     test('getStoredAmountDisplay', () => {
-
         expect(getStoredAmountDisplay('99999 uL (L)')).toBe('0.099999');
         expect(getStoredAmountDisplay('99999 uL (L)', true)).toBe('0.099999 L');
         expect(getStoredAmountDisplay('99999.123 uL (L)')).toBe('0.099999');

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -276,8 +276,9 @@ export function convertUnitsForInput(amount: number, unit: string, displayUnit: 
     if (!currentUnit || !targetUnit) {
         return amount;
     }
+    // show up to 6 decimal places
     return parseFloat((amount * (currentUnit.ratio / targetUnit.ratio)).toFixed(6));
-};
+}
 
 export function convertUnitDisplay(
     amount: number,
@@ -286,26 +287,28 @@ export function convertUnitDisplay(
     includeUnits: boolean,
     emptyDisplay?: string
 ): string {
+    const convertedAmount = convertUnitsForInput(amount, unit, displayUnit);
     // Allow for 0 so can't use !amount
-    if (amount == null) {
+    if (convertedAmount == null) {
         return emptyDisplay ? emptyDisplay : '';
     }
     if (!displayUnit) {
-        return amount.toLocaleString() + (includeUnits && unit ? ' ' + unit : '');
+        return convertedAmount.toLocaleString() + (includeUnits && unit ? ' ' + unit : '');
     }
     if (!unit) {
-        return amount.toLocaleString() + (includeUnits && displayUnit ? ' ' + displayUnit : '');
+        return convertedAmount.toLocaleString() + (includeUnits && displayUnit ? ' ' + displayUnit : '');
     }
 
     const currentUnit: MeasurementUnit = MEASUREMENT_UNITS[unit.toLowerCase()];
     const targetUnit: MeasurementUnit = MEASUREMENT_UNITS[displayUnit.toLowerCase()];
     if (!currentUnit || !targetUnit) {
-        return amount.toLocaleString() + (includeUnits ? ' ' + unit : '');
+        return convertedAmount.toLocaleString() + (includeUnits ? ' ' + unit : '');
     }
 
-    // show up to 6 decimal places
-    const newAmount = parseFloat((amount * (currentUnit.ratio / targetUnit.ratio)).toFixed(6));
-    return (newAmount > 1000 ? newAmount.toLocaleString() : newAmount) + (includeUnits ? ' ' + displayUnit : '');
+    return (
+        (convertedAmount > 1000 ? convertedAmount.toLocaleString() : convertedAmount) +
+        (includeUnits ? ' ' + displayUnit : '')
+    );
 }
 
 // volume unit (displayUnit): 10 mL (L)

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -267,6 +267,18 @@ export function getMultiAltUnitKeys(unitTypeStrs: string[]): string[] {
     return getAltUnitKeys(unitTypeStr);
 }
 
+export function convertUnitsForInput(amount: number, unit: string, displayUnit: string): number {
+    if (!amount || !displayUnit || !unit) {
+        return amount;
+    }
+    const currentUnit: MeasurementUnit = MEASUREMENT_UNITS[unit.toLowerCase()];
+    const targetUnit: MeasurementUnit = MEASUREMENT_UNITS[displayUnit.toLowerCase()];
+    if (!currentUnit || !targetUnit) {
+        return amount;
+    }
+    return parseFloat((amount * (currentUnit.ratio / targetUnit.ratio)).toFixed(6));
+};
+
 export function convertUnitDisplay(
     amount: number,
     unit: string,


### PR DESCRIPTION
#### Rationale
Issue [49507](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49507) When picking up storage amounts for samples being added to the editable grid, we need to be sure the values are just plain numbers that can be edited, not display values with commas in them, which the editable grid doesn't like.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/315
- https://github.com/LabKey/inventory/pull/1177
- https://github.com/LabKey/sampleManagement/pull/2411
- https://github.com/LabKey/biologics/pull/2674

#### Changes
- add `convertUnitsForInput` to avoid commas in editable grid
