### PR TITLE
Introduce "Primary" Plate Sets

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.27.2",
+  "version": "3.27.3-fb-primary-ps.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.27.2",
+      "version": "3.27.3-fb-primary-ps.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.30.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.27.3-fb-primary-ps.0",
+  "version": "3.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.27.3-fb-primary-ps.0",
+      "version": "3.28.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.30.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.27.3-fb-primary-ps.0",
+  "version": "3.28.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.27.2",
+  "version": "3.27.3-fb-primary-ps.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.28.0
+*Released*: 13 March 2024
+- Consolidate logic for generating filters for editable grid cell lookups into `getLookupFilters()` utility
+- Refactor `LookupCell` to a functional component
+- Export `QueryLookupFilterGroup` and `QueryLookupFilterGroupFilter` types
+
 ### version 3.27.2
 *Released*: 12 March 2024
 - Issue 48535: Filter columns shown when expanding lookup columns for customization

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1910,3 +1910,4 @@ export type { BSStyle } from './internal/dropdowns';
 export type { FetchedGroup, SecurityAPIWrapper } from './internal/components/security/APIWrapper';
 export type { UserLimitSettings } from './internal/components/permissions/actions';
 export type { ModalProps } from './internal/Modal';
+export type { QueryLookupFilterGroup, QueryLookupFilterGroupFilter } from './public/QueryColumn';

--- a/packages/components/src/internal/components/assay/PlatePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/assay/PlatePropertiesPanel.tsx
@@ -1,5 +1,8 @@
 import React, { FC, memo, useMemo } from 'react';
 import Formsy from 'formsy-react';
+import { List } from 'immutable';
+
+import { Filter } from '@labkey/api';
 
 import { ExtendedMap } from '../../../public/ExtendedMap';
 import { QueryColumn } from '../../../public/QueryColumn';
@@ -8,6 +11,7 @@ import { QueryFormInputs } from '../forms/QueryFormInputs';
 
 import { getContainerFilterForLookups } from '../../query/api';
 
+import { PLATE_SET_COLUMN } from './constants';
 import { AssayPropertiesPanelProps } from './models';
 
 export const PlatePropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model, onChange, operation }) => {
@@ -15,6 +19,13 @@ export const PlatePropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model
     const queryColumns = useMemo(
         () => new ExtendedMap<string, QueryColumn>(model.plateColumns.toJS()),
         [model.plateColumns]
+    );
+
+    const queryFilters = useMemo(
+        () => ({
+            [PLATE_SET_COLUMN]: List.of(Filter.create('Archived', false), Filter.create('Type', 'assay')),
+        }),
+        []
     );
 
     if (queryColumns.size === 0) {
@@ -31,6 +42,7 @@ export const PlatePropertiesPanel: FC<AssayPropertiesPanelProps> = memo(({ model
                         fieldValues={model.plateProperties.toObject()}
                         operation={operation}
                         queryColumns={queryColumns}
+                        queryFilters={queryFilters}
                         renderFileInputs
                     />
                 </Formsy>

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1208,6 +1208,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             dataKeys,
             disabled,
             editorModel,
+            forUpdate,
             onChange,
             queryInfo,
             readonlyRows,
@@ -1227,7 +1228,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             columnMetadata,
             readonlyRows,
             lockedRows,
-            !allowAdd
+            !allowAdd,
+            forUpdate
         );
         this.hideMask();
 

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1173,6 +1173,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             dataKeys,
             disabled,
             editorModel,
+            forUpdate,
             onChange,
             queryInfo,
             readonlyRows,
@@ -1193,6 +1194,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             readonlyRows,
             lockedRows,
             !allowAdd,
+            forUpdate,
             false
         );
         this.hideMask();

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -149,6 +149,7 @@ const PLATE_TABLES = {
     PLATE: new SchemaQuery(PLATE_SCHEMA, 'Plate'),
     PLATE_SET: new SchemaQuery(PLATE_SCHEMA, 'PlateSet'),
     PLATE_TYPE: new SchemaQuery(PLATE_SCHEMA, 'PlateType'),
+    SAMPLES_IN_PLATE_SETS: new SchemaQuery(PLATE_SCHEMA, 'SamplesInPlateSets'),
     SCHEMA: PLATE_SCHEMA,
     WELL: new SchemaQuery(PLATE_SCHEMA, 'Well'),
     WELL_GROUP: new SchemaQuery(PLATE_SCHEMA, 'WellGroup'),

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -21,14 +21,14 @@ export enum Operation {
     update = 'update',
 }
 
-interface FilterGroupFilter {
+export interface QueryLookupFilterGroupFilter {
     column: string;
     operator: string;
     value: string;
 }
 
-interface FilterGroup {
-    filters: FilterGroupFilter[];
+export interface QueryLookupFilterGroup {
+    filters: QueryLookupFilterGroupFilter[];
     operation: Operation;
 }
 
@@ -36,7 +36,7 @@ export class QueryLookup {
     declare containerFilter: Query.ContainerFilter;
     declare containerPath: string;
     declare displayColumn: string;
-    declare filterGroups: FilterGroup[];
+    declare filterGroups: QueryLookupFilterGroup[];
     declare isPublic: boolean;
     declare junctionLookup: string; // name of the column on the junction table that is also a lookup
     declare keyColumn: string;
@@ -63,7 +63,7 @@ export class QueryLookup {
         );
     }
 
-    getFilterGroup(operation: Operation): FilterGroup {
+    getFilterGroup(operation: Operation): QueryLookupFilterGroup {
         return this.filterGroups?.find(filterGroup => filterGroup.operation === operation);
     }
 

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -49,7 +49,7 @@ export class QueryLookup {
     // declare table: string; -- NOT ALLOWING -- USE queryName
     declare viewName: string;
 
-    constructor(rawLookup: Record<string, any>) {
+    constructor(rawLookup: Partial<QueryLookup>) {
         Object.assign(this, rawLookup, {
             schemaQuery: new SchemaQuery(rawLookup.schemaName, rawLookup.queryName, rawLookup.viewName),
         });


### PR DESCRIPTION
#### Rationale
This introduces the concept of "primary" and "assay" Plate Sets as a type of Plate Set that can be utilized in plate operations. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1447
- https://github.com/LabKey/labkey-ui-premium/pull/359
- https://github.com/LabKey/limsModules/pull/50
- https://github.com/LabKey/platform/pull/5321

#### Changes
- Consolidate logic for generating filters for editable grid cell lookups into `getLookupFilters()` utility.
- Respect applied filters when pasting data. Previously, only the values/keys filters were generated meaning you could successfully paste in a value that would not be accessible via the active `LookupCell` dropdown.
- Add schema reference to `plate.SamplesInPlateSets`
- Refactor `LookupCell` to a functional component
- Export `QueryLookupFilterGroup` and `QueryLookupFilterGroupFilter` types
- Filter to only non-archived "assay" plate sets in the `PlatePropertiesPanel` dropdown.