### PR TITLE
QuerySelect: functional refactor, introduce autoInit prop

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.2",
+  "version": "3.37.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.37.2",
+      "version": "3.37.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.2",
+  "version": "3.37.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.37.3
+*Released*: 2 April 2024
+- Introduce `autoInit` prop on `QuerySelect` that allows for users to skip initialization.
+- Default `autoInit` to `process.env.NODE_ENV !== 'test'`.
+
 ### version 3.37.2
 *Released*: 1 April 2024
 - Issue 49956: Update styling of `PreviewOption` to not truncate text

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -23,7 +23,14 @@ import { resolveErrorMessage } from '../../util/messaging';
 
 import { SelectInputOption, SelectInput, SelectInputProps, SelectInputChange } from './input/SelectInput';
 import { resolveDetailFieldLabel } from './utils';
-import { fetchSearchResults, formatSavedResults, initSelect, QuerySelectModel, saveSearchResults, setSelection } from './model';
+import {
+    fetchSearchResults,
+    formatSavedResults,
+    initSelect,
+    QuerySelectModel,
+    saveSearchResults,
+    setSelection,
+} from './model';
 import { DELIMITER } from './constants';
 
 function getValue(model: QuerySelectModel, multiple: boolean): any {

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -303,7 +303,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
             // ReactSelect respects "isLoading" with a value of {undefined} differently from a value of {false}.
             setIsLoading(undefined);
         } catch (e) {
-            /* ignore -- error already logged/configured in loadOptions() */
+            // ignore -- error already logged/configured in loadOptions()
         }
     }, [loadOptions, shouldLoadOnFocus]);
 

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -132,6 +132,7 @@ type InheritedSelectInputProps = Omit<
 >;
 
 export interface QuerySelectOwnProps extends InheritedSelectInputProps {
+    autoInit?: boolean;
     containerFilter?: Query.ContainerFilter;
     /** The path to the LK container that the queries should be scoped to. */
     containerPath?: string;
@@ -165,6 +166,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     const querySelectTimer = useRef(undefined);
 
     const {
+        autoInit,
         containerFilter,
         containerPath,
         displayColumn,
@@ -209,6 +211,8 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     }, []);
 
     useEffect(() => {
+        if (!autoInit) return;
+
         (async () => {
             try {
                 const model_ = await initSelect(props);
@@ -220,7 +224,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
 
         return clear;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [autoInit]);
 
     const loadOptions = useCallback(
         (input: string): Promise<SelectInputOption[]> => {
@@ -383,6 +387,8 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
 });
 
 QuerySelect.defaultProps = {
+    // Prevent initialization in test environments in lieu of mocking APIWrapper in all test locations
+    autoInit: process.env.NODE_ENV !== 'test',
     delimiter: DELIMITER,
     filterOption: noopFilterOptions,
     fireQSChangeOnInit: false,

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -64,7 +64,11 @@ function formatResults(model: QuerySelectModel, results: Map<string, any>, token
  * @param result select rows result
  * @param token an optional search token that will be used to sort the results
  */
-export function formatSavedResults(model: QuerySelectModel, result: ISelectRowsResult, token?: string): SelectInputOption[] {
+export function formatSavedResults(
+    model: QuerySelectModel,
+    result: ISelectRowsResult,
+    token?: string
+): SelectInputOption[] {
     const { queryInfo, selectedItems } = model;
 
     if (!queryInfo) {
@@ -180,7 +184,9 @@ function initValueColumn(queryInfo: QueryInfo, column?: string): string {
         valueColumn = column;
 
         if (!queryInfo.getColumn(valueColumn)) {
-            throw new Error(`Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). The "valueColumn" "${valueColumn}" does not exist.`);
+            throw new Error(
+                `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). The "valueColumn" "${valueColumn}" does not exist.`
+            );
         }
     } else {
         const pkCols = queryInfo.getPkCols();
@@ -190,10 +196,12 @@ function initValueColumn(queryInfo: QueryInfo, column?: string): string {
         } else if (pkCols.length > 0) {
             throw new Error(
                 `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). Set "valueColumn" explicitly to any of ` +
-                pkCols.map(col => col.fieldKey).join(', ')
+                    pkCols.map(col => col.fieldKey).join(', ')
             );
         } else {
-            throw new Error(`Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). Set "valueColumn" explicitly as this query does not have any primary keys.`);
+            throw new Error(
+                `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). Set "valueColumn" explicitly as this query does not have any primary keys.`
+            );
         }
     }
 


### PR DESCRIPTION
#### Rationale
This converts the implementation of `QuerySelect` to a React functional component which makes it usable with hooks. Additionally, this introduces a new `autoInit` prop that allows for users to skip initialization. This is most useful in test environments where, in general, we don't want this component to be initializing and making requests. I explored an alternative solution where this utilizes the query APIWrapper, however, as expected this still requires significant mocking/fixturing to get working in all cases which isn't worth the investment as this time.

The `autoInit` property defaults to false in test environments and I'm seeing ~25% reduction in total test time in CI for this package.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1460
- https://github.com/LabKey/labkey-ui-premium/pull/374
- https://github.com/LabKey/limsModules/pull/97
- https://github.com/LabKey/platform/pull/5379

#### Changes
- Functional component conversion of `QuerySelect`
- Introduce `autoInit` variable that allows for users to skip initialization. This is most useful in test environments.
- Default `autoInit` to `process.env.NODE_ENV !== 'test'`
- Remove redundant method wrappers