### PR TITLE
Issue 45315: Allow inferDomainFromFile to take file path string in addition to File prop

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1",
+  "version": "3.24.1-fb-assayInferFromFile45315.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.1",
+      "version": "3.24.1-fb-assayInferFromFile45315.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1-fb-assayInferFromFile45315.1",
+  "version": "3.24.1-fb-assayInferFromFile45315.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.1-fb-assayInferFromFile45315.1",
+      "version": "3.24.1-fb-assayInferFromFile45315.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3-fb-assayInferFromFile45315.1",
+  "version": "3.24.3-fb-assayInferFromFile45315.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.3-fb-assayInferFromFile45315.1",
+      "version": "3.24.3-fb-assayInferFromFile45315.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3-fb-assayInferFromFile45315.0",
+  "version": "3.24.3-fb-assayInferFromFile45315.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.3-fb-assayInferFromFile45315.0",
+      "version": "3.24.3-fb-assayInferFromFile45315.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1-fb-assayInferFromFile45315.0",
+  "version": "3.24.1-fb-assayInferFromFile45315.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.1-fb-assayInferFromFile45315.0",
+      "version": "3.24.1-fb-assayInferFromFile45315.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6-fb-assayInferFromFile45315.2",
+  "version": "3.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.6-fb-assayInferFromFile45315.2",
+      "version": "3.25.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3",
+  "version": "3.24.3-fb-assayInferFromFile45315.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.3",
+      "version": "3.24.3-fb-assayInferFromFile45315.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6-fb-assayInferFromFile45315.0",
+  "version": "3.24.6-fb-assayInferFromFile45315.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.6-fb-assayInferFromFile45315.0",
+      "version": "3.24.6-fb-assayInferFromFile45315.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.2",
+  "version": "3.24.2-fb-assayInferFromFile45315.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.2",
+      "version": "3.24.2-fb-assayInferFromFile45315.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6",
+  "version": "3.24.6-fb-assayInferFromFile45315.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.6",
+      "version": "3.24.6-fb-assayInferFromFile45315.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3-fb-assayInferFromFile45315.2",
+  "version": "3.24.3-fb-assayInferFromFile45315.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.3-fb-assayInferFromFile45315.2",
+      "version": "3.24.3-fb-assayInferFromFile45315.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6",
+  "version": "3.24.6-fb-assayInferFromFile45315.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6-fb-assayInferFromFile45315.0",
+  "version": "3.24.6-fb-assayInferFromFile45315.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3",
+  "version": "3.24.3-fb-assayInferFromFile45315.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1",
+  "version": "3.24.1-fb-assayInferFromFile45315.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3-fb-assayInferFromFile45315.0",
+  "version": "3.24.3-fb-assayInferFromFile45315.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1-fb-assayInferFromFile45315.0",
+  "version": "3.24.1-fb-assayInferFromFile45315.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.2",
+  "version": "3.24.2-fb-assayInferFromFile45315.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6-fb-assayInferFromFile45315.2",
+  "version": "3.25.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3-fb-assayInferFromFile45315.2",
+  "version": "3.24.3-fb-assayInferFromFile45315.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.1-fb-assayInferFromFile45315.1",
+  "version": "3.24.1-fb-assayInferFromFile45315.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.3-fb-assayInferFromFile45315.1",
+  "version": "3.24.3-fb-assayInferFromFile45315.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - Issue 45315: Allow inferDomainFromFile to take file path string in addition to File prop
+- Issue 49795: App grid column header title to show for all columns instead of just lookups
 
 ### version 3.24.3
 *Released*: 29 February 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 3.25.0
+*Released*: 4 March 2024
 - Issue 45315: Allow inferDomainFromFile to take file path string in addition to File prop
 - Issue 49795: App grid column header title to show for all columns instead of just lookups
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 45315: Allow inferDomainFromFile to take file path string in addition to File prop
+
 ### version 3.24.1
 *Released*: 27 February 2024
 - Issue 49639: Update more info link in admin page

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -122,6 +122,7 @@ import {
     createWebDavDirectory,
     deleteWebDavResource,
     getWebDavFiles,
+    getWebDavUrl,
     uploadWebDavFile,
     WebDavFile,
 } from './public/files/WebDav';
@@ -1528,6 +1529,7 @@ export {
     TemplateDownloadButton,
     WebDavFile,
     getWebDavFiles,
+    getWebDavUrl,
     uploadWebDavFile,
     createWebDavDirectory,
     deleteWebDavResource,

--- a/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
@@ -192,7 +192,7 @@ describe('ColumnSelectionModal', () => {
             const wrapper = mount(<FieldLabelDisplay column={QUERY_COL} includeFieldKey />);
             expect(wrapper.find('.field-name')).toHaveLength(1);
             expect(wrapper.find('.field-name').text()).toBe(QUERY_COL.caption);
-            expect(wrapper.find(OverlayTrigger)).toHaveLength(0);
+            expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
             expect(wrapper.find('input')).toHaveLength(0);
             wrapper.unmount();
         });

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -56,8 +56,8 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
             />
         );
     }
