### PR TITLE
Issue 50363: Cross Folder lookup editable grid copy/paste and fill down don't account for containerPath / containerFilter

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.2",
+  "version": "3.44.1-fb-crossFolderLookup50363.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.44.1-fb-crossFolderLookup50363.2",
+      "version": "3.44.1-fb-crossFolderLookup50363.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.3",
+  "version": "3.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.44.1-fb-crossFolderLookup50363.3",
+      "version": "3.45.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.1",
+  "version": "3.44.1-fb-crossFolderLookup50363.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.44.1-fb-crossFolderLookup50363.1",
+      "version": "3.44.1-fb-crossFolderLookup50363.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.0",
+  "version": "3.44.1-fb-crossFolderLookup50363.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.44.1-fb-crossFolderLookup50363.0",
+      "version": "3.44.1-fb-crossFolderLookup50363.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1",
+  "version": "3.44.1-fb-crossFolderLookup50363.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.44.1",
+      "version": "3.44.1-fb-crossFolderLookup50363.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.2",
+  "version": "3.44.1-fb-crossFolderLookup50363.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.1",
+  "version": "3.44.1-fb-crossFolderLookup50363.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.0",
+  "version": "3.44.1-fb-crossFolderLookup50363.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1",
+  "version": "3.44.1-fb-crossFolderLookup50363.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-crossFolderLookup50363.3",
+  "version": "3.45.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD May 2024
+### version 3.45.0
+*Released*: 16 May 2024
 - Issue 50363: Cross Folder lookup editable grid copy/paste and fill down don't account for containerPath / containerFilter
   - findLookupValues() to use getContainerFilterForLookups() and accept containerPath optional param
   - fillColumnCells() and insertPastedData() to use containerPath for the given row when validating cell lookup values forUpdate true case

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   - findLookupValues() to use getContainerFilterForLookups() and accept containerPath optional param
   - fillColumnCells() and insertPastedData() to use containerPath for the given row when validating cell lookup values forUpdate true case
   - fillColumnCells() and insertPastedData() to use targetContainerPath forUpdate false case
+  - EditableGrid "Bulk Insert" and "Bulk Update" to use target containerPath prop for lookup field options and validation
 
 ### version 3.44.1
 *Released*: 10 May 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD May 2024
+- Issue 50363: Cross Folder lookup editable grid copy/paste and fill down don't account for containerPath / containerFilter
+  - findLookupValues() to use getContainerFilterForLookups() and accept containerPath optional param
+  - fillColumnCells() and insertPastedData() to use containerPath for the given row when validating cell lookup values
+
 ### version 3.44.1
 *Released*: 10 May 2024
 - Issue 50360: Cross folder bulk edit doesn't work for grid custom view

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,7 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD May 2024
 - Issue 50363: Cross Folder lookup editable grid copy/paste and fill down don't account for containerPath / containerFilter
   - findLookupValues() to use getContainerFilterForLookups() and accept containerPath optional param
-  - fillColumnCells() and insertPastedData() to use containerPath for the given row when validating cell lookup values
+  - fillColumnCells() and insertPastedData() to use containerPath for the given row when validating cell lookup values forUpdate true case
+  - fillColumnCells() and insertPastedData() to use targetContainerPath forUpdate false case
 
 ### version 3.44.1
 *Released*: 10 May 2024

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1330,6 +1330,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             onChange,
             processBulkData,
             queryInfo,
+            containerPath,
         } = this.props;
         const nounPlural = addControlProps?.nounPlural;
         // numItems is a string because we rely on Formsy to grab the value for us (See QueryInfoForm for details). We
@@ -1367,7 +1368,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 numItems,
                 pivotKey,
                 pivotValues,
-                bulkData
+                bulkData,
+                containerPath
             );
             onChange(EditableGridEvent.BULK_ADD, changes.editorModel, changes.dataKeys, changes.data);
         } else {
@@ -1377,7 +1379,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 data,
                 List(queryInfo.getInsertColumns()),
                 numItems,
-                bulkData
+                bulkData,
+                containerPath
             );
             onChange(EditableGridEvent.BULK_ADD, changes.editorModel, changes.dataKeys, changes.data);
         }
