### PR TITLE
Merge from release23.11-SNAPSHOT to release24.2-SNAPSHOT

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.15.1",
+      "version": "3.15.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -363,6 +363,10 @@ Components, models, actions, and utility functions for LabKey applications and p
 * Issue 48828: Don't show sample insights panel while editing in the grid
   -  add `onEditToggle` optional prop for `SampleTabbedGridPanel`
 
+### version 2.390.6
+*Released*: 5 February 2023
+* Issue 49589: LKSM/LKB: More jumping behavior on Chrome & not Firefox
+
 ### version 2.390.5
 *Released*: 27 November 2023
 * Issue 49155: Get proper raw value for measurement units in grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.15.2
+*Released*: 6 February 2024
+- Merge release23.11-SNAPSHOT to release24.2-SNAPSHOT:
+  - includes changes from 2.390.6
+
 ### version 3.15.1
 *Released*: 2 February 2024
 - Issue 49502: StoredAmount and Units for samples editable grid to use display values instead of raw values

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -561,3 +561,16 @@ td > .expired-form-field {
         padding: 8px;
     }
 }
+
+// Issue 49589, 49533 - Chrome 121 scroll-margin behavior is broken
+// This is likely to be fixed in Chrome 123: https://issues.chromium.org/issues/41497496
+.app-body,
+.app-body.with-sub-nav {
+    & .table-responsive {
+        scroll-margin: 0;
+    }
+
+    & .cellular-display {
+        scroll-margin: 0;
+    }
+}


### PR DESCRIPTION
#### Rationale
includes changes from `v2.390.6`: https://github.com/LabKey/labkey-ui-components/pull/1410
