### PR TITLE
Add support for export storage map

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.6-exportStorageMap.0",
+  "version": "3.39.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.39.6-exportStorageMap.0",
+      "version": "3.39.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.2-exportStorageMap.0",
+  "version": "3.39.4-exportStorageMap.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.39.2-exportStorageMap.0",
+      "version": "3.39.4-exportStorageMap.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.38.4-exportStorageMap.0",
+  "version": "3.39.2-exportStorageMap.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.38.4-exportStorageMap.0",
+      "version": "3.39.2-exportStorageMap.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.5-exportStorageMap.0",
+  "version": "3.39.6-exportStorageMap.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.39.5-exportStorageMap.0",
+      "version": "3.39.6-exportStorageMap.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.1",
+  "version": "3.38.4-exportStorageMap.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.39.1",
+      "version": "3.38.4-exportStorageMap.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.4-exportStorageMap.0",
+  "version": "3.39.5-exportStorageMap.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.39.4-exportStorageMap.0",
+      "version": "3.39.5-exportStorageMap.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.1",
+  "version": "3.39.2-exportStorageMap.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.39.6-exportStorageMap.0",
+  "version": "3.39.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 3.39.6
+*Released*: 25 April 2024
 - Add support for exporting a storage map from terminal storage grids
 
 ### version 3.39.5

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Add support for exporting a storage map from terminal storage grids
+
 ### version 3.39.1
 *Released*: 18 April 2024
 - Update CSS for notebook review status pills

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -273,9 +273,6 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
     } else if (type === EXPORT_TYPES.LABEL) {
         controller = BARTENDER_EXPORT_CONTROLLER;
         action = 'printBarTenderLabels.post';
-    } else if (type === EXPORT_TYPES.STORAGE_MAP) {
-        controller = STORAGE_MAP_EXPORT_CONTROLLER;
-        action = 'exportStorageMap.api';
     } else {
         throw new Error('Unknown export type: ' + type);
     }

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -28,6 +28,7 @@ import {
     EXPORT_TYPES,
     FASTA_EXPORT_CONTROLLER,
     GENBANK_EXPORT_CONTROLLER,
+    STORAGE_MAP_EXPORT_CONTROLLER,
     VIEW_NOT_FOUND_EXCEPTION_CLASS,
 } from './constants';
 import { DataViewInfo } from './DataViewInfo';
@@ -272,6 +273,9 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
     } else if (type === EXPORT_TYPES.LABEL) {
         controller = BARTENDER_EXPORT_CONTROLLER;
         action = 'printBarTenderLabels.post';
+    } else if (type === EXPORT_TYPES.STORAGE_MAP) {
+        controller = STORAGE_MAP_EXPORT_CONTROLLER;
+        action = 'exportStorageMap.api';
     } else {
         throw new Error('Unknown export type: ' + type);
     }

--- a/packages/components/src/internal/constants.ts
+++ b/packages/components/src/internal/constants.ts
@@ -27,6 +27,7 @@ export const FASTA_EXPORT_CONTROLLER = 'biologics';
 export const GENBANK_EXPORT_CONTROLLER = 'biologics';
 export const BARTENDER_EXPORT_CONTROLLER = 'sampleManager';
 export const SAMPLE_SET_DISPLAY_TEXT = 'Sample Type';
+export const STORAGE_MAP_EXPORT_CONTROLLER = 'inventory';
 
 export const MAX_EDITABLE_GRID_ROWS = 1000;
 export const LOOKUP_DEFAULT_SIZE = 25;
@@ -43,6 +44,7 @@ export enum EXPORT_TYPES {
     FASTA,
     GENBANK,
     LABEL,
+    STORAGE_MAP,
 }
 
 export enum KEYS {

--- a/packages/components/src/public/QueryModel/ExportMenu.tsx
+++ b/packages/components/src/public/QueryModel/ExportMenu.tsx
@@ -30,6 +30,7 @@ const exportOptions = [
     { type: EXPORT_TYPES.EXCEL, icon: 'fa-file-excel-o', label: 'Excel' },
     { type: EXPORT_TYPES.TSV, icon: 'fa-file-text-o', label: 'TSV' },
     { type: EXPORT_TYPES.LABEL, icon: 'fa-tag', label: 'Label', hidden: true },
+    { type: EXPORT_TYPES.STORAGE_MAP, icon: 'fa-file-excel-o', label: 'Storage Map (Excel)', hidden: true },
     // Note: EXPORT_TYPES and exportRows (used in export function below) also include support for FASTA and GENBANK,
     // but they were never used in the QueryGridPanel version of export. We're explicitly not supporting them in
     // this implementation until we need them.
@@ -50,11 +51,24 @@ const ExportMenuItem: FC<ExportMenuItemProps> = ({ hasSelections, onExport, opti
     if (option.hidden && !supportedTypes?.includes(option.type)) return null;
 
     if (option.type === EXPORT_TYPES.LABEL) {
-        const exportAndPrintHeader = 'Export and Print' + (hasSelections ? ' Selected' : '');
+        const exportAndPrintHeader = 'Export and Print' + (hasSelections ? ' Selected Data' : ' Data');
         return (
             <React.Fragment key={option.type}>
                 <MenuDivider />
                 <MenuHeader text={exportAndPrintHeader} />
+                <MenuItem onClick={onClick}>
+                    <span className={`fa ${option.icon} export-menu-icon`} />
+                    &nbsp; {option.label}
+                </MenuItem>
+            </React.Fragment>
+        );
+    }
+
+    if (option.type === EXPORT_TYPES.STORAGE_MAP) {
+        return (
+            <React.Fragment key={option.type}>
+                <MenuDivider />
+                <MenuHeader text="Export Map" />
                 <MenuItem onClick={onClick}>
                     <span className={`fa ${option.icon} export-menu-icon`} />
                     &nbsp; {option.label}
@@ -95,7 +109,7 @@ const ExportMenuImpl: FC<ExportMenuImplProps> = memo(props => {
         [exportHandler, id, onExport]
     );
 
-    const exportHeader = 'Export' + (hasSelections ? ' Selected' : '');
+    const exportHeader = 'Export' + (hasSelections ? ' Selected' : '') + ' Data';
 
     return (
         hasData && (


### PR DESCRIPTION
#### Rationale
We are adding an item to the Export menu for terminal storage units. This item will produce an Excel spreadsheet containing the data in the default view for the samples in the terminal storage unit. We always export all samples, regardless of the grid selection.  Because of the desire to distinguish between exporting the data and exporting the storage map, we've relabeled the "Data" section with the word "Data" (and labeled the map section as "Export Map").

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/184
- https://github.com/LabKey/platform/pull/5448

#### Changes
- add `EXPORT_TYPES.STORAGE_MAP` and corresponding menu item
- update text in export menu section headers
