### PR TITLE
Issues 49908 and 49394: Fix permission checks for Storage Editor in various contexts

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.36.1-storagePermIssues.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.36.0",
+      "version": "3.36.1-storagePermIssues.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.1-storagePermIssues.0",
+  "version": "3.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.36.1-storagePermIssues.0",
+      "version": "3.37.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.36.1-storagePermIssues.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.1-storagePermIssues.0",
+  "version": "3.37.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 49394: Fix storage permission check for folders further down the hierarchy
+- Issue 49908: use project folder for checking storage designer permissions
+
 ### version 3.36.0
 *Released*: 30 March 2024
 - Introduce `pivotColumn` query metadata section for applying metadata to pivot-generated query columns

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 3.37.1
+*Released*: 1 April 2024
 - Issue 49394: Fix storage permission check for folders further down the hierarchy
 - Issue 49908: use project folder for checking storage designer permissions
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -189,7 +189,7 @@ export function isPremiumProductEnabled(moduleContext?: ModuleContext): boolean 
     return isSampleManagerEnabled(moduleContext) || isBiologicsEnabled(moduleContext);
 }
 
-export function isAppHomeFolder(container?: Container, moduleContext?: ModuleContext): boolean {
+export function isAppHomeFolder(container?: Partial<Container>, moduleContext?: ModuleContext): boolean {
     // If it's a Home project, or if it's a subfolder and products are disabled.
     const currentContainer: Partial<Container> = container ?? getServerContext().container;
     const isTopFolder = currentContainer.isProject || isProjectContainer(currentContainer.path);
@@ -197,7 +197,7 @@ export function isAppHomeFolder(container?: Container, moduleContext?: ModuleCon
     return isTopFolder || (isSubFolder && !isProductProjectsEnabled(moduleContext));
 }
 
-export function getAppHomeFolderPath(container: Container, moduleContext?: ModuleContext): string {
+export function getAppHomeFolderPath(container: Partial<Container>, moduleContext?: ModuleContext): string {
     return isAppHomeFolder(container, moduleContext) ? container.path : container.parentPath;
 }
 

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -20,7 +20,7 @@ import { Row, selectRows, SelectRowsResponse } from '../../query/selectRows';
 
 import { ViewInfo } from '../../ViewInfo';
 
-import { getProjectDataExclusion, getProjectPath, hasModule } from '../../app/utils';
+import { getAppHomeFolderPath, getProjectDataExclusion, getProjectPath, hasModule } from '../../app/utils';
 
 import { resolveErrorMessage } from '../../util/messaging';
 
@@ -115,7 +115,7 @@ export async function getOperationConfirmationData(
 export function getContainersForPermission(permission: PermissionTypes): Promise<string[]> {
     return new Promise((resolve, reject) => {
         Security.getContainers({
-            containerPath: getProjectPath(),
+            containerPath: getAppHomeFolderPath(getServerContext().container),
             includeStandardProperties: false,
             includeSubfolders: true,
             success: (container: Security.ContainerHierarchy) => {


### PR DESCRIPTION
#### Rationale
Issue [49908](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49908):  Use project folder when checking for storage designer permissions
Issue [49394](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49394): Check for storage editor permissions in app home folder

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/99
- https://github.com/LabKey/labkey-ui-premium/pull/376

#### Changes
- Update `getContainersForPermission` to use app home folder
