### PR TITLE
Issue 49502: StoredAmount and Units for samples editable grid to use display values instead of raw values

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.0-fb-storedAmount49502.0",
+  "version": "3.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.15.0-fb-storedAmount49502.0",
+      "version": "3.15.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.0",
+  "version": "3.15.0-fb-storedAmount49502.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.15.0",
+      "version": "3.15.0-fb-storedAmount49502.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.0",
+  "version": "3.15.0-fb-storedAmount49502.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.0-fb-storedAmount49502.0",
+  "version": "3.15.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.15.TBD
-*Released*: TBD
+### version 3.15.1
+*Released*: 2 February 2024
 - Issue 49502: StoredAmount and Units for samples editable grid to use display values instead of raw values
 
 ### version 3.15.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.15.TBD
+*Released*: TBD
+- Issue 49502: StoredAmount and Units for samples editable grid to use display values instead of raw values
+
 ### version 3.15.0
 *Released*: 31 January 2024
 - Support Date-only or Time-only fields

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -262,6 +262,7 @@ import { ErrorBoundary } from './internal/components/error/ErrorBoundary';
 import { AliasRenderer } from './internal/renderers/AliasRenderer';
 import { ANCESTOR_LOOKUP_CONCEPT_URI, AncestorRenderer } from './internal/renderers/AncestorRenderer';
 import { StorageStatusRenderer } from './internal/renderers/StorageStatusRenderer';
+import { StoredAmountRenderer } from './internal/renderers/StoredAmountRenderer';
 import { SampleStatusRenderer } from './internal/renderers/SampleStatusRenderer';
 import { ExpirationDateColumnRenderer } from './internal/renderers/ExpirationDateColumnRenderer';
 import { AppendUnits } from './internal/renderers/AppendUnits';
@@ -1108,6 +1109,7 @@ export {
     NoLinkRenderer,
     ExpirationDateColumnRenderer,
     StorageStatusRenderer,
+    StoredAmountRenderer,
     SampleStatusRenderer,
     ImportAliasRenderer,
     SampleTypeImportAliasRenderer,

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -28,6 +28,8 @@ import { SelectInputChange } from '../forms/input/SelectInput';
 import { TextChoiceInput } from '../forms/input/TextChoiceInput';
 import { QuerySelect } from '../forms/QuerySelect';
 
+import { getQueryColumnRenderers } from '../../global';
+
 import { MODIFICATION_TYPES, SELECTION_TYPES } from './constants';
 import { ValueDescriptor } from './models';
 
@@ -115,9 +117,13 @@ export class LookupCell extends PureComponent<LookupCellProps> {
         }
 
         let selectValue = isMultiple ? rawValues : rawValues[0];
-        // Issue 49502: If the lookup is a measurement unit, then we need to use the unit's display value
-        if (col.isUnitsLookup()) {
-            selectValue = values.find(vd => vd.display !== undefined)?.display;
+
+        // Some column types have special handling of raw data, i.e. StoredAmount and Units (issue 49502)
+        if (col.columnRenderer) {
+            const renderer = getQueryColumnRenderers()[col.columnRenderer.toLowerCase()];
+            if (renderer?.getEditableRawValue) {
+                selectValue = renderer.getEditableRawValue(values);
+            }
         }
 
         return (

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -282,7 +282,7 @@ export class EditorModel
                                 return arr;
                             }, [])
                         );
