### PR TITLE
Enable date/time fields for all domain kinds

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.22.1-fb-jobTimeFields.1",
+  "version": "3.22.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.22.1-fb-jobTimeFields.1",
+      "version": "3.22.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.20.3",
+  "version": "3.20.4-fb-jobTimeFields.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.20.3",
+      "version": "3.20.4-fb-jobTimeFields.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.21.0",
+  "version": "3.21.1-fb-jobTimeFields.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.21.0",
+      "version": "3.21.1-fb-jobTimeFields.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.22.0",
+  "version": "3.22.1-fb-jobTimeFields.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.22.0",
+      "version": "3.22.1-fb-jobTimeFields.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.21.1-fb-jobTimeFields.1",
+  "version": "3.21.1-fb-jobTimeFields.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.21.1-fb-jobTimeFields.1",
+      "version": "3.21.1-fb-jobTimeFields.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.22.1-fb-jobTimeFields.1",
+  "version": "3.22.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.21.1-fb-jobTimeFields.1",
+  "version": "3.21.1-fb-jobTimeFields.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.20.3",
+  "version": "3.20.4-fb-jobTimeFields.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 3.X
 *Released*: X February 2024
 - Support date/time fields for all domain kinds
+  - Enable date and time field type for all domain kinds
+  - Update DatePickerInput to support inline edit mode
+  - Update EditInlineField to use DatePickerInput for date/time type query column
 
 ### version 3.21.0
 *Released*: 14 February 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.X
-*Released*: X February 2024
+### version 3.22.1
+*Released*: 15 February 2024
 - Support date/time fields for all domain kinds
   - Enable date and time field type for all domain kinds
   - Update DatePickerInput to support inline edit mode

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.X
+*Released*: X February 2024
+- Support date/time fields for all domain kinds
+
 ### version 3.20.3
 *Released*: 14 February 2024
 - Merge release24.2-SNAPSHOT to develop:

