### PR TITLE
EditableGrid: Support barcode scanners "streaming" input keys

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.8",
+  "version": "3.24.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.8",
+      "version": "3.24.9",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.8",
+  "version": "3.24.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.9
+*Released*: 5 March 2024
+- EditableGrid: Support barcode scanners "streaming" input keys
+
 ### version 3.24.8
 *Released*: 5 March 2024
 - Issue 49274: App to use chevron arrows instead of plus/minus for expand/collapse (part 2)

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1177,7 +1177,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         );
         this.hideMask();
 
-        onChange(EditableGridEvent.PASTE, changes.editorModel, changes.dataKeys, changes.data);
+        onChange(EditableGridEvent.FILL_TEXT, changes.editorModel, changes.dataKeys, changes.data);
     };
 
     onPaste = async (event: ClipboardEvent): Promise<void> => {

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -55,6 +55,7 @@ import {
     dragFillEvent,
     pasteEvent,
     updateGridFromBulkForm,
+    validateAndInsertPastedData,
 } from './actions';
 import { BorderMask, Cell } from './Cell';
 
@@ -418,6 +419,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             clearSelection: this.clearSelection,
             focusCell: this.focusCell,
             fillDown: this.fillDown,
+            fillText: this.fillText,
             inDrag: this.inDrag,
             modifyCell: this.modifyCell,
             selectCell: this.selectCell,
@@ -1141,6 +1143,41 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const firstRowIdx = parseCellKey(selectionCells[0]).rowIdx;
         const firstRowCellKeys = selectionCells.filter(cellKey => parseCellKey(cellKey).rowIdx === firstRowIdx);
         this._dragFill(firstRowCellKeys);
+    };
+
+    fillText = async (colIdx: number, rowIdx: number, text: string): Promise<void> => {
+        const {
+            allowAdd,
+            columnMetadata,
+            data,
+            dataKeys,
+            disabled,
+            editorModel,
+            onChange,
+            queryInfo,
+            readonlyRows,
+            lockedRows,
+        } = this.props;
+
+        if (disabled) return;
+
+        this.showMask();
+        const changes = await validateAndInsertPastedData(
+            editorModel,
+            dataKeys,
+            data,
+            queryInfo,
+            this.getColumns(),
+            text,
+            columnMetadata,
+            readonlyRows,
+            lockedRows,
+            !allowAdd,
+            false
+        );
+        this.hideMask();
+
+        onChange(EditableGridEvent.PASTE, changes.editorModel, changes.dataKeys, changes.data);
     };
 
     onPaste = async (event: ClipboardEvent): Promise<void> => {

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -39,6 +39,7 @@ export interface LookupCellProps {
     col: QueryColumn;
     colIdx: number;
     containerFilter?: Query.ContainerFilter;
+    defaultInputValue?: string;
     disabled?: boolean;
     filteredLookupKeys?: List<any>;
     filteredLookupValues?: List<string>;
@@ -65,6 +66,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
         const {
             col,
             containerFilter,
+            defaultInputValue,
             disabled,
             filteredLookupKeys,
             filteredLookupValues,
@@ -132,6 +134,7 @@ export class LookupCell extends PureComponent<LookupCellProps> {
                 containerFilter={lookup.containerFilter ?? containerFilter ?? getContainerFilterForLookups()}
                 containerPath={lookup.containerPath}
                 disabled={disabled}
+                defaultInputValue={defaultInputValue}
                 maxRows={LOOKUP_DEFAULT_SIZE}
                 multiple={isMultiple}
                 onKeyDown={onKeyDown}

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1363,7 +1363,8 @@ function insertPastedData(
     columnMetadata: Map<string, EditableColumnMetadata>,
     readonlyRows: string[],
     lockedRows: string[],
-    lockRowCount: boolean
+    lockRowCount: boolean,
+    selectCells: boolean
 ): EditorModelAndGridData {
     const pastedData = paste.payload.data;
     let cellMessages = editorModel.cellMessages;
@@ -1442,7 +1443,9 @@ function insertPastedData(
                 cellValues = cellValues.set(cellKey, cv);
             }
 
-            selectionCells.push(cellKey);
+            if (selectCells) {
+                selectionCells.push(cellKey);
+            }
         });
 
         rowIdx++;
@@ -1497,7 +1500,7 @@ function getPasteValuesByColumn(paste: PasteModel): List<List<string>> {
     return valuesByColumn.asImmutable();
 }
 
-async function validateAndInsertPastedData(
+export async function validateAndInsertPastedData(
     editorModel: EditorModel,
     dataKeys: List<any>,
     data: Map<any, Map<string, any>>,
@@ -1507,7 +1510,8 @@ async function validateAndInsertPastedData(
     columnMetadata: Map<string, EditableColumnMetadata>,
     readonlyRows: string[],
     lockedRows: string[],
-    lockRowCount: boolean
+    lockRowCount: boolean,
+    selectCells: boolean
 ): Promise<EditorModelAndGridData> {
     const { selectedColIdx, selectedRowIdx } = editorModel;
     const readOnlyRowCount =
@@ -1562,7 +1566,8 @@ async function validateAndInsertPastedData(
             columnMetadata,
             readonlyRows,
             lockedRows,
-            lockRowCount
+            lockRowCount,
+            selectCells
         );
     } else {
         const cellKey = genCellKey(selectedColIdx, selectedRowIdx);
@@ -1600,7 +1605,8 @@ export async function pasteEvent(
             columnMetadata,
             readonlyRows,
             lockedRows,
-            lockRowCount
+            lockRowCount,
+            true
         );
     }
 

--- a/packages/components/src/internal/components/editable/constants.ts
+++ b/packages/components/src/internal/components/editable/constants.ts
@@ -39,6 +39,7 @@ export enum EditableGridEvent {
     BULK_UPDATE = 'BULK_UPDATE',
     CLEAR_SELECTION = 'CLEAR_SELECTION',
     DRAG_FILL = 'DRAG_FILL',
+    FILL_TEXT = 'FILL_TEXT',
     FOCUS_CELL = 'FOCUS_CELL',
     MODIFY_CELL = 'MODIFY_CELL',
     PASTE = 'PASTE',

--- a/packages/components/src/internal/components/editable/constants.ts
+++ b/packages/components/src/internal/components/editable/constants.ts
@@ -21,6 +21,7 @@ export enum MODIFICATION_TYPES {
 export interface CellActions {
     clearSelection: () => void;
     fillDown: () => void;
+    fillText: (colIdx: number, rowIdx: number, text: string) => void;
     focusCell: (colIdx: number, rowIdx: number, clearValue?: boolean) => void;
     inDrag: () => boolean; // Not really an action, but useful to be part of this interface
     modifyCell: (colIdx: number, rowIdx: number, newValues: ValueDescriptor[], mod: MODIFICATION_TYPES) => void;

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -104,6 +104,7 @@ const DATA_CHANGE_EVENTS: EditableGridEvent[] = [
     EditableGridEvent.BULK_UPDATE,
     EditableGridEvent.BULK_UPDATE,
     EditableGridEvent.DRAG_FILL,
+    EditableGridEvent.FILL_TEXT,
     EditableGridEvent.MODIFY_CELL,
     EditableGridEvent.PASTE,
     EditableGridEvent.REMOVE_ROWS,

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -50,12 +50,7 @@ function getValue(model: QuerySelectModel, multiple: boolean): any {
     // convert that value to an array here, or Formsy will only return a single value if the input is never touched
     // by the user. Converting it to an array right here gets us the best of both worlds: a pre-populated value that
     // is returned as an array when the user hits submit.
-    if (
-        rawSelectedValue !== undefined &&
-        rawSelectedValue !== '' &&
-        multiple &&
-        !Array.isArray(rawSelectedValue)
-    ) {
+    if (rawSelectedValue !== undefined && rawSelectedValue !== '' && multiple && !Array.isArray(rawSelectedValue)) {
         return [rawSelectedValue];
     }
 

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -26,7 +26,7 @@ import { resolveDetailFieldLabel } from './utils';
 import { initSelect, QuerySelectModel } from './model';
 import { DELIMITER } from './constants';
 
-function getValue(model: QuerySelectModel, props: QuerySelectOwnProps): any {
+function getValue(model: QuerySelectModel, multiple: boolean): any {
     const { rawSelectedValue } = model;
 
     if (rawSelectedValue !== undefined && !Utils.isString(rawSelectedValue)) {
@@ -46,14 +46,14 @@ function getValue(model: QuerySelectModel, props: QuerySelectOwnProps): any {
 
     // Issue 37352
     // For reasons not entirely clear we cannot pass in an array of values to QuerySelect when we initialize it
-    // while multiple is also set to true. Instead we can only pass in one pre-populated value. We then need to
+    // while multiple is also set to true. Instead, we can only pass in one pre-populated value. We then need to
     // convert that value to an array here, or Formsy will only return a single value if the input is never touched
     // by the user. Converting it to an array right here gets us the best of both worlds: a pre-populated value that
     // is returned as an array when the user hits submit.
     if (
         rawSelectedValue !== undefined &&
         rawSelectedValue !== '' &&
-        props.multiple &&
+        multiple &&
         !Array.isArray(rawSelectedValue)
     ) {
         return [rawSelectedValue];
@@ -117,7 +117,7 @@ export type QuerySelectChange = (
 
 /**
  * This is a subset of SelectInputProps that are passed through to the SelectInput. Mainly, this set should
- * represent all props of SelectInput that are not overridden by QuerySelect for it's own
+ * represent all props of SelectInput that are not overridden by QuerySelect for its own
  * purposes (e.g. "options" are populated from the QuerySelect's model and thus are not allowed to
  * be specified by the user).
  */
@@ -132,6 +132,7 @@ type InheritedSelectInputProps = Omit<
     | 'loadOptions'
     | 'onChange' // overridden by QuerySelect. See onQSChange().
     | 'options'
+    | 'selectedOptions'
     | 'valueKey'
 >;
 
@@ -299,13 +300,28 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
 
     render() {
         const {
+            containerFilter,
+            containerPath,
+            displayColumn,
+            fireQSChangeOnInit,
+            loadOnFocus,
+            maxRows,
+            onInitValue,
+            onQSChange,
+            preLoad,
+            queryFilters,
+            requiredColumns,
+            schemaQuery,
+            showLoading,
+            valueColumn,
+            ...selectInputProps
+        } = this.props;
+        const {
             allowDisable,
             containerClass,
             customTheme,
             customStyles,
-            defaultInputValue,
             description,
-            filterOption,
             formsy,
             helpTipRenderer,
             initiallyDisabled,
@@ -314,93 +330,81 @@ export class QuerySelect extends PureComponent<QuerySelectOwnProps, State> {
             labelClass,
             menuPosition,
             multiple,
+            name,
             onToggleDisable,
             openMenuOnFocus,
-            optionRenderer,
             required,
-            showLoading,
-        } = this.props;
+        } = selectInputProps;
         const { defaultOptions, error, isLoading, model } = this.state;
 
         if (error) {
-            const inputProps = {
-                allowDisable,
-                containerClass,
-                customStyles,
-                customTheme,
-                description,
-                disabled: true,
-                formsy,
-                helpTipRenderer,
-                initiallyDisabled,
-                isLoading: false,
-                inputClass,
-                label,
-                labelClass,
-                menuPosition,
-                multiple,
-                name: this.props.name,
-                onToggleDisable,
-                openMenuOnFocus,
-                placeholder: `Error: ${error}`,
-                required,
-                type: 'text',
-            };
-
-            return <SelectInput {...inputProps} />;
-        } else if (model?.isInit) {
-            const inputProps = Object.assign(
-                {
-                    label: label !== undefined ? label : model.queryInfo.title,
-                },
-                this.props,
-                {
-                    allowCreate: false,
-                    autoValue: false, // QuerySelect directly controls value of ReactSelect via selectedOptions
-                    cacheOptions: true,
-                    defaultOptions,
-                    filterOption,
-                    helpTipRenderer,
-                    defaultInputValue,
-                    isLoading,
-                    loadOptions: this.loadOptions,
-                    onChange: this.onChange,
-                    onFocus: this.onFocus,
-                    openMenuOnFocus,
-                    options: undefined, // prevent override
-                    optionRenderer: optionRenderer ? optionRenderer : this.optionRenderer,
-                    selectedOptions: model.getSelectedOptions(),
-                    value: getValue(model, this.props), // needed to initialize the Formsy "value" properly
-                }
+            return (
+                <SelectInput
+                    allowDisable={allowDisable}
+                    containerClass={containerClass}
+                    customStyles={customStyles}
+                    customTheme={customTheme}
+                    description={description}
+                    disabled
+                    formsy={formsy}
+                    helpTipRenderer={helpTipRenderer}
+                    initiallyDisabled={initiallyDisabled}
+                    isLoading={false}
+                    inputClass={inputClass}
+                    label={label}
+                    labelClass={labelClass}
+                    menuPosition={menuPosition}
+                    multiple={multiple}
+                    name={name}
+                    onToggleDisable={onToggleDisable}
+                    openMenuOnFocus={openMenuOnFocus}
+                    placeholder={`Error: ${error}`}
+                    required={required}
+                />
             );
-
-            return <SelectInput {...inputProps} />;
+        } else if (model?.isInit) {
+            return (
+                <SelectInput
+                    label={label !== undefined ? label : model.queryInfo.title}
+                    optionRenderer={this.optionRenderer}
+                    {...selectInputProps}
+                    allowCreate={false}
+                    autoValue={false} // QuerySelect directly controls value of SelectInput via "selectedOptions"
+                    cacheOptions
+                    defaultOptions={defaultOptions}
+                    isLoading={isLoading}
+                    loadOptions={this.loadOptions}
+                    onChange={this.onChange}
+                    onFocus={this.onFocus}
+                    options={undefined} // prevent override
+                    selectedOptions={model.getSelectedOptions()}
+                    value={getValue(model, multiple)} // needed to initialize the Formsy "value" properly
+                />
+            );
         } else if (showLoading) {
-            const inputProps = {
-                allowDisable,
-                containerClass,
-                customStyles,
-                customTheme,
-                description,
-                disabled: true,
-                formsy,
-                helpTipRenderer,
-                inputClass,
-                initiallyDisabled,
-                label,
-                labelClass,
-                menuPosition,
-                multiple,
-                name: this.props.name,
-                openMenuOnFocus,
-                onToggleDisable,
-                placeholder: 'Loading...',
-                required,
-                type: 'text',
-                value: undefined,
-            };
-
-            return <SelectInput {...inputProps} />;
+            return (
+                <SelectInput
+                    allowDisable={allowDisable}
+                    containerClass={containerClass}
+                    customStyles={customStyles}
+                    customTheme={customTheme}
+                    description={description}
+                    disabled
+                    formsy={formsy}
+                    helpTipRenderer={helpTipRenderer}
+                    initiallyDisabled={initiallyDisabled}
+                    label={label}
+                    labelClass={labelClass}
+                    menuPosition={menuPosition}
+                    multiple={multiple}
+                    name={name}
+                    onToggleDisable={onToggleDisable}
+                    openMenuOnFocus={openMenuOnFocus}
+                    placeholder="Loading..."
+                    required={required}
+                    value={undefined}
+                />
+            );
         }
 
         return null;

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -173,6 +173,7 @@ export interface SelectInputProps extends WithFormsyProps {
     containerClass?: string;
     customStyles?: Record<string, any>;
     customTheme?: (theme) => Record<string, any>;
+    defaultInputValue?: string;
     defaultOptions?: boolean | readonly any[];
     delimiter?: string;
     description?: string;
@@ -195,6 +196,7 @@ export interface SelectInputProps extends WithFormsyProps {
     labelClass?: string;
     labelKey?: string;
     loadOptions?: (input: string) => Promise<SelectInputOption[]>;
+    menuPlacement?: string;
     menuPosition?: string;
     multiple?: boolean;
     name?: string;
@@ -251,6 +253,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
         initiallyDisabled: false,
         inputClass: INPUT_WRAPPER_CLASS_NAME,
         labelClass: INPUT_LABEL_CLASS_NAME,
+        menuPlacement: 'auto',
         // Default to 'fixed' because 'absolute' causes issues in several scenarios (Modals, EditableGrid) but it's too
         // difficult to manually set it to fixed in all of these situations (e.g. we don't always know we're in a modal)
         menuPosition: 'fixed',
@@ -520,6 +523,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
             closeMenuOnSelect,
             customTheme,
             customStyles,
+            defaultInputValue,
             defaultOptions,
             delimiter,
             disabled,
@@ -529,6 +533,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
             isLoading,
             isValidNewOption,
             labelKey,
+            menuPlacement,
             menuPosition,
             multiple,
             name,
@@ -580,6 +585,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
             classNamePrefix: 'select-input',
             closeMenuOnSelect,
             components,
+            defaultInputValue,
             delimiter,
             filterOption,
             formatCreateLabel,
@@ -592,7 +598,7 @@ export class SelectInputImpl extends Component<SelectInputProps, State> {
             isLoading,
             isMulti: multiple,
             isValidNewOption,
-            menuPlacement: 'auto',
+            menuPlacement,
             menuPosition,
             name,
             noOptionsMessage: this.noOptionsMessage,

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -309,6 +309,7 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<QuerySelec
 }
 
 export interface QuerySelectModelProps {
+    addExactFilter: boolean;
     allResults: Map<string, Map<string, any>>;
     containerFilter?: Query.ContainerFilter;
     containerPath?: string;
@@ -320,6 +321,7 @@ export interface QuerySelectModelProps {
     queryFilters: List<Filter.IFilter>;
     queryInfo: QueryInfo;
     rawSelectedValue: any;
+    requiredColumns: string[];
     schemaQuery: SchemaQuery;
     searchResults: Map<string, Map<string, any>>;
     selectedItems: Map<string, any>;


### PR DESCRIPTION
#### Rationale
This addresses [Issue 49779](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49779) by introducing recording (buffering) keystrokes into a selected editable grid cell. This recording is only necessary for lookup cells at this time as other cell types, besides date/time cells, support this behavior already.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/27

#### Changes
- Record (aka buffer) and debounce keystrokes for EditableGrid Cells that are lookups. Once input is captured analyze input to focus the cell or fill text.
- Introduce `fillText` cell action that takes a string and effectively pastes it into the grid.
- Expose `defaultInputValue` on `SelectInput` (from the underlying `ReactSelect` prop) and propagate setting through `QuerySelect` and `LookupCell`. Allows for initial value to be recorded into an uncontrolled input (as in React uncontrolled inputs).
- Update `QuerySelect` to pass through all supported props for `SelectInput`.