### PR TITLE
Lineage: Display hierarchy of nodes by "level"

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.25.0",
+  "version": "3.25.1-fb-lineage-level.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.25.0",
+      "version": "3.25.1-fb-lineage-level.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.25.1-fb-lineage-level.0",
+  "version": "3.25.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.25.1-fb-lineage-level.0",
+      "version": "3.25.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.25.0",
+  "version": "3.25.1-fb-lineage-level.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.25.1-fb-lineage-level.0",
+  "version": "3.25.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.25.1
+*Released*: 5 March 2024
+- Issue 49801: Lineage: Display hierarchy of nodes by "level"
+
 ### version 3.25.0
 *Released*: 4 March 2024
 - Issue 45315: Allow inferDomainFromFile to take file path string in addition to File prop

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -779,7 +779,13 @@ function addEdges(
     }
 }
 
-function createVisNode(node: LineageNode, id: string, isSeed: boolean, dir: LINEAGE_DIRECTIONS, depth: number): VisGraphNode {
+function createVisNode(
+    node: LineageNode,
+    id: string,
+    isSeed: boolean,
+    dir: LINEAGE_DIRECTIONS,
+    depth: number
+): VisGraphNode {
     // show the alternate icon image color if this node is the seed or has been selected
     const { image, imageBackup, imageSelected, imageShape } = node.iconProps;
 
@@ -880,7 +886,7 @@ function createCombinedVisNode(
     options: LineageOptions,
     parentNodeName: string,
     dir: LINEAGE_DIRECTIONS,
-    depth: number,
+    depth: number
 ): VisGraphCombinedNode {
     const { combineSize } = options.grouping;
     let typeLabel: string;


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 49801](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49801) by introducing an explicit declaration of the `level` property for all nodes in lineage graphs. By specifying the level property the nodes will be aligned according to their level in the hierarchy ([documentation](https://visjs.github.io/vis-network/docs/network/nodes.html)).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1440
- https://github.com/LabKey/limsModules/pull/31
- https://github.com/LabKey/platform/pull/5300

#### Changes
- Calculate `level` based off of depth and direction in the lineage. From the root node (level 0) parent generations are given negative levels (-1, -2, ...) and child generations are given positive levels (1, 2, ...).
  - Note: When utilizing `level` all nodes are required to participate.
- Special case for our "combined" nodes to offset the level from the processing depth.
- Capture type for `NodesInCombinedNode` parameter.
