### PR TITLE
Navigation Menus: don't use DropdownButton

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.20.3",
+  "version": "3.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.20.3",
+      "version": "3.21.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.20.3",
+  "version": "3.21.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.21.0
+*Released*: 14 February 2024
+- Refactor ProductMenu, ServerNotifications, ProductNavigation, FilterExpressionView to no longer use DropdownButton
+- Update styling for ServerNotifications, ProductNavigation
+
 ### version 3.20.3
 *Released*: 14 February 2024
 - Merge release24.2-SNAPSHOT to develop:

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -127,14 +127,8 @@ export const NavigationBar: FC<Props> = memo(props => {
                                     user={user}
                                 />
                             )}
-                            {_showNotifications && !isAdminPage && (
-                                <div className="navbar-item pull-right navbar-item-notification">
-                                    <ServerNotifications {...notificationsConfig} />
-                                </div>
-                            )}
-                            {_showProductNav && (
-                                <ProductNavigation />
-                            )}
+                            {_showNotifications && !isAdminPage && <ServerNotifications {...notificationsConfig} />}
+                            {_showProductNav && <ProductNavigation />}
                             {showSearchBox && !isAdminPage && (
                                 <div className="navbar-item pull-right">
                                     <div className="hidden-md hidden-sm hidden-xs">

--- a/packages/components/src/internal/components/navigation/ProductMenu.spec.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.spec.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { createRef } from 'react';
 import { ReactWrapper } from 'enzyme';
 import { List, Map } from 'immutable';
 
@@ -184,9 +184,8 @@ describe('ProductMenuButton', () => {
     }
 
     function validate(wrapper: ReactWrapper) {
-        expect(wrapper.find('DropdownButton')).toHaveLength(1);
-        expect(wrapper.find('DropdownButton').prop('open')).toBe(false);
-        expect(wrapper.find('.product-menu-button')).toHaveLength(4);
+        expect(wrapper.find('.product-menu-button')).toHaveLength(1);
+        expect(wrapper.find('button').prop('aria-expanded')).toBe(false);
         expect(wrapper.find(ProductMenuButtonTitle)).toHaveLength(1);
         expect(wrapper.find(ProductMenu)).toHaveLength(0);
         expect(wrapper.find('.with-col-folders')).toHaveLength(0);
@@ -286,6 +285,7 @@ describe('ProductMenu', () => {
             className: 'test-cls',
             error: undefined,
             folderItems: [],
+            menuRef: createRef(),
             onClick: jest.fn(),
             sectionConfigs,
             showFolderMenu: true,

--- a/packages/components/src/internal/components/navigation/ProductMenu.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.tsx
@@ -132,7 +132,15 @@ export const ProductMenuButton: FC<ProductMenuButtonProps> = memo(props => {
 
     return (
         <div className="product-menu">
-            <button className="product-menu-button" onClick={toggleMenu} ref={toggleRef} type="button">
+            <button
+                aria-haspopup="true"
+                aria-expanded={show}
+                className="product-menu-button"
+                onClick={toggleMenu}
+                ref={toggleRef}
+                role="button"
+                type="button"
+            >
                 <ProductMenuButtonTitle container={container} folderItems={folderItems} location={location} />
                 <span className="caret" />
             </button>

--- a/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
@@ -132,7 +132,7 @@ export const UserMenuGroupImpl: FC<UserMenuProps & ImplProps> = props => {
                 <div className="navbar-item pull-right navbar-item__dropdown">
                     <DropdownButton
                         className="admin-dropdown"
-                        buttonClassName="navbar-icon-button-right"
+                        buttonClassName="navbar-menu-button"
                         title={<i className="fa fa-cog navbar-header-icon" />}
                         noCaret
                         pullRight
@@ -156,7 +156,7 @@ export const UserMenuGroupImpl: FC<UserMenuProps & ImplProps> = props => {
                 <div className="navbar-item pull-right navbar-item__dropdown">
                     <DropdownButton
                         className="help-dropdown"
-                        buttonClassName="navbar-icon-button-right"
+                        buttonClassName="navbar-menu-button"
                         title={<i className="fa fa-question-circle navbar-header-icon" />}
                         noCaret
                         pullRight

--- a/packages/components/src/internal/components/notifications/ServerNotifications.spec.tsx
+++ b/packages/components/src/internal/components/notifications/ServerNotifications.spec.tsx
@@ -32,12 +32,16 @@ describe('<ServerNotificaitons/>', () => {
     test('loading', () => {
         const wrapper = mount(
             <ServerNotifications
+                maxRows={8}
                 serverActivity={new ServerNotificationModel({ isLoading: true })}
                 markAllNotificationsRead={markAllNotificationsRead}
                 onViewAll={jest.fn()}
             />
         );
-        expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
+        expect(wrapper.find(ServerActivityList)).toHaveLength(0);
+        wrapper.find('button').simulate('click');
+        expect(wrapper.find('LoadingSpinner')).toHaveLength(1);
         const title = wrapper.find('.navbar-menu-header');
         expect(title.text()).toBe('Notifications');
         expect(wrapper.find(ServerActivityList)).toHaveLength(0);
@@ -59,11 +63,14 @@ describe('<ServerNotificaitons/>', () => {
         });
         const wrapper = mount(
             <ServerNotifications
-                serverActivity={new ServerNotificationModel(serverActivity)}
+                maxRows={8}
+                serverActivity={serverActivity}
                 markAllNotificationsRead={markAllNotificationsRead}
                 onViewAll={jest.fn()}
             />
         );
+        expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
+        wrapper.find('button').simulate('click');
         expect(wrapper.find(LoadingSpinner)).toHaveLength(0);
         const error = wrapper.find('.server-notifications-error');
         expect(error).toHaveLength(1);
@@ -85,12 +92,14 @@ describe('<ServerNotificaitons/>', () => {
 
         const wrapper = mount(
             <ServerNotifications
+                maxRows={8}
                 serverActivity={serverActivity}
                 markAllNotificationsRead={markAllNotificationsRead}
                 onViewAll={jest.fn()}
             />
         );
 
+        wrapper.find('button').simulate('click');
         expect(wrapper.find(ServerActivityList)).toHaveLength(1);
         const title = wrapper.find('.navbar-menu-header');
         expect(title.text()).toBe('Notifications');
@@ -112,12 +121,14 @@ describe('<ServerNotificaitons/>', () => {
 
         const wrapper = mount(
             <ServerNotifications
+                maxRows={8}
                 serverActivity={serverActivity}
                 markAllNotificationsRead={markAllNotificationsRead}
                 onViewAll={jest.fn()}
             />
         );
 
+        wrapper.find('button').simulate('click');
         expect(wrapper.find(ServerActivityList)).toHaveLength(1);
         const title = wrapper.find('.navbar-menu-header');
         expect(title.text()).toContain('Mark all as read');
@@ -139,12 +150,14 @@ describe('<ServerNotificaitons/>', () => {
 
         const wrapper = mount(
             <ServerNotifications
+                maxRows={8}
                 serverActivity={serverActivity}
                 markAllNotificationsRead={markAllNotificationsRead}
                 onViewAll={jest.fn()}
             />
         );
 
+        wrapper.find('button').simulate('click');
         expect(wrapper.find(ServerActivityList)).toHaveLength(1);
         expect(wrapper.find('.fa-spinner')).toHaveLength(0);
         expect(wrapper.find('.fa-bell')).toHaveLength(1);
@@ -165,12 +178,14 @@ describe('<ServerNotificaitons/>', () => {
 
         const wrapper = mount(
             <ServerNotifications
+                maxRows={8}
                 serverActivity={serverActivity}
                 markAllNotificationsRead={markAllNotificationsRead}
                 onViewAll={jest.fn()}
             />
         );
 
+        wrapper.find('button').simulate('click');
         expect(wrapper.find(ServerActivityList)).toHaveLength(1);
         // one spinner for the menu icon and one within the menu itself.
         expect(wrapper.find('.fa-spinner')).toHaveLength(2);

--- a/packages/components/src/internal/components/notifications/ServerNotifications.tsx
+++ b/packages/components/src/internal/components/notifications/ServerNotifications.tsx
@@ -11,15 +11,15 @@ import { ServerNotificationsConfig } from './model';
 import { ServerActivityList } from './ServerActivityList';
 
 export const ServerNotifications: FC<ServerNotificationsConfig> = props => {
-    const { markAllNotificationsRead, maxRows, serverActivity } = props;
+    const { markAllNotificationsRead, maxRows, onRead, serverActivity } = props;
     const { show, setShow, menuRef, toggleRef } = useNavMenuState();
     const toggleMenu = useCallback(() => setShow(s => !s), []);
 
-    const onRead = useCallback(
+    const onRead_ = useCallback(
         async (id: number) => {
             try {
                 await markNotificationsAsRead([id]);
-                props.onRead?.();
+                onRead?.();
             } catch (e) {
                 console.error('Unable to mark notification ' + id + ' as read');
             }
@@ -30,11 +30,11 @@ export const ServerNotifications: FC<ServerNotificationsConfig> = props => {
     const markAllRead = useCallback(async () => {
         try {
             await markAllNotificationsRead();
-            props.onRead?.();
+            onRead?.();
         } catch (e) {
             console.error('Unable to mark all notifications as read');
         }
-    }, [props.onRead]);
+    }, [markAllNotificationsRead, props]);
 
     const unreadCount = useMemo(() => {
         if (!serverActivity || !serverActivity.isLoaded) return 0;
@@ -64,7 +64,7 @@ export const ServerNotifications: FC<ServerNotificationsConfig> = props => {
                 serverActivity={serverActivity}
                 onViewAll={onViewAll}
                 onViewClick={toggleMenu}
-                onRead={onRead}
+                onRead={onRead_}
             />
         );
     }

--- a/packages/components/src/internal/components/notifications/ServerNotifications.tsx
+++ b/packages/components/src/internal/components/notifications/ServerNotifications.tsx
@@ -4,10 +4,11 @@ import classNames from 'classnames';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
+import { useNavMenuState } from '../../useNavMenuState';
+
 import { markNotificationsAsRead } from './actions';
 import { ServerNotificationsConfig } from './model';
 import { ServerActivityList } from './ServerActivityList';
-import { useNavMenuState } from '../../useNavMenuState';
 
 export const ServerNotifications: FC<ServerNotificationsConfig> = props => {
     const { markAllNotificationsRead, maxRows, serverActivity } = props;
@@ -37,8 +38,7 @@ export const ServerNotifications: FC<ServerNotificationsConfig> = props => {
 
     const unreadCount = useMemo(() => {
         if (!serverActivity || !serverActivity.isLoaded) return 0;
-        return 5;
-        // return serverActivity.unreadCount;
+        return serverActivity.unreadCount;
     }, [serverActivity]);
     const hasAnyInProgress = serverActivity?.inProgressCount > 0;
     const onViewAll = useCallback(() => {
@@ -74,7 +74,15 @@ export const ServerNotifications: FC<ServerNotificationsConfig> = props => {
     });
     return (
         <div className="navbar-item pull-right server-notifications navbar-menu">
-            <button type="button" className="navbar-menu-button" onClick={toggleMenu} ref={toggleRef}>
+            <button
+                aria-haspopup="true"
+                aria-expanded={show}
+                className="navbar-menu-button"
+                onClick={toggleMenu}
+                ref={toggleRef}
+                role="button"
+                type="button"
+            >
                 <span className={iconClassName} />
                 {unreadCount > 0 && <span className="badge">{unreadCount}</span>}
             </button>

--- a/packages/components/src/internal/components/notifications/ServerNotifications.tsx
+++ b/packages/components/src/internal/components/notifications/ServerNotifications.tsx
@@ -72,11 +72,9 @@ export const ServerNotifications: FC<ServerNotificationsConfig> = props => {
         'fa-spinner fa-pulse': hasAnyInProgress,
         'fa-bell': !hasAnyInProgress,
     });
-    const buttonClassName = 'btn btn-default navbar-icon-button-right server-notifications-button navbar-menu-button';
-
     return (
-        <div className="navbar-item pull-right navbar-item-notification navbar-menu">
-            <button type="button" className={buttonClassName} onClick={toggleMenu} ref={toggleRef}>
+        <div className="navbar-item pull-right server-notifications navbar-menu">
+            <button type="button" className="navbar-menu-button" onClick={toggleMenu} ref={toggleRef}>
                 <span className={iconClassName} />
                 {unreadCount > 0 && <span className="badge">{unreadCount}</span>}
             </button>

--- a/packages/components/src/internal/components/productnavigation/ProductAppMenuItem.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductAppMenuItem.tsx
@@ -5,21 +5,30 @@ interface ProductAppMenuItemProps {
     disabled?: boolean;
     iconUrl: string;
     iconUrlAlt?: string;
-    onClick: () => void;
+    onClick: (productId: string) => void;
+    productId: string;
     subtitle?: string;
     title: string;
 }
 
 export const ProductAppMenuItem: FC<ProductAppMenuItemProps> = memo(props => {
-    const { iconUrl, iconUrlAlt, title, subtitle, onClick, disabled } = props;
+    const { iconUrl, iconUrlAlt, title, subtitle, onClick, disabled, productId } = props;
     const [hovered, setHovered] = useState<boolean>(false);
     const onEnter = useCallback(() => setHovered(true), [setHovered]);
     const onLeave = useCallback(() => setHovered(false), [setHovered]);
+    const onClick_ = useCallback(
+        event => {
+            // stopImmediatePropagation in order to prevent the document click handler from closing the menu
+            event.nativeEvent.stopImmediatePropagation();
+            onClick(productId);
+        },
+        [onClick, productId]
+    );
 
     return (
         <li
             className={classNames({ 'labkey-page-nav': hovered && !disabled, 'labkey-page-nav-disabled': disabled })}
-            onClick={disabled ? undefined : onClick}
+            onClick={disabled ? undefined : onClick_}
             onMouseEnter={onEnter}
             onMouseLeave={onLeave}
         >

--- a/packages/components/src/internal/components/productnavigation/ProductAppsDrawer.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductAppsDrawer.tsx
@@ -5,8 +5,6 @@ import { LKS_PRODUCT_ID } from '../../app/constants';
 
 import { imageURL } from '../../url/ActionURL';
 
-import { Container } from '../base/models/Container';
-
 import { ProductAppMenuItem } from './ProductAppMenuItem';
 import { ProductModel } from './models';
 import { PRODUCT_ID_IMG_SRC_MAP } from './constants';
@@ -15,7 +13,7 @@ export const DEFAULT_ICON_URL = imageURL('_images', 'mobile-logo-seattle.svg');
 export const DEFAULT_ICON_ALT_URL = imageURL('_images', 'mobile-logo-overcast.svg');
 
 interface ProductAppsDrawerProps {
-    onClick: (productId: string, project?: Container) => void;
+    onClick: (productId: string) => void;
     products: ProductModel[];
 }
 
@@ -28,20 +26,18 @@ export const ProductAppsDrawer: FC<ProductAppsDrawerProps> = memo(props => {
                 key={LKS_PRODUCT_ID}
                 iconUrl={DEFAULT_ICON_URL}
                 iconUrlAlt={DEFAULT_ICON_ALT_URL}
+                productId={LKS_PRODUCT_ID}
                 title="LabKey Server"
                 subtitle={getServerContext().project?.title ?? 'Root'}
-                onClick={() => onClick(LKS_PRODUCT_ID)}
+                onClick={onClick}
             />
             {products.map(product => {
                 const imgSrc = PRODUCT_ID_IMG_SRC_MAP[product.productId.toLowerCase()];
-                let iconUrl;
-                let iconUrlAlt;
+                let iconUrl = imgSrc?.iconUrl ?? DEFAULT_ICON_URL;
+                let iconUrlAlt = imgSrc?.iconUrlAlt ?? DEFAULT_ICON_ALT_URL;
                 if (product.disabled) {
                     iconUrl = imgSrc?.iconUrlDisabled ?? DEFAULT_ICON_URL;
                     iconUrlAlt = imgSrc?.iconUrlDisabled ?? DEFAULT_ICON_URL;
-                } else {
-                    iconUrl = imgSrc?.iconUrl ?? DEFAULT_ICON_URL;
-                    iconUrlAlt = imgSrc?.iconUrlAlt ?? DEFAULT_ICON_ALT_URL;
                 }
                 return (
                     <ProductAppMenuItem
@@ -49,9 +45,10 @@ export const ProductAppsDrawer: FC<ProductAppsDrawerProps> = memo(props => {
                         disabled={product.disabled}
                         iconUrl={iconUrl}
                         iconUrlAlt={iconUrlAlt}
+                        productId={product.productId}
                         title={product.productName}
                         subtitle={product.disabled ? 'Application not enabled in this location' : undefined}
-                        onClick={() => onClick(product.productId)}
+                        onClick={onClick}
                     />
                 );
             })}

--- a/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
@@ -7,11 +7,9 @@ export const ProductNavigation: FC = memo(() => {
     const { show, setShow, menuRef, toggleRef } = useNavMenuState();
     const onCloseMenu = useCallback(() => setShow(false), []);
     const toggleMenu = useCallback(() => setShow(s => !s), []);
-    const buttonClassName = 'btn btn-default navbar-icon-button-right navbar-menu-button';
-
     return (
         <div className="navbar-item pull-right product-navigation-menu hidden-xs navbar-menu">
-            <button type="button" className={buttonClassName} onClick={toggleMenu} ref={toggleRef}>
+            <button type="button" className="navbar-menu-button" onClick={toggleMenu} ref={toggleRef}>
                 <span className="fa fa-th-large navbar-header-icon" />
             </button>
 

--- a/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
@@ -1,7 +1,8 @@
 import React, { FC, memo, useCallback } from 'react';
 
-import { ProductNavigationMenu } from './ProductNavigationMenu';
 import { useNavMenuState } from '../../useNavMenuState';
+
+import { ProductNavigationMenu } from './ProductNavigationMenu';
 
 export const ProductNavigation: FC = memo(() => {
     const { show, setShow, menuRef, toggleRef } = useNavMenuState();
@@ -9,7 +10,15 @@ export const ProductNavigation: FC = memo(() => {
     const toggleMenu = useCallback(() => setShow(s => !s), []);
     return (
         <div className="navbar-item pull-right product-navigation-menu hidden-xs navbar-menu">
-            <button type="button" className="navbar-menu-button" onClick={toggleMenu} ref={toggleRef}>
+            <button
+                aria-haspopup="true"
+                aria-expanded={show}
+                className="navbar-menu-button"
+                onClick={toggleMenu}
+                ref={toggleRef}
+                role="button"
+                type="button"
+            >
                 <span className="fa fa-th-large navbar-header-icon" />
             </button>
 

--- a/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
@@ -1,30 +1,21 @@
-import React, { FC, memo, useCallback, useState } from 'react';
-import { DropdownButton } from 'react-bootstrap';
+import React, { FC, memo, useCallback } from 'react';
 
 import { ProductNavigationMenu } from './ProductNavigationMenu';
+import { useNavMenuState } from '../../useNavMenuState';
 
 export const ProductNavigation: FC = memo(() => {
-    const [show, setShow] = useState<boolean>(false);
+    const { show, setShow, menuRef, toggleRef } = useNavMenuState();
     const onCloseMenu = useCallback(() => setShow(false), []);
-    const toggleMenu = useCallback(() => {
-        setShow(current => !current);
-    }, []);
+    const toggleMenu = useCallback(() => setShow(s => !s), []);
+    const buttonClassName = 'btn btn-default navbar-icon-button-right navbar-menu-button';
 
-    // TODO: This should not be a DropdownButton, it is not rendering any MenuItems. We should consider Popover or
-    //  something similar.
     return (
-        <div className="navbar-item pull-right product-navigation-menu navbar-item__dropdown hidden-xs">
-            <DropdownButton
-                id="product-navigation-button"
-                className="navbar-icon-button-right"
-                title={<i className="fa fa-th-large navbar-header-icon" />}
-                onToggle={toggleMenu}
-                open={show}
-                noCaret
-                pullRight
-            >
-                {show && <ProductNavigationMenu onCloseMenu={onCloseMenu} />}
-            </DropdownButton>
+        <div className="navbar-item pull-right product-navigation-menu hidden-xs navbar-menu">
+            <button type="button" className={buttonClassName} onClick={toggleMenu} ref={toggleRef}>
+                <span className="fa fa-th-large navbar-header-icon" />
+            </button>
+
+            {show && <ProductNavigationMenu onCloseMenu={onCloseMenu} menuRef={menuRef} />}
         </div>
     );
 });

--- a/packages/components/src/internal/components/productnavigation/ProductNavigationHeader.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigationHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo } from 'react';
+import React, { FC, memo, useCallback } from 'react';
 import classNames from 'classnames';
 
 import { LKS_PRODUCT_ID } from '../../app/constants';
@@ -10,8 +10,16 @@ interface ProductNavigationHeaderProps {
 }
 
 export const ProductNavigationHeader: FC<ProductNavigationHeaderProps> = memo(props => {
-    const { productId, title, onClick } = props;
+    const { productId, title } = props;
     const contentCls = classNames('header-title', { clickable: !!productId });
+    const onClick = useCallback(
+        event => {
+            // stopImmediatePropagation in order to prevent the document click handler from closing the menu
+            event.nativeEvent.stopImmediatePropagation();
+            props.onClick();
+        },
+        [props.onClick]
+    );
 
     return (
         <h3 className="product-navigation-header navbar-menu-header">

--- a/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.spec.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigationMenu.spec.tsx
@@ -25,18 +25,16 @@ const DEFAULT_PROPS = {
     products: TEST_PRODUCTS,
     disableLKSContainerLink: false,
     homeVisible: true,
-    tabs: [],
+    menuRef: undefined,
+    onSelection: jest.fn,
     selectedProductId: undefined,
     selectedProject: undefined,
-    onSelection: jest.fn,
+    tabs: [],
 };
 
 describe('ProductNavigationMenu', () => {
     function validate(wrapper: ReactWrapper, rendered = true, wide = false, componentCounts?: Record<string, number>) {
         const count = rendered ? 1 : 0;
-        expect(wrapper.find('.product-navigation-container')).toHaveLength(count);
-        expect(wrapper.find('.navbar-icon-connector')).toHaveLength(count);
-        expect(wrapper.find(ProductNavigationHeader)).toHaveLength(count);
         expect(wrapper.find('.product-navigation-listing')).toHaveLength(count);
         expect(wrapper.find('.wider')).toHaveLength(wide ? 1 : 0);
 
@@ -47,19 +45,19 @@ describe('ProductNavigationMenu', () => {
 
     test('error', () => {
         const wrapper = mount(<ProductNavigationMenuImpl {...DEFAULT_PROPS} error="Test error" />);
-        validate(wrapper, false);
+        validate(wrapper, false, true);
         expect(wrapper.find(Alert).text()).toBe('Test error');
         wrapper.unmount();
     });
 
     test('loading', () => {
         let wrapper = mount(<ProductNavigationMenuImpl {...DEFAULT_PROPS} products={undefined} />);
-        validate(wrapper, false);
+        validate(wrapper, false, true);
         expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
         wrapper.unmount();
 
         wrapper = mount(<ProductNavigationMenuImpl {...DEFAULT_PROPS} tabs={undefined} />);
-        validate(wrapper, false);
+        validate(wrapper, false, true);
         expect(wrapper.find(LoadingSpinner)).toHaveLength(1);
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/search/FilterExpressionView.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.tsx
@@ -1,5 +1,5 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Dropdown, FormControl } from 'react-bootstrap';
+import { FormControl } from 'react-bootstrap';
 
 import { Filter } from '@labkey/api';
 
@@ -49,10 +49,10 @@ export const FilterExpressionView: FC<Props> = memo(props => {
 
     const unusedFilterOptions = useCallback(
         (thisIndex: number): FieldFilterOption[] => {
-            const otherIndex = thisIndex == 1 ? 0 : 1;
+            const otherIndex = thisIndex === 1 ? 0 : 1;
             return fieldFilterOptions?.filter(
                 option =>
-                    (thisIndex == 0 || !option.isSoleFilter) &&
+                    (thisIndex === 0 || !option.isSoleFilter) &&
                     activeFilters[otherIndex]?.filterType.value !== option.value
             );
         },
@@ -321,25 +321,20 @@ export const FilterExpressionView: FC<Props> = memo(props => {
             if (isConceptColumn) {
                 const ontologyBrowserKey = filterIndex + '-' + (isSecondInput ? '2' : '1');
                 const expanded = expandedOntologyKey === ontologyBrowserKey;
-                // FIXME: This is not a proper usage of Dropdown, as it is not rendering any MenuItems this behavior
-                //  should be accomplished some other way (OverlayTrigger + Popover with click events?)
-                //  Note: we can just replace this with some basic logic to show/hide it and render it inline, it does
-                //  not need to render as a floating item, so Dropdown is very unnecessary.
+                const onBrowserToggle = (event): void => {
+                    event.preventDefault();
+                    if (disabled) return;
+                    onOntologyFilterExpand(ontologyBrowserKey, !expanded);
+                };
                 return (
-                    <div>
+                    <div className="ontology-input">
                         {textInput}
-                        <Dropdown
-                            className="ontology-browser__menu"
-                            componentClass="div"
-                            id="ontology-browser__menu"
-                            onToggle={() => onOntologyFilterExpand(ontologyBrowserKey, !expanded)}
-                            open={expanded}
-                            disabled={disabled}
-                        >
-                            <Dropdown.Toggle useAnchor={true}>
-                                <span>{expanded ? 'Close Browser' : `Find ${field.caption} By Tree`}</span>
-                            </Dropdown.Toggle>
-                            <Dropdown.Menu>
+                        <div className="ontology-browser__menu">
+                            <a href="#" onClick={onBrowserToggle}>
+                                {expanded ? 'Close Browser' : `Find ${field.caption} By Tree`}
+                                <span className="caret" />
+                            </a>
+                            {expanded && (
                                 <OntologyBrowserFilterPanel
                                     ontologyId={field.sourceOntology}
                                     conceptSubtree={field.conceptSubtree}
@@ -349,8 +344,8 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                                         updateOntologyFieldValue(filterIndex, filterValue, isSecondInput)
                                     }
                                 />
-                            </Dropdown.Menu>
-                        </Dropdown>
+                            )}
+                        </div>
                     </div>
                 );
             }

--- a/packages/components/src/internal/useNavMenuState.ts
+++ b/packages/components/src/internal/useNavMenuState.ts
@@ -1,0 +1,45 @@
+import { Dispatch, MutableRefObject, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+
+interface ProductMenuState {
+    show: boolean;
+    setShow: Dispatch<SetStateAction<boolean>>;
+    toggleRef: MutableRefObject<HTMLButtonElement>;
+    menuRef: MutableRefObject<HTMLDivElement>;
+}
+
+/**
+ * Hook used to manage state and refs for our various navigation menus (ProductMenu, ProductNavigationMenu,
+ * ServerNotifications)
+ */
+export function useNavMenuState(): ProductMenuState {
+    const [show, setShow] = useState<boolean>(false);
+    const toggleRef = useRef<HTMLButtonElement>();
+    const menuRef = useRef<HTMLDivElement>();
+    const onDocumentClick = useCallback(event => {
+        // Don't take action if we're clicking the toggle, as that handles open/close on its own, and we can't use
+        // preventDocumentHandler in the toggle onClick, or we'll keep the menu open if the user clicks another menu.
+        if (event.target === toggleRef.current) return;
+
+        // Don't take action if we've clicked anything inside the menu. We have to be defensive about the existence of
+        // menuRef because of how React handles events, our onClick handler above will get called before this document
+        // handler, so menuRef.current may be null.
+        if (!menuRef.current?.contains(event.target)) setShow(false);
+    }, []);
+    useEffect(() => {
+        // We only want to listen for clicks on the document if the menu is open
+        if (show) {
+            document.addEventListener('click', onDocumentClick);
+        }
+
+        return () => {
+            document.removeEventListener('click', onDocumentClick);
+        };
+    }, [show, onDocumentClick]);
+
+    return {
+        show,
+        setShow,
+        toggleRef,
+        menuRef,
+    };
+}

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -114,26 +114,17 @@
             font-weight: 400;
         }
     }
-
-    .btn-group.open .dropdown-toggle {
-        background-color: $brand-secondary;
-        border: none;
-        box-shadow: none;
-    }
-
-    .dropdown-menu {
-        padding: 0;
-        margin: 0;
-        width: 925px;
-        left: -62px;
-    }
 }
-
+.navbar-item .dropdown-menu {
+    right: -22px;
+}
 .navbar-menu {
     position: relative;
     display: inline-block;
 }
+.navbar-menu-button {
 
+}
 .navbar-menu__content {
     background-color: #fff;
     border: 1px solid rgba(0, 0, 0, 0.15);
@@ -446,7 +437,7 @@
     }
 
     .open .dropdown-menu {
-      top: 125%;
+      margin-top: 13px;
     }
   }
 }

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -70,6 +70,11 @@
   font-family: FontAwesome, $font-family-sans-serif
 }
 
+.product-menu {
+    position: relative;
+    display: inline-block;
+}
+
 .navbar-left-menu {
     .product-menu-button {
         height: 54px;
@@ -124,50 +129,38 @@
     }
 }
 
-@media (min-width: 992px) {
-    .navbar-left-menu .dropdown-menu {
-        width: 925px;
-        left: -156px;
-    }
+.navbar-menu {
+    position: relative;
+    display: inline-block;
 }
 
-@media (min-width: 1200px) {
-    .navbar-left-menu .dropdown-menu {
-        width: 1082px;
-        left: -136px;
-    }
+.navbar-menu__content {
+    background-color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    margin-top: 5px;
+    position: absolute;
+    z-index: 1000;
+    right: -21px;
+    top: 125%;
 }
 
-@media (min-width: 1418px) {
-    .navbar-left-menu .dropdown-menu {
-        width: 1320px;
-        left: -162px;
-    }
-}
-
-@media (max-width: 767px) { // $screen-xs-max
-    .navbar-left-menu .product-menu-button {
-        max-width: 180px;
-    }
-
-    .navbar-left {
-        padding: 0 0 0 25px;
-
-        .navbar-item {
-            margin-left: 15px;
-        }
-    }
-
-    .navbar-right {
-        padding: 0 10px 0 0;
-
-        .navbar-item {
-            margin-right: 15px;
-        }
-    }
+.product-menu-content,
+.navbar-menu-content {
+    background-color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    position: absolute;
+    z-index: 1000;
 }
 
 .product-menu-content {
+    top: 100%;
+    left: -62px;
+    width: 925px;
+    margin-top: 1px;
     /* Works on Firefox */
     * {
         scrollbar-width: thin;
@@ -364,6 +357,51 @@
   }
 }
 
+@media (min-width: 992px) {
+    .product-menu-content {
+        width: 925px;
+        left: -156px;
+    }
+}
+
+@media (min-width: 1200px) {
+    .product-menu-content {
+        width: 1082px;
+        left: -136px;
+    }
+}
+
+@media (min-width: 1418px) {
+    .product-menu-content {
+        width: 1320px;
+        left: -162px;
+    }
+}
+
+@media (max-width: 767px) { // $screen-xs-max
+    .product-menu-content {
+        max-width: 100vw;
+        left: -76px;
+    }
+
+    .navbar-left {
+        padding: 0 0 0 25px;
+
+        .navbar-item {
+            margin-left: 15px;
+        }
+    }
+
+    .navbar-right {
+        padding: 0 10px 0 0;
+
+        .navbar-item {
+            margin-right: 15px;
+        }
+    }
+}
+
+
 .empty-section {
   font-style: italic;
   color: $light-gray;
@@ -427,20 +465,6 @@
 @media (min-width: 1418px) {
     .navbar .navbar-left .navbar-connector {
         left: 180px;
-    }
-}
-
-.navbar-item.navbar-item-notification, .navbar-item.navbar-item__dropdown {
-    .dropdown-menu {
-        padding: 5px 0;
-    }
-
-    .dropdown-menu-right {
-        right: -19px !important;
-    }
-
-    .navbar-icon-connector.has-unread {
-        right: 28px;
     }
 }
 
@@ -687,6 +711,9 @@
     border-style: solid;
     border-width: 0 10px 10px 10px;
     border-color: transparent transparent $white transparent;
+}
+.navbar-icon-connector.has-unread {
+    right: 28px;
 }
 
 .navbar-header-icon {

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -139,21 +139,16 @@
         background-color: transparent;
     }
 }
+
 .navbar-menu__content {
-    background-color: #fff;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    border-radius: 4px;
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
     margin-top: 5px;
-    position: absolute;
-    z-index: 1000;
     right: -21px;
     top: 125%;
 }
 
 .product-menu-content,
-.navbar-menu-content {
-    background-color: #fff;
+.navbar-menu__content {
+    background-color: $white;
     border: 1px solid rgba(0, 0, 0, 0.15);
     border-radius: 4px;
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -122,8 +122,22 @@
     position: relative;
     display: inline-block;
 }
-.navbar-menu-button {
 
+.open .btn-default.navbar-menu-button, // This selector handles the DropdownButton case
+.navbar-menu-button {
+    padding: 6px 0;
+    border: none;
+    background-color: transparent;
+    box-shadow: none;
+
+    &:focus,
+    &:active,
+    &:hover,
+    &:hover:active {
+        box-shadow: none;
+        border: none;
+        background-color: transparent;
+    }
 }
 .navbar-menu__content {
     background-color: #fff;
@@ -673,19 +687,6 @@
     font-size: 20px;
     margin-top: 6px;
     color: $white;
-}
-
-.navbar-icon-button-right {
-    background-color: transparent !important;
-    border: none;
-    box-shadow: none !important;
-    padding-right: 0;
-    padding-left: 0;
-
-    // dropdown menu is a sibling of the button.
-    ~ ul.dropdown-menu {
-      padding-top: 0;
-    }
 }
 
 .navbar-icon {

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -702,7 +702,7 @@
     height: 0;
     border-style: solid;
     border-width: 0 10px 10px 10px;
-    border-color: transparent transparent $white transparent;
+    border-color: transparent transparent $gray-lighter transparent;
 }
 .navbar-icon-connector.has-unread {
     right: 28px;
@@ -725,10 +725,6 @@
     background-color: $gray-shadow;
     border-bottom: 1px solid $gray-border;
     border-radius: 5px 5px 0 0;
-
-    .navbar-icon-connector {
-        border-color: transparent transparent $gray-lighter transparent;
-    }
 }
 
 .navbar-item.visible-xs.pull-right > .dropdown.open > .btn-default.dropdown-toggle,

--- a/packages/components/src/theme/notification.scss
+++ b/packages/components/src/theme/notification.scss
@@ -107,8 +107,9 @@
     color: $brand-danger;
 }
 
-.btn.server-notifications-button {
+.server-notifications {
     .badge {
+        display: inline-block;
         padding-left: 6px;
         background: $badge-color;
     }

--- a/packages/components/src/theme/notification.scss
+++ b/packages/components/src/theme/notification.scss
@@ -6,16 +6,16 @@
 }
 
 .server-notifications-listing-container {
-    max-height: 500px;
-    overflow-y: scroll;
     border-bottom: 1px solid lightgray;
+    max-height: 500px;
+    overflow-y: auto;
+    width: 350px;
 }
 
 .server-notifications-listing {
     list-style-type: none;
-    padding-left: 0;
-    margin-top: 5px;
-    width: 350px;
+    margin: 0;
+    padding: 0;
 
     & > li {
         border-bottom: 1px solid $gray-lighter;
@@ -39,7 +39,10 @@
                 font-weight: bold;
             }
         }
-  }
+    }
+    & > li:last-of-type {
+        border-bottom: none;
+    }
 }
 
 .server-notification-message {
@@ -72,8 +75,8 @@
 }
 
 .server-notifications-footer {
-    margin: 15px 0 5px 15px;
-    width: 350px;
+    padding: 15px;
+
     &.server-notifications-error {
         color: $brand-danger;
     }

--- a/packages/components/src/theme/product-navigation.scss
+++ b/packages/components/src/theme/product-navigation.scss
@@ -175,7 +175,7 @@
 
     .product-navigation-footer {
         border-top: 1px solid $gray-lighter;
-        padding: 5px 10px 10px 10px;
+        padding: 15px;
     }
 }
 


### PR DESCRIPTION
#### Rationale
This PR removes the remaining usages of react-bootstrap DropdownButton

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1418
- https://github.com/LabKey/biologics/pull/2712
- https://github.com/LabKey/inventory/pull/1200
- https://github.com/LabKey/sampleManagement/pull/2456
- https://github.com/LabKey/platform/pull/5229
- https://github.com/LabKey/testAutomation/pull/1824

#### Changes
- ProductMenu: Don't use DropdownButton
- ServerNotifications: Don't use DropdownButton, fix styling
- ProductNavigation: Don't use DropdownButton, fix styling
- FilterExpressionView: Don't use DropdownButton
