### PR TITLE
Fix form input layout

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3",
+  "version": "3.24.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.3",
+      "version": "3.24.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3",
+  "version": "3.24.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.4
+*Released*: 29 February 2024
+- Fix form input layout
+- Remove `col-md-` and align on `col-sm-9 col-xs-12`
+- Consolidate default input classNames into constants
+
 ### version 3.24.3
 *Released*: 29 February 2024
 - Issue 49763: App to suppress "Plate Metadata" setting on assay designs when not applicable

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -18,10 +18,11 @@ import React, { ReactNode } from 'react';
 import { QueryColumn } from '../../../public/QueryColumn';
 import { generateId } from '../../util/utils';
 
-import { HelpTipRenderer } from './HelpTipRenderer';
 import { Popover } from '../../Popover';
 import { OverlayTrigger } from '../../OverlayTrigger';
 import { Placement } from '../../useOverlayPositioning';
+
+import { HelpTipRenderer } from './HelpTipRenderer';
 import { INPUT_LABEL_CLASS_NAME } from './constants';
 
 export interface LabelOverlayProps {

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -22,6 +22,7 @@ import { HelpTipRenderer } from './HelpTipRenderer';
 import { Popover } from '../../Popover';
 import { OverlayTrigger } from '../../OverlayTrigger';
 import { Placement } from '../../useOverlayPositioning';
+import { INPUT_LABEL_CLASS_NAME } from './constants';
 
 export interface LabelOverlayProps {
     addLabelAsterisk?: boolean;
@@ -42,7 +43,7 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
     static defaultProps = {
         isFormsy: true,
         addLabelAsterisk: false,
-        labelClass: 'control-label col-sm-3 col-xs-12 text-left',
+        labelClass: INPUT_LABEL_CLASS_NAME,
         placement: 'right',
     };
 

--- a/packages/components/src/internal/components/forms/constants.ts
+++ b/packages/components/src/internal/components/forms/constants.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 export const DETAIL_TABLE_CLASSES = 'table table-responsive table-condensed detail-component--table__fixed';
+export const INPUT_CONTAINER_CLASS_NAME = 'form-group row';
+export const INPUT_LABEL_CLASS_NAME = 'control-label col-sm-3 col-xs-12 text-left';
+export const INPUT_WRAPPER_CLASS_NAME = 'col-sm-9 col-xs-12';
 
 export const DELIMITER = ',';
 

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -268,6 +268,8 @@ function detailNonEditableRenderer(col: QueryColumn, data: any): ReactNode {
     return <div className="field__un-editable">{_defaultRenderer(col)(data)}</div>;
 }
 
+const DETAIL_INPUT_WRAPPER_CLASS_NAME = 'col-sm-12';
+
 // TODO: Merge this functionality with <QueryFormInputs />
 export function resolveDetailEditRenderer(
     col: QueryColumn,
@@ -294,11 +296,11 @@ export function resolveDetailEditRenderer(
                     containerPath={options?.containerPath}
                     data={row}
                     formsy
-                    inputClass="col-sm-12"
+                    inputClass={DETAIL_INPUT_WRAPPER_CLASS_NAME}
                     key={col.name}
                     onAdditionalFormDataChange={onAdditionalFormDataChange}
                     onSelectChange={options?.onSelectChange}
-                    selectInputProps={{ inputClass: 'col-sm-12', showLabel }}
+                    selectInputProps={{ inputClass: DETAIL_INPUT_WRAPPER_CLASS_NAME, showLabel }}
                     showLabel={showLabel}
                     value={value}
                 />
@@ -324,7 +326,7 @@ export function resolveDetailEditRenderer(
                         description={col.description}
                         displayColumn={col.lookup.displayColumn}
                         formsy
-                        inputClass="col-sm-12"
+                        inputClass={DETAIL_INPUT_WRAPPER_CLASS_NAME}
                         joinValues={joinValues}
                         key={col.fieldKey}
                         label={col.caption}
@@ -349,7 +351,7 @@ export function resolveDetailEditRenderer(
             return (
                 <TextChoiceInput
                     formsy
-                    inputClass="col-sm-12"
+                    inputClass={DETAIL_INPUT_WRAPPER_CLASS_NAME}
                     queryColumn={col}
                     value={value}
                     autoFocus={options?.autoFocus}
@@ -365,7 +367,7 @@ export function resolveDetailEditRenderer(
             return (
                 <TextAreaInput
                     cols={4}
-                    elementWrapperClassName="col-sm-12"
+                    elementWrapperClassName={DETAIL_INPUT_WRAPPER_CLASS_NAME}
                     queryColumn={col}
                     rows={4}
                     showLabel={showLabel}
@@ -386,7 +388,7 @@ export function resolveDetailEditRenderer(
                         queryColumn={col}
                         showLabel={showLabel}
                         value={value && value.toString().toLowerCase() === 'true'}
-                        wrapperClassName="col-sm-12"
+                        wrapperClassName={DETAIL_INPUT_WRAPPER_CLASS_NAME}
                     />
                 );
             case 'date':
@@ -397,8 +399,8 @@ export function resolveDetailEditRenderer(
                             queryColumn={col}
                             showLabel={showLabel}
                             value={value}
-                            wrapperClassName="col-sm-12"
-                            initValueFormatted={true}
+                            wrapperClassName={DETAIL_INPUT_WRAPPER_CLASS_NAME}
+                            initValueFormatted
                         />
                     );
                 }
@@ -415,7 +417,7 @@ export function resolveDetailEditRenderer(
 
                 return (
                     <TextInput
-                        elementWrapperClassName="col-sm-12"
+                        elementWrapperClassName={DETAIL_INPUT_WRAPPER_CLASS_NAME}
                         queryColumn={col}
                         // Issue 43561: Support name expression fields
                         // NK: If a name expression is applied, then the server does not mark the field as required as

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -20,7 +20,12 @@ import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
-import { INPUT_CONTAINER_CLASS_NAME, INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME, WithFormsyProps } from '../constants';
+import {
+    INPUT_CONTAINER_CLASS_NAME,
+    INPUT_LABEL_CLASS_NAME,
+    INPUT_WRAPPER_CLASS_NAME,
+    WithFormsyProps,
+} from '../constants';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -20,14 +20,16 @@ import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
-import { WithFormsyProps } from '../constants';
+import { INPUT_CONTAINER_CLASS_NAME, INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME, WithFormsyProps } from '../constants';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 
 interface CheckboxInputProps extends DisableableInputProps, WithFormsyProps {
     addLabelAsterisk?: boolean;
+    containerClassName?: string;
     formsy?: boolean;
     label?: any;
+    labelClassName?: string;
     name?: string;
     queryColumn: QueryColumn;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
@@ -44,8 +46,10 @@ interface CheckboxInputState extends DisableableInputState {
 class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInputState> {
     static defaultProps = {
         ...DisableableInput.defaultProps,
+        containerClassName: INPUT_CONTAINER_CLASS_NAME,
+        labelClassName: INPUT_LABEL_CLASS_NAME,
         showLabel: true,
-        wrapperClassName: 'col-sm-9 col-xs-12',
+        wrapperClassName: INPUT_WRAPPER_CLASS_NAME,
     };
 
     constructor(props: CheckboxInputProps) {
@@ -83,9 +87,11 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
         const {
             addLabelAsterisk,
             allowDisable,
+            containerClassName,
             formsy,
             getValue,
             label,
+            labelClassName,
             name,
             queryColumn,
             showLabel,
@@ -101,9 +107,9 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
         // This should not be responsible for rendering the "required-symbol" and should allow for component prop
         // to define label wrapper classes.
         return (
-            <div className="form-group row checkbox-input-form-row">
+            <div className={`${containerClassName} checkbox-input-form-row`}>
                 {renderFieldLabel ? (
-                    <label className="control-label col-sm-3 text-left col-xs-12">
+                    <label className={labelClassName}>
                         {renderFieldLabel(queryColumn)}
                         {queryColumn?.required && <span className="required-symbol"> *</span>}
                     </label>

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -45,7 +45,7 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputProps, CheckboxInp
     static defaultProps = {
         ...DisableableInput.defaultProps,
         showLabel: true,
-        wrapperClassName: 'col-sm-9 col-md-9 col-xs-12',
+        wrapperClassName: 'col-sm-9 col-xs-12',
     };
 
     constructor(props: CheckboxInputProps) {

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -30,7 +30,12 @@ import {
 } from '../../../util/Date';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
-import { WithFormsyProps } from '../constants';
+import {
+    INPUT_CONTAINER_CLASS_NAME,
+    INPUT_LABEL_CLASS_NAME,
+    INPUT_WRAPPER_CLASS_NAME,
+    WithFormsyProps,
+} from '../constants';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 
@@ -38,6 +43,7 @@ export interface DatePickerInputProps extends DisableableInputProps, WithFormsyP
     addLabelAsterisk?: boolean;
     allowRelativeInput?: boolean;
     autoFocus?: boolean;
+    containerClassName?: string;
     disabled?: boolean;
     formsy?: boolean;
     hideTime?: boolean;
@@ -71,17 +77,18 @@ interface DatePickerInputState extends DisableableInputState {
 // export for jest testing
 export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, DatePickerInputState> {
     static defaultProps = {
+        addLabelAsterisk: false,
         allowDisable: false,
+        containerClassName: INPUT_CONTAINER_CLASS_NAME,
         initiallyDisabled: false,
-        isClearable: true,
-        wrapperClassName: 'col-sm-9 col-xs-12',
+        initValueFormatted: false,
         inputClassName: 'form-control',
         inputWrapperClassName: 'block',
-        showLabel: true,
-        addLabelAsterisk: false,
-        initValueFormatted: false,
+        isClearable: true,
         isFormInput: true,
-        labelClassName: 'control-label col-sm-3 text-left col-xs-12',
+        labelClassName: INPUT_LABEL_CLASS_NAME,
+        showLabel: true,
+        wrapperClassName: INPUT_WRAPPER_CLASS_NAME,
     };
 
     input: RefObject<DatePicker>;
@@ -212,6 +219,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
             addLabelAsterisk,
             allowDisable,
             allowRelativeInput,
+            containerClassName,
             autoFocus,
             hideTime,
             inputClassName,
@@ -230,7 +238,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
             value,
             wrapperClassName,
             onBlur,
-            inlineEdit
+            inlineEdit,
         } = this.props;
         const { isDisabled, selectedDate, invalid } = this.state;
         const { dateFormat, timeFormat } = getPickerDateAndTimeFormat(queryColumn, hideTime);
@@ -280,7 +288,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
         if (!isFormInput) return picker;
 
         return (
-            <div className="form-group row">
+            <div className={containerClassName}>
                 {renderFieldLabel ? (
                     <label className={labelClassName}>
                         {renderFieldLabel(queryColumn)}

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -46,7 +46,7 @@ export interface DatePickerInputProps extends DisableableInputProps, WithFormsyP
     inputWrapperClassName?: string;
     isClearable?: boolean;
     isFormInput?: boolean;
-    label?: any;
+    label?: ReactNode;
     labelClassName?: string;
     name?: string;
     onCalendarClose?: () => void;
@@ -74,7 +74,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
         allowDisable: false,
         initiallyDisabled: false,
         isClearable: true,
-        wrapperClassName: 'col-sm-9 col-md-9 col-xs-12',
+        wrapperClassName: 'col-sm-9 col-xs-12',
         inputClassName: 'form-control',
         inputWrapperClassName: 'block',
         showLabel: true,
@@ -266,7 +266,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
             />
         );
 
-        if (this.props.inlineEdit)
+        if (inlineEdit) {
             return (
                 <span className="input-group date-input">
                     {picker}
@@ -275,6 +275,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
                     </span>
                 </span>
             );
+        }
 
         if (!isFormInput) return picker;
 

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -18,7 +18,7 @@ import classNames from 'classnames';
 import { Map } from 'immutable';
 import { withFormsy } from 'formsy-react';
 
-import { WithFormsyProps } from '../constants';
+import { INPUT_WRAPPER_CLASS_NAME, WithFormsyProps } from '../constants';
 import { FieldLabel } from '../FieldLabel';
 import { cancelEvent } from '../../../events';
 
@@ -55,7 +55,7 @@ class FileInputImpl extends DisableableInput<Props, State> {
         ...DisableableInput.defaultProps,
         ...{
             changeDebounceInterval: 0,
-            elementWrapperClassName: 'col-sm-9 col-xs-12',
+            elementWrapperClassName: INPUT_WRAPPER_CLASS_NAME,
             showLabel: true,
         },
     };

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -55,7 +55,7 @@ class FileInputImpl extends DisableableInput<Props, State> {
         ...DisableableInput.defaultProps,
         ...{
             changeDebounceInterval: 0,
-            elementWrapperClassName: 'col-sm-9 col-md-9 col-xs-12',
+            elementWrapperClassName: 'col-sm-9 col-xs-12',
             showLabel: true,
         },
     };

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -18,7 +18,7 @@ import React, {
 import { withFormsy } from 'formsy-react';
 import classNames from 'classnames';
 
-import { WithFormsyProps } from '../constants';
+import { INPUT_WRAPPER_CLASS_NAME, WithFormsyProps } from '../constants';
 
 type LayoutType = 'elementOnly' | 'horizontal' | 'vertical';
 
@@ -202,7 +202,7 @@ const Control: FC<BaseControlProps & LabelProps> = memo(props => {
 });
 
 Control.defaultProps = {
-    elementWrapperClassName: 'col-sm-9',
+    elementWrapperClassName: INPUT_WRAPPER_CLASS_NAME,
     label: null,
     showErrors: true,
 };

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -23,7 +23,13 @@ import { Utils } from '@labkey/api';
 
 import { FieldLabel } from '../FieldLabel';
 
-import { DELIMITER, WithFormsyProps } from '../constants';
+import {
+    DELIMITER,
+    INPUT_CONTAINER_CLASS_NAME,
+    INPUT_LABEL_CLASS_NAME,
+    INPUT_WRAPPER_CLASS_NAME,
+    WithFormsyProps,
+} from '../constants';
 import { QueryColumn } from '../../../../public/QueryColumn';
 import { generateId } from '../../../util/utils';
 
@@ -239,13 +245,13 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
         clearable: true,
         clearCacheOnChange: true,
         closeMenuOnSelect: true,
-        containerClass: 'form-group row',
+        containerClass: INPUT_CONTAINER_CLASS_NAME,
         defaultOptions: true,
         delimiter: DELIMITER,
         initiallyDisabled: false,
-        inputClass: 'col-sm-9 col-xs-12',
-        labelClass: 'control-label col-sm-3 text-left col-xs-12',
-        // Default to fixed because 'absolute' causes issues in several scenarios (Modals, EditableGrid) but it's too
+        inputClass: INPUT_WRAPPER_CLASS_NAME,
+        labelClass: INPUT_LABEL_CLASS_NAME,
+        // Default to 'fixed' because 'absolute' causes issues in several scenarios (Modals, EditableGrid) but it's too
         // difficult to manually set it to fixed in all of these situations (e.g. we don't always know we're in a modal)
         menuPosition: 'fixed',
         openMenuOnFocus: false,

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -35,7 +35,7 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
         ...DisableableInput.defaultProps,
         ...{
             cols: 50,
-            elementWrapperClassName: 'col-md-9 col-xs-12',
+            elementWrapperClassName: 'col-sm-9 col-xs-12',
             labelClassName: 'control-label textarea-control-label text-left col-xs-12',
             rows: 5,
             showLabel: true,

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -19,9 +19,10 @@ import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
+import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../constants';
+
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 import { FormsyTextArea, FormsyTextAreaProps } from './FormsyReactComponents';
-import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../constants';
 
 interface TextAreaInputProps extends DisableableInputProps, Omit<FormsyTextAreaProps, 'onChange'> {
     addLabelAsterisk?: boolean;

--- a/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextAreaInput.tsx
@@ -21,6 +21,7 @@ import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 import { FormsyTextArea, FormsyTextAreaProps } from './FormsyReactComponents';
+import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../constants';
 
 interface TextAreaInputProps extends DisableableInputProps, Omit<FormsyTextAreaProps, 'onChange'> {
     addLabelAsterisk?: boolean;
@@ -35,8 +36,8 @@ export class TextAreaInput extends DisableableInput<TextAreaInputProps, Disablea
         ...DisableableInput.defaultProps,
         ...{
             cols: 50,
-            elementWrapperClassName: 'col-sm-9 col-xs-12',
-            labelClassName: 'control-label textarea-control-label text-left col-xs-12',
+            elementWrapperClassName: INPUT_WRAPPER_CLASS_NAME,
+            labelClassName: `${INPUT_LABEL_CLASS_NAME} textarea-control-label`,
             rows: 5,
             showLabel: true,
         },

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -19,9 +19,10 @@ import { FieldLabel } from '../FieldLabel';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
+import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../constants';
+
 import { FormsyInput, FormsyInputProps } from './FormsyReactComponents';
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
-import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../constants';
 
 export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputProps, 'onChange'> {
     addLabelAsterisk?: boolean;

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -21,6 +21,7 @@ import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { FormsyInput, FormsyInputProps } from './FormsyReactComponents';
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
+import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../constants';
 
 export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputProps, 'onChange'> {
     addLabelAsterisk?: boolean;
@@ -39,8 +40,8 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
     static defaultProps = {
         ...DisableableInput.defaultProps,
         ...{
-            elementWrapperClassName: 'col-sm-9 col-xs-12',
-            labelClassName: 'control-label text-left col-xs-12',
+            elementWrapperClassName: INPUT_WRAPPER_CLASS_NAME,
+            labelClassName: INPUT_LABEL_CLASS_NAME,
             showLabel: true,
             startFocused: false,
         },

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -39,7 +39,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
     static defaultProps = {
         ...DisableableInput.defaultProps,
         ...{
-            elementWrapperClassName: 'col-md-9 col-xs-12',
+            elementWrapperClassName: 'col-sm-9 col-xs-12',
             labelClassName: 'control-label text-left col-xs-12',
             showLabel: true,
             startFocused: false,

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -12,6 +12,7 @@ import { QueryInfo } from '../../../public/QueryInfo';
 import { hasPermissions, User } from '../base/models/User';
 import { SCHEMAS } from '../../schemas';
 import { insertColumnFilter, QueryColumn } from '../../../public/QueryColumn';
+import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../forms/constants';
 import { FileInput } from '../forms/input/FileInput';
 import { Alert } from '../base/Alert';
 import { getActionErrorMessage, resolveErrorMessage } from '../../util/messaging';
@@ -109,17 +110,16 @@ export class UserProfile extends PureComponent<Props, State> {
 
     footer(): ReactNode {
         const { groups } = this.state;
+        if (!groups) return null;
 
-        if (groups) {
-            return (
-                <div className="form-group row">
-                    <label className="control-label col-sm-3 text-left col-xs-12"> Groups </label>
-                    <div className="col-sm-9 col-xs-12">
-                        <GroupsList groups={groups} asRow={false} />
-                    </div>
+        return (
+            <div className="form-group row">
+                <label className={INPUT_LABEL_CLASS_NAME}>Groups</label>
+                <div className={INPUT_WRAPPER_CLASS_NAME}>
+                    <GroupsList groups={groups} asRow={false} />
                 </div>
-            );
-        }
+            </div>
+        );
     }
 
     onAvatarFileChange = (files: {}): void => {

--- a/packages/components/src/internal/components/user/UserProfile.tsx
+++ b/packages/components/src/internal/components/user/UserProfile.tsx
@@ -4,7 +4,6 @@
  */
 import React, { PureComponent, ReactNode } from 'react';
 import { List, OrderedMap } from 'immutable';
-import { Col, Row } from 'react-bootstrap';
 import { ActionURL, PermissionTypes } from '@labkey/api';
 
 import { QueryInfoForm } from '../forms/QueryInfoForm';
@@ -115,7 +114,7 @@ export class UserProfile extends PureComponent<Props, State> {
             return (
                 <div className="form-group row">
                     <label className="control-label col-sm-3 text-left col-xs-12"> Groups </label>
-                    <div className="col-sm-9 col-md-9 col-xs-12">
+                    <div className="col-sm-9 col-xs-12">
                         <GroupsList groups={groups} asRow={false} />
                     </div>
                 </div>
@@ -174,14 +173,14 @@ export class UserProfile extends PureComponent<Props, State> {
                 {isLoading && <LoadingSpinner />}
                 {!isLoading && (
                     <>
-                        <Row>
-                            <Col sm={3} xs={12}>
+                        <div className="row">
+                            <div className="col-sm-3 col-xs-12">
                                 <p className="user-section-header">Avatar</p>
-                            </Col>
-                            <Col sm={2} xs={12}>
+                            </div>
+                            <div className="col-sm-2 col-xs-12">
                                 <img src={avatarSrc} className="detail__header-icon" />
-                            </Col>
-                            <Col sm={7} xs={12}>
+                            </div>
+                            <div className="col-sm-7 col-xs-12">
                                 <FileInput
                                     key={USER_AVATAR_FILE}
                                     showLabel={false}
@@ -195,13 +194,13 @@ export class UserProfile extends PureComponent<Props, State> {
                                         </a>
                                     </div>
                                 )}
-                            </Col>
-                        </Row>
-                        <Row>
-                            <Col xs={12}>
+                            </div>
+                        </div>
+                        <div className="row">
+                            <div className="col-xs-12">
                                 <hr />
-                            </Col>
-                        </Row>
+                            </div>
+                        </div>
 
                         <p className="user-section-header">User Details</p>
 


### PR DESCRIPTION
#### Rationale
This aligns our usages of bootstrap's grid layout within our form inputs. Here is an example of what is happening currently:

<img width="500" alt="image" src="https://github.com/LabKey/labkey-ui-components/assets/3926239/12f88f3e-406a-474f-af57-ab98fad1f869">

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/8

#### Changes
- Remove `col-md-` and align on `col-sm-9 col-xs-12`
- Consolidate default input classNames into constants
