### PR TITLE
Issue 49763: LKSM: suppress "Plate Metadata" setting on assay designs

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1-fb-misc243Coryv2.0",
+  "version": "3.24.1-fb-misc243Coryv2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.1-fb-misc243Coryv2.0",
+      "version": "3.24.1-fb-misc243Coryv2.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1",
+  "version": "3.24.1-fb-misc243Coryv2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.1",
+      "version": "3.24.1-fb-misc243Coryv2.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.2",
+  "version": "3.24.2-fb-misc243Coryv2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.2",
+      "version": "3.24.2-fb-misc243Coryv2.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.0",
+  "version": "3.24.0-fb-misc243Coryv2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.0",
+      "version": "3.24.0-fb-misc243Coryv2.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.2-fb-misc243Coryv2.0",
+  "version": "3.24.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.2-fb-misc243Coryv2.0",
+      "version": "3.24.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1-fb-misc243Coryv2.0",
+  "version": "3.24.1-fb-misc243Coryv2.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.0",
+  "version": "3.24.0-fb-misc243Coryv2.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1",
+  "version": "3.24.1-fb-misc243Coryv2.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.2",
+  "version": "3.24.2-fb-misc243Coryv2.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.2-fb-misc243Coryv2.0",
+  "version": "3.24.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.X
+*Released*: X February 2024
+- Issue 49763: App to suppress "Plate Metadata" setting on assay designs when not applicable
+
 ### version 3.24.0
 *Released*: 26 February 2024
 - Add Modal

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 3.24.X
 *Released*: X February 2024
 - Issue 49763: App to suppress "Plate Metadata" setting on assay designs when not applicable
+- Issue 49274: App to use chevron arrows instead of plus/minus for expand/collapse
 
 ### version 3.24.1
 *Released*: 27 February 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 3.24.3
+*Released*: 29 February 2024
 - Issue 49763: App to suppress "Plate Metadata" setting on assay designs when not applicable
 - Issue 49274: App to use chevron arrows instead of plus/minus for expand/collapse
 

--- a/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
@@ -63,8 +63,8 @@ describe('ColumnSelectionModal', () => {
             expect(wrapper.find('.fa-check')).toHaveLength(1);
             expect(wrapper.find('.fa-plus')).toHaveLength(0);
             expect(wrapper.find('.field-expand-icon')).toHaveLength(1);
-            expect(wrapper.find('.fa-plus-square')).toHaveLength(0);
-            expect(wrapper.find('.fa-plus-minus')).toHaveLength(0);
+            expect(wrapper.find('.fa-chevron-right')).toHaveLength(0);
+            expect(wrapper.find('.fa-chevron-down')).toHaveLength(0);
             wrapper.unmount();
         });
 
@@ -74,8 +74,8 @@ describe('ColumnSelectionModal', () => {
             expect(wrapper.find('.fa-check')).toHaveLength(0);
             expect(wrapper.find('.fa-plus')).toHaveLength(1);
             expect(wrapper.find('.field-expand-icon')).toHaveLength(1);
-            expect(wrapper.find('.fa-plus-square')).toHaveLength(0);
-            expect(wrapper.find('.fa-plus-minus')).toHaveLength(0);
+            expect(wrapper.find('.fa-chevron-right')).toHaveLength(0);
+            expect(wrapper.find('.fa-chevron-down')).toHaveLength(0);
             wrapper.unmount();
         });
 
@@ -85,8 +85,8 @@ describe('ColumnSelectionModal', () => {
             expect(wrapper.find('.fa-check')).toHaveLength(0);
             expect(wrapper.find('.fa-plus')).toHaveLength(1);
             expect(wrapper.find('.field-expand-icon')).toHaveLength(3);
-            expect(wrapper.find('.fa-plus-square')).toHaveLength(1);
-            expect(wrapper.find('.fa-plus-minus')).toHaveLength(0);
+            expect(wrapper.find('.fa-chevron-right')).toHaveLength(1);
+            expect(wrapper.find('.fa-chevron-down')).toHaveLength(0);
             wrapper.unmount();
         });
 
@@ -98,8 +98,8 @@ describe('ColumnSelectionModal', () => {
             expect(wrapper.find('.fa-check')).toHaveLength(0);
             expect(wrapper.find('.fa-plus')).toHaveLength(1);
             expect(wrapper.find('.field-expand-icon')).toHaveLength(3);
-            expect(wrapper.find('.fa-plus-square')).toHaveLength(0);
-            expect(wrapper.find('.fa-minus-square')).toHaveLength(1);
+            expect(wrapper.find('.fa-chevron-right')).toHaveLength(0);
+            expect(wrapper.find('.fa-chevron-down')).toHaveLength(1);
             wrapper.unmount();
         });
     });

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -119,10 +119,10 @@ export const ColumnChoice: FC<ColumnChoiceProps> = memo(props => {
                     ))}
                     <div className="field-expand-icon">
                         {column.isLookup() && !isExpanded && (
-                            <i className="fa fa-plus-square" onClick={_onExpandColumn} />
+                            <i className="fa fa-chevron-right" onClick={_onExpandColumn} />
                         )}
                         {column.isLookup() && isExpanded && (
-                            <i className="fa fa-minus-square" onClick={_onCollapseColumn} />
+                            <i className="fa fa-chevron-down" onClick={_onCollapseColumn} />
                         )}
                     </div>
                 </>

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -6,9 +6,10 @@ import classNames from 'classnames';
 import { QueryColumn } from '../../public/QueryColumn';
 import { QueryInfo } from '../../public/QueryInfo';
 
+import { Modal, ModalProps } from '../Modal';
+
 import { Alert } from './base/Alert';
 import { DragDropHandle } from './base/DragDropHandle';
-import { Modal, ModalProps } from '../Modal';
 import { LoadingSpinner } from './base/LoadingSpinner';
 
 type ExpandedColumnFilter = (column: QueryColumn, showAllColumns: boolean) => boolean;