@@ -1391,7 +1394,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     bulkUpdate = async (updatedData: OrderedMap<string, any>): Promise<Partial<EditorModelProps>> => {
-        const { editorModel, queryInfo, onChange, bulkUpdateProps, metricFeatureArea } = this.props;
+        const { editorModel, queryInfo, onChange, bulkUpdateProps, metricFeatureArea, containerPath } = this.props;
         if (!updatedData) return Promise.resolve(undefined);
 
         const selectedIndices = this.getSelectedRowIndices();
@@ -1401,7 +1404,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             updatedData,
             selectedIndices,
             bulkUpdateProps?.excludeRowIdx,
-            bulkUpdateProps?.isIncludedColumn
+            bulkUpdateProps?.isIncludedColumn,
+            containerPath
         );
         onChange(EditableGridEvent.BULK_UPDATE, editorModelChanges);
 
@@ -1414,8 +1418,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     addRows = async (count: number): Promise<void> => {
-        const { data, dataKeys, editorModel, onChange, queryInfo } = this.props;
-        const changes = await addRows(editorModel, dataKeys, data, List(queryInfo.getInsertColumns()), count);
+        const { data, dataKeys, editorModel, onChange, queryInfo, containerPath } = this.props;
+        const changes = await addRows(editorModel, dataKeys, data, List(queryInfo.getInsertColumns()), count, undefined, containerPath);
         onChange(EditableGridEvent.ADD_ROWS, changes.editorModel, changes.dataKeys, changes.data);
     };
 
@@ -1516,7 +1520,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     renderBulkAdd = (): ReactNode => {
-        const { addControlProps, allowFieldDisable, bulkAddProps, data, forUpdate, maxRows, queryInfo } = this.props;
+        const { addControlProps, allowFieldDisable, bulkAddProps, data, forUpdate, maxRows, queryInfo, containerPath } = this.props;
         const maxToAdd =
             maxRows && maxRows - data.size < MAX_EDITABLE_GRID_ROWS ? maxRows - data.size : MAX_EDITABLE_GRID_ROWS;
         return (
@@ -1540,6 +1544,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 title={bulkAddProps?.title}
                 countText={bulkAddProps?.countText}
                 creationTypeOptions={bulkAddProps?.creationTypeOptions}
+                containerPath={containerPath}
             />
         );
     };
@@ -1650,6 +1655,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             forUpdate,
             queryInfo,
             showAsTab,
+            containerPath,
         } = this.props;
         const { pendingBulkFormData } = this.state;
 
@@ -1668,6 +1674,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 {bulkTabHeaderComponent}
                 <BulkAddUpdateForm
                     asModal={!showAsTab}
