### PR TITLE
Issue 50084: Add `onError` callback property for `FileAttachmentForm`

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.41.0",
+  "version": "3.41.1-virusUploadError.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.41.0",
+      "version": "3.41.1-virusUploadError.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.41.1-virusUploadError.0",
+  "version": "3.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.41.1-virusUploadError.0",
+      "version": "3.42.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.41.0",
+  "version": "3.41.1-virusUploadError.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.41.1-virusUploadError.0",
+  "version": "3.42.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
+### version 3.42.0
+*Released*: 6 May 2024
 - Issue 50084: Add onError handler for FileAttachmentForm to allow appropriate behavior by wrapping components when errors are detected
 
 ### version 3.41.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+- Issue 50084: Add onError handler for FileAttachmentForm to allow appropriate behavior by wrapping components when errors are detected
+
 ### version 3.41.0
 *Released*: 30 April 2024
 - Support prop `ExtraExportMenuOptions` on ExportMenu component

--- a/packages/components/src/public/files/FileAttachmentForm.tsx
+++ b/packages/components/src/public/files/FileAttachmentForm.tsx
@@ -52,6 +52,7 @@ interface FileAttachmentFormProps {
     label?: string;
     labelLong?: string;
     onCancel?: () => void;
+    onError?: (error: string) => void;
     onFileChange?: (files: Map<string, File>) => void;
     onFileRemoval?: (attachmentName: string) => void;
     // map between file extension and the callback function to use instead of the standard uploadDataFileForPreview
@@ -283,6 +284,9 @@ export class FileAttachmentForm extends React.Component<FileAttachmentFormProps,
     }
 
     updateErrors(errorMessage: string): void {
+        if (errorMessage) {
+            this.props.onError?.(errorMessage);
+        }
         this.setState(() => ({ errorMessage }));
     }
 


### PR DESCRIPTION
#### Rationale
Issue [50084](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50084)

#### Related Pull Requests

- https://github.com/LabKey/labkey-ui-premium/pull/405
- https://github.com/LabKey/limsModules/pull/225


#### Changes
- Add `onError` callback property to `FileAttachmentForm`
