### PR TITLE
Prioritized 24.4 Issues

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.36.1-fb-kerr-free.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.36.0",
+      "version": "3.36.1-fb-kerr-free.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.1-fb-kerr-free.0",
+  "version": "3.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.36.1-fb-kerr-free.0",
+      "version": "3.36.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.1-fb-kerr-free.0",
+  "version": "3.36.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.36.0",
+  "version": "3.36.1-fb-kerr-free.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.36.1
+*Released*: 2 April 2024
+- Cache assay protocol requests on the client. Uncache when assay definitions are uncached.
+- Hack usage of `menuShouldScrollIntoView` in `SelectInput` to recalculate menu positioning after initial load.
+
 ### version 3.36.0
 *Released*: 30 March 2024
 - Introduce `pivotColumn` query metadata section for applying metadata to pivot-generated query columns


### PR DESCRIPTION
#### Rationale
This addresses [Issue 48259](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48259) and a targeted aspect of [Issue 49922](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49922) for the v24.4 release.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/104

#### Changes
- Cache assay protocol requests on the client. Uncache when assay definitions are uncached.
- Hack usage of `menuShouldScrollIntoView` in `SelectInput` to recalculate menu positioning after initial load.
