### PR TITLE
ProductMenu: improve layout of static menu sections

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.3",
+  "version": "3.39.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.39.3",
+      "version": "3.39.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.3",
+  "version": "3.39.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.39.4
+*Released*: 19 April 2024
+- Fix `ProductMenu` layout for static menu sections
+
 ### version 3.39.3
 *Released*: 19 April 2024
 - Issue 49792: Details tooltip sometimes cut off

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -512,6 +512,7 @@ export function addAssaysSectionConfig(
 export function getPlatesSectionConfig(): MenuSectionConfig {
     return new MenuSectionConfig({
         iconURL: imageURL('_images', 'plates.svg'),
+        staticContent: true,
     });
 }
 
@@ -552,6 +553,7 @@ const USER_SECTION_CONFIG = new MenuSectionConfig({
 const REQUESTS_SECTION_CONFIG = new MenuSectionConfig({
     useOriginalURL: true,
     iconURL: imageURL('_images', 'default.svg'),
+    staticContent: true,
 });
 
 function getBioWorkflowNotebookMediaConfigs(): Map<string, MenuSectionConfig> {

--- a/packages/components/src/internal/components/navigation/ProductMenu.spec.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.spec.tsx
@@ -1,18 +1,3 @@
-/*
- * Copyright (c) 2019 LabKey Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import React, { createRef } from 'react';
 import { ReactWrapper } from 'enzyme';
 import { List, Map } from 'immutable';
@@ -282,7 +267,6 @@ describe('ProductMenu', () => {
     function getDefaultProps(): ProductMenuProps {
         return {
             appProperties: SAMPLE_MANAGER_APP_PROPERTIES,
-            className: 'test-cls',
             error: undefined,
             folderItems: [],
             menuRef: createRef(),

--- a/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenuSection.tsx
@@ -135,7 +135,7 @@ export const ProductMenuSection: FC<MenuSectionProps> = memo(props => {
                     </li>
                 </ul>
             </div>
-            <div className="product-menu-section">
+            <div className={classNames('product-menu-section', { 'menu-section-static': config.staticContent })}>
                 <ul>
                     {isEmpty && (
                         <>

--- a/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
+++ b/packages/components/src/internal/components/navigation/__snapshots__/ProductMenuSection.spec.tsx.snap
@@ -14,6 +14,7 @@ exports[`ProductMenuSection empty section no text 1`] = `
       "iconCls": undefined,
       "iconURL": "/testProduct/images/samples.svg",
       "showActiveJobIcon": true,
+      "staticContent": false,
       "useOriginalURL": false,
     }
   }
@@ -69,6 +70,7 @@ exports[`ProductMenuSection empty section with empty text and create link 1`] = 
       "iconCls": undefined,
       "iconURL": "/testProduct/images/samples.svg",
       "showActiveJobIcon": true,
+      "staticContent": false,
       "useOriginalURL": false,
     }
   }
@@ -130,6 +132,7 @@ exports[`ProductMenuSection not empty, but all items hidden 1`] = `
       "iconCls": undefined,
       "iconURL": "/testProduct/images/samples.svg",
       "showActiveJobIcon": true,
+      "staticContent": false,
       "useOriginalURL": false,
     }
   }
@@ -216,6 +219,7 @@ exports[`ProductMenuSection one column section 1`] = `
       "iconCls": undefined,
       "iconURL": "/testProduct4Columns/images/assays.svg",
       "showActiveJobIcon": true,
+      "staticContent": false,
       "useOriginalURL": false,
     }
   }
@@ -330,6 +334,7 @@ exports[`ProductMenuSection one column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct4Columns/images/assays.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -367,6 +372,7 @@ exports[`ProductMenuSection one column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct4Columns/images/assays.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -404,6 +410,7 @@ exports[`ProductMenuSection one column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct4Columns/images/assays.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -441,6 +448,7 @@ exports[`ProductMenuSection one column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct4Columns/images/assays.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -478,6 +486,7 @@ exports[`ProductMenuSection one column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct4Columns/images/assays.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -518,6 +527,7 @@ exports[`ProductMenuSection one-column section 1`] = `
       "iconCls": undefined,
       "iconURL": "/testProduct3Columns/images/samples.svg",
       "showActiveJobIcon": true,
+      "staticContent": false,
       "useOriginalURL": false,
     }
   }
@@ -620,6 +630,7 @@ exports[`ProductMenuSection one-column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct3Columns/images/samples.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -657,6 +668,7 @@ exports[`ProductMenuSection one-column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct3Columns/images/samples.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -701,6 +713,7 @@ exports[`ProductMenuSection one-column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct3Columns/images/samples.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -738,6 +751,7 @@ exports[`ProductMenuSection one-column section 1`] = `
               "iconCls": undefined,
               "iconURL": "/testProduct3Columns/images/samples.svg",
               "showActiveJobIcon": true,
+              "staticContent": false,
               "useOriginalURL": false,
             }
           }
@@ -783,6 +797,7 @@ exports[`ProductMenuSection section with custom headerURL and headerText 1`] = `
       "iconCls": undefined,
       "iconURL": "/testProduct/images/samples.svg",
       "showActiveJobIcon": true,
+      "staticContent": false,
       "useOriginalURL": false,
     }
   }

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -234,6 +234,7 @@ export class MenuSectionConfig extends Record({
     iconCls: undefined,
     iconURL: undefined,
     showActiveJobIcon: true,
+    staticContent: false,
     useOriginalURL: false,
 }) {
     declare activeJobIconCls?: string;
@@ -246,5 +247,8 @@ export class MenuSectionConfig extends Record({
     declare iconCls?: string;
     declare iconURL?: string;
     declare showActiveJobIcon?: boolean;
+    // Inform the display that this section's content is static (unchanging).
+    // This helps inform the layout when these sections are laid out alongside sections with dynamic content.
+    declare staticContent?: boolean;
     declare useOriginalURL?: boolean;
 }

--- a/packages/components/src/theme/navbar.scss
+++ b/packages/components/src/theme/navbar.scss
@@ -688,8 +688,6 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    flex-grow: 2;
-    height: 100%;
 }
 
 .col-product-section:first-child {
@@ -705,8 +703,16 @@
 }
 
 .product-menu-section {
+    flex-shrink: 1;
     overflow-x: hidden;
     overflow-y: auto;
+}
+
+// This allows for menu sections with static content to grow to their content
+// while non-static sections default to shrink.
+.menu-section-static {
+    flex-grow: 1;
+    flex-shrink: 0;
 }
 
 .no-scroll {


### PR DESCRIPTION
#### Rationale
This addresses a small layout problem introduced by #1469 where static content menu sections (e.g. "Requests", "Plates") are getting squeezed out by the dynamic content menu sections (e.g. "Sample Types", "Storage"). The fix is to utilize `flex-grow` and `flex-shrink` attributes on the menu sections depending on if the content is static.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/172

#### Changes
- Introduce `staticContent` bit on `MenuSectionConfig` and set the property for appropriate menu sections.
- Add `menu-section-static` CSS class to static content menu sections.
