### PR TITLE
Fix cell lookup options to respect selected target project

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.35.1-fb-lookupCellContainer.1",
+  "version": "3.35.1-fb-lookupCellContainer.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.35.1-fb-lookupCellContainer.1",
+      "version": "3.35.1-fb-lookupCellContainer.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.36.0",
+      "version": "3.37.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.35.0",
+  "version": "3.35.1-fb-lookupCellContainer.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.35.0",
+      "version": "3.35.1-fb-lookupCellContainer.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.35.0",
+  "version": "3.35.1-fb-lookupCellContainer.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.35.1-fb-lookupCellContainer.1",
+  "version": "3.35.1-fb-lookupCellContainer.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.37.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.X
+*Released*: X 2024
+- Reload EntityInsertPanel LookupCell on targetContainer change
+
 ### version 3.35.0
 *Released*: 29 March 2024
 - Chart builder in app: App initial create chart modal

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.X
-*Released*: X 2024
+### version 3.37.0
+*Released*: 1 April 2024
 - Reload EntityInsertPanel LookupCell on targetContainer change
 
 ### version 3.36.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -648,6 +648,7 @@ import {
     SampleStateType,
     SELECTION_KEY_TYPE,
     UNIQUE_ID_FIND_FIELD,
+    SAMPLE_ALL_PROJECT_LOOKUP_FIELDS,
 } from './internal/components/samples/constants';
 import { createMockWithRouteLeave } from './internal/mockUtils';
 import { ConceptModel } from './internal/components/ontology/models';