-    // only show hover tooltip for lookup child fields. Issue 46256: use encoded fieldKeyPath
-    if (!includeFieldKey || column.fieldKeyPath.indexOf('/') === -1) {
+    // Issue 46256: use encoded fieldKeyPath, Issue 49795: show tooltip more often to account for renamed fields, etc.
+    if (!includeFieldKey) {
         return <div className="field-name">{initialTitle}</div>;
     }
 

--- a/packages/components/src/internal/components/__snapshots__/PreviewGrid.spec.tsx.snap
+++ b/packages/components/src/internal/components/__snapshots__/PreviewGrid.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`PreviewGrid render PreviewGrid with data 1`] = `
             }
             title="Contains a short name for this data object
 If not provided, a unique name will be generated from the expression:
-null"
+null (Name)"
           >
             Name
           </th>
@@ -71,7 +71,7 @@ null"
                 "minWidth": undefined,
               }
             }
-            title="Contains a reference to a user-editable comment about this row"
+            title="Contains a reference to a user-editable comment about this row (Flag)"
           >
             Flag
           </th>
@@ -90,6 +90,7 @@ null"
                 "minWidth": undefined,
               }
             }
+            title="mixtureTypeId"
           >
             Mixture Type
           </th>
@@ -108,7 +109,7 @@ null"
                 "minWidth": undefined,
               }
             }
-            title="The expiration period in days."
+            title="The expiration period in days. (expirationTime)"
           >
             Expiration Time
           </th>
@@ -324,7 +325,7 @@ exports[`PreviewGrid render PreviewGrid with different numCols and numRows 1`] =
             }
             title="Contains a short name for this data object
 If not provided, a unique name will be generated from the expression:
-null"
+null (Name)"
           >
             Name
           </th>
@@ -343,7 +344,7 @@ null"
                 "minWidth": undefined,
               }
             }
-            title="Contains a reference to a user-editable comment about this row"
+            title="Contains a reference to a user-editable comment about this row (Flag)"
           >
             Flag
           </th>

--- a/packages/components/src/internal/components/assay/utils.ts
+++ b/packages/components/src/internal/components/assay/utils.ts
@@ -28,11 +28,9 @@ export function inferDomainFromFile(
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error(error);
-                // reject(
-                //     'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
-                // );
-                // TODO debugging, revert before merge
-                reject(error.exception + ' (' + file + ')');
+                reject(
+                    'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
+                );
             }),
         });
     });

--- a/packages/components/src/internal/components/assay/utils.ts
+++ b/packages/components/src/internal/components/assay/utils.ts
@@ -6,7 +6,7 @@ import { processRequest } from '../../query/api';
 
 // TODO: Move this out of assay/utils
 export function inferDomainFromFile(
-    file: File,
+    file: File | string, // file or webdav url path
     numLinesToInclude: number,
     domainKindName?: string
 ): Promise<InferDomainResponse> {

--- a/packages/components/src/internal/components/assay/utils.ts
+++ b/packages/components/src/internal/components/assay/utils.ts
@@ -28,10 +28,9 @@ export function inferDomainFromFile(
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error(error);
-                // reject(
-                //     'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
-                // );
-                reject(error.exception);
+                reject(
+                    'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
+                );
             }),
         });
     });

--- a/packages/components/src/internal/components/assay/utils.ts
+++ b/packages/components/src/internal/components/assay/utils.ts
@@ -28,9 +28,10 @@ export function inferDomainFromFile(
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error(error);
-                reject(
-                    'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
-                );
+                // reject(
+                //     'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
+                // );
+                reject(error.exception);
             }),
         });
     });

--- a/packages/components/src/internal/components/assay/utils.ts
+++ b/packages/components/src/internal/components/assay/utils.ts
@@ -28,9 +28,11 @@ export function inferDomainFromFile(
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error(error);
-                reject(
-                    'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
-                );
+                // reject(
+                //     'There was a problem determining the fields in the uploaded file.  Please check the format of the file.'
+                // );
+                // TODO debugging, revert before merge
+                reject(error.exception + ' (' + file + ')');
             }),
         });
     });

--- a/packages/components/src/internal/components/base/Grid.test.tsx
+++ b/packages/components/src/internal/components/base/Grid.test.tsx
@@ -361,7 +361,7 @@ describe('getColumnHoverText', () => {
                 index: 'name',
                 phiProtected: false,
             })
-        ).toBe(undefined);
+        ).toBe('name');
     });
 
     test('with hover text', () => {
@@ -372,7 +372,7 @@ describe('getColumnHoverText', () => {
                 fieldKeyPath: 'name',
                 phiProtected: false,
             })
-        ).toBe('desc');
+        ).toBe('desc (name)');
         expect(
             getColumnHoverText({
                 description: ' desc ',
@@ -380,7 +380,7 @@ describe('getColumnHoverText', () => {
                 fieldKeyPath: 'name',
                 phiProtected: true,
             })
-        ).toBe('desc  (PHI protected data removed)');
+        ).toBe('desc (name) (PHI protected data removed)');
         expect(
             getColumnHoverText({
                 description: ' desc ',
@@ -388,7 +388,7 @@ describe('getColumnHoverText', () => {
                 fieldKeyPath: 'parent/name',
                 phiProtected: true,
             })
-        ).toBe('desc  (parent/name) (PHI protected data removed)');
+        ).toBe('desc (parent/name) (PHI protected data removed)');
         expect(
             getColumnHoverText({
                 description: ' desc ',
@@ -396,7 +396,7 @@ describe('getColumnHoverText', () => {
                 fieldKeyPath: 'parent/name',
                 phiProtected: false,
             })
-        ).toBe('desc  (parent/name)');
+        ).toBe('desc (parent/name)');
         expect(
             getColumnHoverText({
                 description: undefined,

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -78,13 +78,13 @@ function resolveColumns(data: List<Map<string, any>>): List<GridColumn> {
 
 // export for jest testing
 export function getColumnHoverText(info: any): string {
-    let description = info?.description || '';
+    let description = info?.description?.trim() || '';
     let sepLeft = description.length > 0 ? '(' : '';
     let sepRight = description.length > 0 ? ')' : '';
 
     // show field key for lookups to help determine path to field when the name is generic (i.e. "Name" is
-    // from "Ancestors/Sources/Lab/Name"),  46256: use encoded fieldKeyPath
-    description += info?.fieldKeyPath?.indexOf('/') > -1 ? ' ' + sepLeft + info.index + sepRight : '';
+    // from "Ancestors/Sources/Lab/Name"),  46256: use encoded fieldKeyPath, 49795: show tooltip for all columns
+    description += info?.index ? ' ' + sepLeft + info.index + sepRight : '';
     sepLeft = description.length > 0 ? '(' : '';
     sepRight = description.length > 0 ? ')' : '';
 

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -198,10 +198,7 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
                                     {headerCell ? headerCell(column, i, columns.size) : title}
                                     {/* headerCell will render the helpTip, so only render here if not using headerCell() */}
                                     {!headerCell && column.helpTipRenderer && (
-                                        <LabelHelpTip
-                                            title={title}
-                                            popoverClassName="label-help-arrow-top"
-                                        >
+                                        <LabelHelpTip title={title} popoverClassName="label-help-arrow-top">
                                             <HelpTipRenderer type={column.helpTipRenderer} />
                                         </LabelHelpTip>
                                     )}

--- a/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
+++ b/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
@@ -96,7 +96,7 @@ export class CollapsiblePanelHeader extends React.PureComponent<Props> {
             <div id={id} onClick={togglePanel} className={panelHeaderClass}>
                 {/* Header help icon*/}
                 {iconHelpMsg && (
-                    <LabelHelpTip iconComponent={this.getHeaderIconComponent()} placement="top" title={title}>
+                    <LabelHelpTip iconComponent={this.getHeaderIconComponent()} title={title}>
                         {iconHelpMsg}
                     </LabelHelpTip>
                 )}
@@ -114,7 +114,7 @@ export class CollapsiblePanelHeader extends React.PureComponent<Props> {
 
                 {/* Help tip*/}
                 {children && (
-                    <LabelHelpTip placement="top" title={title}>
+                    <LabelHelpTip title={title}>
                         {children}
                     </LabelHelpTip>
                 )}

--- a/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
+++ b/packages/components/src/internal/components/domainproperties/CollapsiblePanelHeader.tsx
@@ -114,11 +114,7 @@ export class CollapsiblePanelHeader extends React.PureComponent<Props> {
                 )}
 
                 {/* Help tip*/}
-                {children && (
-                    <LabelHelpTip title={title}>
-                        {children}
-                    </LabelHelpTip>
-                )}
+                {children && <LabelHelpTip title={title}>{children}</LabelHelpTip>}
 
                 {/* Header details, shown on the right side*/}
                 {controlledCollapse && headerDetails && (

--- a/packages/components/src/internal/url/AppURL.ts
+++ b/packages/components/src/internal/url/AppURL.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionURL, Filter } from '@labkey/api';
+import { ActionURL, Filter, LabKey } from '@labkey/api';
 
 export function createProductUrlFromParts(
     urlProductId: string,
@@ -118,6 +118,8 @@ export function buildURL(controller: string, action: string, params?: any, optio
 
     return ActionURL.buildURL(controller, action, options?.container, parameters);
 }
+
+declare var LABKEY: LabKey;
 
 type URLParam = boolean | number | string;
 

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -812,8 +812,12 @@
     text-transform: capitalize;
     font-weight: bold;
 }
-.drag-drop-handle .fa-ellipsis-v {
-    margin-right: 2px;
+.drag-drop-handle {
+    white-space: nowrap;
+
+    .fa-ellipsis-v {
+        margin-right: 2px;
+    }
 }
 
 .domain-system-fields {


### PR DESCRIPTION
#### Rationale
Issue [45315](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45315): Allow inferDomainFromFile to take file path string in addition to File prop

Issue [49795](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49795): App grid column header title to show for all columns instead of just lookups

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5277
- https://github.com/LabKey/limsModules/pull/18

#### Changes
- Allow inferDomainFromFile to take file path string in addition to File prop
- CollapsiblePanelHeader tooltip placement right instead of top
- App grid column header title to show for all columns instead of just lookups