### PR TITLE
Product Menu: Flex layout

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.38.0",
+  "version": "3.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.38.0",
+      "version": "3.38.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.38.0",
+  "version": "3.38.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.38.1
+*Released*: 11 April 2024
+- Update product menu DOM structure to better support flex layout container/item paradigm.
+- Use flex layout both horizontally (row-wise) across the product and vertically (column-wise) within each section column.
+- Scroll within dynamic menu sections leaving the section headers position constant.
+- Apply a "no-scroll" CSS class to the document body when product navigation is open. This prevents page scrolling.
+
 ### version 3.38.0
 *Released*: 10 April 2024
 - Add ability for users to choose colors associated with sample statuses

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.spec.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.spec.tsx
@@ -1,18 +1,3 @@
-/*
- * Copyright (c) 2019 LabKey Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import React from 'react';
 import { List } from 'immutable';
 
@@ -25,7 +10,7 @@ import { ProductMenuSection } from './ProductMenuSection';
 import { MenuSectionModel, MenuSectionConfig } from './model';
 import { TEST_PROJECT_CONTAINER } from '../../containerFixtures';
 
-describe('ProductMenuSection render', () => {
+describe('ProductMenuSection', () => {
     const sampleSetItems = List<MenuSectionModel>([
         {
             id: 1,
@@ -284,7 +269,7 @@ describe('ProductMenuSection render', () => {
             />,
             getDefaultServerContext()
         );
-        expect(menuSection.find('ul').length).toBe(1);
+        expect(menuSection.find('ul').length).toBe(2);
         expect(menuSection.find('i.fa-spinner').length).toBe(1); // verify active job indicator
         expect(menuSection).toMatchSnapshot();
         menuSection.unmount();
@@ -313,7 +298,7 @@ describe('ProductMenuSection render', () => {
             getDefaultServerContext()
         );
 
-        expect(menuSection.find('ul').length).toBe(1);
+        expect(menuSection.find('ul').length).toBe(2);
         expect(menuSection.find('i.fa-spinner').length).toBe(0); // no active jobs present
         expect(menuSection).toMatchSnapshot();
         menuSection.unmount();

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.spec.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.spec.tsx
@@ -6,9 +6,10 @@ import { AppURL } from '../../url/AppURL';
 import { mountWithServerContext } from '../../test/enzymeTestHelpers';
 import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
+import { TEST_PROJECT_CONTAINER } from '../../containerFixtures';
+
 import { ProductMenuSection } from './ProductMenuSection';
 import { MenuSectionModel, MenuSectionConfig } from './model';
-import { TEST_PROJECT_CONTAINER } from '../../containerFixtures';
 
 describe('ProductMenuSection', () => {
     const sampleSetItems = List<MenuSectionModel>([

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, PureComponent, ReactNode } from 'react';
+import React, { FC, memo, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
@@ -28,18 +28,24 @@ interface MenuSectionLinkProps {
     item: MenuItemModel;
 }
 
-const MenuSectionLink: FC<MenuSectionLinkProps> = ({ config, item }) => {
-    const { activeJobIconCls, showActiveJobIcon, useOriginalURL } = config;
-    const isAppUrl = (item.url instanceof AppURL || item.url.indexOf('#') === 0) && !useOriginalURL;
-    const body =
-        item.hasActiveJob && showActiveJobIcon ? (
+const MenuSectionItemLabel: FC<MenuSectionLinkProps> = memo(({ config, item }) => {
+    if (item.hasActiveJob && config.showActiveJobIcon) {
+        return (
             <>
-                <i className={classNames('fa', activeJobIconCls)} />
+                <i className={classNames('fa', config.activeJobIconCls)} />
                 <span className="spacer-left product-menu-item">{item.label}</span>
             </>
-        ) : (
-            item.label
         );
+    }
+
+    return <>{item.label}</>;
+});
+
+MenuSectionItemLabel.displayName = 'MenuSectionItemLabel';
+
+const MenuSectionLink: FC<MenuSectionLinkProps> = ({ config, item }) => {
+    const isAppUrl = (item.url instanceof AppURL || item.url.indexOf('#') === 0) && !config.useOriginalURL;
+    const body = <MenuSectionItemLabel config={config} item={item} />;
 
     if (isAppUrl) {
         // Hack: sometimes our server returns strings that are actually proper AppURLs (workflow, eln, and more). We can
@@ -58,35 +64,37 @@ interface MenuSectionProps {
     section: MenuSectionModel;
 }
 
-export class ProductMenuSection extends PureComponent<MenuSectionProps> {
-    render(): ReactNode {
-        const { config, section, currentProductId, containerPath } = this.props;
-        const { activeJobIconCls, showActiveJobIcon } = config;
+export const ProductMenuSection: FC<MenuSectionProps> = memo(props => {
+    const { config, section, currentProductId, containerPath } = props;
 
-        if (!section) return null;
+    if (!section) return null;
 
-        let icon;
-        if (config.iconURL) {
-            icon = (
-                <img
-                    alt={section.label + ' icon'}
-                    className={'menu-section-image ' + (config.iconCls || '')}
-                    src={config.iconURL}
-                    height="24px"
-                    width="24px"
-                />
-            );
-        } else if (config.iconCls) {
-            icon = <span className={(config.iconCls || '') + ' menu-section-icon'} />;
-        }
-        const headerText = config.headerText ?? section.label;
-        const label = icon ? (
-            <>
-                {icon} {headerText}
-            </>
-        ) : (
-            headerText
+    let icon: ReactNode;
+    if (config.iconURL) {
+        icon = (
+            <img
+                alt={section.label + ' icon'}
+                className={'menu-section-image ' + (config.iconCls || '')}
+                src={config.iconURL}
+                height="24px"
+                width="24px"
+            />
         );
+    } else if (config.iconCls) {
+        icon = <span className={(config.iconCls || '') + ' menu-section-icon'} />;
+    }
+    const headerText = config.headerText ?? section.label;
+    const label = icon ? (
+        <>
+            {icon} {headerText}
+        </>
+    ) : (
+        headerText
+    );
+
+    // In order to make sure we don't break useRouteLeave we need to use <Link> for AppURLs and <a> for non-app URLs
+    let headerEl = label;
+    if (headerEl) {
         const headerURL = config.useOriginalURL
             ? section.url
             : createProductUrlFromPartsWithContainer(
@@ -96,60 +104,51 @@ export class ProductMenuSection extends PureComponent<MenuSectionProps> {
                   undefined,
                   config.headerURLPart ?? section.key
               );
-        const headerURLIsAppURL = headerURL instanceof AppURL;
-        let headerEl = label;
-        let emptyLink;
 
-        // In order to make sure we don't break useRouteLeave we need to use <Link> for AppURLs and <a> for non-app URLs
-        if (headerURL && headerURLIsAppURL) {
+        if (headerURL instanceof AppURL) {
             headerEl = <Link to={headerURL.toString()}>{label}</Link>;
-        } else if (headerURL && !headerURLIsAppURL) {
+        } else {
             headerEl = <a href={getHref(headerURL)}>{label}</a>;
         }
+    }
 
-        if (config.emptyAppURL) {
-            const emptyURL = createProductUrl(section.productId, currentProductId, config.emptyAppURL, containerPath);
-            if (emptyURL instanceof AppURL) emptyLink = <Link to={emptyURL.toString()}>{config.emptyURLText}</Link>
-            else emptyLink = <a href={emptyURL}>{config.emptyURLText}</a>
+    let emptyLink: ReactNode;
+    if (config.emptyAppURL) {
+        const emptyURL = createProductUrl(section.productId, currentProductId, config.emptyAppURL, containerPath);
+        if (emptyURL instanceof AppURL) {
+            emptyLink = <Link to={emptyURL.toString()}>{config.emptyURLText}</Link>;
+        } else {
+            emptyLink = <a href={emptyURL}>{config.emptyURLText}</a>;
         }
+    }
 
-        const visibleItems = section.items.filter(item => !item.hidden);
+    const visibleItems = section.items.filter(item => !item.hidden).sortBy(item => item.label, naturalSort);
+    const isEmpty = section.items.isEmpty() || visibleItems.isEmpty();
 
-        return (
-            <ul>
-                <li className="menu-section-header clickable-item">
-                    {headerEl}
-                </li>
-                <li>
-                    <hr />
-                </li>
-                {section.items.isEmpty() || visibleItems.isEmpty() ? (
-                    <>
-                        {(config.emptyText || config.filteredEmptyText) && (
-                            <li className="empty-section">
-                                {section.items.isEmpty() ? config.emptyText : config.filteredEmptyText}
-                            </li>
-                        )}
-                        {emptyLink && (
-                            <li className="empty-section-link">
-                                {emptyLink}
-                            </li>
-                        )}
-                    </>
-                ) : (
-                    visibleItems
-                        .sortBy(item => item.label, naturalSort)
-                        .map(item => {
-                            const labelDisplay =
-                                item.hasActiveJob && showActiveJobIcon ? (
-                                    <>
-                                        <i className={classNames('fa', activeJobIconCls)} />
-                                        <span className="spacer-left product-menu-item">{item.label}</span>
-                                    </>
-                                ) : (
-                                    item.label
-                                );
-
+    return (
+        <>
+            <div className="product-menu-section-header">
+                <ul>
+                    <li className="menu-section-header clickable-item">{headerEl}</li>
+                    <li>
+                        <hr />
+                    </li>
+                </ul>
+            </div>
+            <div className="product-menu-section">
+                <ul>
+                    {isEmpty && (
+                        <>
+                            {(config.emptyText || config.filteredEmptyText) && (
+                                <li className="empty-section">
+                                    {section.items.isEmpty() ? config.emptyText : config.filteredEmptyText}
+                                </li>
+                            )}
+                            {emptyLink && <li className="empty-section-link">{emptyLink}</li>}
+                        </>
+                    )}
+                    {!isEmpty &&
+                        visibleItems.map(item => {
                             if (item.url) {
                                 return (
                                     <li key={item.label} className="clickable-item">
@@ -157,10 +156,17 @@ export class ProductMenuSection extends PureComponent<MenuSectionProps> {
                                     </li>
                                 );
                             }
-                            return <li key={item.label}>{labelDisplay}</li>;
-                        })
-                )}
-            </ul>
-        );
-    }
-}
+
+                            return (
+                                <li key={item.label}>
+                                    <MenuSectionItemLabel config={config} item={item} />
+                                </li>
+                            );
+                        })}
+                </ul>
+            </div>
+        </>
+    );
+});
+
+ProductMenuSection.displayName = 'ProductMenuSection';

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProductMenuSection render empty section no text 1`] = `
+exports[`ProductMenuSection empty section no text 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
@@ -31,22 +31,31 @@ exports[`ProductMenuSection render empty section no text 1`] = `
     }
   }
 >
-  <ul>
-    <li
-      className="menu-section-header clickable-item"
-    >
-      <Link
-        to="/samples"
-      />
-    </li>
-    <li>
-      <hr />
-    </li>
-  </ul>
+  <div
+    className="product-menu-section-header"
+  >
+    <ul>
+      <li
+        className="menu-section-header clickable-item"
+      >
+        <Link
+          to="/samples"
+        />
+      </li>
+      <li>
+        <hr />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="product-menu-section"
+  >
+    <ul />
+  </div>
 </ProductMenuSection>
 `;
 
-exports[`ProductMenuSection render empty section with empty text and create link 1`] = `
+exports[`ProductMenuSection empty section with empty text and create link 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
@@ -77,27 +86,37 @@ exports[`ProductMenuSection render empty section with empty text and create link
     }
   }
 >
-  <ul>
-    <li
-      className="menu-section-header clickable-item"
-    >
-      <Link
-        to="/samples"
-      />
-    </li>
-    <li>
-      <hr />
-    </li>
-    <li
-      className="empty-section"
-    >
-      Test empty text
-    </li>
-  </ul>
+  <div
+    className="product-menu-section-header"
+  >
+    <ul>
+      <li
+        className="menu-section-header clickable-item"
+      >
+        <Link
+          to="/samples"
+        />
+      </li>
+      <li>
+        <hr />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="product-menu-section"
+  >
+    <ul>
+      <li
+        className="empty-section"
+      >
+        Test empty text
+      </li>
+    </ul>
+  </div>
 </ProductMenuSection>
 `;
 
-exports[`ProductMenuSection render not empty, but all items hidden 1`] = `
+exports[`ProductMenuSection not empty, but all items hidden 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
@@ -153,27 +172,37 @@ exports[`ProductMenuSection render not empty, but all items hidden 1`] = `
     }
   }
 >
-  <ul>
-    <li
-      className="menu-section-header clickable-item"
-    >
-      <Link
-        to="/samples"
-      />
-    </li>
-    <li>
-      <hr />
-    </li>
-    <li
-      className="empty-section"
-    >
-      Empty due to exclusion
-    </li>
-  </ul>
+  <div
+    className="product-menu-section-header"
+  >
+    <ul>
+      <li
+        className="menu-section-header clickable-item"
+      >
+        <Link
+          to="/samples"
+        />
+      </li>
+      <li>
+        <hr />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="product-menu-section"
+  >
+    <ul>
+      <li
+        className="empty-section"
+      >
+        Empty due to exclusion
+      </li>
+    </ul>
+  </div>
 </ProductMenuSection>
 `;
 
-exports[`ProductMenuSection render one column section 1`] = `
+exports[`ProductMenuSection one column section 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
@@ -265,47 +294,217 @@ exports[`ProductMenuSection render one column section 1`] = `
     }
   }
 >
-  <ul>
-    <li
-      className="menu-section-header clickable-item"
-    >
-      <Link
-        to="/assays"
-      />
-    </li>
-    <li>
-      <hr />
-    </li>
-    <li
-      key="Assay 1"
-    >
-      Assay 1
-    </li>
-    <li
-      key="Assay 2"
-    >
-      Assay 2
-    </li>
-    <li
-      key="Assay 3"
-    >
-      Assay 3
-    </li>
-    <li
-      key="Assay 4"
-    >
-      Assay 4
-    </li>
-    <li
-      key="Assay 5"
-    >
-      Assay 5
-    </li>
-  </ul>
+  <div
+    className="product-menu-section-header"
+  >
+    <ul>
+      <li
+        className="menu-section-header clickable-item"
+      >
+        <Link
+          to="/assays"
+        />
+      </li>
+      <li>
+        <hr />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="product-menu-section"
+  >
+    <ul>
+      <li
+        key="Assay 1"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct4Columns/images/assays.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 11,
+              "key": undefined,
+              "label": "Assay 1",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Assay 1
+        </MenuSectionItemLabel>
+      </li>
+      <li
+        key="Assay 2"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct4Columns/images/assays.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 12,
+              "key": undefined,
+              "label": "Assay 2",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Assay 2
+        </MenuSectionItemLabel>
+      </li>
+      <li
+        key="Assay 3"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct4Columns/images/assays.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 13,
+              "key": undefined,
+              "label": "Assay 3",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Assay 3
+        </MenuSectionItemLabel>
+      </li>
+      <li
+        key="Assay 4"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct4Columns/images/assays.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 14,
+              "key": undefined,
+              "label": "Assay 4",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Assay 4
+        </MenuSectionItemLabel>
+      </li>
+      <li
+        key="Assay 5"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct4Columns/images/assays.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 15,
+              "key": undefined,
+              "label": "Assay 5",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Assay 5
+        </MenuSectionItemLabel>
+      </li>
+    </ul>
+  </div>
 </ProductMenuSection>
 `;
 
-exports[`ProductMenuSection render one-column section 1`] = `
+exports[`ProductMenuSection one-column section 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
@@ -385,49 +584,187 @@ exports[`ProductMenuSection render one-column section 1`] = `
     }
   }
 >
-  <ul>
-    <li
-      className="menu-section-header clickable-item"
-    >
-      <Link
-        to="/samples"
-      />
-    </li>
-    <li>
-      <hr />
-    </li>
-    <li
-      key="Sample Set 1"
-    >
-      Sample Set 1
-    </li>
-    <li
-      key="Sample Set 2"
-    >
-      <i
-        className="fa fa-spinner fa-pulse"
-      />
-      <span
-        className="spacer-left product-menu-item"
+  <div
+    className="product-menu-section-header"
+  >
+    <ul>
+      <li
+        className="menu-section-header clickable-item"
       >
-        Sample Set 2
-      </span>
-    </li>
-    <li
-      key="Sample Set 3"
-    >
-      Sample Set 3
-    </li>
-    <li
-      key="Sample Set 4"
-    >
-      Sample Set 4
-    </li>
-  </ul>
+        <Link
+          to="/samples"
+        />
+      </li>
+      <li>
+        <hr />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="product-menu-section"
+  >
+    <ul>
+      <li
+        key="Sample Set 1"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct3Columns/images/samples.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 1,
+              "key": undefined,
+              "label": "Sample Set 1",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Sample Set 1
+        </MenuSectionItemLabel>
+      </li>
+      <li
+        key="Sample Set 2"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct3Columns/images/samples.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 2,
+              "key": undefined,
+              "label": "Sample Set 2",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": true,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          <i
+            className="fa fa-spinner fa-pulse"
+          />
+          <span
+            className="spacer-left product-menu-item"
+          >
+            Sample Set 2
+          </span>
+        </MenuSectionItemLabel>
+      </li>
+      <li
+        key="Sample Set 3"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct3Columns/images/samples.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 3,
+              "key": undefined,
+              "label": "Sample Set 3",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Sample Set 3
+        </MenuSectionItemLabel>
+      </li>
+      <li
+        key="Sample Set 4"
+      >
+        <MenuSectionItemLabel
+          config={
+            Immutable.Record {
+              "activeJobIconCls": "fa-spinner fa-pulse",
+              "emptyText": undefined,
+              "filteredEmptyText": undefined,
+              "emptyAppURL": undefined,
+              "emptyURLText": "Get started...",
+              "headerURLPart": undefined,
+              "headerText": undefined,
+              "iconCls": undefined,
+              "iconURL": "/testProduct3Columns/images/samples.svg",
+              "showActiveJobIcon": true,
+              "useOriginalURL": false,
+            }
+          }
+          item={
+            Immutable.Record {
+              "id": 4,
+              "key": undefined,
+              "label": "Sample Set 4",
+              "url": undefined,
+              "hidden": false,
+              "orderNum": undefined,
+              "originalUrl": undefined,
+              "requiresLogin": false,
+              "hasActiveJob": false,
+              "fromSharedContainer": false,
+            }
+          }
+        >
+          Sample Set 4
+        </MenuSectionItemLabel>
+      </li>
+    </ul>
+  </div>
 </ProductMenuSection>
 `;
 
-exports[`ProductMenuSection render section with custom headerURL and headerText 1`] = `
+exports[`ProductMenuSection section with custom headerURL and headerText 1`] = `
 <ProductMenuSection
   config={
     Immutable.Record {
@@ -463,17 +800,26 @@ exports[`ProductMenuSection render section with custom headerURL and headerText 
     }
   }
 >
-  <ul>
-    <li
-      className="menu-section-header clickable-item"
-    >
-      <Link
-        to="%2Fsample%2Fnew%3Fsort%3Ddate"
-      />
-    </li>
-    <li>
-      <hr />
-    </li>
-  </ul>
+  <div
+    className="product-menu-section-header"
+  >
+    <ul>
+      <li
+        className="menu-section-header clickable-item"
+      >
+        <Link
+          to="%2Fsample%2Fnew%3Fsort%3Ddate"
+        />
+      </li>
+      <li>
+        <hr />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="product-menu-section"
+  >
+    <ul />
+  </div>
 </ProductMenuSection>
 `;

--- a/packages/components/src/internal/useNavMenuState.ts
+++ b/packages/components/src/internal/useNavMenuState.ts
@@ -1,10 +1,10 @@
 import { Dispatch, MutableRefObject, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
 
 interface ProductMenuState {
-    show: boolean;
-    setShow: Dispatch<SetStateAction<boolean>>;
-    toggleRef: MutableRefObject<HTMLButtonElement>;
     menuRef: MutableRefObject<HTMLDivElement>;
+    setShow: Dispatch<SetStateAction<boolean>>;
+    show: boolean;
+    toggleRef: MutableRefObject<HTMLButtonElement>;
 }
 
 /**
@@ -30,6 +30,9 @@ export function useNavMenuState(): ProductMenuState {
         if (show) {
             document.addEventListener('click', onDocumentClick);
         }
+
+        // Prevent scrolling the body when a navigation menu is shown
+        document.body.classList.toggle('no-scroll', show);
 
         return () => {
             document.removeEventListener('click', onDocumentClick);

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -692,6 +692,10 @@
     height: 100%;
 }
 
+.col-product-section:first-child {
+    padding-left: 8px;
+}
+
 .col-product-section:last-child {
     padding-right: 8px;
 }

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -161,33 +161,8 @@
     left: -62px;
     width: 925px;
     margin-top: 1px;
-    /* Works on Firefox */
-    * {
-        scrollbar-width: thin;
-        scrollbar-color: $light-gray $white;
-    }
-
-    /* Works on Chrome, Edge, and Safari */
-    *::-webkit-scrollbar {
-        width: 12px;
-    }
-
-    *::-webkit-scrollbar-track {
-        background-color: $white;
-    }
-
-    *::-webkit-scrollbar-thumb {
-        background-color: $light-gray;
-        border-radius: 20px;
-        border: 3px solid $white;
-    }
-
-  .sections-content {
-      display: inline;
-  }
 
   .col-folders {
-      width: 25%;
       background-color: $gray-shadow;
       border-radius: 4px 0 0 4px;
       padding-left: 8px;
@@ -240,43 +215,9 @@
       }
   }
 
