### PR TITLE
Issue 45256: Support "formattedValue" for display

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.16.0",
+  "version": "3.16.1-fb-field-value.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.16.0",
+      "version": "3.16.1-fb-field-value.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.16.1-fb-field-value.0",
+  "version": "3.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.16.1-fb-field-value.0",
+      "version": "3.17.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.16.0",
+  "version": "3.16.1-fb-field-value.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.16.1-fb-field-value.0",
+  "version": "3.17.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.17.0
+*Released*: 6 February 2024
+- Issue 45256: Support "formattedValue" for display
+- Switch arguments to `resolveDetailFieldValue` to optionally resolve `formattedValue` and `displayValue`.
+- Introduce `resolveDetailFieldLabel` to make it more clear what is being resolved when reading a usage.
+
 ### version 3.16.0
 *Released*: 2 February 2024
 - Issue 49440: User may not be in the core.Users table (if permission was removed), so check the core.SiteUsers table as well

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -22,7 +22,7 @@ import { SchemaQuery } from '../../../public/SchemaQuery';
 import { resolveErrorMessage } from '../../util/messaging';
 
 import { SelectInputOption, SelectInput, SelectInputProps } from './input/SelectInput';
-import { resolveDetailFieldValue } from './utils';
+import { resolveDetailFieldLabel } from './utils';
 import { initSelect, QuerySelectModel } from './model';
 import { DELIMITER } from './constants';
 
@@ -79,7 +79,7 @@ const PreviewOption: FC<any> = props => {
             <>
                 {columns.map((column, i) => {
                     if (item !== undefined) {
-                        let text = resolveDetailFieldValue(item.get(column.name));
+                        let text = resolveDetailFieldLabel(item.get(column.name));
                         if (!Utils.isString(text)) {
                             text = text ? text.toString() : '';
                         }

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -279,7 +279,7 @@ export function resolveDetailEditRenderer(
         }
 
         const showLabel = !options?.hideLabel ?? false;
-        let value = resolveDetailFieldValue(data, true);
+        let value = resolveDetailFieldValue(data);
 
         const ColumnInputRenderer = resolveInputRenderer(col);
         if (ColumnInputRenderer) {
@@ -334,7 +334,7 @@ export function resolveDetailEditRenderer(
                         required={col.required}
                         schemaQuery={col.lookup.schemaQuery}
                         showLabel={showLabel}
-                        value={resolveDetailFieldValue(data, true)}
+                        value={value}
                         valueColumn={col.lookup.keyColumn}
                     />
                 );

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -279,7 +279,7 @@ export function resolveDetailEditRenderer(
         }
 
         const showLabel = !options?.hideLabel ?? false;
-        let value = resolveDetailFieldValue(data, col.isLookup());
+        let value = resolveDetailFieldValue(data, true);
 
         const ColumnInputRenderer = resolveInputRenderer(col);
         if (ColumnInputRenderer) {
@@ -377,9 +377,6 @@ export function resolveDetailEditRenderer(
 
         switch (col.jsonType) {
             case 'boolean':
-                // boolean checkbox state needs to be based off of the data value (not formattedValue)
-                value = resolveDetailFieldValue(data, false, true);
-
                 return (
                     <CheckboxInput
                         queryColumn={col}

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -221,11 +221,11 @@ const InputGroup: FC<InputGroupProps> = props => {
 
     return (
         <div className="input-group">
-            {!!addonBefore && <span className="input-group-prepend">{addonBefore}</span>}
-            {!!buttonBefore && <span className="input-group-prepend">{buttonBefore}</span>}
+            {!!addonBefore && <span className="input-group-addon">{addonBefore}</span>}
+            {!!buttonBefore && <span className="input-group-addon">{buttonBefore}</span>}
             {children}
-            {!!addonAfter && <span className="input-group-append">{addonAfter}</span>}
-            {!!buttonAfter && <span className="input-group-append">{buttonAfter}</span>}
+            {!!addonAfter && <span className="input-group-addon">{addonAfter}</span>}
+            {!!buttonAfter && <span className="input-group-addon">{buttonAfter}</span>}
         </div>
     );
 };

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -33,7 +33,7 @@ import { parseCsvString } from '../../util/utils';
 import { SelectInputOption } from './input/SelectInput';
 import { DELIMITER } from './constants';
 import { QuerySelectOwnProps } from './QuerySelect';
-import { resolveDetailFieldValue } from './utils';
+import { resolveDetailFieldLabel, resolveDetailFieldValue } from './utils';
 
 function formatResults(model: QuerySelectModel, results: Map<string, any>, token?: string): SelectInputOption[] {
     const { displayColumn, queryInfo, valueColumn } = model;
@@ -42,11 +42,13 @@ function formatResults(model: QuerySelectModel, results: Map<string, any>, token
         return [];
     }
 
-    let options = results.map(result => ({
-        label: (resolveDetailFieldValue(result.get(displayColumn)) ??
-            resolveDetailFieldValue(result.get(valueColumn))) as string,
-        value: result.getIn([valueColumn, 'value']),
-    }));
+    let options = results.map(result => {
+        return {
+            label: (resolveDetailFieldLabel(result.get(displayColumn)) ??
+                resolveDetailFieldLabel(result.get(valueColumn))) as string,
+            value: resolveDetailFieldValue(result.get(valueColumn)),
+        };
+    });
 
     // Issue 46618: If a sort key is applied, then skip sorting on the client to retain sort done on server.
     if (!queryInfo.getColumn(displayColumn)?.hasSortKey) {

--- a/packages/components/src/internal/components/forms/utils.test.ts
+++ b/packages/components/src/internal/components/forms/utils.test.ts
@@ -35,7 +35,7 @@ describe('resolveDetailFieldValue', () => {
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: undefined, formattedValue: 'Formatted Test 1' }),
-                true,
+                true
             )
         ).toBe(undefined);
         expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true)).toBe('test1');

--- a/packages/components/src/internal/components/forms/utils.test.ts
+++ b/packages/components/src/internal/components/forms/utils.test.ts
@@ -31,32 +31,66 @@ describe('resolveDetailFieldValue', () => {
         expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }))).toBe('test1');
     });
 
-    test('ignoreFormattedValue prop', () => {
+    test('resolveDisplayValue prop', () => {
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: undefined, formattedValue: 'Formatted Test 1' }),
+                true,
+            )
+        ).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true)).toBe('test1');
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
+                true
+            )
+        ).toBe('Test Display');
+
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: undefined, formattedValue: undefined }),
                 false
             )