+                    containerPath={containerPath}
                     data={data}
                     dataKeys={dataKeys}
                     editorModel={editorModel}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1139,7 +1139,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     _dragFill = async (initialSelection: string[]): Promise<void> => {
-        const { editorModel, onChange, data, dataKeys, queryInfo, readonlyRows, lockedRows } = this.props;
+        const { editorModel, forUpdate, onChange, data, dataKeys, queryInfo, readonlyRows, lockedRows } = this.props;
 
         if (editorModel.isMultiSelect) {
             const loweredColumnMetadata = this.getLoweredColumnMetadata();
@@ -1154,7 +1154,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 columns,
                 columnMetadata,
                 readonlyRows,
-                lockedRows
+                lockedRows,
+                forUpdate
             );
             onChange(EditableGridEvent.DRAG_FILL, { cellMessages, cellValues });
             this.setState({ initialSelection: undefined });

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1139,7 +1139,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     _dragFill = async (initialSelection: string[]): Promise<void> => {
-        const { editorModel, forUpdate, containerPath, onChange, data, dataKeys, queryInfo, readonlyRows, lockedRows } = this.props;
+        const { editorModel, forUpdate, containerPath, onChange, data, dataKeys, queryInfo, readonlyRows, lockedRows } =
+            this.props;
 
         if (editorModel.isMultiSelect) {
             const loweredColumnMetadata = this.getLoweredColumnMetadata();
@@ -1419,7 +1420,15 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
     addRows = async (count: number): Promise<void> => {
         const { data, dataKeys, editorModel, onChange, queryInfo, containerPath } = this.props;
-        const changes = await addRows(editorModel, dataKeys, data, List(queryInfo.getInsertColumns()), count, undefined, containerPath);
+        const changes = await addRows(
+            editorModel,
+            dataKeys,
+            data,
+            List(queryInfo.getInsertColumns()),
+            count,
+            undefined,
+            containerPath
+        );
         onChange(EditableGridEvent.ADD_ROWS, changes.editorModel, changes.dataKeys, changes.data);
     };
 
@@ -1520,7 +1529,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     renderBulkAdd = (): ReactNode => {
-        const { addControlProps, allowFieldDisable, bulkAddProps, data, forUpdate, maxRows, queryInfo, containerPath } = this.props;
+        const { addControlProps, allowFieldDisable, bulkAddProps, data, forUpdate, maxRows, queryInfo, containerPath } =
+            this.props;
         const maxToAdd =
             maxRows && maxRows - data.size < MAX_EDITABLE_GRID_ROWS ? maxRows - data.size : MAX_EDITABLE_GRID_ROWS;
         return (

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1139,7 +1139,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     _dragFill = async (initialSelection: string[]): Promise<void> => {
-        const { editorModel, forUpdate, onChange, data, dataKeys, queryInfo, readonlyRows, lockedRows } = this.props;
+        const { editorModel, forUpdate, containerPath, onChange, data, dataKeys, queryInfo, readonlyRows, lockedRows } = this.props;
 
         if (editorModel.isMultiSelect) {
             const loweredColumnMetadata = this.getLoweredColumnMetadata();
@@ -1155,7 +1155,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 columnMetadata,
                 readonlyRows,
                 lockedRows,
-                forUpdate
+                forUpdate,
+                containerPath
             );
             onChange(EditableGridEvent.DRAG_FILL, { cellMessages, cellValues });
             this.setState({ initialSelection: undefined });
@@ -1198,6 +1199,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             queryInfo,
             readonlyRows,
             lockedRows,
+            containerPath,
         } = this.props;
 
         if (disabled) return;
@@ -1215,6 +1217,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             lockedRows,
             !allowAdd,
             forUpdate,
+            containerPath,
             false
         );
         this.hideMask();
@@ -1235,6 +1238,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             queryInfo,
             readonlyRows,
             lockedRows,
+            containerPath,
         } = this.props;
 
         if (disabled) return;
@@ -1251,7 +1255,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             readonlyRows,
             lockedRows,
             !allowAdd,
-            forUpdate
+            forUpdate,
+            containerPath
         );
         this.hideMask();
 

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -521,6 +521,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['0-0'],
             ['0-1', '0-2', '0-3'],
+            true,
             dataKeys,
             data
         );
@@ -540,6 +541,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['0-0', '0-1', '0-2'],
             ['0-3', '0-4'],
+            true,
             dataKeys,
             data
         );
@@ -558,6 +560,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['1-0', '1-1', '1-2'],
             ['1-3', '1-4'],
+            true,
             dataKeys,
             data
         );
@@ -576,6 +579,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['1-1', '1-2'],
             ['1-0'],
+            true,
             dataKeys,
             data
         );
@@ -592,6 +596,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['2-0', '2-1', '2-2'],
             ['2-3', '2-4'],
+            true,
             dataKeys,
             data
         );
@@ -610,6 +615,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['2-1', '2-2'],
             ['2-0'],
+            true,
             dataKeys,
             data
         );
@@ -626,6 +632,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['6-0'],
             ['6-1', '6-2', '6-3'],
+            true,
             dataKeys,
             data
         );
@@ -645,6 +652,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['6-2'],
             ['6-0', '6-1'],
+            true,
             dataKeys,
             data
         );
@@ -664,6 +672,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['7-0'],
             ['7-1', '7-2', '7-3'],
+            true,
             dataKeys,
             data
         );
@@ -683,6 +692,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['7-2'],
             ['7-0', '7-1'],
