### PR TITLE
Tabs

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.25.2",
+  "version": "3.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.25.2",
+      "version": "3.26.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.25.2",
+  "version": "3.26.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.??.?
+*Released*: ?? March 2024
+- Add Tabs and Tab components
+- Replace usages of react-bootstrap Tabs/Tab
+
 ### version 3.25.2
 *Released*: 5 March 2024
 - Merge release24.3-SNAPSHOT to develop:

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.??.?
-*Released*: ?? March 2024
+### version 3.26.0
+*Released*: 6 March 2024
 - Add Tabs and Tab components
 - Replace usages of react-bootstrap Tabs/Tab
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -876,6 +876,7 @@ import { ActiveUserLimit, ActiveUserLimitMessage } from './internal/components/s
 import { NameIdSettings } from './internal/components/settings/NameIdSettings';
 import { AuditSettings } from './internal/components/settings/AuditSettings';
 import { BaseModal, Modal, ModalHeader } from './internal/Modal';
+import { Tab, Tabs } from './internal/Tabs';
 
 // See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 enableMapSet();
@@ -1760,6 +1761,8 @@ export {
     BaseModal,
     Modal,
     ModalHeader,
+    Tab,
+    Tabs,
 };
 
 //  Due to babel-loader & typescript babel plugins we need to export/import types separately. The babel plugins require

--- a/packages/components/src/internal/Tabs.test.tsx
+++ b/packages/components/src/internal/Tabs.test.tsx
@@ -1,0 +1,139 @@
+import React, { useCallback, useState } from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Tab, Tabs } from './Tabs';
+
+describe('Tabs', () => {
+    test('Uncontrolled', () => {
+        render(
+            <Tabs>
+                <Tab eventKey="one" title="Tab One">
+                    <p>One</p>
+                </Tab>
+                <Tab eventKey="two" title="Tab Two">
+                    <p>Two</p>
+                </Tab>
+            </Tabs>
+        );
+
+        let tabs = document.querySelectorAll('li');
+        const tabContents = document.querySelectorAll('.tab-pane');
+        expect(tabs).toHaveLength(2);
+        expect(tabContents).toHaveLength(2);
+        expect(tabs[0].textContent).toEqual('Tab One');
+        expect(tabs[0].classList[0]).toEqual('active');
+        expect(tabContents[0].textContent).toEqual('One');
+        expect(tabs[1].textContent).toEqual('Tab Two');
+        expect(tabContents[1].textContent).toEqual('Two');
+
+        userEvent.click(document.querySelectorAll('li a')[1]);
+        tabs = document.querySelectorAll('li');
+        expect(tabs[0].classList).toHaveLength(0);
+        expect(tabs[1].classList[0]).toEqual('active');
+    });
+
+    const ControlledTabs = props => {
+        const [activeKey, setActiveKey] = useState('two');
+        const onSelect = useCallback(
+            (...args) => {
+                props.onSelect(...args);
+                setActiveKey(args[0]);
+            },
+            [props.onSelect]
+        );
+        return (
+            <Tabs activeKey={activeKey} onSelect={onSelect}>
+                <Tab eventKey="one" title="Tab One">
+                    <p>One</p>
+                </Tab>
+                <Tab eventKey="two" title="Tab Two">
+                    <p>Two</p>
+                </Tab>
+            </Tabs>
+        );
+    };
+
+    test('Controlled', () => {
+        const onSelect = jest.fn();
+        render(<ControlledTabs onSelect={onSelect} />);
+        let tabs = document.querySelectorAll('li');
+        expect(tabs[0].classList).toHaveLength(0);
+        expect(tabs[1].classList[0]).toEqual('active');
+        userEvent.click(document.querySelectorAll('li a')[0]);
+        expect(onSelect).toHaveBeenCalledWith('one');
+        tabs = document.querySelectorAll('li');
+        expect(tabs[0].classList[0]).toEqual('active');
+        expect(tabs[1].classList).toHaveLength(0);
+    });
+
+    const SometimesRenderChildren = () => {
+        const [activeKey, setActiveKey] = useState('one');
+        const onSelect = useCallback(tabKey => {
+            setActiveKey(tabKey);
+        }, []);
+
+        return (
+            <Tabs activeKey={activeKey} onSelect={onSelect}>
+                <Tab eventKey="one" title="Tab One">
+                    <p>One</p>
+                </Tab>
+                <Tab eventKey="two" title="Tab Two">
+                    <p>Two</p>
+                </Tab>
+                {activeKey !== 'one' && (
+                    <Tab eventKey="three" title="Secret Third Tab">
+                        <p>Wow I'm a secret!</p>
+                    </Tab>
+                )}
+            </Tabs>
+        );
+    };
+
+    test('Children that are not rendered', () => {
+        render(<SometimesRenderChildren />);
+        let tabs = document.querySelectorAll('li');
+        expect(tabs).toHaveLength(2);
+        userEvent.click(document.querySelectorAll('li a')[1]);
+        tabs = document.querySelectorAll('li');
+        expect(tabs).toHaveLength(3);
+        expect(tabs[2].textContent).toEqual('Secret Third Tab');
+    });
+
+    test('No children within Tab', () => {
+        render(
+            <Tabs>
+                <Tab eventKey="one" title="Tab One" />
+                <Tab eventKey="two" title="Tab Two" />
+            </Tabs>
+        );
+
+        const tabs = document.querySelectorAll('li');
+        const tabContents = document.querySelectorAll('.tab-pane');
+        expect(tabs).toHaveLength(2);
+        expect(tabContents).toHaveLength(2);
+        expect(tabContents[0].textContent).toEqual('');
+        expect(tabContents[1].textContent).toEqual('');
+    });
+    test('ReactNode for title', () => {
+        render(
+            <Tabs>
+                <Tab eventKey="one" title="Tab One">
+                    <p>One</p>
+                </Tab>
+                <Tab
+                    eventKey="two"
+                    title={
+                        <span>
+                            Tab Two <span className="fa fa-check-circle" />
+                        </span>
+                    }
+                >
+                    <p>Two</p>
+                </Tab>
+            </Tabs>
+        );
+        const tab = document.querySelector('li span.fa-check-circle');
+        expect(tab).not.toBeNull();
+    });
+});

