### PR TITLE
Mark project settings as dirty after title change

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6-projectNameSettings.0",
+  "version": "3.24.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.6-projectNameSettings.0",
+      "version": "3.24.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.5",
+  "version": "3.24.6-projectNameSettings.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.5",
+      "version": "3.24.6-projectNameSettings.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6-projectNameSettings.0",
+  "version": "3.24.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.5",
+  "version": "3.24.6-projectNameSettings.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 3.24.6
+*Released*: 29 February 2024
 - Mark project settings as dirty after title change
 
 ### version 3.24.5

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Mark project settings as dirty after title change
+
 ### version 3.24.5
 *Released*: 29 February 2024
 - Issue 49804: Fix grid style

--- a/packages/components/src/internal/components/project/ProjectNameSetting.tsx
+++ b/packages/components/src/internal/components/project/ProjectNameSetting.tsx
@@ -7,12 +7,13 @@ interface Props extends InjectedRouteLeaveProps {
     defaultName?: string;
     defaultTitle?: string;
     onNameChange?: (name?: string) => void;
+    onTitleChange?: () => void;
 }
 
 const MAX_FOLDER_NAME_LENGTH = 255;
 
 export const ProjectNameSetting: FC<Props> = memo(props => {
-    const { autoFocus, defaultTitle, defaultName, onNameChange, setIsDirty } = props;
+    const { autoFocus, defaultTitle, defaultName, onNameChange, onTitleChange, setIsDirty } = props;
     const [name, setName] = useState<string>(defaultName);
     const [nameIsTitle, setNameIsTitle] = useState<boolean>(defaultName ? defaultName === defaultTitle : true);
     const toggleLabel = 'Use Project Name for Project Label';
@@ -27,9 +28,10 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
         [onNameChange, setIsDirty]
     );
 
-    const onTitleChange = useCallback(() => {
+    const _onTitleChange = useCallback(() => {
         setIsDirty(true);
-    }, [setIsDirty]);
+        onTitleChange?.();
+    }, [onTitleChange, setIsDirty]);
 
     const toggleNameIsTitle = useCallback(() => {
         setNameIsTitle(_nameIsTitle => !_nameIsTitle);
@@ -91,7 +93,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                             defaultValue={nameIsTitle ? name : defaultTitle}
                             key="uncontrolled"
                             name="title"
-                            onChange={onTitleChange}
+                            onChange={_onTitleChange}
                             type="text"
                         />
                     )}

--- a/packages/components/src/internal/components/project/ProjectSettings.tsx
+++ b/packages/components/src/internal/components/project/ProjectSettings.tsx
@@ -47,10 +47,19 @@ export const ProjectSettings: FC<ProjectSettingsProps> = memo(props => {
     const dispatch = useServerContextDispatch();
     const [getIsDirty, setIsDirty] = useRouteLeave();
 
-    const onNameChange_ = useCallback((name: string) => {
-        setHasValidName(name?.trim().length > 0);
+    const onNameChange = useCallback(
+        (name: string) => {
+            setHasValidName(name?.trim().length > 0);
+            setNameDirty(true);
+            onChange(true);
+        },
+        [onChange]
+    );
+
+    const onTitleChange = useCallback(() => {
         onChange(true);
-    }, [onChange]);
+        setNameDirty(true);
+    }, [nameDirty, project.name]);
 
     const onDataTypeChange_ = useCallback(() => {
         setDataTypeDirty(true);
@@ -220,7 +229,8 @@ export const ProjectSettings: FC<ProjectSettingsProps> = memo(props => {
                         <ProjectNameSetting
                             defaultName={project.name}
                             defaultTitle={project.title}
-                            onNameChange={onNameChange_}
+                            onNameChange={onNameChange}
+                            onTitleChange={onTitleChange}
                             setIsDirty={setIsDirty}
                             getIsDirty={getIsDirty}
                         />


### PR DESCRIPTION
#### Rationale
Previous change to add more dirty page checks for the ProjectSettings page inadvertently removed a setting of the dirty bit that will trigger the save button to be enabled.

#### Related Pull Requests
- #1425 
- https://github.com/LabKey/limsModules/pull/22
- https://github.com/LabKey/labkey-ui-premium/pull/348

#### Changes
- Add callback for title change as well as name change for `ProjectNameSettings`