### PR TITLE
Misc fixes for 24.3 app issues (49591, 49352, 49640, 48834, 47601)

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.21.0",
+  "version": "3.21.0-fb-misc243Cory.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.21.0",
+      "version": "3.21.0-fb-misc243Cory.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.22.1",
+  "version": "3.22.1-fb-misc243Cory.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.22.1",
+      "version": "3.22.1-fb-misc243Cory.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.22.1-fb-misc243Cory.0",
+  "version": "3.22.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.22.1-fb-misc243Cory.0",
+      "version": "3.22.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.22.1",
+  "version": "3.22.1-fb-misc243Cory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.21.0",
+  "version": "3.21.0-fb-misc243Cory.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.22.1-fb-misc243Cory.0",
+  "version": "3.22.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD February 2024
+### version 3.22.2
+*Released*: 19 February 2024
 - Issue 49352: Breadcrumb fix to remove CSS content and replace with new `<li>` separator
 - Issue 48834: Lineage detail panel to use table-layout auto instead of fixed
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD February 2024
+- Issue 49352: Breadcrumb fix to remove CSS content and replace with new `<li>` separator
+- Issue 48834: Lineage detail panel to use table-layout auto instead of fixed
+
 ### version 3.21.0
 *Released*: 14 February 2024
 - Refactor ProductMenu, ServerNotifications, ProductNavigation, FilterExpressionView to no longer use DropdownButton

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -3,6 +3,8 @@ import { List, OrderedMap } from 'immutable';
 import { Panel } from 'react-bootstrap';
 import { Query } from '@labkey/api';
 
+import classNames from 'classnames';
+
 import { DETAIL_TABLE_CLASSES } from '../constants';
 
 import { decodePart } from '../../../../public/SchemaQuery';
@@ -142,6 +144,7 @@ export interface DetailDisplaySharedProps extends RenderOptions {
     fieldHelpTexts?: Record<string, string>;
     fileInputRenderer?: (col: QueryColumn, data: any) => ReactNode;
     onAdditionalFormDataChange?: (name: string, value: any) => any;
+    tableCls?: string;
     titleRenderer?: TitleRenderer;
 }
 
@@ -161,6 +164,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
         fileInputRenderer,
         fieldHelpTexts,
         onAdditionalFormDataChange,
+        tableCls,
     } = props;
 
     const detailRenderer = useMemo(() => {
@@ -200,7 +204,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
                     }, OrderedMap<string, any>());
 
                     return (
-                        <table className={DETAIL_TABLE_CLASSES} key={i}>
+                        <table className={classNames(DETAIL_TABLE_CLASSES, tableCls)} key={i}>
                             <tbody>
                                 {fields
                                     .map((field, key) => {

--- a/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
@@ -28,7 +28,12 @@ const LineageDetailImpl: FC<LineageDetailProps & InjectedQueryModels> = memo(pro
     const detailColumns = [...queryModels.model.detailColumns, ...additionalCols];
 
     return (
-        <DetailPanel model={queryModels.model} queryColumns={detailColumns} detailRenderer={_resolveDetailRenderer} />
+        <DetailPanel
+            tableCls="detail-component--table__auto"
+            model={queryModels.model}
+            queryColumns={detailColumns}
+            detailRenderer={_resolveDetailRenderer}
+        />
     );
 });
 

--- a/packages/components/src/internal/components/navigation/Breadcrumb.tsx
+++ b/packages/components/src/internal/components/navigation/Breadcrumb.tsx
@@ -34,9 +34,14 @@ export const Breadcrumb: FC<Props> = props => {
 
     return (
         <ol className={classNames('breadcrumb', props.className)}>
-            {React.Children.map(children, child => (
-                <li>{child}</li>
-            ))}
+            {React.Children.map(children, (child, i) => {
+                return (
+                    <>
+                        {i > 0 && <li className="separator">&nbsp;/&nbsp;</li>}
+                        <li>{child}</li>
+                    </>
+                );
+            })}
         </ol>
     );
 };

--- a/packages/components/src/theme/breadcrumb.scss
+++ b/packages/components/src/theme/breadcrumb.scss
@@ -10,3 +10,14 @@
     text-align: right;
   }
 }
+
+// Issue 49352: Breadcrumb seprator should be selectable / copyable
+.breadcrumb > li + li:before {
+    padding: 0 2px;
+    content: '';
+}
+.breadcrumb > li.separator {
+    color: $gray-light;
+    font-weight: bold;
+    padding-left: 0;
+}

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -8,6 +8,20 @@
   }
 }
 
+.detail-component--table__auto {
+    table-layout: auto;
+    border: unset;
+
+    tbody tr:first-child td {
+        border-top: none;
+    }
+
+    // first child td width is 20%
+    tbody tr td:first-child {
+        width: 50%;
+    }
+}
+
 .detail-component--sequence--container__relative {
   position: relative;
   height: 300px;


### PR DESCRIPTION
#### Rationale
- Issue [49352](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49352): Copying Box ID's for Excel Upload: slashes and spaces for box locations
- Issue [48834](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48834): Attachment cards render outside of source/sample detail panel on lineage page

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1422
- https://github.com/LabKey/labkey-ui-premium/pull/336
- https://github.com/LabKey/sampleManagement/pull/2465
- https://github.com/LabKey/inventory/pull/1205
- https://github.com/LabKey/biologics/pull/2722

#### Changes
- Lineage detail panel to use table-layout auto instead of fixed
- Breadcrumb fix to remove CSS content and replace with new `<li>` separator
