### PR TITLE
Issue 49956: Update styling of PreviewOption to not truncate text

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.36.1-querySelectStyling.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.36.0",
+      "version": "3.36.1-querySelectStyling.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.1-querySelectStyling.0",
+  "version": "3.37.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.36.1-querySelectStyling.0",
+      "version": "3.37.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.36.1-querySelectStyling.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.2-querySelectStyling.0",
+  "version": "3.37.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 49956: Update styling of `PreviewOption` to not turncate text
+
 ### version 3.36.0
 *Released*: 30 March 2024
 - Introduce `pivotColumn` query metadata section for applying metadata to pivot-generated query columns

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -80,7 +80,7 @@ const PreviewOption: FC<any> = props => {
                         }
 
                         return (
-                            <div key={i} className="text__truncate">
+                            <div key={i}>
                                 {columns.length > 1 && <strong>{column.caption}: </strong>}
                                 <span>{text}</span>
                             </div>
@@ -88,7 +88,7 @@ const PreviewOption: FC<any> = props => {
                     }
 
                     return (
-                        <div key={i} className="text__truncate">
+                        <div key={i}>
                             <span>{label}</span>
                         </div>
                     );


### PR DESCRIPTION
#### Rationale
Issue [49956](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49956)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/375

#### Changes
- Remove use of `text__truncate` style for `PreviewOptions`