### PR TITLE
Issue 49274: App to use chevron arrows instead of plus/minus for expand/collapse (part 2)

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6",
+  "version": "3.24.6-fb-expandCollapse49274.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.6",
+      "version": "3.24.6-fb-expandCollapse49274.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7-fb-expandCollapse49274.0",
+  "version": "3.24.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.7-fb-expandCollapse49274.0",
+      "version": "3.24.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7",
+  "version": "3.24.7-fb-expandCollapse49274.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.7",
+      "version": "3.24.7-fb-expandCollapse49274.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7-fb-expandCollapse49274.0",
+  "version": "3.24.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.6",
+  "version": "3.24.6-fb-expandCollapse49274.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.7",
+  "version": "3.24.7-fb-expandCollapse49274.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.24.TBD
-*Released*: TBD
+### version 3.24.8
+*Released*: 5 March 2024
 - Issue 49274: App to use chevron arrows instead of plus/minus for expand/collapse (part 2)
 
 ### version 3.24.7

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.TBD
+*Released*: TBD
+- Issue 49274: App to use chevron arrows instead of plus/minus for expand/collapse (part 2)
+
 ### version 3.24.6
 *Released*: 29 February 2024
 - Mark project settings as dirty after title change

--- a/packages/components/src/internal/components/base/FieldExpansionToggle.test.tsx
+++ b/packages/components/src/internal/components/base/FieldExpansionToggle.test.tsx
@@ -18,8 +18,8 @@ describe('FieldExpansionToggle', () => {
             />
         );
         expect(document.querySelectorAll('.field-icon')).toHaveLength(1);
-        expect(document.querySelectorAll('.fa-plus-square')).toHaveLength(1);
-        expect(document.querySelectorAll('.fa-minus-square')).toHaveLength(0);
+        expect(document.querySelectorAll('.fa-chevron-right')).toHaveLength(1);
+        expect(document.querySelectorAll('.fa-chevron-down')).toHaveLength(0);
         expect(document.querySelectorAll('.field-highlighted')).toHaveLength(1);
         expect(onClick).toHaveBeenCalledTimes(0);
         userEvent.click(screen.getByTitle('Click to expand'));
@@ -39,8 +39,8 @@ describe('FieldExpansionToggle', () => {
             />
         );
         expect(document.querySelectorAll('.field-icon')).toHaveLength(1);
-        expect(document.querySelectorAll('.fa-plus-square')).toHaveLength(0);
-        expect(document.querySelectorAll('.fa-minus-square')).toHaveLength(1);
+        expect(document.querySelectorAll('.fa-chevron-right')).toHaveLength(0);
+        expect(document.querySelectorAll('.fa-chevron-down')).toHaveLength(1);
         expect(document.querySelectorAll('.field-highlighted')).toHaveLength(0); // only highlighted when not expanded
         expect(onClick).toHaveBeenCalledTimes(0);
         userEvent.click(screen.getByTitle('Click to collapse'));
@@ -61,8 +61,8 @@ describe('FieldExpansionToggle', () => {
         );
         expect(document.querySelectorAll('.field-icon')).toHaveLength(1);
         expect(document.querySelectorAll('.expand-custom-cls')).toHaveLength(1);
-        expect(document.querySelectorAll('.fa-plus-square')).toHaveLength(1);
-        expect(document.querySelectorAll('.fa-minus-square')).toHaveLength(0);
+        expect(document.querySelectorAll('.fa-chevron-right')).toHaveLength(1);
+        expect(document.querySelectorAll('.fa-chevron-down')).toHaveLength(0);
         expect(document.querySelectorAll('.field-highlighted')).toHaveLength(0);
         expect(onClick).toHaveBeenCalledTimes(0);
         userEvent.click(screen.getByTitle('Custom click to expand'));

--- a/packages/components/src/internal/components/base/FieldExpansionToggle.tsx
+++ b/packages/components/src/internal/components/base/FieldExpansionToggle.tsx
@@ -16,8 +16,8 @@ export class FieldExpansionToggle extends React.Component<Props, any> {
         const { expanded, expandedTitle, collapsedTitle, cls, highlighted, id, onClick } = this.props;
         const className = classNames('fa fa-lg', {
             'field-highlighted': highlighted && !expanded,
-            'fa-minus-square': expanded,
-            'fa-plus-square': !expanded,
+            'fa-chevron-down': expanded,
+            'fa-chevron-right': !expanded,
         });
 
         return (

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.spec.tsx.snap
@@ -569,7 +569,7 @@ exports[`DomainRow Sample Field 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>
@@ -2375,7 +2375,7 @@ exports[`DomainRow client side warning on field 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>
@@ -4262,7 +4262,7 @@ exports[`DomainRow date time field 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>
@@ -6143,7 +6143,7 @@ exports[`DomainRow decimal field 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>
@@ -8051,7 +8051,7 @@ exports[`DomainRow participant id field 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>
@@ -9748,7 +9748,7 @@ exports[`DomainRow server side error on reserved field 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>
@@ -11597,7 +11597,7 @@ exports[`DomainRow string field test 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>
@@ -13521,7 +13521,7 @@ exports[`DomainRow with empty domain form 1`] = `
                                     title="Show additional field properties"
                                   >
                                     <span
-                                      className="fa fa-lg fa-plus-square"
+                                      className="fa fa-lg fa-chevron-right"
                                     />
                                   </div>
                                 </FieldExpansionToggle>

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
@@ -1369,7 +1369,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -2147,7 +2147,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -2679,7 +2679,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -3210,7 +3210,7 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -5511,7 +5511,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -6289,7 +6289,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -6821,7 +6821,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -7352,7 +7352,7 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -8583,7 +8583,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -9361,7 +9361,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -9893,7 +9893,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -10424,7 +10424,7 @@ exports[`AssayDesignerPanels initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.test.tsx.snap
@@ -2071,7 +2071,7 @@ exports[`DataClassDesigner initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -2568,7 +2568,7 @@ exports[`DataClassDesigner initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>
@@ -3067,7 +3067,7 @@ exports[`DataClassDesigner initModel 1`] = `
                       title="Show additional field properties"
                     >
                       <span
-                        class="fa fa-lg fa-plus-square"
+                        class="fa fa-lg fa-chevron-right"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49274

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1439
- https://github.com/LabKey/limsModules/pull/29
- https://github.com/LabKey/platform/pull/5293
- https://github.com/LabKey/testAutomation/pull/1844 

#### Changes
- use chevron right/down for field expansion in field editor rows
