### PR TITLE
Issue 49659: Remove direct use of `LabelOverlay` for `TextChoiceInput` `SelectInput` usage

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.3-bulkUpdateTextChoice.0",
+  "version": "3.15.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.15.3-bulkUpdateTextChoice.0",
+      "version": "3.15.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.2",
+  "version": "3.15.3-bulkUpdateTextChoice.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.15.2",
+      "version": "3.15.3-bulkUpdateTextChoice.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.3-bulkUpdateTextChoice.0",
+  "version": "3.15.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.15.2",
+  "version": "3.15.3-bulkUpdateTextChoice.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### verstion 3.15.X
+*Released*: ? February 2024
+- Issue 49569: Remove direct use of `LabelOverlay` for `TextChoiceInput` `SelectInput` usage
+
 ### version 3.15.2
 *Released*: 6 February 2024
 - Merge release23.11-SNAPSHOT to release24.2-SNAPSHOT:

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### verstion 3.15.X
-*Released*: ? February 2024
+### version 3.15.3
+*Released*: 12 February 2024
 - Issue 49569: Remove direct use of `LabelOverlay` for `TextChoiceInput` `SelectInput` usage
 
 ### version 3.15.2

--- a/packages/components/src/internal/components/forms/QueryFormInputs.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.spec.tsx
@@ -50,9 +50,7 @@ describe('QueryFormInputs', () => {
         expect(formWrapper.find(SelectInput)).toHaveLength(1); // this is from the TextChoiceInput
         // default properties don't render file inputs
         expect(formWrapper.find(FileInput)).toHaveLength(0);
-
-        // by default all inputs except TextChoiceInput should render labels with FieldLabel
-        expect(formWrapper.find(FieldLabel)).toHaveLength(8);
+        expect(formWrapper.find(FieldLabel)).toHaveLength(9);
 
         formWrapper.unmount();
     });
@@ -70,7 +68,7 @@ describe('QueryFormInputs', () => {
         );
 
         expect(formWrapper.find(FieldLabel)).toHaveLength(0);
-        expect(formWrapper.find('.jest-field-label-test')).toHaveLength(8);
+        expect(formWrapper.find('.jest-field-label-test')).toHaveLength(9);
 
         formWrapper.unmount();
     });

--- a/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextChoiceInput.tsx
@@ -4,7 +4,6 @@ import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { SelectInput, SelectInputProps } from './SelectInput';
 import { DisableableInput, DisableableInputState } from './DisableableInput';
-import { LabelOverlay } from '../LabelOverlay';
 
 interface Props extends Omit<SelectInputProps, 'options'> {
     queryColumn: QueryColumn;
@@ -17,7 +16,7 @@ export class TextChoiceInput extends DisableableInput<Props, DisableableInputSta
 
         return (
             <SelectInput
-                label={<LabelOverlay column={queryColumn} inputId={queryColumn.fieldKey} isFormsy={false} />}
+                label={queryColumn.caption}
                 name={queryColumn.fieldKey}
                 required={queryColumn.required}
                 {...selectInputProps}


### PR DESCRIPTION
#### Rationale
Issue [49569](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49659)

#### Related Pull Requests
- #1361 
- https://github.com/LabKey/labkey-ui-premium/pull/331
- https://github.com/LabKey/sampleManagement/pull/2453
- https://github.com/LabKey/inventory/pull/1198
- https://github.com/LabKey/biologics/pull/2708

#### Changes
- Revert change that supplied `LabelOverlay` directly as the label for `SelectInput` usage in `TextChoiceInput`
