### PR TITLE
Lineage: Display hierarchy of nodes by "level"

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7",
+  "version": "3.24.8-fb-lineage-level.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.7",
+      "version": "3.24.8-fb-lineage-level.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7",
+  "version": "3.24.8-fb-lineage-level.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 49801](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49801) by introducing an explicit declaration of the `level` property for all nodes in lineage graphs. By specifying the level property the nodes will be aligned according to their level in the hierarchy ([documentation](https://visjs.github.io/vis-network/docs/network/nodes.html)).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1438
- https://github.com/LabKey/limsModules/pull/28
- https://github.com/LabKey/platform/pull/5292

#### Changes
- Calculate `level` based off of depth and direction in the lineage. From the root node (level 0) parent generations are given negative levels (-1, -2, ...) and child generations are given positive levels (1, 2, ...).
  - Note: When utilizing `level` all nodes are required to participate.
- Special case for our "combined" nodes to offset the level from the processing depth.
- Capture type for `NodesInCombinedNode` parameter.
