### PR TITLE
Fix Issue 49589

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.5",
+  "version": "2.390.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "2.390.5",
+      "version": "2.390.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.27.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "2.390.5",
+  "version": "2.390.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 2.390.6
+*Released*: 5 February 2023
+* Issue 49589: LKSM/LKB: More jumping behavior on Chrome & not Firefox
+
 ### version 2.390.5
 *Released*: 27 November 2023
 * Issue 49155: Get proper raw value for measurement units in grid

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -553,3 +553,16 @@ td > .expired-form-field {
         padding: 8px;
     }
 }
+
+// Issue 49589, 49533 - Chrome 121 scroll-margin behavior is broken
+// This is likely to be fixed in Chrome 123: https://issues.chromium.org/issues/41497496
+.app-body,
+.app-body.with-sub-nav {
+    & .table-responsive {
+        scroll-margin: 0;
+    }
+
+    & .cellular-display {
+        scroll-margin: 0;
+    }
+}


### PR DESCRIPTION
#### Rationale
Fix issue with scroll-margin causing jumping in Chrome

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1410
- https://github.com/LabKey/biologics/pull/2695
- https://github.com/LabKey/inventory/pull/1189
- https://github.com/LabKey/sampleManagement/pull/2436

#### Changes
- Fix Issue 49589
