### PR TITLE
Issue 49612: Handle ending drag action "mouse up" outside the editable grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.20.0",
+      "version": "3.20.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.20.1
+*Released*: 13 February 2024
+- Issue 49612: Handle ending drag action "mouse up" outside the editable grid
+
 ### version 3.20.0
 *Released*: 13 February 2024
 - Plate Set assay import

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -141,6 +141,8 @@ const COUNT_COL = new GridColumn({
     ),
 });
 
+type GridMouseEvent = React.MouseEvent<HTMLDivElement> | MouseEvent;
+
 // the column index for cell values and cell messages does not include either the selection
 // column or the row number column, so we adjust the value passed to <Cell> to accommodate.
 function inputCellFactory(
@@ -907,7 +909,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     headerCell = (col: GridColumn): ReactNode => {
         const { allowBulkRemove, allowBulkUpdate, queryInfo } = this.props;
 
-        if ((allowBulkRemove || allowBulkUpdate) && col.index.toLowerCase() == GRID_SELECTION_INDEX) {
+        if ((allowBulkRemove || allowBulkUpdate) && col.index.toLowerCase() === GRID_SELECTION_INDEX) {
             return headerSelectionCell(this.selectAll, this.state.selectedState, false);
         }
 
@@ -928,7 +930,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         this.toggleMask(false);
     };
 
-    handleDrag = (event: React.MouseEvent): boolean => {
+    handleDrag = (event: GridMouseEvent): boolean => {
         if (!this.props.editorModel.hasFocus) {
             event.preventDefault();
             return true;
@@ -937,7 +939,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         return false;
     };
 
-    beginDrag = (event: React.MouseEvent): void => {
+    beginDrag = (event: GridMouseEvent): void => {
         const { disabled, editorModel } = this.props;
         if (this.handleDrag(event) && !disabled) {
             clearTimeout(this.dragDelay);
@@ -963,7 +965,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
     inDrag = (): boolean => this.state.inDrag;
 
-    endDrag = (event: React.MouseEvent): void => {
+    endDrag = (event: GridMouseEvent): void => {
         if (this.handleDrag(event)) {
             if (this.dragDelay) {
                 clearTimeout(this.dragDelay);
@@ -1006,8 +1008,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const isShift = event.shiftKey;
         const colIdx = editorModel.selectedColIdx;
         const rowIdx = editorModel.selectedRowIdx;
-        let nextCol;
-        let nextRow;
+        let nextCol: number;
+        let nextRow: number;
 
         switch (event.key) {
             case Key.ARROW_LEFT:
@@ -1095,7 +1097,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         }
     };
 
-    _dragFill = async (initialSelection: string[]) => {
+    _dragFill = async (initialSelection: string[]): Promise<void> => {
         const { editorModel, onChange, data, dataKeys, queryInfo, readonlyRows, lockedRows } = this.props;
 
         if (editorModel.isMultiSelect) {
@@ -1118,7 +1120,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         }
     };
 
-    onMouseUp = (event: React.MouseEvent): void => {
+    onMouseUp = (event: GridMouseEvent): void => {
         if (this.props.disabled) return;
         this.endDrag(event);
         const initialSelection = this.state.initialSelection;
@@ -1127,7 +1129,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
     // Issue 49612: Handle ending drag action "mouse up" outside the editable grid
     onDocumentMouseUp = (event: MouseEvent): void => {
-        this.onMouseUp(event as any);
+        this.onMouseUp(event);
     };
 
     fillDown = (): void => {


### PR DESCRIPTION
#### Rationale
This addresses [Issue 49612](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49612) by handling "mouse up" performed outside of the editable grid when performing a drag operation.

#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/2710
- https://github.com/LabKey/sampleManagement/pull/2455
- https://github.com/LabKey/inventory/pull/1199

#### Changes
- Bind event listener on the document for `mouseup`
- Add type `GridMouseEvent` to consolidate types of mouse events that are handled
