### PR TITLE
Issue 50319:  Add sample status fields for lineage details query config

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.41.0",
+  "version": "3.41.1-lineageSampleStatus.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.41.0",
+      "version": "3.41.1-lineageSampleStatus.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.41.1-lineageSampleStatus.0",
+  "version": "3.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.41.1-lineageSampleStatus.0",
+      "version": "3.42.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.42.1-lineageSampleStatus.0",
+  "version": "3.42.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.41.0",
+  "version": "3.41.1-lineageSampleStatus.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD
+### version 3.42.1
+*Released*: 6 May 2024
 - Issue 50319: Sample status tag display issues on lineage sample detail panel
 
 ### version 3.42.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD
+- Issue 50319: Sample status tag display issues on lineage sample detail panel
+
 ### version 3.41.0
 *Released*: 30 April 2024
 - Support prop `ExtraExportMenuOptions` on ExportMenu component

--- a/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
@@ -10,6 +10,7 @@ import { SchemaQuery } from '../../../../public/SchemaQuery';
 import { ViewInfo } from '../../../ViewInfo';
 import { QueryColumn } from '../../../../public/QueryColumn';
 import { InjectedQueryModels, QueryConfigMap, withQueryModels } from '../../../../public/QueryModel/withQueryModels';
+import { SAMPLE_STATE_COLOR_COLUMN_NAME, SAMPLE_STATE_TYPE_COLUMN_NAME } from '../../samples/constants';
 
 const ADDITIONAL_DETAIL_FIELDS = ['properties'];
 
@@ -48,7 +49,7 @@ export const LineageDetail: FC<LineageDetailProps> = memo(({ item }) => {
                 // Issue 45028: Display details view columns in lineage
                 schemaQuery: new SchemaQuery(item.schemaName, item.queryName, ViewInfo.DETAIL_NAME),
                 // Must specify '*' columns be requested to resolve "properties" columns
-                requiredColumns: ['*'],
+                requiredColumns: ['*', SAMPLE_STATE_COLOR_COLUMN_NAME, SAMPLE_STATE_TYPE_COLUMN_NAME],
             },
         }),
         [item]

--- a/packages/components/src/internal/components/samples/SampleStatusTag.test.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusTag.test.tsx
@@ -151,7 +151,7 @@ describe('getStatusTagStyle', () => {
             borderColor: 'lightgray',
         });
         expect(getStatusTagStyle({ color: undefined, label: 'Custom', statusType: undefined })).toStrictEqual({
-            color: 'white',
+            color: '#555555',
             backgroundColor: undefined,
             borderColor: 'lightgray',
         });

--- a/packages/components/src/internal/components/samples/SampleStatusTag.tsx
+++ b/packages/components/src/internal/components/samples/SampleStatusTag.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 // exported for Jest test
 export function hexToRGB(hex: string): number[] {
-    const bigInt = parseInt(hex?.replace('#', ''), 16);
+    const bigInt = hex ? parseInt(hex?.replace('#', ''), 16) : 0;
     const r = (bigInt >> 16) & 255;
     const g = (bigInt >> 8) & 255;
     const b = bigInt & 255;
@@ -48,7 +48,7 @@ export function getStatusTagStyle(status: SampleStatus): CSSProperties {
     return {
         borderColor: 'lightgray',
         backgroundColor: status.color,
-        color: luminance <= 0.5 ? 'white' : '#555555',
+        color: luminance <= 0.5 && luminance > 0 ? 'white' : '#555555',
     };
 }
 


### PR DESCRIPTION
#### Rationale
Issue [50139](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50319)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/227


#### Changes
- Add sample status columns as required columns
- Default text color to light grey instead of white when there is no status color defined (since default background is white)
