### PR TITLE
ChartBuilder fix for selenium tests and JS error on cancel

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.3",
+  "version": "3.37.3-fb-chartBuilderTestFix.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.37.3",
+      "version": "3.37.3-fb-chartBuilderTestFix.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.4",
+  "version": "3.37.4-fb-chartBuilderTestFix.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.37.4",
+      "version": "3.37.4-fb-chartBuilderTestFix.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.4-fb-chartBuilderTestFix.0",
+  "version": "3.37.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.37.4-fb-chartBuilderTestFix.0",
+      "version": "3.37.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.4-fb-chartBuilderTestFix.0",
+  "version": "3.37.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.4",
+  "version": "3.37.4-fb-chartBuilderTestFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.37.3",
+  "version": "3.37.3-fb-chartBuilderTestFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD April 2024
+- ChartBuilder fix for tests (createNotification not defined) and JS error (onHide to handle evt parameter
+
 ### version 3.37.3
 *Released*: 2 April 2024
 - Introduce `autoInit` prop on `QuerySelect` that allows for users to skip initialization.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD April 2024
+### version 3.37.5
+*Released*: 4 April 2024
 - ChartBuilder fix for tests (createNotification not defined) and JS error (onHide to handle evt parameter
 
 ### version 3.37.4

--- a/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
+++ b/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
@@ -669,11 +669,15 @@ export const ChartBuilderModal: FC<ChartBuilderModalProps> = memo(({ actions, mo
         await actions.loadCharts(model.id);
     }, [actions, model.id, onHide, savedChartModel]);
 
+    const onCancel = useCallback(() => {
+        onHide();
+    }, [onHide]);
+
     const footer = (
         <ChartBuilderFooter
             afterDelete={afterDelete}
             disabled={!hasName || !hasRequiredValues}
-            onCancel={onHide}
+            onCancel={onCancel}
             onSaveChart={onSaveChart}
             savedChartModel={savedChartModel}
             saving={saving}
@@ -684,7 +688,7 @@ export const ChartBuilderModal: FC<ChartBuilderModalProps> = memo(({ actions, mo
     return (
         <Modal
             className="chart-builder-modal"
-            onCancel={onHide}
+            onCancel={onCancel}
             title={savedChartModel ? 'Edit Chart' : 'Create Chart'}
             footer={footer}
         >

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -21,8 +21,15 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
     const { charts, containerPath, id, queryInfo, selectedReportId } = model;
     const [savedChartModel, setSavedChartModel] = useState<GenericChartModel>(undefined);
     const [showEditModal, setShowEditModal] = useState<boolean>(false);
-    const { createNotification } = useNotificationsContext();
     const { moduleContext } = useServerContext();
+
+    // useNotificationsContext will not always be available depending on if the app wraps the NotificationsContext.Provider
+    let _createNotification;
+    try {
+        _createNotification = useNotificationsContext().createNotification;
+    } catch (e) {
+        // this is expected for LKS usages, so don't throw or console.error
+    }
 
     const selectedChart = useMemo(
         () => charts?.find(chart => chart.reportId === selectedReportId),
@@ -54,10 +61,10 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
         (successMsg?: string) => {
             setShowEditModal(false);
             if (successMsg) {
-                createNotification({ message: successMsg, alertClass: 'success' });
+                _createNotification({ message: successMsg, alertClass: 'success' });
             }
         },
-        [createNotification]
+        [_createNotification]
     );
 
     // If we don't have a queryInfo we can't get filters off the model, so we can't render the chart

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -61,7 +61,7 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
         (successMsg?: string) => {
             setShowEditModal(false);
             if (successMsg) {
-                _createNotification({ message: successMsg, alertClass: 'success' });
+                _createNotification?.({ message: successMsg, alertClass: 'success' });
             }
         },
         [_createNotification]


### PR DESCRIPTION
#### Rationale
- crawler test failure related to ChartBuilder / Charts menu without createNofication defined
- ChartBuilder hits a JS error on cancel

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1465
- https://github.com/LabKey/platform/pull/5394
- https://github.com/LabKey/limsModules/pull/110

#### Changes
- ChartBuilderModal.tsx fix for onCancel case to call onHide directly
- ChartPanel.tsx to be defensive re: useNotificationsContext().createNotification for LKS case
