### PR TITLE
Lineage Settings: fix input change handling

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6",
+  "version": "3.24.7-fb-closure-cf.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.6",
+      "version": "3.24.7-fb-closure-cf.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7-fb-closure-cf.0",
+  "version": "3.24.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.7-fb-closure-cf.0",
+      "version": "3.24.7",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7-fb-closure-cf.0",
+  "version": "3.24.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6",
+  "version": "3.24.7-fb-closure-cf.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.7
+*Released*: 1 March 2024
+- Lineage Settings: fix input change handling
+
 ### version 3.24.6
 *Released*: 29 February 2024
 - Mark project settings as dirty after title change

--- a/packages/components/src/internal/components/lineage/LineageSettings.tsx
+++ b/packages/components/src/internal/components/lineage/LineageSettings.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, memo, useCallback, useMemo, useRef, useState } from 'react';
+import React, { ChangeEventHandler, FC, memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
 
@@ -52,8 +52,20 @@ export const LineageSettings: FC<Props> = memo(props => {
         [onSettingsChange, options]
     );
 
-    const onFilterChange = useCallback(
-        (evt: ChangeEvent<HTMLInputElement>) => {
+    const onDepthChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+        evt => {
+            const { name, value } = evt.target;
+            const nValue = parseInt(value, 10);
+            applyOptions(options_ => ({
+                ...options_,
+                grouping: { ...options_.grouping, [name]: nValue },
+            }));
+        },
+        [applyOptions]
+    );
+
+    const onFilterChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+        evt => {
             const { checked, name } = evt.target;
             applyOptions(options_ => {
                 const { originalFilters } = options_;
@@ -83,8 +95,8 @@ export const LineageSettings: FC<Props> = memo(props => {
         [applyOptions]
     );
 
-    const onGroupingChange = useCallback(
-        (evt: ChangeEvent<HTMLInputElement>) => {
+    const onGroupingChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+        evt => {
             const { name, value } = evt.target;
             const nValue = parseInt(value, 10);
             if (GROUPING_COMBINED_SIZE_MIN < nValue) {
@@ -150,7 +162,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                     max={DEFAULT_GROUPING_OPTIONS.childDepth * 2}
                     min={0}
                     name="childDepth"
-                    onChange={onGroupingChange}
+                    onChange={onDepthChange}
                     type="number"
                 />
 
@@ -172,7 +184,7 @@ export const LineageSettings: FC<Props> = memo(props => {
                     max={DEFAULT_GROUPING_OPTIONS.parentDepth * 2}
                     min={0}
                     name="parentDepth"
-                    onChange={onGroupingChange}
+                    onChange={onDepthChange}
                     type="number"
                 />
 


### PR DESCRIPTION
#### Rationale
I noticed that changes to the depth parameters were not having any effect. It turns out I failed to differentiate `onDepthChange` from `onGroupingChange` when introducing a minimum grouping combined size in #1286.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/24

#### Changes
- Introduce `onDepthChange` and utilize for processing changes to parent/child depth.