@@ -458,7 +459,12 @@ export const ColumnSelectionModal: FC<ColumnSelectionModalProps> = memo(props =>
     }, [expandedColumnFilter, isLoaded, queryInfo, showAllColumns]);
 
     return (
-        <Modal {...confirmModalProps} bsSize="lg" canConfirm={isDirty && selectedColumns.length > 0} onConfirm={onConfirm}>
+        <Modal
+            {...confirmModalProps}
+            bsSize="lg"
+            canConfirm={isDirty && selectedColumns.length > 0}
+            onConfirm={onConfirm}
+        >
             <Alert>{error}</Alert>
             <Alert>{queryError}</Alert>
             {!isLoaded && <LoadingSpinner />}

--- a/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
+++ b/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
+
 import { isApp } from '../../app/utils';
 
 import { LabelHelpTip } from '../base/LabelHelpTip';

--- a/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
+++ b/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
@@ -78,8 +78,8 @@ export class CollapsiblePanelHeader extends React.PureComponent<Props> {
         const isApp_ = isApp();
         const iconHelpMsg = panelStatus && panelStatus !== 'NONE' ? this.getHeaderIconHelpMsg() : undefined;
         const collapsedIconClass = classNames('fa', 'fa-lg', {
-            'fa-plus-square': collapsed,
-            'fa-minus-square': !collapsed,
+            'fa-chevron-right': collapsed,
+            'fa-chevron-down': !collapsed,
             'domain-form-expand-btn': collapsed,
             'domain-form-collapse-btn': !collapsed,
         });

--- a/packages/components/src/internal/components/domainproperties/SystemFields.tsx
+++ b/packages/components/src/internal/components/domainproperties/SystemFields.tsx
@@ -107,7 +107,7 @@ export const SystemFields: FC<Props> = memo(({ fields, disabledSystemFields, onS
                         Default System Fields
                     </div>
                     <div className="domain-system-fields-header__icon" onClick={onToggle}>
-                        <i className={classNames('fa fa-lg', collapsed ? 'fa-chevron-right' : 'fa-chevron-down')}/>
+                        <i className={classNames('fa fa-lg', collapsed ? 'fa-chevron-right' : 'fa-chevron-down')} />
                     </div>
                 </div>
             </div>

--- a/packages/components/src/internal/components/domainproperties/SystemFields.tsx
+++ b/packages/components/src/internal/components/domainproperties/SystemFields.tsx
@@ -103,11 +103,11 @@ export const SystemFields: FC<Props> = memo(({ fields, disabledSystemFields, onS
         <>
             <div className="domain-system-fields">
                 <div className="domain-system-fields-header">
-                    <div className="domain-system-fields-header__icon" onClick={onToggle}>
-                        <i className={classNames('fa fa-lg', collapsed ? 'fa-plus-square' : 'fa-minus-square')} />
-                    </div>
                     <div className="domain-system-fields-header__text" onClick={onToggle}>
                         Default System Fields
+                    </div>
+                    <div className="domain-system-fields-header__icon" onClick={onToggle}>
+                        <i className={classNames('fa fa-lg', collapsed ? 'fa-chevron-right' : 'fa-chevron-down')}/>
                     </div>
                 </div>
             </div>

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/CollapsiblePanelHeader.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/CollapsiblePanelHeader.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`<CollapsiblePanelHeader/> custom properties 1`] = `
       class="pull-right"
     >
       <span
-        class="fa fa-lg fa-plus-square domain-form-expand-btn"
+        class="fa fa-lg fa-chevron-right domain-form-expand-btn"
       />
     </span>
     <span
@@ -49,7 +49,7 @@ exports[`<CollapsiblePanelHeader/> default properties 1`] = `
       class="pull-right"
     >
       <span
-        class="fa fa-lg fa-plus-square domain-form-expand-btn"
+        class="fa fa-lg fa-chevron-right domain-form-expand-btn"
       />
     </span>
   </div>
@@ -78,7 +78,7 @@ exports[`<CollapsiblePanelHeader/> invalid, iconHelpMsg, and expanded 1`] = `
       class="pull-right"
     >
       <span
-        class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+        class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
       />
     </span>
   </div>
@@ -152,7 +152,7 @@ exports[`<CollapsiblePanelHeader/> panelStatus TODO and help tip 1`] = `
       class="pull-right"
     >
       <span
-        class="fa fa-lg fa-plus-square domain-form-expand-btn"
+        class="fa fa-lg fa-chevron-right domain-form-expand-btn"
       />
     </span>
     <div

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -246,7 +246,8 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                             : 'COMPLETE'
                     }
                     validate={validatePanel === PROPERTIES_PANEL_INDEX}
-                    appPropertiesOnly={hideAdvancedProperties}
+                    appPropertiesOnly={appPropertiesOnly}
+                    hideAdvancedProperties={hideAdvancedProperties}
                     hideStudyProperties={!!domainFormDisplayOptions && domainFormDisplayOptions.hideStudyPropertyTypes}
                     onToggle={(collapsed, callback) => {
                         onTogglePanel(PROPERTIES_PANEL_INDEX, collapsed, callback);

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -40,26 +40,26 @@ import { FORM_IDS, SCRIPTS_DIR } from './constants';
 import { getScriptEngineForExtension, getValidPublishTargets } from './actions';
 
 interface AssayPropertiesInputProps extends DomainFieldLabelProps {
-    appPropertiesOnly?: boolean;
+    hideAdvancedProperties?: boolean;
     colSize?: number;
 }
 
 export const AssayPropertiesInput: FC<AssayPropertiesInputProps> = memo(props => {
-    const { appPropertiesOnly, children, colSize, ...domainFieldProps } = props;
+    const { hideAdvancedProperties, children, colSize, ...domainFieldProps } = props;
     const colXs = colSize ? 'col-xs-' + colSize : undefined;
 
     return (
         <div className="row margin-top">
             <div
                 className={classNames('col col-xs-3', {
-                    'col-lg-2': appPropertiesOnly,
-                    'col-lg-4': !appPropertiesOnly,
+                    'col-lg-2': hideAdvancedProperties,
+                    'col-lg-4': !hideAdvancedProperties,
                 })}
             >
                 <DomainFieldLabel {...domainFieldProps} />
             </div>
             <div
-                className={classNames('col', colXs, { 'col-lg-10': appPropertiesOnly, 'col-lg-8': !appPropertiesOnly })}
+                className={classNames('col', colXs, { 'col-lg-10': hideAdvancedProperties, 'col-lg-8': !hideAdvancedProperties })}
             >
                 {children}
             </div>
@@ -74,7 +74,7 @@ AssayPropertiesInput.defaultProps = {
 };
 
 interface InputProps {
-    appPropertiesOnly?: boolean;
+    hideAdvancedProperties?: boolean;
     model: AssayProtocolModel;
     onChange: (evt) => void;
     canRename?: boolean;
@@ -82,7 +82,7 @@ interface InputProps {
 
 export function NameInput(props: InputProps) {
     return (
-        <AssayPropertiesInput label="Name" required={true} appPropertiesOnly={props.appPropertiesOnly}>
+        <AssayPropertiesInput label="Name" required={true} hideAdvancedProperties={props.hideAdvancedProperties}>
             <FormControl
                 id={FORM_IDS.ASSAY_NAME}
                 type="text"
@@ -99,7 +99,7 @@ export function DescriptionInput(props: InputProps) {
     return (
         <AssayPropertiesInput
             label="Description"
-            appPropertiesOnly={props.appPropertiesOnly}
+            hideAdvancedProperties={props.hideAdvancedProperties}
             helpTipBody={<p>A short description for this assay design.</p>}
         >
             <textarea
@@ -134,7 +134,7 @@ export function PlateTemplatesInput(props: InputProps) {
             label="Plate Template"
             required={true}
             colSize={6}
-            appPropertiesOnly={props.appPropertiesOnly}
+            hideAdvancedProperties={props.hideAdvancedProperties}
             helpTipBody={
                 <p>
                     Specify the plate template definition used to map spots or wells on the plate to data fields in this
@@ -168,7 +168,7 @@ export function DetectionMethodsInput(props: InputProps) {
             label="Detection Method"
             required={true}
             colSize={6}
-            appPropertiesOnly={props.appPropertiesOnly}
+            hideAdvancedProperties={props.hideAdvancedProperties}
         >
             <FormControl
                 componentClass="select"
@@ -193,7 +193,7 @@ export function MetadataInputFormatsInput(props: InputProps) {
             label="Metadata Input Format"
             required={true}
             colSize={6}
-            appPropertiesOnly={props.appPropertiesOnly}
+            hideAdvancedProperties={props.hideAdvancedProperties}
             helpTipBody={
                 <>
                     <p>
@@ -230,7 +230,7 @@ export const AssayStatusInput = props => {
     return (
         <AssayPropertiesInput
             label="Active"
-            appPropertiesOnly={props.appPropertiesOnly}
+            hideAdvancedProperties={props.hideAdvancedProperties}
             helpTipBody={
                 <p>If disabled, this assay design will be considered archived, and will be hidden in certain views.</p>
             }
@@ -244,7 +244,7 @@ export function EditableRunsInput(props: InputProps) {
     return (
         <AssayPropertiesInput
             label="Editable Runs"
-            appPropertiesOnly={props.appPropertiesOnly}
+            hideAdvancedProperties={props.hideAdvancedProperties}
             helpTipBody={
                 <p>
                     If enabled, users with sufficient permissions can edit values at the run level after the initial
@@ -266,7 +266,7 @@ export function EditableResultsInput(props: InputProps) {
     return (
         <AssayPropertiesInput
             label="Editable Results"
-            appPropertiesOnly={props.appPropertiesOnly}
+            hideAdvancedProperties={props.hideAdvancedProperties}
             helpTipBody={
                 <p>
                     If enabled, users with sufficient permissions can edit and delete at the individual results row

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -59,7 +59,10 @@ export const AssayPropertiesInput: FC<AssayPropertiesInputProps> = memo(props =>
                 <DomainFieldLabel {...domainFieldProps} />
             </div>
             <div
-                className={classNames('col', colXs, { 'col-lg-10': hideAdvancedProperties, 'col-lg-8': !hideAdvancedProperties })}
+                className={classNames('col', colXs, {
+                    'col-lg-10': hideAdvancedProperties,
+                    'col-lg-8': !hideAdvancedProperties,
+                })}
             >
                 {children}
             </div>

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
@@ -182,6 +182,40 @@ describe('AssayPropertiesPanel', () => {
         wrapper.unmount();
     });
 
+    test('visible properties for hideAdvancedProperties based on populated AssayProtocolModel', () => {
+        const model = AssayProtocolModel.create({
+            allowBackgroundUpload: true,
+            allowEditableResults: true,
+            allowPlateMetadata: true,
+            allowQCStates: true,
+            availableDetectionMethods: ['a', 'b', 'c'],
+            availableMetadataInputFormats: { test1: 'abc' },
+            availablePlateTemplates: ['d', 'e', 'f'],
+            moduleTransformScripts: ['validation.pl'],
+        });
+
+        const wrapper = mountWithServerContext(
+            <AssayPropertiesPanel {...BASE_PROPS} model={model} onChange={jest.fn} hideAdvancedProperties />,
+            SERVER_CONTEXT
+        );
+        expect(wrapper.find(NameInput)).toHaveLength(1);
+        expect(wrapper.find(DescriptionInput)).toHaveLength(1);
+        expect(wrapper.find(PlateMetadataInput)).toHaveLength(1);
+        expect(wrapper.find(QCStatesInput)).toHaveLength(0);
+        expect(wrapper.find(PlateTemplatesInput)).toHaveLength(1);
+        expect(wrapper.find(DetectionMethodsInput)).toHaveLength(1);
+        expect(wrapper.find(MetadataInputFormatsInput)).toHaveLength(1);
+        expect(wrapper.find(EditableRunsInput)).toHaveLength(1);
+        expect(wrapper.find(EditableResultsInput)).toHaveLength(1);
+        expect(wrapper.find(BackgroundUploadInput)).toHaveLength(0);
+        expect(wrapper.find(TransformScriptsInput)).toHaveLength(0);
+        expect(wrapper.find(SaveScriptDataInput)).toHaveLength(0);
+        expect(wrapper.find(ModuleProvidedScriptsInput)).toHaveLength(0);
+        expect(wrapper.find(AutoLinkDataInput)).toHaveLength(0);
+        expect(wrapper.find(AutoLinkCategoryInput)).toHaveLength(0);
+        wrapper.unmount();
+    });
+
     test('visible properties for appPropertiesOnly based on populated AssayProtocolModel', () => {
         const model = AssayProtocolModel.create({
             allowBackgroundUpload: true,
@@ -196,6 +230,40 @@ describe('AssayPropertiesPanel', () => {
 
         const wrapper = mountWithServerContext(
             <AssayPropertiesPanel {...BASE_PROPS} model={model} onChange={jest.fn} appPropertiesOnly />,
+            SERVER_CONTEXT
+        );
+        expect(wrapper.find(NameInput)).toHaveLength(1);
+        expect(wrapper.find(DescriptionInput)).toHaveLength(1);
+        expect(wrapper.find(PlateMetadataInput)).toHaveLength(0);
+        expect(wrapper.find(QCStatesInput)).toHaveLength(1);
+        expect(wrapper.find(PlateTemplatesInput)).toHaveLength(1);
+        expect(wrapper.find(DetectionMethodsInput)).toHaveLength(1);
+        expect(wrapper.find(MetadataInputFormatsInput)).toHaveLength(1);
+        expect(wrapper.find(EditableRunsInput)).toHaveLength(1);
+        expect(wrapper.find(EditableResultsInput)).toHaveLength(1);
+        expect(wrapper.find(BackgroundUploadInput)).toHaveLength(1);
+        expect(wrapper.find(TransformScriptsInput)).toHaveLength(0);
+        expect(wrapper.find(SaveScriptDataInput)).toHaveLength(0);
+        expect(wrapper.find(ModuleProvidedScriptsInput)).toHaveLength(1);
+        expect(wrapper.find(AutoLinkDataInput)).toHaveLength(1);
+        expect(wrapper.find(AutoLinkCategoryInput)).toHaveLength(1);
+        wrapper.unmount();
+    });
+
+    test('visible properties for hideAdvancedProperties and appPropertiesOnly', () => {
+        const model = AssayProtocolModel.create({
+            allowBackgroundUpload: true,
+            allowEditableResults: true,
+            allowPlateMetadata: true,
+            allowQCStates: true,
+            availableDetectionMethods: ['a', 'b', 'c'],
+            availableMetadataInputFormats: { test1: 'abc' },
+            availablePlateTemplates: ['d', 'e', 'f'],
+            moduleTransformScripts: ['validation.pl'],
+        });
+
+        const wrapper = mountWithServerContext(
+            <AssayPropertiesPanel {...BASE_PROPS} model={model} onChange={jest.fn} hideAdvancedProperties appPropertiesOnly />,
             SERVER_CONTEXT
         );
         expect(wrapper.find(NameInput)).toHaveLength(1);

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
@@ -63,13 +63,13 @@ describe('AssayPropertiesPanel', () => {
         form.unmount();
     });
 
-    test('asPanel, helpTopic, and appPropertiesOnly', () => {
+    test('asPanel, helpTopic, and hideAdvancedProperties', () => {
         const form = mountWithServerContext(
             <AssayPropertiesPanel
                 {...BASE_PROPS}
                 model={EMPTY_MODEL}
                 asPanel={false}
-                appPropertiesOnly
+                hideAdvancedProperties
                 helpTopic="defineAssaySchema"
                 onChange={jest.fn}
             />
@@ -85,7 +85,7 @@ describe('AssayPropertiesPanel', () => {
                 {...BASE_PROPS}
                 model={EMPTY_MODEL}
                 helpTopic={null}
-                appPropertiesOnly
+                hideAdvancedProperties
                 onChange={jest.fn}
             />
         );

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.spec.tsx
@@ -263,7 +263,13 @@ describe('AssayPropertiesPanel', () => {
         });
 
         const wrapper = mountWithServerContext(
-            <AssayPropertiesPanel {...BASE_PROPS} model={model} onChange={jest.fn} hideAdvancedProperties appPropertiesOnly />,
+            <AssayPropertiesPanel
+                {...BASE_PROPS}
+                model={model}
+                onChange={jest.fn}
+                hideAdvancedProperties
+                appPropertiesOnly
+            />,
             SERVER_CONTEXT
         );
         expect(wrapper.find(NameInput)).toHaveLength(1);

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -11,7 +11,7 @@ import {
 import { SectionHeading } from '../SectionHeading';
 import { BasePropertiesPanel, BasePropertiesPanelProps } from '../BasePropertiesPanel';
 
-import {hasModule, isAssayQCEnabled, isPlatesEnabled, isPremiumProductEnabled} from '../../../app/utils';
+import { hasModule, isAssayQCEnabled, isPlatesEnabled, isPremiumProductEnabled } from '../../../app/utils';
 
 import { useServerContext } from '../../base/ServerContext';
 
@@ -46,7 +46,8 @@ interface AssayPropertiesFormProps {
 }
 
 const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
-    const { appPropertiesOnly, hideAdvancedProperties, children, hideStudyProperties, model, onChange, canRename } = props;
+    const { appPropertiesOnly, hideAdvancedProperties, children, hideStudyProperties, model, onChange, canRename } =
+        props;
     const { moduleContext } = useServerContext();
 
     const onValueChange = useCallback(
@@ -105,8 +106,17 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
             <Col xs={12} lg={hideAdvancedProperties ? 12 : 6}>
                 <div className="domain-field-padding-bottom">
                     <SectionHeading title="Basic Properties" />
-                    <NameInput model={model} onChange={onInputChange} hideAdvancedProperties={hideAdvancedProperties} canRename={canRename} />
-                    <DescriptionInput model={model} onChange={onInputChange} hideAdvancedProperties={hideAdvancedProperties} />
+                    <NameInput
+                        model={model}
+                        onChange={onInputChange}
+                        hideAdvancedProperties={hideAdvancedProperties}
+                        canRename={canRename}
+                    />
+                    <DescriptionInput
+                        model={model}
+                        onChange={onInputChange}
+                        hideAdvancedProperties={hideAdvancedProperties}
+                    />
                     {model.allowPlateTemplateSelection() && (
                         <PlateTemplatesInput
                             model={model}
@@ -144,7 +154,11 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
                 </div>
                 <div className="domain-field-padding-bottom">
                     <SectionHeading title="Editing Settings" />
-                    <EditableRunsInput model={model} onChange={onInputChange} hideAdvancedProperties={hideAdvancedProperties} />
+                    <EditableRunsInput
+                        model={model}
+                        onChange={onInputChange}
+                        hideAdvancedProperties={hideAdvancedProperties}
+                    />
                     {model.allowEditableResults && (
                         <EditableResultsInput
                             model={model}
@@ -196,7 +210,17 @@ interface OwnProps extends AssayPropertiesFormProps {
 type Props = OwnProps & BasePropertiesPanelProps;
 
 const AssayPropertiesPanelImpl: FC<Props & InjectedDomainPropertiesPanelCollapseProps> = memo(props => {
-    const { appPropertiesOnly, hideAdvancedProperties, canRename, asPanel, children, helpTopic, hideStudyProperties, model, onChange } = props;
+    const {
+        appPropertiesOnly,
+        hideAdvancedProperties,
+        canRename,
+        asPanel,
+        children,
+        helpTopic,
+        hideStudyProperties,
+        model,
+        onChange,
+    } = props;
     const [isValid, setIsValid] = useState<boolean>(true);
 
     const updateValidStatus = useCallback(

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -38,6 +38,7 @@ import { BOOLEAN_FIELDS, FORM_ID_PREFIX, PROPERTIES_HEADER_ID } from './constant
 
 interface AssayPropertiesFormProps {
     appPropertiesOnly?: boolean;
+    hideAdvancedProperties?: boolean;
     hideStudyProperties?: boolean;
     model: AssayProtocolModel;
     onChange: (model: AssayProtocolModel) => void;
@@ -45,7 +46,7 @@ interface AssayPropertiesFormProps {
 }
 
 const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
-    const { appPropertiesOnly, children, hideStudyProperties, model, onChange, canRename } = props;
+    const { appPropertiesOnly, hideAdvancedProperties, children, hideStudyProperties, model, onChange, canRename } = props;
     const { moduleContext } = useServerContext();
 
     const onValueChange = useCallback(
@@ -101,33 +102,33 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
                 </Row>
             )}
 
-            <Col xs={12} lg={appPropertiesOnly ? 12 : 6}>
+            <Col xs={12} lg={hideAdvancedProperties ? 12 : 6}>
                 <div className="domain-field-padding-bottom">
                     <SectionHeading title="Basic Properties" />
-                    <NameInput model={model} onChange={onInputChange} appPropertiesOnly={appPropertiesOnly} canRename={canRename} />
-                    <DescriptionInput model={model} onChange={onInputChange} appPropertiesOnly={appPropertiesOnly} />
+                    <NameInput model={model} onChange={onInputChange} hideAdvancedProperties={hideAdvancedProperties} canRename={canRename} />
+                    <DescriptionInput model={model} onChange={onInputChange} hideAdvancedProperties={hideAdvancedProperties} />
                     {model.allowPlateTemplateSelection() && (
                         <PlateTemplatesInput
                             model={model}
                             onChange={onInputChange}
-                            appPropertiesOnly={appPropertiesOnly}
+                            hideAdvancedProperties={hideAdvancedProperties}
                         />
                     )}
                     {model.allowDetectionMethodSelection() && (
                         <DetectionMethodsInput
                             model={model}
                             onChange={onInputChange}
-                            appPropertiesOnly={appPropertiesOnly}
+                            hideAdvancedProperties={hideAdvancedProperties}
                         />
                     )}
                     {model.allowMetadataInputFormatSelection() && (
                         <MetadataInputFormatsInput
                             model={model}
                             onChange={onInputChange}
-                            appPropertiesOnly={appPropertiesOnly}
+                            hideAdvancedProperties={hideAdvancedProperties}
                         />
                     )}
-                    {!appPropertiesOnly && model.allowQCStates && isAssayQCEnabled(moduleContext) && (
+                    {!hideAdvancedProperties && model.allowQCStates && isAssayQCEnabled(moduleContext) && (
                         <QCStatesInput model={model} onChange={onInputChange} />
                     )}
                     {!appPropertiesOnly && model.allowPlateMetadata && (
@@ -137,24 +138,24 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
                         <AssayStatusInput
                             model={model}
                             onChange={onStatusChange}
-                            appPropertiesOnly={appPropertiesOnly}
+                            hideAdvancedProperties={hideAdvancedProperties}
                         />
                     )}
                 </div>
                 <div className="domain-field-padding-bottom">
                     <SectionHeading title="Editing Settings" />
-                    <EditableRunsInput model={model} onChange={onInputChange} appPropertiesOnly={appPropertiesOnly} />
+                    <EditableRunsInput model={model} onChange={onInputChange} hideAdvancedProperties={hideAdvancedProperties} />
                     {model.allowEditableResults && (
                         <EditableResultsInput
                             model={model}
                             onChange={onInputChange}
-                            appPropertiesOnly={appPropertiesOnly}
+                            hideAdvancedProperties={hideAdvancedProperties}
                         />
                     )}
                 </div>
             </Col>
 
-            {!appPropertiesOnly && (
+            {!hideAdvancedProperties && (
                 <Col xs={12} lg={6}>
                     <div className="domain-field-padding-bottom">
                         <SectionHeading title="Import Settings" />
@@ -172,7 +173,7 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
                 </Col>
             )}
 
-            {!appPropertiesOnly && !hideStudyProperties && hasModule('study', moduleContext) && (
+            {!hideAdvancedProperties && !hideStudyProperties && hasModule('study', moduleContext) && (
                 <Col xs={12} lg={6}>
                     <div className="domain-field-padding-bottom">
                         <SectionHeading title="Link to Study Settings" />
@@ -195,7 +196,7 @@ interface OwnProps extends AssayPropertiesFormProps {
 type Props = OwnProps & BasePropertiesPanelProps;
 
 const AssayPropertiesPanelImpl: FC<Props & InjectedDomainPropertiesPanelCollapseProps> = memo(props => {
-    const { appPropertiesOnly, canRename, asPanel, children, helpTopic, hideStudyProperties, model, onChange } = props;
+    const { appPropertiesOnly, hideAdvancedProperties, canRename, asPanel, children, helpTopic, hideStudyProperties, model, onChange } = props;
     const [isValid, setIsValid] = useState<boolean>(true);
 
     const updateValidStatus = useCallback(
@@ -214,6 +215,7 @@ const AssayPropertiesPanelImpl: FC<Props & InjectedDomainPropertiesPanelCollapse
     const form = (
         <AssayPropertiesForm
             appPropertiesOnly={appPropertiesOnly}
+            hideAdvancedProperties={hideAdvancedProperties}
             hideStudyProperties={hideStudyProperties}
             model={model}
             onChange={updateValidStatus}
@@ -243,6 +245,7 @@ const AssayPropertiesPanelImpl: FC<Props & InjectedDomainPropertiesPanelCollapse
 
 AssayPropertiesPanelImpl.defaultProps = {
     appPropertiesOnly: false,
+    hideAdvancedProperties: false,
     hideStudyProperties: false,
     asPanel: true,
     helpTopic: DEFINE_ASSAY_SCHEMA_TOPIC,

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesPanel.tsx
@@ -11,7 +11,7 @@ import {
 import { SectionHeading } from '../SectionHeading';
 import { BasePropertiesPanel, BasePropertiesPanelProps } from '../BasePropertiesPanel';
 
-import { hasModule, isAssayQCEnabled, isPremiumProductEnabled } from '../../../app/utils';
+import {hasModule, isAssayQCEnabled, isPlatesEnabled, isPremiumProductEnabled} from '../../../app/utils';
 
 import { useServerContext } from '../../base/ServerContext';
 
@@ -131,7 +131,7 @@ const AssayPropertiesForm: FC<AssayPropertiesFormProps> = memo(props => {
                     {!hideAdvancedProperties && model.allowQCStates && isAssayQCEnabled(moduleContext) && (
                         <QCStatesInput model={model} onChange={onInputChange} />
                     )}
-                    {!appPropertiesOnly && model.allowPlateMetadata && (
+                    {(!appPropertiesOnly || isPlatesEnabled(moduleContext)) && model.allowPlateMetadata && (
                         <PlateMetadataInput model={model} onChange={onInputChange} />
                     )}
                     {isPremiumProductEnabled(moduleContext) && (

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -212,7 +212,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -373,7 +373,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -534,7 +534,7 @@ exports[`AssayDesignerPanels appPropertiesOnly for new assay 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -720,7 +720,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -977,7 +977,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -1130,7 +1130,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -1903,7 +1903,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -3746,7 +3746,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -3937,7 +3937,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -4098,7 +4098,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -4259,7 +4259,7 @@ exports[`AssayDesignerPanels default properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -4438,7 +4438,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain for new assay 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -4629,7 +4629,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain for new assay 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -4790,7 +4790,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain for new assay 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -4976,7 +4976,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -5267,7 +5267,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -6045,7 +6045,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -7895,7 +7895,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -8186,7 +8186,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -8339,7 +8339,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div
@@ -9117,7 +9117,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <div

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
@@ -821,40 +821,6 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                     </textarea>
                   </div>
                 </div>
-                <div
-                  class="row margin-top"
-                >
-                  <div
-                    class="col col-xs-3 col-lg-4"
-                  >
-                    Plate 
-                    <span
-                      class="domain-no-wrap"
-                    >
-                      Metadata
-                      <div
-                        class="overlay-trigger"
-                      >
-                        <span
-                          class="label-help-target"
-                        >
-                          <span
-                            class="label-help-icon fa fa-question-circle"
-                          />
-                        </span>
-                      </div>
-                      
-                    </span>
-                  </div>
-                  <div
-                    class="col col-xs-9 col-lg-8"
-                  >
-                    <input
-                      id="assay-design-plateMetadata"
-                      type="checkbox"
-                    />
-                  </div>
-                </div>
               </div>
               <div
                 class="domain-field-padding-bottom"

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
+exports[`AssayPropertiesPanel asPanel, helpTopic, and hideAdvancedProperties 1`] = `
 <ComponentWithDomainPropertiesPanelCollapse
-  appPropertiesOnly={true}
   asPanel={false}
   collapsed={false}
   controlledCollapse={false}
   helpTopic="defineAssaySchema"
+  hideAdvancedProperties={true}
   initCollapsed={false}
   model={
     Immutable.Record {
@@ -137,12 +137,12 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
   validate={false}
 >
   <Component
-    appPropertiesOnly={true}
+    appPropertiesOnly={false}
     asPanel={false}
     collapsed={false}
     controlledCollapse={false}
     helpTopic="defineAssaySchema"
-    hideAdvancedProperties={false}
+    hideAdvancedProperties={true}
     hideStudyProperties={false}
     model={
       Immutable.Record {
@@ -274,8 +274,8 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
     validate={false}
   >
     <AssayPropertiesForm
-      appPropertiesOnly={true}
-      hideAdvancedProperties={false}
+      appPropertiesOnly={false}
+      hideAdvancedProperties={true}
       hideStudyProperties={false}
       model={
         Immutable.Record {
@@ -415,11 +415,11 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
           <Col
             bsClass="col"
             componentClass="div"
-            lg={6}
+            lg={12}
             xs={12}
           >
             <div
-              className="col-lg-6 col-xs-12"
+              className="col-lg-12 col-xs-12"
             >
               <div
                 className="domain-field-padding-bottom"
@@ -434,7 +434,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   </div>
                 </SectionHeading>
                 <NameInput
-                  hideAdvancedProperties={false}
+                  hideAdvancedProperties={true}
                   model={
                     Immutable.Record {
                       "allowBackgroundUpload": false,
@@ -563,7 +563,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                 >
                   <Component
                     colSize={9}
-                    hideAdvancedProperties={false}
+                    hideAdvancedProperties={true}
                     label="Name"
                     required={true}
                   >
@@ -571,7 +571,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                       className="row margin-top"
                     >
                       <div
-                        className="col col-xs-3 col-lg-4"
+                        className="col col-xs-3 col-lg-2"
                       >
                         <DomainFieldLabel
                           label="Name"
@@ -586,7 +586,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         </DomainFieldLabel>
                       </div>
                       <div
-                        className="col col-xs-9 col-lg-8"
+                        className="col col-xs-9 col-lg-10"
                       >
                         <FormControl
                           bsClass="form-control"
@@ -613,7 +613,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   </Component>
                 </NameInput>
                 <DescriptionInput
-                  hideAdvancedProperties={false}
+                  hideAdvancedProperties={true}
                   model={
                     Immutable.Record {
                       "allowBackgroundUpload": false,
@@ -747,14 +747,14 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         A short description for this assay design.
                       </p>
                     }
-                    hideAdvancedProperties={false}
+                    hideAdvancedProperties={true}
                     label="Description"
                   >
                     <div
                       className="row margin-top"
                     >
                       <div
-                        className="col col-xs-3 col-lg-4"
+                        className="col col-xs-3 col-lg-2"
                       >
                         <DomainFieldLabel
                           helpTipBody={
@@ -804,7 +804,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         </DomainFieldLabel>
                       </div>
                       <div
-                        className="col col-xs-9 col-lg-8"
+                        className="col col-xs-9 col-lg-10"
                       >
                         <textarea
                           className="form-control"
@@ -830,7 +830,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   </div>
                 </SectionHeading>
                 <EditableRunsInput
-                  hideAdvancedProperties={false}
+                  hideAdvancedProperties={true}
                   model={
                     Immutable.Record {
                       "allowBackgroundUpload": false,
@@ -964,14 +964,14 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         If enabled, users with sufficient permissions can edit values at the run level after the initial import is complete. These changes will be audited.
                       </p>
                     }
-                    hideAdvancedProperties={false}
+                    hideAdvancedProperties={true}
                     label="Editable Runs"
                   >
                     <div
                       className="row margin-top"
                     >
                       <div
-                        className="col col-xs-3 col-lg-4"
+                        className="col col-xs-3 col-lg-2"
                       >
                         <DomainFieldLabel
                           helpTipBody={
@@ -1022,7 +1022,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         </DomainFieldLabel>
                       </div>
                       <div
-                        className="col col-xs-9 col-lg-8"
+                        className="col col-xs-9 col-lg-10"
                       >
                         <input
                           checked={false}
@@ -1034,30 +1034,6 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                     </div>
                   </Component>
                 </EditableRunsInput>
-              </div>
-            </div>
-          </Col>
-          <Col
-            bsClass="col"
-            componentClass="div"
-            lg={6}
-            xs={12}
-          >
-            <div
-              className="col-lg-6 col-xs-12"
-            >
-              <div
-                className="domain-field-padding-bottom"
-              >
-                <SectionHeading
-                  title="Import Settings"
-                >
-                  <div
-                    className="domain-field-section-heading"
-                  >
-                    Import Settings
-                  </div>
-                </SectionHeading>
               </div>
             </div>
           </Col>
@@ -4354,10 +4330,10 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
 
 exports[`AssayPropertiesPanel without helpTopic 1`] = `
 <ComponentWithDomainPropertiesPanelCollapse
-  appPropertiesOnly={true}
   collapsed={false}
   controlledCollapse={false}
   helpTopic={null}
+  hideAdvancedProperties={true}
   initCollapsed={false}
   model={
     Immutable.Record {
@@ -4488,12 +4464,12 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
   validate={false}
 >
   <Component
-    appPropertiesOnly={true}
+    appPropertiesOnly={false}
     asPanel={true}
     collapsed={false}
     controlledCollapse={false}
     helpTopic={null}
-    hideAdvancedProperties={false}
+    hideAdvancedProperties={true}
     hideStudyProperties={false}
     model={
       Immutable.Record {
@@ -4625,13 +4601,13 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
     validate={false}
   >
     <BasePropertiesPanel
-      appPropertiesOnly={true}
+      appPropertiesOnly={false}
       asPanel={true}
       collapsed={false}
       controlledCollapse={false}
       headerId="assay-properties-hdr"
       helpTopic={null}
-      hideAdvancedProperties={false}
+      hideAdvancedProperties={true}
       hideStudyProperties={false}
       isValid={true}
       model={
@@ -4816,8 +4792,8 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                   className="panel-body"
                 >
                   <AssayPropertiesForm
-                    appPropertiesOnly={true}
-                    hideAdvancedProperties={false}
+                    appPropertiesOnly={false}
+                    hideAdvancedProperties={true}
                     hideStudyProperties={false}
                     model={
                       Immutable.Record {
@@ -4957,11 +4933,11 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                         <Col
                           bsClass="col"
                           componentClass="div"
-                          lg={6}
+                          lg={12}
                           xs={12}
                         >
                           <div
-                            className="col-lg-6 col-xs-12"
+                            className="col-lg-12 col-xs-12"
                           >
                             <div
                               className="domain-field-padding-bottom"
@@ -4976,7 +4952,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 </div>
                               </SectionHeading>
                               <NameInput
-                                hideAdvancedProperties={false}
+                                hideAdvancedProperties={true}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -5105,7 +5081,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                               >
                                 <Component
                                   colSize={9}
-                                  hideAdvancedProperties={false}
+                                  hideAdvancedProperties={true}
                                   label="Name"
                                   required={true}
                                 >
@@ -5113,7 +5089,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                     className="row margin-top"
                                   >
                                     <div
-                                      className="col col-xs-3 col-lg-4"
+                                      className="col col-xs-3 col-lg-2"
                                     >
                                       <DomainFieldLabel
                                         label="Name"
@@ -5128,7 +5104,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       </DomainFieldLabel>
                                     </div>
                                     <div
-                                      className="col col-xs-9 col-lg-8"
+                                      className="col col-xs-9 col-lg-10"
                                     >
                                       <FormControl
                                         bsClass="form-control"
@@ -5155,7 +5131,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 </Component>
                               </NameInput>
                               <DescriptionInput
-                                hideAdvancedProperties={false}
+                                hideAdvancedProperties={true}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -5289,14 +5265,14 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       A short description for this assay design.
                                     </p>
                                   }
-                                  hideAdvancedProperties={false}
+                                  hideAdvancedProperties={true}
                                   label="Description"
                                 >
                                   <div
                                     className="row margin-top"
                                   >
                                     <div
-                                      className="col col-xs-3 col-lg-4"
+                                      className="col col-xs-3 col-lg-2"
                                     >
                                       <DomainFieldLabel
                                         helpTipBody={
@@ -5346,7 +5322,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       </DomainFieldLabel>
                                     </div>
                                     <div
-                                      className="col col-xs-9 col-lg-8"
+                                      className="col col-xs-9 col-lg-10"
                                     >
                                       <textarea
                                         className="form-control"
@@ -5372,7 +5348,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 </div>
                               </SectionHeading>
                               <EditableRunsInput
-                                hideAdvancedProperties={false}
+                                hideAdvancedProperties={true}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -5506,14 +5482,14 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       If enabled, users with sufficient permissions can edit values at the run level after the initial import is complete. These changes will be audited.
                                     </p>
                                   }
-                                  hideAdvancedProperties={false}
+                                  hideAdvancedProperties={true}
                                   label="Editable Runs"
                                 >
                                   <div
                                     className="row margin-top"
                                   >
                                     <div
-                                      className="col col-xs-3 col-lg-4"
+                                      className="col col-xs-3 col-lg-2"
                                     >
                                       <DomainFieldLabel
                                         helpTipBody={
@@ -5564,7 +5540,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       </DomainFieldLabel>
                                     </div>
                                     <div
-                                      className="col col-xs-9 col-lg-8"
+                                      className="col col-xs-9 col-lg-10"
                                     >
                                       <input
                                         checked={false}
@@ -5576,30 +5552,6 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                   </div>
                                 </Component>
                               </EditableRunsInput>
-                            </div>
-                          </div>
-                        </Col>
-                        <Col
-                          bsClass="col"
-                          componentClass="div"
-                          lg={6}
-                          xs={12}
-                        >
-                          <div
-                            className="col-lg-6 col-xs-12"
-                          >
-                            <div
-                              className="domain-field-padding-bottom"
-                            >
-                              <SectionHeading
-                                title="Import Settings"
-                              >
-                                <div
-                                  className="domain-field-section-heading"
-                                >
-                                  Import Settings
-                                </div>
-                              </SectionHeading>
                             </div>
                           </div>
                         </Col>

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayPropertiesPanel.spec.tsx.snap
@@ -142,6 +142,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
     collapsed={false}
     controlledCollapse={false}
     helpTopic="defineAssaySchema"
+    hideAdvancedProperties={false}
     hideStudyProperties={false}
     model={
       Immutable.Record {
@@ -274,6 +275,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
   >
     <AssayPropertiesForm
       appPropertiesOnly={true}
+      hideAdvancedProperties={false}
       hideStudyProperties={false}
       model={
         Immutable.Record {
@@ -413,11 +415,11 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
           <Col
             bsClass="col"
             componentClass="div"
-            lg={12}
+            lg={6}
             xs={12}
           >
             <div
-              className="col-lg-12 col-xs-12"
+              className="col-lg-6 col-xs-12"
             >
               <div
                 className="domain-field-padding-bottom"
@@ -432,7 +434,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   </div>
                 </SectionHeading>
                 <NameInput
-                  appPropertiesOnly={true}
+                  hideAdvancedProperties={false}
                   model={
                     Immutable.Record {
                       "allowBackgroundUpload": false,
@@ -560,8 +562,8 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   onChange={[Function]}
                 >
                   <Component
-                    appPropertiesOnly={true}
                     colSize={9}
+                    hideAdvancedProperties={false}
                     label="Name"
                     required={true}
                   >
@@ -569,7 +571,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                       className="row margin-top"
                     >
                       <div
-                        className="col col-xs-3 col-lg-2"
+                        className="col col-xs-3 col-lg-4"
                       >
                         <DomainFieldLabel
                           label="Name"
@@ -584,7 +586,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         </DomainFieldLabel>
                       </div>
                       <div
-                        className="col col-xs-9 col-lg-10"
+                        className="col col-xs-9 col-lg-8"
                       >
                         <FormControl
                           bsClass="form-control"
@@ -611,7 +613,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   </Component>
                 </NameInput>
                 <DescriptionInput
-                  appPropertiesOnly={true}
+                  hideAdvancedProperties={false}
                   model={
                     Immutable.Record {
                       "allowBackgroundUpload": false,
@@ -739,20 +741,20 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   onChange={[Function]}
                 >
                   <Component
-                    appPropertiesOnly={true}
                     colSize={9}
                     helpTipBody={
                       <p>
                         A short description for this assay design.
                       </p>
                     }
+                    hideAdvancedProperties={false}
                     label="Description"
                   >
                     <div
                       className="row margin-top"
                     >
                       <div
-                        className="col col-xs-3 col-lg-2"
+                        className="col col-xs-3 col-lg-4"
                       >
                         <DomainFieldLabel
                           helpTipBody={
@@ -802,7 +804,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         </DomainFieldLabel>
                       </div>
                       <div
-                        className="col col-xs-9 col-lg-10"
+                        className="col col-xs-9 col-lg-8"
                       >
                         <textarea
                           className="form-control"
@@ -828,7 +830,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   </div>
                 </SectionHeading>
                 <EditableRunsInput
-                  appPropertiesOnly={true}
+                  hideAdvancedProperties={false}
                   model={
                     Immutable.Record {
                       "allowBackgroundUpload": false,
@@ -956,20 +958,20 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                   onChange={[Function]}
                 >
                   <Component
-                    appPropertiesOnly={true}
                     colSize={9}
                     helpTipBody={
                       <p>
                         If enabled, users with sufficient permissions can edit values at the run level after the initial import is complete. These changes will be audited.
                       </p>
                     }
+                    hideAdvancedProperties={false}
                     label="Editable Runs"
                   >
                     <div
                       className="row margin-top"
                     >
                       <div
-                        className="col col-xs-3 col-lg-2"
+                        className="col col-xs-3 col-lg-4"
                       >
                         <DomainFieldLabel
                           helpTipBody={
@@ -1020,7 +1022,7 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                         </DomainFieldLabel>
                       </div>
                       <div
-                        className="col col-xs-9 col-lg-10"
+                        className="col col-xs-9 col-lg-8"
                       >
                         <input
                           checked={false}
@@ -1032,6 +1034,30 @@ exports[`AssayPropertiesPanel asPanel, helpTopic, and appPropertiesOnly 1`] = `
                     </div>
                   </Component>
                 </EditableRunsInput>
+              </div>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            lg={6}
+            xs={12}
+          >
+            <div
+              className="col-lg-6 col-xs-12"
+            >
+              <div
+                className="domain-field-padding-bottom"
+              >
+                <SectionHeading
+                  title="Import Settings"
+                >
+                  <div
+                    className="domain-field-section-heading"
+                  >
+                    Import Settings
+                  </div>
+                </SectionHeading>
               </div>
             </div>
           </Col>
@@ -1181,6 +1207,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
     collapsed={false}
     controlledCollapse={false}
     helpTopic="defineAssaySchema"
+    hideAdvancedProperties={false}
     hideStudyProperties={false}
     model={
       Immutable.Record {
@@ -1318,6 +1345,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
       controlledCollapse={false}
       headerId="assay-properties-hdr"
       helpTopic="defineAssaySchema"
+      hideAdvancedProperties={false}
       hideStudyProperties={false}
       isValid={true}
       model={
@@ -1540,6 +1568,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                   </HelpTopicURL>
                   <AssayPropertiesForm
                     appPropertiesOnly={false}
+                    hideAdvancedProperties={false}
                     hideStudyProperties={false}
                     model={
                       Immutable.Record {
@@ -1698,7 +1727,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 </div>
                               </SectionHeading>
                               <NameInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -1826,8 +1855,8 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
+                                  hideAdvancedProperties={false}
                                   label="Name"
                                   required={true}
                                 >
@@ -1877,7 +1906,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 </Component>
                               </NameInput>
                               <DescriptionInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -2005,13 +2034,13 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       A short description for this assay design.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Description"
                                 >
                                   <div
@@ -2094,7 +2123,7 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 </div>
                               </SectionHeading>
                               <EditableRunsInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -2222,13 +2251,13 @@ exports[`AssayPropertiesPanel default properties 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       If enabled, users with sufficient permissions can edit values at the run level after the initial import is complete. These changes will be audited.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Editable Runs"
                                 >
                                   <div
@@ -2478,6 +2507,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
     collapsed={false}
     controlledCollapse={false}
     helpTopic="defineAssaySchema"
+    hideAdvancedProperties={false}
     hideStudyProperties={false}
     model={
       Immutable.Record {
@@ -2615,6 +2645,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
       controlledCollapse={false}
       headerId="assay-properties-hdr"
       helpTopic="defineAssaySchema"
+      hideAdvancedProperties={false}
       hideStudyProperties={false}
       isValid={true}
       model={
@@ -2837,6 +2868,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                   </HelpTopicURL>
                   <AssayPropertiesForm
                     appPropertiesOnly={false}
+                    hideAdvancedProperties={false}
                     hideStudyProperties={false}
                     model={
                       Immutable.Record {
@@ -2995,7 +3027,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 </div>
                               </SectionHeading>
                               <NameInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -3123,8 +3155,8 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
+                                  hideAdvancedProperties={false}
                                   label="Name"
                                   required={true}
                                 >
@@ -3174,7 +3206,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 </Component>
                               </NameInput>
                               <DescriptionInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -3302,13 +3334,13 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       A short description for this assay design.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Description"
                                 >
                                   <div
@@ -3391,7 +3423,7 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 </div>
                               </SectionHeading>
                               <EditableRunsInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -3519,13 +3551,13 @@ exports[`AssayPropertiesPanel panelCls, initCollapsed, and markComplete 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       If enabled, users with sufficient permissions can edit values at the run level after the initial import is complete. These changes will be audited.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Editable Runs"
                                 >
                                   <div
@@ -3687,6 +3719,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
     collapsed={false}
     controlledCollapse={false}
     helpTopic="defineAssaySchema"
+    hideAdvancedProperties={false}
     hideStudyProperties={false}
     model={
       Immutable.Record {
@@ -3736,6 +3769,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
       controlledCollapse={false}
       headerId="assay-properties-hdr"
       helpTopic="defineAssaySchema"
+      hideAdvancedProperties={false}
       hideStudyProperties={false}
       isValid={true}
       model={
@@ -3870,6 +3904,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                   </HelpTopicURL>
                   <AssayPropertiesForm
                     appPropertiesOnly={false}
+                    hideAdvancedProperties={false}
                     hideStudyProperties={false}
                     model={
                       Immutable.Record {
@@ -3940,7 +3975,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 </div>
                               </SectionHeading>
                               <NameInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -3980,8 +4015,8 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
+                                  hideAdvancedProperties={false}
                                   label="Name"
                                   required={true}
                                 >
@@ -4031,7 +4066,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 </Component>
                               </NameInput>
                               <DescriptionInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -4071,13 +4106,13 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       A short description for this assay design.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Description"
                                 >
                                   <div
@@ -4160,7 +4195,7 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 </div>
                               </SectionHeading>
                               <EditableRunsInput
-                                appPropertiesOnly={false}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -4200,13 +4235,13 @@ exports[`AssayPropertiesPanel with initial model 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={false}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       If enabled, users with sufficient permissions can edit values at the run level after the initial import is complete. These changes will be audited.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Editable Runs"
                                 >
                                   <div
@@ -4458,6 +4493,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
     collapsed={false}
     controlledCollapse={false}
     helpTopic={null}
+    hideAdvancedProperties={false}
     hideStudyProperties={false}
     model={
       Immutable.Record {
@@ -4595,6 +4631,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
       controlledCollapse={false}
       headerId="assay-properties-hdr"
       helpTopic={null}
+      hideAdvancedProperties={false}
       hideStudyProperties={false}
       isValid={true}
       model={
@@ -4780,6 +4817,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                 >
                   <AssayPropertiesForm
                     appPropertiesOnly={true}
+                    hideAdvancedProperties={false}
                     hideStudyProperties={false}
                     model={
                       Immutable.Record {
@@ -4919,11 +4957,11 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                         <Col
                           bsClass="col"
                           componentClass="div"
-                          lg={12}
+                          lg={6}
                           xs={12}
                         >
                           <div
-                            className="col-lg-12 col-xs-12"
+                            className="col-lg-6 col-xs-12"
                           >
                             <div
                               className="domain-field-padding-bottom"
@@ -4938,7 +4976,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 </div>
                               </SectionHeading>
                               <NameInput
-                                appPropertiesOnly={true}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -5066,8 +5104,8 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={true}
                                   colSize={9}
+                                  hideAdvancedProperties={false}
                                   label="Name"
                                   required={true}
                                 >
@@ -5075,7 +5113,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                     className="row margin-top"
                                   >
                                     <div
-                                      className="col col-xs-3 col-lg-2"
+                                      className="col col-xs-3 col-lg-4"
                                     >
                                       <DomainFieldLabel
                                         label="Name"
@@ -5090,7 +5128,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       </DomainFieldLabel>
                                     </div>
                                     <div
-                                      className="col col-xs-9 col-lg-10"
+                                      className="col col-xs-9 col-lg-8"
                                     >
                                       <FormControl
                                         bsClass="form-control"
@@ -5117,7 +5155,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 </Component>
                               </NameInput>
                               <DescriptionInput
-                                appPropertiesOnly={true}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -5245,20 +5283,20 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={true}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       A short description for this assay design.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Description"
                                 >
                                   <div
                                     className="row margin-top"
                                   >
                                     <div
-                                      className="col col-xs-3 col-lg-2"
+                                      className="col col-xs-3 col-lg-4"
                                     >
                                       <DomainFieldLabel
                                         helpTipBody={
@@ -5308,7 +5346,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       </DomainFieldLabel>
                                     </div>
                                     <div
-                                      className="col col-xs-9 col-lg-10"
+                                      className="col col-xs-9 col-lg-8"
                                     >
                                       <textarea
                                         className="form-control"
@@ -5334,7 +5372,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 </div>
                               </SectionHeading>
                               <EditableRunsInput
-                                appPropertiesOnly={true}
+                                hideAdvancedProperties={false}
                                 model={
                                   Immutable.Record {
                                     "allowBackgroundUpload": false,
@@ -5462,20 +5500,20 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                 onChange={[Function]}
                               >
                                 <Component
-                                  appPropertiesOnly={true}
                                   colSize={9}
                                   helpTipBody={
                                     <p>
                                       If enabled, users with sufficient permissions can edit values at the run level after the initial import is complete. These changes will be audited.
                                     </p>
                                   }
+                                  hideAdvancedProperties={false}
                                   label="Editable Runs"
                                 >
                                   <div
                                     className="row margin-top"
                                   >
                                     <div
-                                      className="col col-xs-3 col-lg-2"
+                                      className="col col-xs-3 col-lg-4"
                                     >
                                       <DomainFieldLabel
                                         helpTipBody={
@@ -5526,7 +5564,7 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                       </DomainFieldLabel>
                                     </div>
                                     <div
-                                      className="col col-xs-9 col-lg-10"
+                                      className="col col-xs-9 col-lg-8"
                                     >
                                       <input
                                         checked={false}
@@ -5538,6 +5576,30 @@ exports[`AssayPropertiesPanel without helpTopic 1`] = `
                                   </div>
                                 </Component>
                               </EditableRunsInput>
+                            </div>
+                          </div>
+                        </Col>
+                        <Col
+                          bsClass="col"
+                          componentClass="div"
+                          lg={6}
+                          xs={12}
+                        >
+                          <div
+                            className="col-lg-6 col-xs-12"
+                          >
+                            <div
+                              className="domain-field-padding-bottom"
+                            >
+                              <SectionHeading
+                                title="Import Settings"
+                              >
+                                <div
+                                  className="domain-field-section-heading"
+                                >
+                                  Import Settings
+                                </div>
+                              </SectionHeading>
                             </div>
                           </div>
                         </Col>

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`DataClassDesigner custom properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -201,7 +201,7 @@ exports[`DataClassDesigner custom properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
       </div>
@@ -218,16 +218,16 @@ exports[`DataClassDesigner custom properties 1`] = `
               class="domain-system-fields-header"
             >
               <div
-                class="domain-system-fields-header__icon"
-              >
-                <i
-                  class="fa fa-lg fa-minus-square"
-                />
-              </div>
-              <div
                 class="domain-system-fields-header__text"
               >
                 Default System Fields
+              </div>
+              <div
+                class="domain-system-fields-header__icon"
+              >
+                <i
+                  class="fa fa-lg fa-chevron-down"
+                />
               </div>
             </div>
           </div>
@@ -543,7 +543,7 @@ exports[`DataClassDesigner default properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -932,7 +932,7 @@ exports[`DataClassDesigner default properties 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
       </div>
@@ -949,16 +949,16 @@ exports[`DataClassDesigner default properties 1`] = `
               class="domain-system-fields-header"
             >
               <div
-                class="domain-system-fields-header__icon"
-              >
-                <i
-                  class="fa fa-lg fa-minus-square"
-                />
-              </div>
-              <div
                 class="domain-system-fields-header__text"
               >
                 Default System Fields
+              </div>
+              <div
+                class="domain-system-fields-header__icon"
+              >
+                <i
+                  class="fa fa-lg fa-chevron-down"
+                />
               </div>
             </div>
           </div>
@@ -1281,7 +1281,7 @@ exports[`DataClassDesigner initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-minus-square domain-form-collapse-btn"
+            class="fa fa-lg fa-chevron-down domain-form-collapse-btn"
           />
         </span>
       </div>
@@ -1664,7 +1664,7 @@ exports[`DataClassDesigner initModel 1`] = `
           class="pull-right"
         >
           <span
-            class="fa fa-lg fa-plus-square domain-form-expand-btn"
+            class="fa fa-lg fa-chevron-right domain-form-expand-btn"
           />
         </span>
         <span
@@ -1686,16 +1686,16 @@ exports[`DataClassDesigner initModel 1`] = `
               class="domain-system-fields-header"
             >
               <div
-                class="domain-system-fields-header__icon"
-              >
-                <i
-                  class="fa fa-lg fa-minus-square"
-                />
-              </div>
-              <div
                 class="domain-system-fields-header__text"
               >
                 Default System Fields
+              </div>
+              <div
+                class="domain-system-fields-header__icon"
+              >
+                <i
+                  class="fa fa-lg fa-chevron-down"
+                />
               </div>
             </div>
           </div>

--- a/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataset/__snapshots__/DatasetPropertiesPanel.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`Dataset Properties Panel Edit existing dataset 1`] = `
       className="pull-right"
     >
       <span
-        className="fa fa-lg fa-minus-square domain-form-collapse-btn"
+        className="fa fa-lg fa-chevron-down domain-form-collapse-btn"
       />
     </span>
   </div>
@@ -645,7 +645,7 @@ exports[`Dataset Properties Panel New dataset 1`] = `
       className="pull-right"
     >
       <span
-        className="fa fa-lg fa-minus-square domain-form-collapse-btn"
+        className="fa fa-lg fa-chevron-down domain-form-collapse-btn"
       />
     </span>
   </div>

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Filter } from '@labkey/api';
+import { ActionURL, Filter, getServerContext } from '@labkey/api';
 
 export function createProductUrlFromParts(
     urlProductId: string,
@@ -134,7 +134,7 @@ export class AppURL {
         let baseUrl = '';
         for (let i = 0; i < parts.length; i++) {
             if (parts[i] === undefined || parts[i] === null || parts[i] === '') {
-                if (LABKEY.devMode) {
+                if (getServerContext().devMode) {
                     throw (
                         'AppURL: Unable to create URL with empty parts. Parts are [' +
                         parts.map(p => p + '').join(', ') +

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -280,6 +280,7 @@
 }
 
 .domain-form-collapse-btn {
+  vertical-align: top;
   color: white;
 
   &:hover {
@@ -827,9 +828,11 @@
 
 .domain-system-fields-header__icon {
     color: $gray-no-highlight;
-    margin-bottom: 2px;
-    margin-right: 10px;
+    margin-left: 10px;
     cursor: pointer;
+    &:hover {
+        color: $gray-dark;
+    }
 }
 
 .domain-system-fields-header__text {

--- a/packages/components/src/theme/filter.scss
+++ b/packages/components/src/theme/filter.scss
@@ -28,13 +28,16 @@
     }
 
     .list-group-item .field-expand-icon {
-        color: $gray-lighten;
+        color: $light-gray;
         height: 16px;
         width: 16px;
         margin-right: 5px;
 
         .fa {
             cursor: pointer;
+            &:hover {
+                color: $gray-dark;
+            }
         }
     }
 


### PR DESCRIPTION
#### Rationale
Issue [49763](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49763): LKSM: suppress "Plate Metadata" setting on assay designs
Issue [49274](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49274): App to use chevron arrows instead of plus/minus for expand/collapse

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1428
- https://github.com/LabKey/labkey-ui-premium/pull/344
- https://github.com/LabKey/limsModules/pull/7
- https://github.com/LabKey/testAutomation/pull/1843

#### Changes
- AssayPropertiesInput rename of appPropertiesOnly prop to hideAdvancedProperties
- Use appPropertiesOnly with isPlatesEnable instead of hideAdvancedProperties to hide/show Plate Metadata assay prop
- Expand/collapse changes from plus/minus icon to chevron right/down