+            true,
             dataKeys,
             data
         );
@@ -702,6 +712,7 @@ describe('fillColumnCells', () => {
             editorModel.cellValues,
             ['5-0', '5-1', '5-2'],
             ['5-3', '5-4', '5-5'],
+            true,
             dataKeys,
             data
         );

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -11,6 +11,7 @@ import {
     addColumns,
     changeColumn,
     fillColumnCells,
+    getFolderValueFromDataRow,
     parseIntIfNumber,
     removeColumn,
     splitPrefixedNumber,
@@ -345,6 +346,9 @@ describe('column mutation actions', () => {
 });
 
 describe('fillColumnCells', () => {
+    const data = fromJS({ 123: {}, 456: {}, 789: {} });
+    const dataKeys = fromJS([123, 456, 789]);
+
     const editorModel = new EditorModel({ id: 'generate|fill|sequence' }).merge({
         cellMessages: Map<string, CellMessage>({
             '1-0': 'description 1 message',
@@ -516,7 +520,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['0-0'],
-            ['0-1', '0-2', '0-3']
+            ['0-1', '0-2', '0-3'],
+            dataKeys,
+            data
         );
         // Filled values should be copies of the initial selection
         for (let i = 1; i <= 3; i++) {
@@ -533,7 +539,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['0-0', '0-1', '0-2'],
-            ['0-3', '0-4']
+            ['0-3', '0-4'],
+            dataKeys,
+            data
         );
         expect(cellValues.get('0-3').get(0).display).toEqual('S-4');
         expect(cellValues.get('0-3').get(0).raw).toEqual('S-4');
@@ -549,7 +557,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['1-0', '1-1', '1-2'],
-            ['1-3', '1-4']
+            ['1-3', '1-4'],
+            dataKeys,
+            data
         );
         expect(cellValues.get('1-3').get(0).display).toEqual('7');
         expect(cellValues.get('1-3').get(0).raw).toEqual(7);
@@ -565,7 +575,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['1-1', '1-2'],
-            ['1-0']
+            ['1-0'],
+            dataKeys,
+            data
         );
         expect(cellValues.get('1-0').get(0).display).toEqual('1');
         expect(cellValues.get('1-0').get(0).raw).toEqual(1);
@@ -579,7 +591,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['2-0', '2-1', '2-2'],
-            ['2-3', '2-4']
+            ['2-3', '2-4'],
+            dataKeys,
+            data
         );
         expect(cellValues.get('2-3').get(0).display).toEqual('-1.5');
         expect(cellValues.get('2-3').get(0).raw).toEqual(-1.5);
@@ -595,7 +609,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['2-1', '2-2'],
-            ['2-0']
+            ['2-0'],
+            dataKeys,
+            data
         );
         expect(cellValues.get('2-0').get(0).display).toEqual('3');
         expect(cellValues.get('2-0').get(0).raw).toEqual(3);
@@ -609,7 +625,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['6-0'],
-            ['6-1', '6-2', '6-3']
+            ['6-1', '6-2', '6-3'],
+            dataKeys,
+            data
         );
         // Filled values should be copies of the initial selection
         for (let i = 1; i <= 3; i++) {
@@ -626,7 +644,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['6-2'],
-            ['6-0', '6-1']
+            ['6-0', '6-1'],
+            dataKeys,
+            data
         );
         // Filled values should be copies of the initial selection
         for (let i = 0; i <= 2; i++) {
@@ -643,7 +663,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['7-0'],
-            ['7-1', '7-2', '7-3']
+            ['7-1', '7-2', '7-3'],
+            dataKeys,
+            data
         );
         // Filled values should be copies of the initial selection
         for (let i = 1; i <= 3; i++) {
@@ -660,7 +682,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['7-2'],
-            ['7-0', '7-1']
+            ['7-0', '7-1'],
+            dataKeys,
+            data
         );
         // Filled values should be copies of the initial selection
         for (let i = 0; i <= 2; i++) {
@@ -677,7 +701,9 @@ describe('fillColumnCells', () => {
             editorModel.cellMessages,
             editorModel.cellValues,
             ['5-0', '5-1', '5-2'],
-            ['5-3', '5-4', '5-5']
+            ['5-3', '5-4', '5-5'],
+            dataKeys,
+            data
         );
         expect(cellValues.get('5-3').get(0).display).toEqual('qwer');
         expect(cellValues.get('5-3').get(0).raw).toEqual('qwer');
@@ -685,6 +711,40 @@ describe('fillColumnCells', () => {
         expect(cellValues.get('5-4').get(0).raw).toEqual('asdf');
         expect(cellValues.get('5-5').get(0).display).toEqual('zxcv');
         expect(cellValues.get('5-5').get(0).raw).toEqual('zxcv');
+    });
+});
+
+describe('getFolderValueFromDataRow', () => {
+    const dataEmpty = fromJS({ '123': {}, '456': {}, '789': {} });
+    const dataWithout = fromJS({ '123': { test: 'a' }, '456': { test: 'b' }, '789': { test: 'c' } });
+    const dataFolder = fromJS({
+        '123': { test: 'a', folder: 'f1' },
+        '456': { test: 'b', Folder: 'f2' },
+        '789': { test: 'c', FOLDER: 'f3' },
+    });
+    const dataContainer = fromJS({
+        '123': { test: 'a', container: 'c1' },
+        '456': { test: 'b', Container: 'c2' },
+        '789': { test: 'c', CONTAINER: 'c3' },
+    });
+    const dataKeys = fromJS(['123', '456', '789']);
+
+    test('undefined', () => {
+        expect(getFolderValueFromDataRow('0-0', dataKeys, dataEmpty)).toBe(undefined);
+        expect(getFolderValueFromDataRow('1-1', dataKeys, dataEmpty)).toBe(undefined);
+        expect(getFolderValueFromDataRow('2-2', dataKeys, dataEmpty)).toBe(undefined);
+        expect(getFolderValueFromDataRow('0-0', dataKeys, dataWithout)).toBe(undefined);
+        expect(getFolderValueFromDataRow('1-1', dataKeys, dataWithout)).toBe(undefined);
+        expect(getFolderValueFromDataRow('2-2', dataKeys, dataWithout)).toBe(undefined);
+    });
+
+    test('defined', () => {
+        expect(getFolderValueFromDataRow('0-0', dataKeys, dataFolder)).toBe('f1');
+        expect(getFolderValueFromDataRow('1-1', dataKeys, dataFolder)).toBe('f2');
+        expect(getFolderValueFromDataRow('2-2', dataKeys, dataFolder)).toBe('f3');
+        expect(getFolderValueFromDataRow('0-0', dataKeys, dataContainer)).toBe('c1');
+        expect(getFolderValueFromDataRow('1-1', dataKeys, dataContainer)).toBe('c2');
+        expect(getFolderValueFromDataRow('2-2', dataKeys, dataContainer)).toBe('c3');
     });
 });
 

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -522,6 +522,7 @@ describe('fillColumnCells', () => {
             ['0-0'],
             ['0-1', '0-2', '0-3'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -542,6 +543,7 @@ describe('fillColumnCells', () => {
             ['0-0', '0-1', '0-2'],
             ['0-3', '0-4'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -561,6 +563,7 @@ describe('fillColumnCells', () => {
             ['1-0', '1-1', '1-2'],
             ['1-3', '1-4'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -580,6 +583,7 @@ describe('fillColumnCells', () => {
             ['1-1', '1-2'],
             ['1-0'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -597,6 +601,7 @@ describe('fillColumnCells', () => {
             ['2-0', '2-1', '2-2'],
             ['2-3', '2-4'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -616,6 +621,7 @@ describe('fillColumnCells', () => {
             ['2-1', '2-2'],
             ['2-0'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -633,6 +639,7 @@ describe('fillColumnCells', () => {
             ['6-0'],
             ['6-1', '6-2', '6-3'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -653,6 +660,7 @@ describe('fillColumnCells', () => {
             ['6-2'],
             ['6-0', '6-1'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -673,6 +681,7 @@ describe('fillColumnCells', () => {
             ['7-0'],
             ['7-1', '7-2', '7-3'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -693,6 +702,7 @@ describe('fillColumnCells', () => {
             ['7-2'],
             ['7-0', '7-1'],
             true,
+            undefined,
             dataKeys,
             data
         );
@@ -713,6 +723,7 @@ describe('fillColumnCells', () => {
             ['5-0', '5-1', '5-2'],
             ['5-3', '5-4', '5-5'],
             true,
+            undefined,
             dataKeys,
             data
         );

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -330,7 +330,11 @@ async function prepareInsertRowDataFromBulkForm(
             // If it's the display value, which happens to be a number, much confusion will arise.
             const values = data.toString().split(',');
             for (const val of values) {
-                const { message, valueDescriptor } = await getLookupDisplayValue(col, parseIntIfNumber(val), containerPath);
+                const { message, valueDescriptor } = await getLookupDisplayValue(
+                    col,
+                    parseIntIfNumber(val),
+                    containerPath
+                );
                 cv = cv.push(valueDescriptor);
                 if (message) {
                     messages = messages.push(message);
@@ -668,7 +672,11 @@ async function prepareUpdateRowDataFromBulkForm(
             // If it's the display value, which happens to be a number, much confusion will arise.
             const rawValues = data.toString().split(',');
             for (const val of rawValues) {
-                const { message, valueDescriptor } = await getLookupDisplayValue(col, parseIntIfNumber(val), containerPath);
+                const { message, valueDescriptor } = await getLookupDisplayValue(
+                    col,
+                    parseIntIfNumber(val),
+                    containerPath
+                );
                 cv = cv.push(valueDescriptor);
                 if (message) {
                     messages = messages.set(colIdx, message);
@@ -1097,7 +1105,11 @@ export async function fillColumnCells(
     return { cellValues, cellMessages };
 }
 
-export function getFolderValueFromDataRow(cellKey: string, dataKeys: List<any>, data: Map<any, Map<string, any>>): string {
+export function getFolderValueFromDataRow(
+    cellKey: string,
+    dataKeys: List<any>,
+    data: Map<any, Map<string, any>>
+): string {
     const { rowIdx } = parseCellKey(cellKey);
     const dataRow = data.get(dataKeys.get(rowIdx))?.toJS();
     const value = getValueFromRow(dataRow, 'Folder') ?? getValueFromRow(dataRow, 'Container');
@@ -1474,7 +1486,9 @@ async function insertPastedData(
                 if (col?.isPublicLookup()) {
                     // If the column is a lookup and forUpdate is true, then we need to query for the rowIds so we can set the correct raw values,
                     // otherwise insert will fail. This is most common for cross-folder sample selection (Issue 50363)
-                    const containerPath = forUpdate ? getFolderValueFromDataRow(cellKey, dataKeys, data) : targetContainerPath;
+                    const containerPath = forUpdate
+                        ? getFolderValueFromDataRow(cellKey, dataKeys, data)
+                        : targetContainerPath;
 
                     const cacheKey = `${col.fieldKey}||${containerPath}`;
                     let descriptors = lookupColumnContainerCache[cacheKey];

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1079,7 +1079,7 @@ export async function fillColumnCells(
     return { cellValues, cellMessages };
 }
 
-function getFolderValueFromDataRow(cellKey: string, dataKeys: List<any>, data: Map<any, Map<string, any>>): string {
+export function getFolderValueFromDataRow(cellKey: string, dataKeys: List<any>, data: Map<any, Map<string, any>>): string {
     const { rowIdx } = parseCellKey(cellKey);
     const dataRow = data.get(dataKeys.get(rowIdx));
     return (


### PR DESCRIPTION
#### Rationale
Issue [50363](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50363): Cross Folder lookup editable grid copy/paste and fill down don't account for containerPath / containerFilter

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1493
- https://github.com/LabKey/labkey-ui-premium/pull/411
- https://github.com/LabKey/limsModules/pull/255

#### Changes
- findLookupValues() to use getContainerFilterForLookups() and accept containerPath optional param
- fillColumnCells() and insertPastedData() to use containerPath for the given row when validating cell lookup values