-        ).toBe(undefined);
+        ).toBe('test1');
         expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), false)).toBe('test1');
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
                 false
             )
+        ).toBe('test1');
+    });
+
+    test('resolveFormattedValue prop', () => {
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: undefined, formattedValue: undefined }),
+                undefined,
+                true
+            )
+        ).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), undefined, true)).toBe('test1');
+        expect(
+            resolveDetailFieldValue(
+                fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
+                undefined,
+                true
+            )
         ).toBe('Test Formatted');
 
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: undefined, formattedValue: undefined }),
-                true
+                undefined,
+                false
             )
         ).toBe('test1');
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true)).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), undefined, false)).toBe('test1');
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
-                true
+                undefined,
+                false
             )
         ).toBe('test1');
     });

--- a/packages/components/src/internal/components/forms/utils.test.ts
+++ b/packages/components/src/internal/components/forms/utils.test.ts
@@ -26,36 +26,22 @@ describe('resolveDetailFieldValue', () => {
     });
 
     test('data value defined', () => {
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: undefined }))).toBe(undefined);
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: undefined }))).toBe('test1');
         expect(resolveDetailFieldValue(fromJS({ value: 'test1' }))).toBe('test1');
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }))).toBe('Test Display');
-    });
-
-    test('lookup prop', () => {
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: undefined }), false)).toBe(undefined);
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), false)).toBe('test1');
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }), false)).toBe(
-            'Test Display'
-        );
-
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: undefined }), true)).toBe('test1');
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true)).toBe('test1');
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }), true)).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1', displayValue: 'Test Display' }))).toBe('test1');
     });
 
     test('ignoreFormattedValue prop', () => {
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: undefined, formattedValue: undefined }),
-                false,
                 false
             )
         ).toBe(undefined);
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), false, false)).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), false)).toBe('test1');
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
-                false,
                 false
             )
         ).toBe('Test Formatted');
@@ -63,15 +49,13 @@ describe('resolveDetailFieldValue', () => {
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: undefined, formattedValue: undefined }),
-                true,
                 true
             )
         ).toBe('test1');
-        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true, true)).toBe('test1');
+        expect(resolveDetailFieldValue(fromJS({ value: 'test1' }), true)).toBe('test1');
         expect(
             resolveDetailFieldValue(
                 fromJS({ value: 'test1', displayValue: 'Test Display', formattedValue: 'Test Formatted' }),
-                true,
                 true
             )
         ).toBe('test1');

--- a/packages/components/src/internal/components/forms/utils.ts
+++ b/packages/components/src/internal/components/forms/utils.ts
@@ -33,30 +33,29 @@ const isFieldArray = (value: any): value is FieldArray => Array.isArray(value);
 
 const isFieldMap = (value: any): value is FieldMap => Map.isMap(value);
 
