### PR TITLE
Issue 49858: LKSM: Saving grid filter on Storage Status takes 5+ minutes to load grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.11-fb-issue49858.2",
+  "version": "3.24.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.11-fb-issue49858.2",
+      "version": "3.24.11",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.11-fb-issue49858.1",
+  "version": "3.24.11-fb-issue49858.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.11-fb-issue49858.1",
+      "version": "3.24.11-fb-issue49858.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.10",
+  "version": "3.24.11-fb-issue49858.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.10",
+      "version": "3.24.11-fb-issue49858.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.10",
+  "version": "3.24.11-fb-issue49858.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.11-fb-issue49858.1",
+  "version": "3.24.11-fb-issue49858.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.11-fb-issue49858.2",
+  "version": "3.24.11",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.24.X
-*Released*: X March 2024
+### version 3.24.11
+*Released*: 8 March 2024
 - Issue 49858: LKSM: Saving grid filter on Storage Status takes 5+ minutes to load grid
   - Don't include view filters for getRows call
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.X
+*Released*: X March 2024
+- Issue 49858: LKSM: Saving grid filter on Storage Status takes 5+ minutes to load grid
+  - Don't include view filters for getRows call
+
 ### version 3.24.10
 *Released*: 7 March 2024
 - Issue 49835: App Workflow task value not saving when starting from assay "Import Data" page

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -576,7 +576,7 @@ export class QueryModel {
         return this.baseFilters.filter(filter => filter.getColumnName().toLowerCase() === 'replaced');
     }
 
-    get modelFilters(): Filter.IFilter[] {
+    getModelFilters(excludeViewFilters?: boolean): Filter.IFilter[] {
         const { baseFilters, queryInfo, keyValue } = this;
 
         if (!queryInfo) {
@@ -600,7 +600,11 @@ export class QueryModel {
             return [...pkFilter, ...this.detailFilters];
         }
 
-        return [...baseFilters, ...this.viewFilters];
+        return excludeViewFilters ? [...baseFilters] : [...baseFilters, ...this.viewFilters];
+    }
+
+    get modelFilters(): Filter.IFilter[] {
+        return this.getModelFilters(false);
     }
 
     get viewFilters(): Filter.IFilter[] {
@@ -622,6 +626,13 @@ export class QueryModel {
     get filters(): Filter.IFilter[] {
         const modelFilters = this.modelFilters;
 
+        if (this.keyValue !== undefined) return modelFilters;
+
+        return [...modelFilters, ...this.filterArray];
+    }
+
+    get loadRowsFilters(): Filter.IFilter[] {
+        const modelFilters = this.getModelFilters(true);
         if (this.keyValue !== undefined) return modelFilters;
 
         return [...modelFilters, ...this.filterArray];
@@ -1085,7 +1096,7 @@ export class QueryModel {
             viewName: this.viewName,
             containerPath: this.containerPath,
             containerFilter: this.containerFilter,
-            filterArray: this.filters,
+            filterArray: this.loadRowsFilters,
             sort: this.sortString,
             columns: this.columnString,
             parameters: this.queryParameters,


### PR DESCRIPTION
#### Rationale
Issue [49858](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49858): LKSM: Saving grid filter on Storage Status takes 5+ minutes to load grid

When viewName is specified for a selectRows.api, it would include the filters that are defined for the view so there is no need for the client to explicitly supply those filters. Our QueryModel loadRowsConfig currently explicitly include the filters that are defined in views in the payload, resulting in the filters applied twice when generating the sql. 'Storage Status' is a computed column which sees very bad performance when it's used more than once in the where condition

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1444
- https://github.com/LabKey/limsModules/pull/38

#### Changes
- dont include filters defined in saved view in loadRowsConfig to avoid duplicate sql filter generation