@@ -1281,6 +1282,7 @@ export {
     SAMPLE_DATA_EXPORT_CONFIG,
     SAMPLE_EXPORT_CONFIG,
     SAMPLE_INSERT_EXTRA_COLUMNS,
+    SAMPLE_ALL_PROJECT_LOOKUP_FIELDS,
     IS_ALIQUOT_COL,
     SampleCreationType,
     ALIQUOT_CREATION,

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -67,6 +67,7 @@ export interface CellProps {
     selected?: boolean;
     selection?: boolean;
     values?: List<ValueDescriptor>;
+    containerPath?: string;
 }
 
 interface State {
@@ -378,6 +379,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
             selected,
             selection,
             values,
+            containerPath
         } = this.props;
 
         const { filteredLookupKeys } = this.state;
@@ -492,6 +494,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
                     rowIdx={rowIdx}
                     select={cellActions.selectCell}
                     values={values}
+                    containerPath={containerPath}
                 />
             );
         }

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -49,6 +49,7 @@ export interface CellProps {
     col: QueryColumn;
     colIdx: number;
     containerFilter?: Query.ContainerFilter;
+    containerPath?: string;
     filteredLookupKeys?: List<any>;
     filteredLookupValues?: List<string>;
     focused?: boolean;
@@ -58,7 +59,6 @@ export interface CellProps {
     locked?: boolean;
     lookupValueFilters?: Filter.IFilter[];
     message?: CellMessage;
-    name?: string;
     placeholder?: string;
     readOnly?: boolean;
     renderDragHandle?: boolean;
@@ -67,7 +67,7 @@ export interface CellProps {
     selected?: boolean;
     selection?: boolean;
     values?: List<ValueDescriptor>;
-    containerPath?: string;
+    name?: string;
 }
 
 interface State {
@@ -379,7 +379,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
             selected,
             selection,
             values,
-            containerPath
+            containerPath,
         } = this.props;
 
         const { filteredLookupKeys } = this.state;

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -164,7 +164,7 @@ function inputCellFactory(
     containerFilter: Query.ContainerFilter,
     forUpdate: boolean,
     initialSelection: string[],
-    containerPath?: string,
+    containerPath?: string
 ): GridColumnCellRenderer {
     return (value, row, c, rn, cn) => {
         let colOffset = 0;
@@ -300,6 +300,7 @@ export interface SharedEditableGridProps {
     bulkAddProps?: Partial<QueryInfoFormProps>;
     bulkAddText?: string;
     bulkRemoveText?: string;
+    bulkTabHeaderComponent?: ReactNode;
     bulkUpdateProps?: Partial<BulkUpdateQueryInfoFormProps>;
     bulkUpdateText?: string;
     columnMetadata?: Map<string, EditableColumnMetadata>;
@@ -309,7 +310,6 @@ export interface SharedEditableGridProps {
     disabled?: boolean;
     emptyGridMsg?: string;
     exportColFilter?: (col: QueryColumn) => boolean;
-    extraExportColumns?: Array<Partial<QueryColumn>>;
     forUpdate?: boolean;
     hideCountCol?: boolean;
     hideTopControls?: boolean;
@@ -335,7 +335,7 @@ export interface SharedEditableGridProps {
     saveBtnClickedCount?: number;
     hideCheckboxCol?: boolean;
     gridTabHeaderComponent?: ReactNode;
-    bulkTabHeaderComponent?: ReactNode;
+    extraExportColumns?: Array<Partial<QueryColumn>>;
 }
 
 export interface EditableGridBtnProps {

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -163,7 +163,8 @@ function inputCellFactory(
     cellActions: CellActions,
     containerFilter: Query.ContainerFilter,
     forUpdate: boolean,
-    initialSelection: string[]
+    initialSelection: string[],
+    containerPath?: string,
 ): GridColumnCellRenderer {
     return (value, row, c, rn, cn) => {
         let colOffset = 0;
@@ -254,6 +255,7 @@ function inputCellFactory(
                     filteredLookupKeys={columnMetadata?.filteredLookupKeys}
                     getFilteredLookupKeys={columnMetadata?.getFilteredLookupKeys}
                     linkedValues={linkedValues}
+                    containerPath={containerPath}
                 />
             </td>
         );
@@ -303,6 +305,7 @@ export interface SharedEditableGridProps {
     columnMetadata?: Map<string, EditableColumnMetadata>;
     condensed?: boolean;
     containerFilter?: Query.ContainerFilter;
+    containerPath?: string;
     disabled?: boolean;
     emptyGridMsg?: string;
     exportColFilter?: (col: QueryColumn) => boolean;
@@ -812,6 +815,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             readonlyRows,
             lockedRows,
             hideCheckboxCol,
+            containerPath,
         } = this.props;
 
         let gridColumns = List<GridColumn>();
@@ -862,7 +866,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                         this.cellActions,
                         metadata?.containerFilter ?? containerFilter,
                         forUpdate,
-                        this.state.initialSelection
+                        this.state.initialSelection,
+                        containerPath
                     ),
                     index: qCol.fieldKey,
                     fixedWidth,

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -39,6 +39,7 @@ export interface LookupCellProps {
     col: QueryColumn;
     colIdx: number;
     containerFilter?: Query.ContainerFilter;
+    containerPath?: string;
     defaultInputValue?: string;
     disabled?: boolean;
     filteredLookupKeys?: List<any>;
@@ -48,9 +49,8 @@ export interface LookupCellProps {
     modifyCell: (colIdx: number, rowIdx: number, newValues: ValueDescriptor[], mod: MODIFICATION_TYPES) => void;
     onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
     rowIdx: number;
-    select: (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES, resetValue?: boolean) => void;
     values: List<ValueDescriptor>;
-    containerPath?: string;
+    select: (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES, resetValue?: boolean) => void;
 }
 
 interface QueryLookupCellProps extends LookupCellProps {

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -50,6 +50,7 @@ export interface LookupCellProps {
     rowIdx: number;
     select: (colIdx: number, rowIdx: number, selection?: SELECTION_TYPES, resetValue?: boolean) => void;
     values: List<ValueDescriptor>;
+    containerPath?: string;
 }
 
 interface QueryLookupCellProps extends LookupCellProps {
@@ -71,6 +72,7 @@ const QueryLookupCell: FC<QueryLookupCellProps> = memo(props => {
         onSelectChange,
         rawValues,
         values,
+        containerPath,
     } = props;
     const { columnRenderer, lookup } = col;
     const isMultiple = col.isJunctionLookup();
@@ -106,7 +108,7 @@ const QueryLookupCell: FC<QueryLookupCellProps> = memo(props => {
         <QuerySelect
             {...gridCellSelectInputProps}
             containerFilter={lookup.containerFilter ?? containerFilter ?? getContainerFilterForLookups()}
-            containerPath={lookup.containerPath}
+            containerPath={lookup.containerPath ?? containerPath}
             defaultInputValue={defaultInputValue}
             disabled={disabled}
             maxRows={LOOKUP_DEFAULT_SIZE}

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -198,6 +198,7 @@ export const SAMPLE_STORAGE_COLUMNS_WITH_SUBSELECT_EXPR = [
     'StorageRow',
     'StorageCol',
     'CheckedOut',
+    'StorageLocation',
 ];
 
 export const SAMPLE_INSERT_EXTRA_COLUMNS = [...AMOUNT_AND_UNITS_COLUMNS, ...SAMPLE_STORAGE_COLUMNS, ALIQUOTED_FROM_COL];

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -202,6 +202,9 @@ export const SAMPLE_STORAGE_COLUMNS_WITH_SUBSELECT_EXPR = [
 
 export const SAMPLE_INSERT_EXTRA_COLUMNS = [...AMOUNT_AND_UNITS_COLUMNS, ...SAMPLE_STORAGE_COLUMNS, ALIQUOTED_FROM_COL];
 
+// those lookup values are at Home project level, no need to reload on target folder change
+export const SAMPLE_ALL_PROJECT_LOOKUP_FIELDS = ['SampleState', 'Units'];
+
 export const SAMPLE_EXPORT_CONFIG = {
     'exportAlias.name': DEFAULT_SAMPLE_FIELD_CONFIG.label,
     'exportAlias.aliquotedFromLSID': ALIQUOTED_FROM_COL,


### PR DESCRIPTION
#### Rationale
The EntityInsertPanel allows user to select a different target container than the current container. The selected target container should be used to fetch lookup cell options. Note that if a lookup was defined with a specific container, then the specific container will be used in favor of target container.  

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1459
- https://github.com/LabKey/labkey-ui-premium/pull/372
- https://github.com/LabKey/limsModules/pull/93

#### Changes
- add containerPath prop for LookupCell