-  &.with-col-folders {
-      .col-product-section {
-          width: 15%;
-      }
-      &.with-section-count-4 .col-product-section {
-          width: 18%;
-      }
-      &.with-section-count-3 .col-product-section {
-          width: 25%;
-      }
-  }
-  &:not(.with-col-folders) {
-      padding-left: 8px;
-
-      .col-product-section {
-          width: 20%;
-      }
-      &.with-section-count-4 .col-product-section {
-          width: 25%;
-      }
-      &.with-section-count-3 .col-product-section {
-          width: 33%;
-      }
-  }
-
-  .col-product-section:last-child {
-      padding-right: 8px;
-  }
-
   .menu-section {
-    vertical-align: top;
-    display: inline-block;
     word-break: break-word;
     padding-bottom: 16px;
-    height: 100%;
-    overflow-x: hidden;
-    overflow-y: auto;
 
     .menu-section-header {
       font-family: FontAwesome, $font-family-sans-serif;
@@ -295,9 +236,6 @@
     }
 
     ul {
-      display: inline-block;
-      width: 100%;
-      vertical-align: top;
       list-style-type: none;
       margin: 0;
       padding: 0;
@@ -728,4 +666,45 @@
 .navbar-item.visible-xs.pull-right > .btn-group.open.dropdown-toggle:active {
     background-color: transparent !important;
     box-shadow: none;
+}
+
+.product-menu-content-body {
+    display: flex;
+    height: 100%;
+}
+
+.product-menu-content-body .col-folders {
+    flex: 25;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.product-menu-content-body .sections-content {
+    display: flex;
+    flex: 75;
+}
+
+.col-product-section {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    flex-grow: 2;
+    height: 100%;
+}
+
+.col-product-section:last-child {
+    padding-right: 8px;
+}
+
+.product-menu-section-header {
+    height: 62px;
+}
+
+.product-menu-section {
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.no-scroll {
+    overflow: hidden;
 }


### PR DESCRIPTION
#### Rationale
This updates the `ProductMenu` (often referred to as the "Mega Menu") to utilize flex layout for menu sections. This simplifies the layout logic that is necessary and makes it so we can include static menu sections (e.g. plates) underneath dynamic menu sections (e.g. samples).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1469
- https://github.com/LabKey/limsModules/pull/125
- https://github.com/LabKey/testAutomation/pull/1888

#### Changes
- Update product menu DOM structure to better support flex layout container/item paradigm.
- Use flex layout both horizontally (row-wise) across the product and vertically (column-wise) within each section column.
- Scroll within dynamic menu sections leaving the section headers position constant.
- Apply a "no-scroll" CSS class to the document body when product navigation is open. This prevents page scrolling.