-const resolveFieldValue = (data: FieldValue, lookup?: boolean, ignoreFormattedValue?: boolean): string => {
+const resolveFieldValue = (data: FieldValue, ignoreFormattedValue?: boolean): string => {
     if (!ignoreFormattedValue && data.hasOwnProperty('formattedValue')) {
         return data.formattedValue;
     }
 
-    const o = lookup !== true && data.hasOwnProperty('displayValue') ? data.displayValue : data.value;
-    return o !== null && o !== undefined ? o : undefined;
+    // Issue 45256: Ignore the "displayValue" as it may be built from a query XML annotated "textExpression"
+    return data.value === null ? undefined : data.value;
 };
 
 export function resolveDetailFieldValue(
     data: FieldList | FieldArray | FieldMap | FieldValue,
-    lookup?: boolean,
     ignoreFormattedValue?: boolean
 ): string | string[] {
     if (data) {
         if (isFieldList(data) && data.size) {
-            return data.toJS().map(d => resolveFieldValue(d, lookup, ignoreFormattedValue));
+            return data.toJS().map(d => resolveFieldValue(d, ignoreFormattedValue));
         } else if (isFieldArray(data) && data.length) {
-            return data.map(d => resolveFieldValue(d, lookup, ignoreFormattedValue));
+            return data.map(d => resolveFieldValue(d, ignoreFormattedValue));
         } else if (isFieldMap(data)) {
-            return resolveFieldValue(data.toJS(), lookup, ignoreFormattedValue);
+            return resolveFieldValue(data.toJS(), ignoreFormattedValue);
         }
 
-        return resolveFieldValue(data as FieldValue, lookup, ignoreFormattedValue);
+        return resolveFieldValue(data as FieldValue, ignoreFormattedValue);
     }
 
     return undefined;

--- a/packages/components/src/internal/components/forms/utils.ts
+++ b/packages/components/src/internal/components/forms/utils.ts
@@ -26,6 +26,7 @@ interface FieldValue {
 type FieldArray = FieldValue[];
 type FieldMap = Map<string, any>;
 type FieldList = List<FieldMap>;
+type Field = FieldList | FieldArray | FieldMap | FieldValue;
 
 const isFieldList = (value: any): value is FieldList => List.isList(value);
 
@@ -33,30 +34,42 @@ const isFieldArray = (value: any): value is FieldArray => Array.isArray(value);
 
 const isFieldMap = (value: any): value is FieldMap => Map.isMap(value);
 
-const resolveFieldValue = (data: FieldValue, ignoreFormattedValue?: boolean): string => {
-    if (!ignoreFormattedValue && data.hasOwnProperty('formattedValue')) {
-        return data.formattedValue;
+const resolveFieldValue = (
+    fieldValue: FieldValue,
+    resolveDisplayValue?: boolean,
+    resolveFormattedValue?: boolean
+): string => {
+    if (resolveFormattedValue && fieldValue.hasOwnProperty('formattedValue')) {
+        return fieldValue.formattedValue;
     }
 
-    // Issue 45256: Ignore the "displayValue" as it may be built from a query XML annotated "textExpression"
-    return data.value === null ? undefined : data.value;
+    if (resolveDisplayValue && fieldValue.hasOwnProperty('displayValue')) {
+        return fieldValue.displayValue;
+    }
+
+    return fieldValue.value === null ? undefined : fieldValue.value;
 };
 
 export function resolveDetailFieldValue(
-    data: FieldList | FieldArray | FieldMap | FieldValue,
-    ignoreFormattedValue?: boolean
+    field: Field,
+    resolveDisplayValue?: boolean,
+    resolveFormattedValue?: boolean
 ): string | string[] {
-    if (data) {
-        if (isFieldList(data) && data.size) {
-            return data.toJS().map(d => resolveFieldValue(d, ignoreFormattedValue));
-        } else if (isFieldArray(data) && data.length) {
-            return data.map(d => resolveFieldValue(d, ignoreFormattedValue));
-        } else if (isFieldMap(data)) {
-            return resolveFieldValue(data.toJS(), ignoreFormattedValue);
+    if (field) {
+        if (isFieldList(field) && field.size) {
+            return field.toJS().map(d => resolveFieldValue(d, resolveDisplayValue, resolveFormattedValue));
+        } else if (isFieldArray(field) && field.length) {
+            return field.map(d => resolveFieldValue(d, resolveDisplayValue, resolveFormattedValue));
+        } else if (isFieldMap(field)) {
+            return resolveFieldValue(field.toJS(), resolveDisplayValue, resolveFormattedValue);
         }
 
-        return resolveFieldValue(data as FieldValue, ignoreFormattedValue);
+        return resolveFieldValue(field as FieldValue, resolveDisplayValue, resolveFormattedValue);
     }
 
     return undefined;
+}
+
+export function resolveDetailFieldLabel(field: Field): string | string[] {
+    return resolveDetailFieldValue(field, true, true);
 }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45256](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45256) by updating our `resolveDetailFieldValue` to a) default to returning the `value` and b) better supporting resolution of the optional `formattedValue` and `displayValue` properties. In the end the expectation is that for non-lookups the `value` is what appears in form inputs so we do not end up round-tripping the formatted/display value.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1408
- https://github.com/LabKey/biologics/pull/2693
- https://github.com/LabKey/sampleManagement/pull/2434
- https://github.com/LabKey/inventory/pull/1187

#### Changes
- Switch arguments to `resolveDetailFieldValue` to optionally resolve `formattedValue` and `displayValue`.
- Introduce `resolveDetailFieldLabel` to make it more clear what is being resolved when reading a usage.
- Update unit tests
- (Miscellaneous) Fix intended usage of `input-group-addon`