--- a/packages/components/src/internal/Tabs.tsx
+++ b/packages/components/src/internal/Tabs.tsx
@@ -32,8 +32,9 @@ interface TabContext {
 const Context = createContext<TabContext>(undefined);
 
 interface TabProps {
-    children: ReactNode;
+    children?: ReactNode;
     className?: string;
+    disabled?: boolean;
     eventKey: string;
     title: ReactNode;
 }
@@ -77,6 +78,9 @@ export const Tabs: FC<TabsProps> = props => {
         },
         [onSelect]
     );
+    const onDisabledTabClick = useCallback(event => {
+        cancelEvent(event);
+    }, []);
 
     // Need this useEffect to allow for controlled usages of the selected tab state
     useEffect(() => {
@@ -89,15 +93,17 @@ export const Tabs: FC<TabsProps> = props => {
             if (child === null) return null;
             const eventKey = child?.props?.eventKey;
             const title = child?.props?.title;
+            const disabled = child?.props?.disabled;
+            const tabClassName = classNames({ active: eventKey === activeKey, disabled });
             return (
-                <li className={eventKey === activeKey ? 'active' : ''} key={eventKey}>
+                <li className={tabClassName} key={eventKey}>
                     <a
                         id={tabId(id, eventKey)}
                         role="tab"
                         aria-controls={paneId(id, eventKey)}
                         href="#"
                         data-event-key={eventKey}
-                        onClick={onTabClick}
+                        onClick={disabled ? onDisabledTabClick : onTabClick}
                     >
                         {title}
                     </a>

--- a/packages/components/src/internal/Tabs.tsx
+++ b/packages/components/src/internal/Tabs.tsx
@@ -91,16 +91,18 @@ export const Tabs: FC<TabsProps> = props => {
             const eventKey = child?.props?.eventKey;
             const title = child?.props?.title;
             const disabled = child?.props?.disabled;
-            const tabClassName = classNames({ active: eventKey === activeKey, disabled });
+            const active = eventKey === activeKey;
+            const tabClassName = classNames({ active, disabled });
             return (
                 <li className={tabClassName} key={eventKey} role="presentation">
                     <a
-                        id={tabId(id, eventKey)}
-                        role="tab"
                         aria-controls={paneId(id, eventKey)}
-                        href="#"
+                        aria-selected={active}
                         data-event-key={eventKey}
+                        href="#"
+                        id={tabId(id, eventKey)}
                         onClick={disabled ? cancelEvent : onTabClick}
+                        role="tab"
                     >
                         {title}
                     </a>

--- a/packages/components/src/internal/Tabs.tsx
+++ b/packages/components/src/internal/Tabs.tsx
@@ -41,9 +41,16 @@ interface TabProps {
 
 export const Tab: FC<TabProps> = ({ children, className, eventKey }) => {
     const { id, activeKey } = useContext(Context);
-    const className_ = classNames('tab-pane', className, { active: activeKey === eventKey });
+    const active = activeKey === eventKey;
+    const className_ = classNames('tab-pane', className, { active });
     return (
-        <div aria-labelledby={tabId(id, eventKey)} className={className_} id={paneId(id, eventKey)} role="tabpanel">
+        <div
+            aria-labelledby={tabId(id, eventKey)}
+            aria-hidden={!active}
+            className={className_}
+            id={paneId(id, eventKey)}
+            role="tabpanel"
+        >
             {children}
         </div>
     );

--- a/packages/components/src/internal/Tabs.tsx
+++ b/packages/components/src/internal/Tabs.tsx
@@ -1,0 +1,118 @@
+import React, {
+    Children,
+    createContext,
+    FC,
+    MouseEvent,
+    ReactElement,
+    ReactNode,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
+import classNames from 'classnames';
+
+import { cancelEvent } from './events';
+import { generateId } from './util/utils';
+
+function tabId(id: string, eventKey: string): string {
+    return `${id}-tab-${eventKey}`;
+}
+
+function paneId(id: string, eventKey: string): string {
+    return `${id}-pane-${eventKey}`;
+}
+
+interface TabContext {
+    id: string;
+    activeKey: string;
+}
+
+const Context = createContext<TabContext>(undefined);
+
+interface TabProps {
+    children: ReactNode;
+    eventKey: string;
+    title: ReactNode;
+}
+
+export const Tab: FC<TabProps> = ({ children, eventKey }) => {
+    const { id, activeKey } = useContext(Context);
+    const className = classNames('tab-pane', { active: activeKey === eventKey });
+    return (
+        <div aria-labelledby={tabId(id, activeKey)} className={className} id={paneId(id, activeKey)} role="tabpanel">
+            {children}
+        </div>
+    );
+};
+
+interface TabsProps {
+    activeKey?: string;
+    children: ReactElement<TabProps> | Array<ReactElement<TabProps>>;
+    className?: string;
+    onSelect?: (eventKey: string) => void;
+}
+
+export const Tabs: FC<TabsProps> = props => {
+    const { children, onSelect } = props;
+    const id = useMemo(() => generateId('tabs'), []);
+    const className = classNames('lk-tabs', props.className);
+    const [activeKey, setActiveKey] = useState<string>(() => {
+        if (props.activeKey !== undefined) return props.activeKey;
+        // Child is null if we do something like {canSeeSpecialTab && (<Tab eventKey="specialTab">...</Tab>}
+        const firstNotNull = Children.toArray(children).find(child => {
+            return child !== null;
+        }) as ReactElement<TabProps>;
+        return firstNotNull.props.eventKey;
+    });
+    const tabContext = useMemo(() => ({ id, activeKey }), [id, activeKey]);
+    const onTabClick = useCallback(
+        (event: MouseEvent<HTMLAnchorElement>) => {
+            cancelEvent(event);
+            const targetEventKey = event.currentTarget.dataset.eventKey;
+            if (onSelect !== undefined) onSelect(targetEventKey);
+            else setActiveKey(targetEventKey);
+        },
+        [onSelect]
+    );
+
+    // Need this useEffect to allow for controlled usages of the selected tab state
+    useEffect(() => {
+        if (props.activeKey !== undefined) setActiveKey(props.activeKey);
+    }, [props.activeKey]);
+
+    const tabs = useMemo(() => {
+        return Children.map(children, (child: ReactElement<TabProps>) => {
+            // Child is null if we do something like {canSeeSpecialTab && (<Tab eventKey="specialTab">...</Tab>}
+            if (child === null) return null;
+            const eventKey = child?.props?.eventKey;
+            const title = child?.props?.title;
+            return (
+                <li className={eventKey === activeKey ? 'active' : ''} key={eventKey}>
+                    <a
+                        id={tabId(id, eventKey)}
+                        role="tab"
+                        aria-controls={paneId(id, eventKey)}
+                        href="#"
+                        data-event-key={eventKey}
+                        onClick={onTabClick}
+                    >
+                        {title}
+                    </a>
+                </li>
+            );
+        });
+    }, [children, activeKey, id, onTabClick]);
+
+    return (
+        <div className={className}>
+            <ul className="nav nav-tabs" role="tablist">
+                {tabs}
+            </ul>
+            <div className="tab-content">
+                <Context.Provider value={tabContext}>{children}</Context.Provider>
+            </div>
+        </div>
+    );
+};

--- a/packages/components/src/internal/Tabs.tsx
+++ b/packages/components/src/internal/Tabs.tsx
@@ -78,9 +78,6 @@ export const Tabs: FC<TabsProps> = props => {
         },
         [onSelect]
     );
-    const onDisabledTabClick = useCallback(event => {
-        cancelEvent(event);
-    }, []);
 
     // Need this useEffect to allow for controlled usages of the selected tab state
     useEffect(() => {
@@ -103,7 +100,7 @@ export const Tabs: FC<TabsProps> = props => {
                         aria-controls={paneId(id, eventKey)}
                         href="#"
                         data-event-key={eventKey}
-                        onClick={disabled ? onDisabledTabClick : onTabClick}
+                        onClick={disabled ? cancelEvent : onTabClick}
                     >
                         {title}
                     </a>

--- a/packages/components/src/internal/Tabs.tsx
+++ b/packages/components/src/internal/Tabs.tsx
@@ -43,7 +43,7 @@ export const Tab: FC<TabProps> = ({ children, className, eventKey }) => {
     const { id, activeKey } = useContext(Context);
     const className_ = classNames('tab-pane', className, { active: activeKey === eventKey });
     return (
-        <div aria-labelledby={tabId(id, activeKey)} className={className_} id={paneId(id, activeKey)} role="tabpanel">
+        <div aria-labelledby={tabId(id, eventKey)} className={className_} id={paneId(id, eventKey)} role="tabpanel">
             {children}
         </div>
     );
@@ -93,7 +93,7 @@ export const Tabs: FC<TabsProps> = props => {
             const disabled = child?.props?.disabled;
             const tabClassName = classNames({ active: eventKey === activeKey, disabled });
             return (
-                <li className={tabClassName} key={eventKey}>
+                <li className={tabClassName} key={eventKey} role="presentation">
                     <a
                         id={tabId(id, eventKey)}
                         role="tab"

--- a/packages/components/src/internal/Tabs.tsx
+++ b/packages/components/src/internal/Tabs.tsx
@@ -33,15 +33,16 @@ const Context = createContext<TabContext>(undefined);
 
 interface TabProps {
     children: ReactNode;
+    className?: string;
     eventKey: string;
     title: ReactNode;
 }
 
-export const Tab: FC<TabProps> = ({ children, eventKey }) => {
+export const Tab: FC<TabProps> = ({ children, className, eventKey }) => {
     const { id, activeKey } = useContext(Context);
-    const className = classNames('tab-pane', { active: activeKey === eventKey });
+    const className_ = classNames('tab-pane', className, { active: activeKey === eventKey });
     return (
-        <div aria-labelledby={tabId(id, activeKey)} className={className} id={paneId(id, activeKey)} role="tabpanel">
+        <div aria-labelledby={tabId(id, activeKey)} className={className_} id={paneId(id, activeKey)} role="tabpanel">
             {children}
         </div>
     );

--- a/packages/components/src/internal/components/assay/AssayPicker.spec.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.spec.tsx
@@ -18,15 +18,14 @@ describe('AssayPicker', () => {
 
         // Verify all three tabs shown and standard assay selected
         expect(wrapper.find('.nav-tabs li')).toHaveLength(3);
-        expect(wrapper.find('.nav-tabs li.active a#assay-picker-tabs-tab-standard')).toHaveLength(1);
+        expect(wrapper.find('.nav-tabs li').at(0).props().className).toEqual('active')
         expect(wrapper.find('#assay-type-select-container')).toHaveLength(3);
 
         // Click import tab and verify it's shown
         expect(wrapper.find('.nav-tabs li.active a#assay-picker-tabs-tab-import')).toHaveLength(0);
-        const importTab = wrapper.find('.nav-tabs li a#assay-picker-tabs-tab-import');
-        expect(importTab).toHaveLength(1);
+        const importTab = wrapper.find('.nav-tabs li a').at(2);
         importTab.simulate('click');
-        expect(wrapper.find('.nav-tabs li.active a#assay-picker-tabs-tab-import')).toHaveLength(1);
+        expect(wrapper.find('.nav-tabs li').at(2).props().className).toEqual('active');
         expect(wrapper.find('.file-upload--container')).toHaveLength(1);
 
         wrapper.unmount();
@@ -47,15 +46,11 @@ describe('AssayPicker', () => {
 
         // Verify only two tabs and specialty tab selected
         expect(wrapper.find('.nav-tabs li')).toHaveLength(2);
-        expect(wrapper.find('.nav-tabs li a#assay-picker-tabs-tab-import')).toHaveLength(0);
-        expect(wrapper.find('.nav-tabs li.active a#assay-picker-tabs-tab-specialty')).toHaveLength(1);
+        expect(wrapper.find('.nav-tabs li').at(0).text()).toEqual('Standard Assay');
+        expect(wrapper.find('.nav-tabs li').at(1).text()).toEqual('Specialty Assays');
+        expect(wrapper.find('.nav-tabs li').at(1).props().className).toEqual('active')
         expect(wrapper.find('#assay-type-select-container')).toHaveLength(0);
         expect(wrapper.find('.alert-info')).toHaveLength(1);
-
-        const activeTab = wrapper.find('.nav-tabs li a#assay-picker-tabs-tab-standard');
-        expect(activeTab).toHaveLength(1);
-        activeTab.simulate('click');
-        expect(wrapper.find('#assay-type-select-container')).toHaveLength(0);
 
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/assay/AssayPicker.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.tsx
@@ -1,5 +1,5 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Col, Nav, NavItem, Row, Tab } from 'react-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import { ActionURL, Ajax, Utils } from '@labkey/api';
 
@@ -10,6 +10,8 @@ import { useNotificationsContext } from '../notifications/NotificationsContext';
 import { handleRequestFailure } from '../../util/utils';
 
 import { isLoading, LoadingState } from '../../../public/LoadingState';
+
+import { Tab, Tabs } from '../../Tabs';
 
 import { AssayContainerLocation } from './AssayContainerLocation';
 import { SpecialtyAssayPanel } from './SpecialtyAssayPanel';
@@ -187,49 +189,29 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
     }, [containers, container, onContainerChange, showContainerSelect]);
 
     return (
-        <Tab.Container
-            activeKey={tab}
-            defaultActiveKey={AssayPickerTabs.STANDARD_ASSAY_TAB}
-            id="assay-picker-tabs"
-            onSelect={onSelectTab as any}
-        >
-            <Row className="clearfix">
-                <Col sm={12}>
-                    <Nav bsStyle="tabs">
-                        <NavItem eventKey={AssayPickerTabs.STANDARD_ASSAY_TAB}>Standard Assay</NavItem>
-                        <NavItem eventKey={AssayPickerTabs.SPECIALTY_ASSAY_TAB}>Specialty Assays</NavItem>
-                        {showImport && <NavItem eventKey={AssayPickerTabs.XAR_IMPORT_TAB}>Import Assay Design</NavItem>}
-                    </Nav>
-                </Col>
-                <Col sm={12}>
-                    <Tab.Content animation>
-                        <Tab.Pane className="margin-bottom margin-top" eventKey={AssayPickerTabs.STANDARD_ASSAY_TAB}>
-                            <StandardAssayPanel provider={standardProvider}>
-                                {showContainerSelect && <div className="margin-top">{containerSelect}</div>}
-                            </StandardAssayPanel>
-                        </Tab.Pane>
-                        <Tab.Pane className="margin-bottom margin-top" eventKey={AssayPickerTabs.SPECIALTY_ASSAY_TAB}>
-                            <SpecialtyAssayPanel
-                                hasPremium={hasPremium}
-                                onChange={selectProvider}
-                                selected={provider}
-                                values={providers}
-                            >
-                                {showContainerSelect && providers.length > 1 && (
-                                    <div className="margin-top">{containerSelect}</div>
-                                )}
-                            </SpecialtyAssayPanel>
-                        </Tab.Pane>
-                        {showImport && (
-                            <Tab.Pane className="margin-bottom margin-top" eventKey={AssayPickerTabs.XAR_IMPORT_TAB}>
-                                <AssayDesignUploadPanel onFileChange={onFileSelect} onFileRemove={onFileRemove}>
-                                    {showContainerSelect && <div className="margin-bottom">{containerSelect}</div>}
-                                </AssayDesignUploadPanel>
-                            </Tab.Pane>
-                        )}
-                    </Tab.Content>
-                </Col>
-            </Row>
-        </Tab.Container>
+        <Tabs activeKey={tab} onSelect={onSelectTab}>
+            <Tab eventKey={AssayPickerTabs.STANDARD_ASSAY_TAB} title="Standard Assay" className="margin-top">
+                <StandardAssayPanel provider={standardProvider}>
+                    {showContainerSelect && <div className="margin-top">{containerSelect}</div>}
+                </StandardAssayPanel>
+            </Tab>
+            <Tab eventKey={AssayPickerTabs.SPECIALTY_ASSAY_TAB} title="Specialty Assays" className="margin-top">
+                <SpecialtyAssayPanel
+                    hasPremium={hasPremium}
+                    onChange={selectProvider}
+                    selected={provider}
+                    values={providers}
+                >
+                    {showContainerSelect && providers.length > 1 && <div className="margin-top">{containerSelect}</div>}
+                </SpecialtyAssayPanel>
+            </Tab>
+            {showImport && (
+                <Tab eventKey={AssayPickerTabs.XAR_IMPORT_TAB} title="Import Assay Design" className="margin-top">
+                    <AssayDesignUploadPanel onFileChange={onFileSelect} onFileRemove={onFileRemove}>
+                        {showContainerSelect && <div className="margin-bottom">{containerSelect}</div>}
+                    </AssayDesignUploadPanel>
+                </Tab>
+            )}
+        </Tabs>
     );
 });

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -16,8 +16,8 @@
 import { Query, Utils } from '@labkey/api';
 import classNames from 'classnames';
 import { List, Map, OrderedMap, Set } from 'immutable';
-import React, { ChangeEvent, PureComponent, ReactNode, SyntheticEvent } from 'react';
-import { Nav, NavItem, OverlayTrigger, Popover, Tab, TabContainer } from 'react-bootstrap';
+import React, { ChangeEvent, PureComponent, ReactNode } from 'react';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
 
 import { Operation, QueryColumn } from '../../../public/QueryColumn';
 import { QueryInfo } from '../../../public/QueryInfo';
@@ -46,6 +46,8 @@ import { GridColumn, GridColumnCellRenderer } from '../base/models/GridColumn';
 
 import { BulkAddUpdateForm } from '../forms/BulkAddUpdateForm';
 import { QueryInfoForm, QueryInfoFormProps } from '../forms/QueryInfoForm';
+
+import { Tab, Tabs } from '../../Tabs';
 
 import {
     addRows,
@@ -1492,10 +1494,9 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         });
     };
 
-    onTabChange = (event: SyntheticEvent<TabContainer, Event>): void => {
+    onTabChange = (newTabKey: string): void => {
         const { bulkUpdateProps } = this.props;
         const { activeEditTab } = this.state;
-        const newTabKey: EditableGridTabs = event as any; // Crummy cast to make TS happy
 
         if (newTabKey === EditableGridTabs.Grid && activeEditTab === EditableGridTabs.BulkUpdate) {
             this.applyPendingBulkFormData();
@@ -1645,34 +1646,26 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             return (
                 <>
                     {tabBtnProps?.placement === 'top' && this.renderButtons()}
-                    <Tab.Container
-                        activeKey={activeEditTab}
-                        id="editable-grid-tabs"
-                        className={tabContainerCls}
-                        onSelect={this.onTabChange}
-                    >
-                        <div>
-                            <Nav bsStyle="tabs">
-                                {/* {allowBulkAdd && <NavItem eventKey={EditableGridTabs.BulkAdd}>Add Bulk</NavItem>} TODO tabbed bulk add not yet supported */}
-                                {allowBulkUpdate && (
-                                    <NavItem disabled={bulkDisabled} eventKey={EditableGridTabs.BulkUpdate}>
-                                        Edit in Bulk
-                                    </NavItem>
-                                )}
-                                {showGrid && <NavItem eventKey={EditableGridTabs.Grid}>Edit Individually</NavItem>}
-                            </Nav>
-                            <Alert>{error}</Alert>
-                            <Tab.Content className="top-spacing">
-                                <Tab.Pane eventKey={EditableGridTabs.BulkAdd}>
-                                    {activeEditTab === EditableGridTabs.BulkAdd && this.renderBulkAdd()}
-                                </Tab.Pane>
-                                <Tab.Pane eventKey={EditableGridTabs.BulkUpdate}>
-                                    {activeEditTab === EditableGridTabs.BulkUpdate && this.renderBulkUpdate()}
-                                </Tab.Pane>
-                                <Tab.Pane eventKey={EditableGridTabs.Grid}>{gridContent}</Tab.Pane>
-                            </Tab.Content>
-                        </div>
-                    </Tab.Container>
+                    <Tabs activeKey={activeEditTab} className={tabContainerCls} onSelect={this.onTabChange}>
+                        {/* TODO: tabbed bulk add note yet supported */}
+                        {allowBulkUpdate && (
+                            <Tab
+                                className="top-spacing"
+                                disabled={bulkDisabled}
+                                eventKey={EditableGridTabs.BulkUpdate}
+                                title="Edit in Bulk"
+                            >
+                                <Alert>{error}</Alert>
+                                {this.renderBulkUpdate()}
+                            </Tab>
+                        )}
+                        {showGrid && (
+                            <Tab className="top-spacing" eventKey={EditableGridTabs.Grid} title="Edit Individually">
+                                <Alert>{error}</Alert>
+                                {gridContent}
+                            </Tab>
+                        )}
+                    </Tabs>
                     {tabBtnProps?.placement === 'bottom' && this.renderButtons()}
                 </>
             );

--- a/packages/components/src/internal/components/entities/utils.test.ts
+++ b/packages/components/src/internal/components/entities/utils.test.ts
@@ -267,7 +267,7 @@ describe('getJobCreationHref', () => {
         expect(getJobCreationHref(queryModel, '1')).toContain('templateId=1');
     });
     test('samplesIncluded', () => {
-        expect(getJobCreationHref(queryModel)).toBe('#/workflow/new?selectionKey=id&sampleTab=2');
+        expect(getJobCreationHref(queryModel)).toBe('#/workflow/new?selectionKey=id&sampleTab=search');
         expect(getJobCreationHref(queryModel, undefined, true)).toBe('#/workflow/new?selectionKey=id');
     });
     test('picklistName', () => {

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -139,9 +139,8 @@ export function getJobCreationHref(
     const params = getURLParamsForSampleSelectionKey(model, picklistName, isAssay, sampleFieldKey, ignoreFilter);
 
     if (templateId) params['templateId'] = templateId;
-    if (!samplesIncluded) params['sampleTab'] = 2; // i.e. JOB_SAMPLE_SEARCH_TAB_ID
+    if (!samplesIncluded) params['sampleTab'] = 'search'; // i.e. JOB_SAMPLE_SEARCH_TAB_ID
 
     const actionUrl = createProductUrlFromParts(targetProductId, currentProductId, params, WORKFLOW_KEY, 'new');
     return actionUrl instanceof AppURL ? actionUrl.toHref() : actionUrl;
 }
-

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -3,9 +3,9 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import React, { FC, memo, PureComponent, ReactNode, useCallback, useMemo, useState } from 'react';
-import { Tab, Tabs } from 'react-bootstrap';
 import { List } from 'immutable';
 
+import { Tab, Tabs } from '../../../Tabs';
 import { LineageSummary } from '../LineageSummary';
 import {
     createLineageNodeCollections,
@@ -34,12 +34,12 @@ interface LineageNodeDetailProps {
 
 interface LineageNodeDetailState {
     stepIdx: number;
-    tabKey: number;
+    tabKey: string;
 }
 
 const initialState: LineageNodeDetailState = {
     stepIdx: undefined,
-    tabKey: 1,
+    tabKey: 'details',
 };
 
 export class LineageNodeDetail extends PureComponent<LineageNodeDetailProps, LineageNodeDetailState> {
@@ -54,7 +54,7 @@ export class LineageNodeDetail extends PureComponent<LineageNodeDetailProps, Lin
         }
     }
 
-    changeTab = (tabKey: number): void => {
+    changeTab = (tabKey: string): void => {
         this.setState({ tabKey });
     };
 
@@ -90,14 +90,12 @@ export class LineageNodeDetail extends PureComponent<LineageNodeDetailProps, Lin
                 {node.isRun ? (
                     <Tabs
                         activeKey={tabKey}
-                        defaultActiveKey={1}
-                        id="lineage-run-tabs"
-                        onSelect={this.changeTab as any}
+                        onSelect={this.changeTab}
                     >
-                        <Tab eventKey={1} title="Details">
+                        <Tab eventKey="details" title="Details">
                             {nodeDetails}
                         </Tab>
-                        <Tab eventKey={2} title="Run Properties">
+                        <Tab eventKey="runProperties" title="Run Properties">
                             <DetailsListSteps node={node} onSelect={this.selectStep} />
                             <DetailsListLineageIO item={node} />
                         </Tab>
@@ -173,12 +171,12 @@ interface RunStepNodeDetailProps {
 
 const RunStepNodeDetail: FC<RunStepNodeDetailProps> = memo(props => {
     const { node, onBack, stepIdx } = props;
-    const [tabKey, setTabKey] = useState<number>(1);
+    const [tabKey, setTabKey] = useState<string>('details');
     const step = node.steps.get(stepIdx);
     const stepName = step.protocol?.name || step.name;
     const hasProvenanceModule = useMemo(() => hasModule('provenance'), []);
 
-    const changeTab = useCallback((newTabKey: number) => {
+    const changeTab = useCallback((newTabKey: string) => {
         setTabKey(newTabKey);
     }, []);
 
@@ -191,13 +189,13 @@ const RunStepNodeDetail: FC<RunStepNodeDetailProps> = memo(props => {
                 <span className="spacer-left">&gt;</span>
                 <span className="spacer-left">{stepName}</span>
             </DetailHeader>
-            <Tabs activeKey={tabKey} defaultActiveKey={1} id="lineage-run-step-tabs" onSelect={changeTab as any}>
-                <Tab eventKey={1} title="Step Details">
+            <Tabs activeKey={tabKey} onSelect={changeTab}>
+                <Tab eventKey="details" title="Step Details">
                     <LineageDetail item={step} />
                     <DetailsListLineageIO item={step} />
                 </Tab>
                 {hasProvenanceModule && (
-                    <Tab eventKey={2} title="Provenance Map" className="lineage-run-step-provenance-map">
+                    <Tab eventKey="provenanceMap" title="Provenance Map" className="lineage-run-step-provenance-map">
                         <RunStepProvenanceMap item={step} />
                     </Tab>
                 )}

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -88,10 +88,7 @@ export class LineageNodeDetail extends PureComponent<LineageNodeDetailProps, Lin
             <div className="lineage-node-detail">
                 <NodeDetailHeader node={node} seed={seed} />
                 {node.isRun ? (
-                    <Tabs
-                        activeKey={tabKey}
-                        onSelect={this.changeTab}
-                    >
+                    <Tabs activeKey={tabKey} onSelect={this.changeTab}>
                         <Tab eventKey="details" title="Details">
                             {nodeDetails}
                         </Tab>

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.spec.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { NavItem, Tab } from 'react-bootstrap';
 import { mount, ReactWrapper } from 'enzyme';
 
 import { ConceptInformationTabs, ConceptInfoTabs } from './ConceptInformationTabs';
@@ -13,8 +12,7 @@ const DEFAULT_PROPS = {
 
 describe('ConceptInformationTabs', () => {
     function validate(wrapper: ReactWrapper) {
-        expect(wrapper.find(Tab.Container)).toHaveLength(1);
-        expect(wrapper.find(NavItem)).toHaveLength(2);
+        expect(wrapper.find('li[role="presentation"]')).toHaveLength(2);
         expect(wrapper.find('.ontology-concept-overview-container')).toHaveLength(2);
         expect(wrapper.find(ConceptOverviewPanelImpl)).toHaveLength(1);
         expect(wrapper.find(ConceptPathInfo)).toHaveLength(1);
@@ -34,14 +32,6 @@ describe('ConceptInformationTabs', () => {
         );
         validate(wrapper);
         expect(wrapper.find(ConceptOverviewPanelImpl).prop('concept')).toBe(concept);
-        wrapper.unmount();
-    });
-
-    test('activeTab and defaultActiveKey', () => {
-        const wrapper = mount(<ConceptInformationTabs {...DEFAULT_PROPS} alternatePathClickHandler={jest.fn} />);
-        validate(wrapper);
-        expect(wrapper.find(Tab.Container).prop('defaultActiveKey')).toBe(ConceptInfoTabs.CONCEPT_OVERVIEW_TAB);
-        expect(wrapper.find(Tab.Container).prop('activeKey')).toBe(ConceptInfoTabs.CONCEPT_OVERVIEW_TAB);
         wrapper.unmount();
     });
 });

--- a/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
+++ b/packages/components/src/internal/components/ontology/ConceptInformationTabs.tsx
@@ -1,5 +1,6 @@
-import React, { FC, memo, SyntheticEvent, useCallback, useState } from 'react';
-import { Col, Nav, NavItem, Row, Tab, TabContainer } from 'react-bootstrap';
+import React, { FC, memo } from 'react';
+
+import { Tab, Tabs } from '../../Tabs';
 
 import { ConceptModel, PathModel } from './models';
 import { ConceptOverviewPanelImpl } from './ConceptOverviewPanel';
@@ -18,52 +19,26 @@ export enum ConceptInfoTabs {
 
 export const ConceptInformationTabs: FC<ConceptInformationTabsProps> = memo(props => {
     const { concept, selectedPath, alternatePathClickHandler } = props;
-    const [activeTab, setActiveTab] = useState<ConceptInfoTabs>(ConceptInfoTabs.CONCEPT_OVERVIEW_TAB);
-
-    const onSelectionChange = useCallback(
-        (event: SyntheticEvent<TabContainer, Event>) => {
-            const tab: ConceptInfoTabs = event as any; // Crummy cast to make TS happy
-            setActiveTab(tab);
-        },
-        [setActiveTab]
-    );
-
     return (
-        <Tab.Container
-            id="concept-information-tabs"
-            className="concept-information-tabs"
-            onSelect={onSelectionChange}
-            activeKey={activeTab}
-            defaultActiveKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
-        >
-            <Row className="clearfix">
-                <Col>
-                    <Nav bsStyle="tabs">
-                        <NavItem eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}>Overview</NavItem>
-                        <NavItem eventKey={ConceptInfoTabs.PATH_INFO_TAB}>Path Information</NavItem>
-                    </Nav>
-                </Col>
-                <Col>
-                    <Tab.Content animation>
-                        <Tab.Pane
-                            className="ontology-concept-overview-container"
-                            eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
-                        >
-                            <ConceptOverviewPanelImpl concept={concept} selectedPath={selectedPath} />
-                        </Tab.Pane>
-                        <Tab.Pane
-                            className="ontology-concept-pathinfo-container"
-                            eventKey={ConceptInfoTabs.PATH_INFO_TAB}
-                        >
-                            <ConceptPathInfo
-                                selectedCode={concept?.code}
-                                selectedPath={selectedPath}
-                                alternatePathClickHandler={alternatePathClickHandler}
-                            />
-                        </Tab.Pane>
-                    </Tab.Content>
-                </Col>
-            </Row>
-        </Tab.Container>
+        <Tabs className="concept-information-tabs">
+            <Tab
+                className="ontology-concept-overview-container"
+                eventKey={ConceptInfoTabs.CONCEPT_OVERVIEW_TAB}
+                title="Overview"
+            >
+                <ConceptOverviewPanelImpl concept={concept} selectedPath={selectedPath} />
+            </Tab>
+            <Tab
+                className="ontology-concept-pathinfo-container"
+                eventKey={ConceptInfoTabs.PATH_INFO_TAB}
+                title="Path Information"
+            >
+                <ConceptPathInfo
+                    selectedCode={concept?.code}
+                    selectedPath={selectedPath}
+                    alternatePathClickHandler={alternatePathClickHandler}
+                />
+            </Tab>
+        </Tabs>
     );
 });

--- a/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
+++ b/packages/components/src/internal/components/picklist/ChoosePicklistModal.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { Tab, Tabs } from 'react-bootstrap';
 
 import { Utils } from '@labkey/api';
 
@@ -11,6 +10,7 @@ import { Modal } from '../../Modal';
 import { resolveErrorMessage } from '../../util/messaging';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { ColorIcon } from '../base/ColorIcon';
+import { Tab, Tabs } from '../../Tabs';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
@@ -359,8 +359,8 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
 
                     <div className="row choices-container">
                         <div className="col-md-6">
-                            <Tabs id="choose-items-tabs" className="choose-items-tabs" animation={false}>
-                                <Tab eventKey={1} title="Your Picklists">
+                            <Tabs className="choose-items-tabs">
+                                <Tab eventKey="yours" title="Your Picklists">
                                     <PicklistList
                                         activeItem={activeItem}
                                         emptyMessage={myEmptyMessage}
@@ -370,7 +370,7 @@ export const ChoosePicklistModalDisplay: FC<ChoosePicklistModalProps & ChoosePic
                                     />
                                 </Tab>
 
-                                <Tab eventKey={2} title="Shared Picklists">
+                                <Tab eventKey="shared" title="Shared Picklists">
                                     <PicklistList
                                         activeItem={activeItem}
                                         emptyMessage={teamEmptyMessage}

--- a/packages/components/src/internal/components/search/QueryFilterPanel.spec.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.spec.tsx
@@ -39,8 +39,14 @@ describe('QueryFilterPanel', () => {
         expect(wrapper.find('.filter-modal__col_fields').hostNodes()).toHaveLength(1);
         expect(wrapper.find('.filter-modal__col_filter_exp').hostNodes()).toHaveLength(1);
         expect(wrapper.find(ChoicesListItem)).toHaveLength(fieldItems);
-        expect(wrapper.find(FilterExpressionView)).toHaveLength(showFilterExpression ? 1 : 0);
-        expect(wrapper.find(FilterFacetedSelector)).toHaveLength(showChooseValues ? 1 : 0);
+
+        if (showFilterExpression) {
+            expect(wrapper.find('li[role="presentation"]').at(0).prop('className')).toBe('active');
+        }
+
+        if (showChooseValues) {
+            expect(wrapper.find('li[role="presentation"]').at(1).prop('className')).toBe('active');
+        }
     }
 
     test('default props', () => {
@@ -120,8 +126,7 @@ describe('QueryFilterPanel', () => {
         expect(wrapper.find('.list-group-item.active').text()).toBe('Text');
         expect(wrapper.find('.field-modal__col-sub-title').first().text()).toBe('Find values for Text');
         expect(wrapper.find('.field-modal__empty-msg').hostNodes()).toHaveLength(0);
-        expect(wrapper.find(NavItem)).toHaveLength(2);
-        expect(wrapper.find('#filter-field-tabs').first().prop('activeKey')).toBe('ChooseValues');
+        expect(wrapper.find('a[role="tab"]')).toHaveLength(2);
         expect(wrapper.find('.field-modal__field_dot')).toHaveLength(0);
         wrapper.unmount();
     });
@@ -132,8 +137,7 @@ describe('QueryFilterPanel', () => {
         expect(wrapper.find('.list-group-item.active').text()).toBe('Integer');
         expect(wrapper.find('.field-modal__col-sub-title').text()).toBe('Find values for Integer');
         expect(wrapper.find('.field-modal__empty-msg').hostNodes()).toHaveLength(0);
-        expect(wrapper.find(NavItem)).toHaveLength(1);
-        expect(wrapper.find('#filter-field-tabs').first().prop('activeKey')).toBe('Filter');
+        expect(wrapper.find('a[role="tab"]')).toHaveLength(1);
         wrapper.unmount();
     });
 
@@ -156,8 +160,7 @@ describe('QueryFilterPanel', () => {
         expect(wrapper.find('.list-group-item.active').text()).toBe('Text');
         expect(wrapper.find('.field-modal__col-sub-title').first().text()).toBe('Find values for Text');
         expect(wrapper.find('.field-modal__empty-msg').hostNodes()).toHaveLength(0);
-        expect(wrapper.find(NavItem)).toHaveLength(2);
-        expect(wrapper.find('#filter-field-tabs').first().prop('activeKey')).toBe('Filter');
+        expect(wrapper.find('a[role="tab"]')).toHaveLength(2);
         expect(wrapper.find('.field-modal__field_dot')).toHaveLength(1);
         wrapper.unmount();
     });

--- a/packages/components/src/internal/components/search/QueryFilterPanel.spec.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.spec.tsx
@@ -17,8 +17,6 @@ import { AssayResultDataType } from '../entities/constants';
 
 import { QueryColumn } from '../../../public/QueryColumn';
 
-import { FilterExpressionView } from './FilterExpressionView';
-import { FilterFacetedSelector } from './FilterFacetedSelector';
 import { QueryFilterPanel } from './QueryFilterPanel';
 import { FieldFilter } from './models';
 

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -1,5 +1,5 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Row, Col, Nav, NavItem, Tab } from 'react-bootstrap';
+import { Row, Col } from 'react-bootstrap';
 import { fromJS, List } from 'immutable';
 import classNames from 'classnames';
 
@@ -22,6 +22,7 @@ import { FilterFacetedSelector } from './FilterFacetedSelector';
 import { FilterExpressionView } from './FilterExpressionView';
 import { FieldFilter } from './models';
 import { isChooseValuesFilter } from './utils';
+import { Tab, Tabs } from '../../Tabs';
 
 enum FieldFilterTabs {
     ChooseValues = 'ChooseValues',
@@ -29,7 +30,6 @@ enum FieldFilterTabs {
 }
 
 const DEFAULT_VIEW_NAME = ''; // always use default view for selection, if none provided
-const CHOOSE_VALUES_TAB_KEY = 'Choose values';
 
 interface Props {
     allowRelativeDateFilter?: boolean;
@@ -219,7 +219,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
         (tabKey: any) => {
             setActiveTab(tabKey);
 
-            if (tabKey === CHOOSE_VALUES_TAB_KEY) {
+            if (tabKey === FieldFilterTabs.ChooseValues) {
                 api.query.incrementClientSideMetricCount(metricFeatureArea, 'goToChooseValuesTab');
             }
         },
@@ -283,74 +283,53 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                             'field-modal__col-content-disabled': hasNotInQueryFilter,
                         })}
                     >
-                        <Tab.Container
-                            activeKey={activeTab}
-                            className="field-modal__tabs content-tabs"
-                            id="filter-field-tabs"
-                            onSelect={key => onTabChange(key)}
-                        >
-                            <div>
-                                <Nav bsStyle="tabs" disabled={hasNotInQueryFilter}>
-                                    <NavItem eventKey={FieldFilterTabs.Filter}>Filter</NavItem>
-                                    {allowFaceting(activeField) && (
-                                        <NavItem eventKey={FieldFilterTabs.ChooseValues}>
-                                            {CHOOSE_VALUES_TAB_KEY}
-                                        </NavItem>
-                                    )}
-                                </Nav>
-                                <Tab.Content
-                                    animation
-                                    className="filter-modal__values-col-content"
-                                    disabled={hasNotInQueryFilter}
-                                >
-                                    <Tab.Pane eventKey={FieldFilterTabs.Filter}>
-                                        <div className="field-modal__col-sub-title">
-                                            Find values for {activeField.caption}
-                                        </div>
-                                        {activeTab === FieldFilterTabs.Filter && (
-                                            <FilterExpressionView
-                                                allowRelativeDateFilter={allowRelativeDateFilter}
-                                                key={activeFieldKey}
-                                                field={activeField}
-                                                fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
-                                                onFieldFilterUpdate={(newFilters, index) =>
-                                                    onFilterUpdate(activeField, newFilters, index)
-                                                }
-                                                disabled={hasNotInQueryFilter}
-                                                includeAllAncestorFilter={
-                                                    isAncestor && activeField?.fieldKey.toLowerCase() === 'name'
-                                                }
-                                            />
-                                        )}
-                                    </Tab.Pane>
-                                    {activeTab === FieldFilterTabs.ChooseValues && allowFaceting(activeField) && (
-                                        <Tab.Pane eventKey={FieldFilterTabs.ChooseValues}>
-                                            <div className="field-modal__col-sub-title">
-                                                Find values for {activeField.caption}
-                                            </div>
-                                            <FilterFacetedSelector
-                                                selectDistinctOptions={{
-                                                    ...selectDistinctOptions,
-                                                    column: activeFieldKey,
-                                                    schemaName: queryInfo.schemaName,
-                                                    queryName,
-                                                    viewName,
-                                                    filterArray: fieldDistinctValueFilters,
-                                                }}
-                                                fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
-                                                fieldKey={activeFieldKey}
-                                                canBeBlank={!activeField?.required && !activeField.nameExpression}
-                                                key={activeFieldKey}
-                                                onFieldFilterUpdate={(newFilters, index) =>
-                                                    onFilterUpdate(activeField, newFilters, index)
-                                                }
-                                                disabled={hasNotInQueryFilter}
-                                            />
-                                        </Tab.Pane>
-                                    )}
-                                </Tab.Content>
-                            </div>
-                        </Tab.Container>
+                        <Tabs activeKey={activeTab} className="field-modal__tabs content-tabs" onSelect={onTabChange}>
+                            <Tab eventKey={FieldFilterTabs.Filter} title="Filter">
+                                <div className="field-modal__col-sub-title">
+                                    Find values for {activeField.caption}
+                                </div>
+                                {activeTab === FieldFilterTabs.Filter && (
+                                    <FilterExpressionView
+                                        allowRelativeDateFilter={allowRelativeDateFilter}
+                                        key={activeFieldKey}
+                                        field={activeField}
+                                        fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
+                                        onFieldFilterUpdate={(newFilters, index) =>
+                                            onFilterUpdate(activeField, newFilters, index)
+                                        }
+                                        disabled={hasNotInQueryFilter}
+                                        includeAllAncestorFilter={
+                                            isAncestor && activeField?.fieldKey.toLowerCase() === 'name'
+                                        }
+                                    />
+                                )}
+                            </Tab>
+                            {allowFaceting(activeField) && (
+                                <Tab eventKey={FieldFilterTabs.ChooseValues} title="Choose values">
+                                    <div className="field-modal__col-sub-title">
+                                        Find values for {activeField.caption}
+                                    </div>
+                                    <FilterFacetedSelector
+                                        selectDistinctOptions={{
+                                            ...selectDistinctOptions,
+                                            column: activeFieldKey,
+                                            schemaName: queryInfo.schemaName,
+                                            queryName,
+                                            viewName,
+                                            filterArray: fieldDistinctValueFilters,
+                                        }}
+                                        fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
+                                        fieldKey={activeFieldKey}
+                                        canBeBlank={!activeField?.required && !activeField.nameExpression}
+                                        key={activeFieldKey}
+                                        onFieldFilterUpdate={(newFilters, index) =>
+                                            onFilterUpdate(activeField, newFilters, index)
+                                        }
+                                        disabled={hasNotInQueryFilter}
+                                    />
+                                </Tab>
+                            )}
+                        </Tabs>
                     </div>
                 )}
             </Col>


### PR DESCRIPTION
#### Rationale
This PR adds an internal implementation of the react-boostrap Tabs component. It is largely API compatible, however it does remove several props (defaultActiveKey, id)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1432
- https://github.com/LabKey/labkey-ui-premium/pull/347
- https://github.com/LabKey/platform/pull/5284
- https://github.com/LabKey/limsModules/pull/21
- https://github.com/LabKey/testAutomation/pull/1848

#### Changes
- Add Tab, Tabs components
- Replace usages of react-boostrap Tab/Tabs
