### PR TITLE
Issue 49835: App Workflow task value not saving when starting from assay "Import Data" page

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.9",
+  "version": "3.24.9-fb-workflowTask49835.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.9",
+      "version": "3.24.9-fb-workflowTask49835.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.9-fb-workflowTask49835.0",
+  "version": "3.24.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.9-fb-workflowTask49835.0",
+      "version": "3.24.10",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.9-fb-workflowTask49835.0",
+  "version": "3.24.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.9",
+  "version": "3.24.9-fb-workflowTask49835.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.TBD
+*Released*: TBD March 2024
+- Issue 49835: App Workflow task value not saving when starting from assay "Import Data" page
+
 ### version 3.24.9
 *Released*: 5 March 2024
 - EditableGrid: Support barcode scanners "streaming" input keys

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.24.TBD
-*Released*: TBD March 2024
+### version 3.24.10
+*Released*: 7 March 2024
 - Issue 49835: App Workflow task value not saving when starting from assay "Import Data" page
 
 ### version 3.24.9

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -466,13 +466,11 @@ class AssayImportPanelsBody extends Component<Props, State> {
     };
 
     handleWorkflowTaskChange = (name: string, value: any): void => {
-        this.handleChange('runProperties', OrderedMap<string, any>({ workflowTask: value }), () => {
-            this.setState(state => ({
-                model: state.model.merge({
-                    workflowTask: value,
-                }) as AssayWizardModel,
-            }));
-        });
+        this.setState(state => ({
+            model: state.model.merge({
+                workflowTask: value,
+            }) as AssayWizardModel,
+        }));
     };
 
     handleRunChange = (fieldValues: any, isChanged?: boolean): void => {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49835

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1443
- https://github.com/LabKey/limsModules/pull/35
- https://github.com/LabKey/platform/pull/5308

#### Changes
- AssayImportPanels doesn't need to set runProperties on workflowTask change since that is on the AssayWizardModel
