### PR TITLE
Issue 49852 - Don't attempt to render tiff thumbnails

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.40.0",
+  "version": "3.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.40.0",
+      "version": "3.40.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.40.0",
+  "version": "3.40.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.40.0
+### version 3.40.1
 *Released*: 29 April 2024
 - No longer include `tif` files in the `isImage` check
   - Most browsers cannot render `tif` files

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,6 +3,12 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 3.40.0
 *Released*: 29 April 2024
+- No longer include `tif` files in the `isImage` check
+  - Most browsers cannot render `tif` files
+  - Fixes Issue 49852
+
+### version 3.40.0
+*Released*: 29 April 2024
 - Support cross-folder "Edit in Bulk"
   - Update getOperationNotPermittedMessage to work for both Edit in Grid and Edit in Bulk scenarios
   - BulkUpdateForm getUpdatedData() to include Folder in updated rows, if it exists in originalData

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -472,7 +472,8 @@ function getFileExtensionType(value: string): string {
 }
 
 export function isImage(value): boolean {
-    const validImageExtensions = ['jpg', 'jpeg', 'bmp', 'gif', 'ico', 'png', 'svg', 'tif'];
+    // Note: don't add tif, or tiff here, most browsers will not render them (see Issue 49852)
+    const validImageExtensions = ['jpg', 'jpeg', 'bmp', 'gif', 'ico', 'png', 'svg'];
     const extensionType = getFileExtensionType(value);
     return validImageExtensions.indexOf(extensionType) > -1;
 }


### PR DESCRIPTION
#### Rationale
Our attachment related components (AttachmentCard, FileColumnRenderer) attempt to render TIFF files, however most browsers do not support rendering TIFF files. This PR updates `isImage` to not include `tif` or `tiff` extensions.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1483
- https://github.com/LabKey/labkey-ui-premium/pull/399
- https://github.com/LabKey/limsModules/pull/202

#### Changes
- Remove `tif` from supported image extensions