--- a/packages/components/src/internal/components/EditInlineField.test.tsx
+++ b/packages/components/src/internal/components/EditInlineField.test.tsx
@@ -168,7 +168,7 @@ describe('EditInlineField', () => {
                 {...DEFAULT_PROPS}
                 type="date"
                 value="2022-08-11 18:00:00"
-                column={new QueryColumn({ format: 'MM/dd/YYYY HH:mm:ss' })}
+                column={new QueryColumn({ format: 'MM/dd/YYYY HH:mm:ss', caption: 'DateField' })}
             />,
             { serverContext: SERVER_CONTEXT, appContext: APP_CONTEXT }
         );

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -144,7 +144,7 @@ export const EditInlineField: FC<Props> = memo(props => {
             if (typeof date === 'string') setTimeJsonValue(date);
             else setDateValue(date);
         },
-        [isTime]
+        []
     );
 
     const onFormsyColumnChange = useCallback(

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -100,10 +100,10 @@ export const EditInlineField: FC<Props> = memo(props => {
     }, [dateFormat, emptyText, isDate, value, _value]);
 
     const getInputValue = useCallback((): any => {
-        if (isTime)
-            return timeJsonValue;
+        if (isTime) return timeJsonValue;
         if (isDate) {
-            if (useJsonDateFormat) return isDateOnly? getJsonDateFormatString(dateValue) : getJsonDateTimeFormatString(dateValue);
+            if (useJsonDateFormat)
+                return isDateOnly ? getJsonDateFormatString(dateValue) : getJsonDateTimeFormatString(dateValue);
             return dateValue?.valueOf();
         }
         if (column) return columnBasedValue;
@@ -138,13 +138,14 @@ export const EditInlineField: FC<Props> = memo(props => {
         setState({ ignoreBlur: false });
     }, [allowBlank, getInputValue, isDate, saveEdit, state.ignoreBlur]);
 
-    const onDateChange = useCallback((date: Date | string) => {
-        if (date instanceof Array) throw new Error('Unsupported date/time type');
-        if (typeof date === 'string')
-            setTimeJsonValue(date);
-        else
-            setDateValue(date);
-    }, [isTime]);
+    const onDateChange = useCallback(
+        (date: Date | string) => {
+            if (date instanceof Array) throw new Error('Unsupported date/time type');
+            if (typeof date === 'string') setTimeJsonValue(date);
+            else setDateValue(date);
+        },
+        [isTime]
+    );
 
     const onFormsyColumnChange = useCallback(
         (data: Record<string, any>) => {
@@ -192,35 +193,36 @@ export const EditInlineField: FC<Props> = memo(props => {
 
     return (
         <div className={className}>
-            {state.editing && isDateOrTime && (
-                !!column ?
-                    <DatePickerInput
-                        autoFocus
-                        name={name}
-                        formsy={false}
-                        queryColumn={column}
-                        showLabel={false}
-                        value={isDate ? dateValue : _value}
-                        inputWrapperClassName="form-control"
-                        onBlur={onBlur}
-                        onKeyDown={onKeyDown}
-                        onChange={onDateChange}
-                        placeholderText={placeholder}
-                        inlineEdit={true}
-                    /> :
-                    <DateInput
-                        autoFocus
-                        name={name}
-                        onBlur={onBlur}
-                        onKeyDown={onKeyDown}
-                        onChange={onDateChange}
-                        onMonthChange={onDateChange}
-                        placeholderText={placeholder}
-                        selected={dateValue}
-                        showTimeSelect={!!column}
-                        dateFormat={dateInputDateFormat}
-                        timeFormat={parseDateFNSTimeFormat(dateInputDateFormat)}
-                    />
+            {state.editing && isDateOrTime && !!column && (
+                <DatePickerInput
+                    autoFocus
+                    name={name}
+                    formsy={false}
+                    queryColumn={column}
+                    showLabel={false}
+                    value={isDate ? dateValue : _value}
+                    inputWrapperClassName="form-control"
+                    onBlur={onBlur}
+                    onKeyDown={onKeyDown}
+                    onChange={onDateChange}
+                    placeholderText={placeholder}
+                    inlineEdit={true}
+                />
+            )}
+            {state.editing && isDateOrTime && !column && (
+                <DateInput
+                    autoFocus
+                    name={name}
+                    onBlur={onBlur}
+                    onKeyDown={onKeyDown}
+                    onChange={onDateChange}
+                    onMonthChange={onDateChange}
+                    placeholderText={placeholder}
+                    selected={dateValue}
+                    showTimeSelect={!!column}
+                    dateFormat={dateInputDateFormat}
+                    timeFormat={parseDateFNSTimeFormat(dateInputDateFormat)}
+                />
             )}
             {state.editing && isTextArea && (
                 <span className="input-group">

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -454,7 +454,15 @@ class AssayImportPanelsBody extends Component<Props, State> {
             this.props.setIsDirty?.(true);
         }
 
-        this.handleChange('batchProperties', Map<string, any>(values ? values : {}));
+        const cleanedValues = Object.keys(values).reduce((result, key) => {
+            const value = values[key];
+            if (value !== undefined) {
+                result[key] = value;
+            }
+            return result;
+        }, {});
+
+        this.handleChange('batchProperties', OrderedMap<string, any>(cleanedValues));
     };
 
     handleWorkflowTaskChange = (name: string, value: any): void => {

--- a/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.spec.tsx
@@ -692,7 +692,7 @@ describe('DomainForm', () => {
         // Get type field and verify available options
         const typeField = form.find({ id: createFormInputId(DOMAIN_FIELD_TYPE, 0, 0), className: 'form-control' });
         expect(typeField.length).toEqual(1);
-        expect(typeField.children().length).toEqual(11); // Check number of options
+        expect(typeField.children().length).toEqual(13); // Check number of options
         expect(typeField.find({ value: 'int' }).length).toEqual(1); // sanity check
         expect(typeField.find({ value: 'flag' }).length).toEqual(0);
         expect(typeField.find({ value: 'fileLink' }).length).toEqual(0);

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -332,20 +332,6 @@ function _isAvailablePropType(type: PropDescType, domain: DomainDesign, ontologi
         return false;
     }
 
-    if (type === TIME_TYPE || type === DATE_TYPE) {
-        switch (domain?.domainKindName) {
-            case Domain.KINDS.SAMPLE_TYPE:
-            case Domain.KINDS.DATA_CLASS:
-            case Domain.KINDS.INT_LIST:
-            case Domain.KINDS.VAR_LIST:
-            case Domain.KINDS.STUDY_DATASET_DATE:
-            case Domain.KINDS.STUDY_DATASET_VISIT:
-                return true;
-        }
-        if (domain?.domainURI?.indexOf(':AssayDomain-Data.') > 0) return true;
-        return false;
-    }
-
     return true;
 }
 

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
@@ -1441,6 +1441,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -1484,6 +1489,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -2209,6 +2219,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -2252,6 +2267,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -2731,6 +2751,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -2774,6 +2799,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -3252,6 +3282,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -3295,6 +3330,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -5543,6 +5583,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -5586,6 +5631,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -6311,6 +6361,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -6354,6 +6409,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -6833,6 +6893,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -6876,6 +6941,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -7354,6 +7424,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -7397,6 +7472,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -8575,6 +8655,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -8618,6 +8703,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -9343,6 +9433,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -9386,6 +9481,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -9865,6 +9965,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -9908,6 +10013,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"
@@ -10386,6 +10496,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               Boolean
                             </option>
                             <option
+                              value="date"
+                            >
+                              Date
+                            </option>
+                            <option
                               value="dateTime"
                             >
                               Date Time
@@ -10429,6 +10544,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                               value="textChoice"
                             >
                               Text Choice
+                            </option>
+                            <option
+                              value="time"
+                            >
+                              Time
                             </option>
                             <option
                               value="users"

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -15,7 +15,7 @@
  */
 import React, { FC, ReactNode, RefObject } from 'react';
 import { withFormsy } from 'formsy-react';
-import DatePicker, { ReactDatePickerProps } from 'react-datepicker';
+import DatePicker from 'react-datepicker';
 
 import { FieldLabel } from '../FieldLabel';
 import {
@@ -195,21 +195,9 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
         this.input.current?.setFocus();
     };
 
-    onSelect = (date: Date, event: React.SyntheticEvent<any> | undefined): void => {
+    onSelect = (): void => {
         // focus the input so an onBlur action gets triggered after selection has been made
         this.input.current?.setFocus();
-    };
-
-    getAdditionalConfig = (): Partial<ReactDatePickerProps> => {
-        const { inlineEdit, onBlur } = this.props;
-        if (inlineEdit)
-            return {
-                onSelect: this.onSelect,
-                onBlur,
-                shouldCloseOnSelect: false,
-            };
-
-        return {};
     };
 
     render(): ReactNode {
@@ -234,6 +222,8 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
             showLabel,
             value,
             wrapperClassName,
+            onBlur,
+            inlineEdit
         } = this.props;
         const { isDisabled, selectedDate, invalid } = this.state;
         const { dateFormat, timeFormat } = getPickerDateAndTimeFormat(queryColumn, hideTime);
@@ -241,7 +231,6 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
         const isTimeOnly = queryColumn.isTimeColumn;
         const picker = (
             <DatePicker
-                {...this.getAdditionalConfig()}
                 ref={this.input}
                 autoComplete="off"
                 autoFocus={autoFocus}
@@ -264,6 +253,9 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
                 timeFormat={timeFormat}
                 value={allowRelativeInput && !isTimeOnly && isRelativeDateFilterValue(value) ? value : undefined}
                 wrapperClassName={inputWrapperClassName}
+                onSelect={inlineEdit ? this.onSelect : undefined}
+                onBlur={inlineEdit ? onBlur : undefined}
+                shouldCloseOnSelect={inlineEdit ? false : undefined}
             />
         );
 

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -177,8 +177,15 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
     };
 
     onChangeRaw = (event?: any): void => {
+        const { queryColumn } = this.props;
+        const isTime = queryColumn.isTimeColumn;
         const value = event?.target?.value;
-        if (isRelativeDateFilterValue(value)) {
+
+        if (isTime) {
+            if (!value) {
+                this.onChange(null);
+            }
+        } else if (isRelativeDateFilterValue(value)) {
             this.setState({ relativeInputValue: value });
             this.props.onChange?.(value);
         } else {

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -173,8 +173,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
         }
 
         // event is null when selecting time picker
-        if (!event && this.props.inlineEdit)
-            this.input.current.setFocus();
+        if (!event && this.props.inlineEdit) this.input.current.setFocus();
     };
 
     onChangeRaw = (event?: any): void => {
@@ -201,18 +200,17 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
         this.input.current?.setFocus();
     };
 
-
-    getAdditionalConfig = () : Partial<ReactDatePickerProps> => {
+    getAdditionalConfig = (): Partial<ReactDatePickerProps> => {
         const { inlineEdit, onBlur } = this.props;
         if (inlineEdit)
             return {
                 onSelect: this.onSelect,
-                onBlur: onBlur,
+                onBlur,
                 shouldCloseOnSelect: false,
-            }
+            };
 
         return {};
-    }
+    };
 
     render(): ReactNode {
         const {

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -116,7 +116,7 @@ export function getFormattedTimeString(date: Date, queryColumn?: QueryColumn) {
 }
 
 export function getFormattedStringFromDate(date: Date, queryColumn: QueryColumn, hideTime?: boolean) {
-    if (!date) return null;
+    if (!date) return undefined;
 
     const isTimeOnly = queryColumn.isTimeColumn;
     const isDateOnly = queryColumn.isDateOnlyColumn || hideTime;

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -339,7 +339,7 @@ export function getJsonDateTimeFormatString(date: Date): string {
 }
 
 export function getJsonTimeFormatString(date: Date): string {
-    return _formatDate(date, 'YYYY-MM-dd HH:mm:ss').split(' ')[1];
+    return _formatDate(date, 'YYYY-MM-dd HH:mm:ss')?.split(' ')[1];
 }
 
 export function getJsonDateFormatString(date: Date): string {

--- a/packages/components/src/theme/fields.scss
+++ b/packages/components/src/theme/fields.scss
@@ -68,6 +68,10 @@
 .edit-inline-field {
     padding-top: 10px;
     word-break: break-word;
+
+    .react-datepicker__triangle {
+        left: -10px !important;
+    }
 }
 
 .edit-inline-field__label {


### PR DESCRIPTION
#### Rationale
Date and Time fields types were previously disabled for objectproperty backed domain types. This PR enables the 2 data types for all domains. Additionally, EditInlineField is updated to better support date/datetime/time field types.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1420
- https://github.com/LabKey/labkey-ui-premium/pull/333
- https://github.com/LabKey/platform/pull/5236
- https://github.com/LabKey/biologics/pull/2717
- https://github.com/LabKey/inventory/pull/1203
- https://github.com/LabKey/sampleManagement/pull/2459

#### Changes
  - Enable date and time field type for all domain kinds
  - Update DatePickerInput to support inline edit mode
  - Update EditInlineField to use DatePickerInput for date/time type query column