-                    } else if (!col.isUnitsLookup() && col.lookup.displayColumn === col.lookup.keyColumn) {
+                    } else if (col.lookup.displayColumn === col.lookup.keyColumn) {
                         row = row.set(
                             col.name,
                             values.size === 1 ? quoteValueWithDelimiters(values.first()?.display, ',') : undefined

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -13,6 +13,8 @@ import { EXPORT_TYPES } from '../../constants';
 
 import { SelectInputOption, SelectInputProps } from '../forms/input/SelectInput';
 
+import { getQueryColumnRenderers } from '../../global';
+
 import { EditorModel, EditorModelProps, EditableGridModels } from './models';
 import { CellActions, CellCoordinates, MODIFICATION_TYPES } from './constants';
 
@@ -89,6 +91,14 @@ export function getUpdatedDataFromGrid(
                 const isDate = isDateTime && col.isDateOnlyColumn;
                 // Convert empty cell to null
                 if (value === '') value = null;
+
+                // Some column types have special handling of raw data, i.e. StoredAmount and Units (issue 49502)
+                if (col?.columnRenderer) {
+                    const renderer = getQueryColumnRenderers()[col.columnRenderer.toLowerCase()];
+                    if (renderer?.getOriginalRawValue) {
+                        originalValue = renderer.getOriginalRawValue(originalValue);
+                    }
+                }
 
                 // Lookup columns store a list but grid only holds a single value
                 if (List.isList(originalValue) && !Array.isArray(value)) {

--- a/packages/components/src/internal/renderers/StoredAmountRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/StoredAmountRenderer.test.tsx
@@ -1,0 +1,32 @@
+import { fromJS, List } from 'immutable';
+
+import { ValueDescriptor } from '../components/editable/models';
+
+import { StoredAmountRenderer } from './StoredAmountRenderer';
+
+describe('StoredAmountRenderer', () => {
+    test('getEditableRawValue', () => {
+        expect(StoredAmountRenderer.getEditableRawValue(List.of())).toBe(undefined);
+        expect(StoredAmountRenderer.getEditableRawValue(List.of({} as ValueDescriptor))).toBe(undefined);
+        expect(StoredAmountRenderer.getEditableRawValue(List.of({} as ValueDescriptor, {} as ValueDescriptor))).toBe(
+            undefined
+        );
+        expect(StoredAmountRenderer.getEditableRawValue(List.of({ raw: 1 } as ValueDescriptor))).toBe(undefined);
+        expect(StoredAmountRenderer.getEditableRawValue(List.of({ raw: 1, display: 'test' } as ValueDescriptor))).toBe(
+            'test'
+        );
+    });
+
+    test('getOriginalRawValue', () => {
+        expect(StoredAmountRenderer.getOriginalRawValue(1)).toBe(1);
+        expect(StoredAmountRenderer.getOriginalRawValue('test')).toBe('test');
+        expect(StoredAmountRenderer.getOriginalRawValue(List.of({}))).toBe(undefined);
+        expect(StoredAmountRenderer.getOriginalRawValue(List.of({ value: 1 }))).toBe(undefined);
+        expect(StoredAmountRenderer.getOriginalRawValue(List.of({ value: 1, displayValue: 'test' }))).toBe('test');
+        expect(StoredAmountRenderer.getOriginalRawValue(List.of(fromJS({})))).toBe(undefined);
+        expect(StoredAmountRenderer.getOriginalRawValue(List.of(fromJS({ value: 1 })))).toBe(undefined);
+        expect(StoredAmountRenderer.getOriginalRawValue(List.of(fromJS({ value: 1, displayValue: 'test' })))).toBe(
+            'test'
+        );
+    });
+});

--- a/packages/components/src/internal/renderers/StoredAmountRenderer.tsx
+++ b/packages/components/src/internal/renderers/StoredAmountRenderer.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { List, Map } from 'immutable';
+
+import { ValueDescriptor } from '../components/editable/models';
+
+import { DefaultRenderer } from './DefaultRenderer';
+
+interface Props {
+    data: Map<any, any>;
+}
+
+export class StoredAmountRenderer extends React.PureComponent<Props, any> {
+    static getEditableRawValue = (values: List<ValueDescriptor>): string[] => {
+        return values.size === 1 ? values.first()?.display : undefined;
+    };
+    static getOriginalRawValue = (values: any): string[] => {
+        if (!List.isList(values)) return values;
+        return Map.isMap(values.get(0)) ? values.get(0).get('displayValue') : values.get(0).displayValue;
+    };
+
+    render() {
+        return <DefaultRenderer data={this.props.data} />;
+    }
+}


### PR DESCRIPTION
#### Rationale
Issue [49502](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49502): StoredAmount and Units for samples editable grid to use display values instead of raw values

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1406
- https://github.com/LabKey/labkey-ui-premium/pull/322
- https://github.com/LabKey/biologics/pull/2689
- https://github.com/LabKey/sampleManagement/pull/2428
- https://github.com/LabKey/inventory/pull/1185

#### Changes
- add new StoredAmountRenderer with impl for getEditableRawValue() and getOriginalRawValue()
- use StoredAmountRenderer for units LookupCell to get initial value for select
- use StoredAmountRenderer for getUpdatedDataForGrid()
