### PR TITLE
Bootstrap Cleanup

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.45.1",
+  "version": "3.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.45.1",
+      "version": "3.46.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.45.1",
+  "version": "3.44.1-fb-bootstrap-cleanup.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.44.1-fb-bootstrap-cleanup.5",
+  "version": "3.46.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.XX.X
+*Released*: ?? May 2024
+- Add `CheckboxLK`
+  - This is a replacement for react-boostrap's Checkbox
+  - It will be renamed to `Checkbox` when we stop using the react-bootstrap version
+- Reduce usages of various react-bootstrap components (e.g. FormGroup, FormControl)
+- OverlayTrigger: Don't require an `id`
+
 ### version 3.45.1
 *Released*: 16 May 2024
 - Introduce `EditorModel.convertQueryModelDataToGridResponse()` to streamline initializing data from a `QueryModel` for an `EditorModel`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -8,6 +8,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   - It will be renamed to `Checkbox` when we stop using the react-bootstrap version
 - Reduce usages of various react-bootstrap components (e.g. FormGroup, FormControl)
 - OverlayTrigger: Don't require an `id`
+- Add `withServerContext`
 
 ### version 3.45.1
 *Released*: 16 May 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.XX.X
-*Released*: ?? May 2024
+### version 3.46.0
+*Released*: 16 May 2024
 - Add `CheckboxLK`
   - This is a replacement for react-boostrap's Checkbox
   - It will be renamed to `Checkbox` when we stop using the react-bootstrap version

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -885,6 +885,7 @@ import { NameIdSettings } from './internal/components/settings/NameIdSettings';
 import { AuditSettings } from './internal/components/settings/AuditSettings';
 import { BaseModal, Modal, ModalHeader } from './internal/Modal';
 import { Tab, Tabs } from './internal/Tabs';
+import { CheckboxLK } from './internal/Checkbox';
 
 // See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 enableMapSet();
@@ -1778,6 +1779,7 @@ export {
     ModalHeader,
     Tab,
     Tabs,
+    CheckboxLK,
     // Custom labels
     getModuleCustomLabels,
 };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -48,6 +48,7 @@ import {
     useServerContext,
     useServerContextDispatch,
     withAppUser,
+    withServerContext,
 } from './internal/components/base/ServerContext';
 import { naturalSort, naturalSortByProperty } from './public/sort';
 import { AssayDefinitionModel, AssayDomainTypes, AssayLink } from './internal/AssayDefinitionModel';
@@ -1657,6 +1658,7 @@ export {
     useServerContext,
     useServerContextDispatch,
     withAppUser,
+    withServerContext,
     QueryColumn,
     QueryInfo,
     QueryLookup,

--- a/packages/components/src/internal/Checkbox.tsx
+++ b/packages/components/src/internal/Checkbox.tsx
@@ -1,0 +1,35 @@
+import React, { ChangeEventHandler, FC, memo, MouseEventHandler } from 'react';
+import classNames from 'classnames';
+
+interface Props {
+    checked: boolean;
+    className?: string;
+    disabled?: boolean;
+    id?: string;
+    name: string;
+    onChange: ChangeEventHandler<HTMLInputElement>;
+    onClick?: MouseEventHandler<HTMLInputElement>; // Note: you probably shouldn't be using this
+}
+
+// Note: This will be renamed to Checkbox when all react-bootstrap usages of Checkbox are removed.
+export const CheckboxLK: FC<Props> = memo(props => {
+    const { checked, children, className, disabled = false, id, name, onChange, onClick } = props;
+    return (
+        <div className={classNames('checkbox', className)}>
+            <label>
+                <input
+                    checked={checked}
+                    className=""
+                    disabled={disabled}
+                    id={id}
+                    name={name}
+                    onChange={onChange}
+                    onClick={onClick}
+                    type="checkbox"
+                />
+                {children}
+            </label>
+        </div>
+    )
+});
+CheckboxLK.displayName = 'Checkbox';

--- a/packages/components/src/internal/OverlayTrigger.tsx
+++ b/packages/components/src/internal/OverlayTrigger.tsx
@@ -8,12 +8,14 @@ import React, {
     useCallback,
     MutableRefObject,
     CSSProperties,
+    useMemo,
 } from 'react';
 import { createPortal } from 'react-dom';
 
 import classNames from 'classnames';
 
 import { usePortalRef } from './hooks';
+import { generateId } from './util/utils';
 
 interface OverlayTriggerState<T extends Element = HTMLDivElement> {
     onClick: () => void;
@@ -89,7 +91,7 @@ export type TriggerType = 'click' | 'hover';
 interface Props {
     className?: string;
     delay?: number;
-    id: string;
+    id?: string;
     overlay: ReactElement<OverlayComponent>; // See note in doc string below
     style?: CSSProperties;
     triggerType?: TriggerType;
@@ -120,8 +122,9 @@ export const OverlayTrigger: FC<Props> = ({
     triggerType = 'hover',
     style,
 }) => {
+    const id_ = useMemo(() => id ?? generateId(), [id]);
     const { onMouseEnter, onMouseLeave, onClick, portalEl, show, targetRef } = useOverlayTriggerState(
-        id,
+        id_,
         triggerType === 'hover',
         triggerType === 'click',
         delay

--- a/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import { mount, ReactWrapper } from 'enzyme';
 
-import { OverlayTrigger } from 'react-bootstrap';
-
 import { Draggable } from 'react-beautiful-dnd';
 
 import { ExtendedMap } from '../../public/ExtendedMap';
@@ -26,6 +24,7 @@ import {
     FieldLabelDisplay,
 } from './ColumnSelectionModal';
 import { LoadingSpinner } from './base/LoadingSpinner';
+import { OverlayTrigger } from '../OverlayTrigger';
 
 describe('ColumnSelectionModal', () => {
     const QUERY_COL = new QueryColumn({

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, FC, memo, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 import classNames from 'classnames';
 
@@ -7,6 +6,10 @@ import { QueryColumn } from '../../public/QueryColumn';
 import { QueryInfo } from '../../public/QueryInfo';
 
 import { Modal, ModalProps } from '../Modal';
+
+import { Popover } from '../Popover';
+
+import { OverlayTrigger } from '../OverlayTrigger';
 
 import { Alert } from './base/Alert';
 import { DragDropHandle } from './base/DragDropHandle';
@@ -42,6 +45,15 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
     const onChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
         setTitle(evt.target.value);
     }, []);
+    const id = column.index + '-fieldlabel-popover';
+    const popover = useMemo(
+        () => (
+            <Popover id={id} placement="left">
+                {column.index}
+            </Popover>
+        ),
+        [column.index, id]
+    );
 
     if (editing) {
         return (
@@ -61,17 +73,8 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
         return <div className="field-name">{initialTitle}</div>;
     }
 
-    const id = column.index + '-fieldlabel-popover';
-
     return (
-        <OverlayTrigger
-            overlay={
-                <Popover id={id} key={id}>
-                    {column.index}
-                </Popover>
-            }
-            placement="left"
-        >
+        <OverlayTrigger overlay={popover}>
             <div className="field-name">{initialTitle}</div>
         </OverlayTrigger>
     );

--- a/packages/components/src/internal/components/base/Progress.tsx
+++ b/packages/components/src/internal/components/base/Progress.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { ProgressBar } from 'react-bootstrap';
+import classNames from 'classnames';
 
 import { Modal } from '../../Modal';
 
@@ -101,8 +101,23 @@ export class Progress extends React.Component<Props, State> {
 
         if (!show) return null;
 
-        const indicator = show && (
-            <ProgressBar active now={percent} bsStyle={percent === 100 ? 'success' : undefined} />
+        const progressClassName = classNames('progress-bar', 'progress-bar-striped', 'active', {
+            'progress-bar-success': percent === 100,
+        });
+        const progressWidth = percent + '%';
+        const indicator = (
+            <div className="progress">
+                <div
+                    role="progressbar"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={percent}
+                    className={progressClassName}
+                    style={{ width: progressWidth }}
+                >
+                    <span className="sr-only">{percent}%</span>
+                </div>
+            </div>
         );
 
         if (modal) {

--- a/packages/components/src/internal/components/base/ServerContext.tsx
+++ b/packages/components/src/internal/components/base/ServerContext.tsx
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { createContext, FC, useContext, useReducer } from 'react';
-import { LabKey } from '@labkey/api';
+import React, { ComponentType, createContext, FC, useContext, useMemo, useReducer } from 'react';
+import { getServerContext, LabKey } from '@labkey/api';
 
 import { Container } from './models/Container';
 import { User } from './models/User';
@@ -77,4 +77,17 @@ export const withAppUser = (ctx: LabKey): ServerContext => {
         container: new Container(ctx.container),
         user: new User(ctx.user),
     });
+};
+
+/**
+ * Use this component wrapper for pages in LKS that need access to useServerContext.
+ * @param Component the component you want to wrap
+ */
+export const withServerContext = (Component: ComponentType<any>) => {
+    const initialServerContext = useMemo(() => withAppUser(getServerContext()), []);
+    return (
+        <ServerContextProvider initialContext={initialServerContext}>
+            <Component />
+        </ServerContextProvider>
+    );
 };

--- a/packages/components/src/internal/components/base/ServerContext.tsx
+++ b/packages/components/src/internal/components/base/ServerContext.tsx
@@ -84,10 +84,12 @@ export const withAppUser = (ctx: LabKey): ServerContext => {
  * @param Component the component you want to wrap
  */
 export const withServerContext = (Component: ComponentType<any>) => {
-    const initialServerContext = useMemo(() => withAppUser(getServerContext()), []);
-    return (
-        <ServerContextProvider initialContext={initialServerContext}>
-            <Component />
-        </ServerContextProvider>
-    );
+    return () => {
+        const initialServerContext = useMemo(() => withAppUser(getServerContext()), []);
+        return (
+            <ServerContextProvider initialContext={initialServerContext}>
+                <Component />
+            </ServerContextProvider>
+        );
+    };
 };

--- a/packages/components/src/internal/components/base/ServerContext.tsx
+++ b/packages/components/src/internal/components/base/ServerContext.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ComponentType, createContext, FC, useContext, useMemo, useReducer } from 'react';
+import React, { ComponentType, createContext, FC, PropsWithChildren, useContext, useMemo, useReducer } from 'react';
 import { getServerContext, LabKey } from '@labkey/api';
 
 import { Container } from './models/Container';
@@ -83,13 +83,13 @@ export const withAppUser = (ctx: LabKey): ServerContext => {
  * Use this component wrapper for pages in LKS that need access to useServerContext.
  * @param Component the component you want to wrap
  */
-export const withServerContext = (Component: ComponentType<any>) => {
-    return () => {
+export function withServerContext<T = {}>(Component: ComponentType<T>): FC<T> {
+    return (props: PropsWithChildren<T>) => {
         const initialServerContext = useMemo(() => withAppUser(getServerContext()), []);
         return (
             <ServerContextProvider initialContext={initialServerContext}>
-                <Component />
+                <Component {...props} />
             </ServerContextProvider>
         );
     };
-};
+}

--- a/packages/components/src/internal/components/base/Setting.tsx
+++ b/packages/components/src/internal/components/base/Setting.tsx
@@ -1,8 +1,9 @@
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
-import { Checkbox } from 'react-bootstrap';
 import { Ajax, Utils } from '@labkey/api';
 
 import { resolveErrorMessage } from '../../util/messaging';
+
+import { CheckboxLK } from '../../Checkbox';
 
 import { LoadingSpinner } from './LoadingSpinner';
 import { Alert } from './Alert';
@@ -98,9 +99,9 @@ export const Setting: FC<SettingProps> = memo(props => {
 
             {!loading && (
                 <form>
-                    <Checkbox checked={enabled} onChange={save} disabled={saving}>
+                    <CheckboxLK checked={enabled} name={name} onChange={save} disabled={saving}>
                         {label}
-                    </Checkbox>
+                    </CheckboxLK>
                 </form>
             )}
         </div>

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { List } from 'immutable';
-import { Checkbox, FormControl } from 'react-bootstrap';
+import { FormControl } from 'react-bootstrap';
 import { ActionURL } from '@labkey/api';
 
 import { Modal } from '../../Modal';
@@ -40,6 +40,7 @@ import {
 } from './constants';
 
 import { DomainFieldLabel } from './DomainFieldLabel';
+import { CheckboxLK } from '../../Checkbox';
 
 interface AdvancedSettingsProps {
     defaultDefaultValueType: string;
@@ -254,38 +255,38 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
             <>
                 <div className="domain-adv-display-options">Display Options</div>
                 <div>These options configure how and in which views this field will be visible.</div>
-                <Checkbox
+                <CheckboxLK
                     checked={hidden === false}
                     onChange={this.handleCheckbox}
                     name={createFormInputName(DOMAIN_FIELD_HIDDEN)}
                     id={createFormInputId(DOMAIN_FIELD_HIDDEN, domainIndex, index)}
                 >
                     Show field on default view of the grid
-                </Checkbox>
-                <Checkbox
+                </CheckboxLK>
+                <CheckboxLK
                     checked={shownInUpdateView === true}
                     onChange={this.handleCheckbox}
                     name={createFormInputName(DOMAIN_FIELD_SHOWNINUPDATESVIEW)}
                     id={createFormInputId(DOMAIN_FIELD_SHOWNINUPDATESVIEW, domainIndex, index)}
                 >
                     Show on update form when updating a single row of data
-                </Checkbox>
-                <Checkbox
+                </CheckboxLK>
+                <CheckboxLK
                     checked={shownInInsertView === true}
                     onChange={this.handleCheckbox}
                     name={createFormInputName(DOMAIN_FIELD_SHOWNININSERTVIEW)}
                     id={createFormInputId(DOMAIN_FIELD_SHOWNININSERTVIEW, domainIndex, index)}
                 >
                     Show on insert form when updating a single row of data
-                </Checkbox>
-                <Checkbox
+                </CheckboxLK>
+                <CheckboxLK
                     checked={shownInDetailsView === true}
                     onChange={this.handleCheckbox}
                     name={createFormInputName(DOMAIN_FIELD_SHOWNINDETAILSVIEW)}
                     id={createFormInputId(DOMAIN_FIELD_SHOWNINDETAILSVIEW, domainIndex, index)}
                 >
                     Show on details page for a single row
-                </Checkbox>
+                </CheckboxLK>
             </>
         );
     };
@@ -390,7 +391,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                     <div className="col-xs-3" />
                 </div>
                 {field.dataType === DATETIME_TYPE && (
-                    <Checkbox
+                    <CheckboxLK
                         checked={excludeFromShifting}
                         onChange={this.handleCheckbox}
                         name={createFormInputName(DOMAIN_FIELD_EXCLUDE_FROM_SHIFTING)}
@@ -401,10 +402,10 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                             Participant date fields with this property checked will not be shifted on export/publication
                             when the "Shift Participant Dates" option is selected.
                         </LabelHelpTip>
-                    </Checkbox>
+                    </CheckboxLK>
                 )}
                 {PropDescType.isMeasure(field.dataType.rangeURI) && (
-                    <Checkbox
+                    <CheckboxLK
                         checked={measure}
                         onChange={this.handleCheckbox}
                         name={createFormInputName(DOMAIN_FIELD_MEASURE)}
@@ -424,10 +425,10 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                                 </p>
                             </div>
                         </LabelHelpTip>
-                    </Checkbox>
+                    </CheckboxLK>
                 )}
                 {PropDescType.isDimension(field.dataType.rangeURI) && (
-                    <Checkbox
+                    <CheckboxLK
                         checked={dimension}
                         onChange={this.handleCheckbox}
                         name={createFormInputName(DOMAIN_FIELD_DIMENSION)}
@@ -447,9 +448,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                                 </p>
                             </div>
                         </LabelHelpTip>
-                    </Checkbox>
+                    </CheckboxLK>
                 )}
-                <Checkbox
+                <CheckboxLK
                     checked={recommendedVariable}
                     onChange={this.handleCheckbox}
                     name={createFormInputName(DOMAIN_FIELD_RECOMMENDEDVARIABLE)}
@@ -462,9 +463,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                             recommended when creating new charts or reports.
                         </div>
                     </LabelHelpTip>
-                </Checkbox>
+                </CheckboxLK>
                 {PropDescType.isMvEnableable(field.dataType.rangeURI) && (
-                    <Checkbox
+                    <CheckboxLK
                         checked={mvEnabled}
                         onChange={this.handleCheckbox}
                         name={createFormInputName(DOMAIN_FIELD_MVENABLED)}
@@ -485,10 +486,10 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                                 </p>
                             </div>
                         </LabelHelpTip>
-                    </Checkbox>
+                    </CheckboxLK>
                 )}
                 {allowUniqueConstraintProperties && (
-                    <Checkbox
+                    <CheckboxLK
                         checked={uniqueConstraint || field.isPrimaryKey}
                         disabled={field.isPrimaryKey}
                         onChange={this.handleCheckbox}
@@ -499,7 +500,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                         <LabelHelpTip title="Unique Constraint">
                             <div>Add a unique constraint via a database-level index for this field.</div>
                         </LabelHelpTip>
-                    </Checkbox>
+                    </CheckboxLK>
                 )}
             </>
         );

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -16,7 +16,7 @@
 import React, { FC, memo, ReactNode } from 'react';
 import { List, Map } from 'immutable';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import { Checkbox, FormControl, Panel } from 'react-bootstrap';
+import { FormControl, Panel } from 'react-bootstrap';
 import classNames from 'classnames';
 
 import { FIELD_EDITOR_TOPIC, HelpLink } from '../../util/helpLinks';
@@ -107,6 +107,7 @@ import {
 import { DomainPropertiesGrid } from './DomainPropertiesGrid';
 import { SystemFields } from './SystemFields';
 import { DomainPropertiesAPIWrapper } from './APIWrapper';
+import { CheckboxLK } from '../../Checkbox';
 
 interface IDomainFormInput {
     api?: DomainPropertiesAPIWrapper;
@@ -1108,7 +1109,7 @@ export class DomainFormImpl extends React.PureComponent<IDomainFormInput, IDomai
                     <div className="row domain-row-container">
                         <div className="domain-row-handle" />
                         <div className="domain-row-action-section">
-                            <Checkbox
+                            <CheckboxLK
                                 className="domain-field-check-icon"
                                 name="domain-select-all-checkbox"
                                 id="domain-select-all-checkbox"

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainForm.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainForm.test.tsx.snap
@@ -144,12 +144,11 @@ exports[`DomainForm domain form updated field, cleared details 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -907,12 +906,11 @@ exports[`DomainForm domain form updated field, cleared details 1`] = `
               class="domain-row-action-section"
             >
               <div
-                class="domain-field-check-icon checkbox"
+                class="checkbox domain-field-check-icon"
               >
-                <label
-                  title=""
-                >
+                <label>
                   <input
+                    class=""
                     id="domain-select-all-checkbox"
                     name="domain-select-all-checkbox"
                     type="checkbox"
@@ -1686,12 +1684,11 @@ exports[`DomainForm domain form with all field types 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -7120,12 +7117,11 @@ exports[`DomainForm domain form with all field types 1`] = `
               class="domain-row-action-section"
             >
               <div
-                class="domain-field-check-icon checkbox"
+                class="checkbox domain-field-check-icon"
               >
-                <label
-                  title=""
-                >
+                <label>
                   <input
+                    class=""
                     id="domain-select-all-checkbox"
                     name="domain-select-all-checkbox"
                     type="checkbox"
@@ -12680,12 +12676,11 @@ exports[`DomainForm domain form with updated fields 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -14758,12 +14753,11 @@ exports[`DomainForm domain form with updated fields 1`] = `
               class="domain-row-action-section"
             >
               <div
-                class="domain-field-check-icon checkbox"
+                class="checkbox domain-field-check-icon"
               >
-                <label
-                  title=""
-                >
+                <label>
                   <input
+                    class=""
                     id="domain-select-all-checkbox"
                     name="domain-select-all-checkbox"
                     type="checkbox"

--- a/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/assay/__snapshots__/AssayDesignerPanels.test.tsx.snap
@@ -1263,12 +1263,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -2037,12 +2036,11 @@ exports[`AssayDesignerPanels appPropertiesOnly with initModel 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -5391,12 +5389,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -6165,12 +6162,11 @@ exports[`AssayDesignerPanels hideEmptyBatchDomain with initModel 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -8453,12 +8449,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"
@@ -9227,12 +9222,11 @@ exports[`AssayDesignerPanels initModel 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"

--- a/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/__snapshots__/DataClassDesigner.test.tsx.snap
@@ -1966,12 +1966,11 @@ exports[`DataClassDesigner initModel 1`] = `
                 class="domain-row-action-section"
               >
                 <div
-                  class="domain-field-check-icon checkbox"
+                  class="checkbox domain-field-check-icon"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
+                      class=""
                       id="domain-select-all-checkbox"
                       name="domain-select-all-checkbox"
                       type="checkbox"

--- a/packages/components/src/internal/components/files/FileTree.spec.tsx
+++ b/packages/components/src/internal/components/files/FileTree.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Checkbox } from 'react-bootstrap';
 import { mount, ReactWrapper, shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
 import { Treebeard, animations } from 'react-treebeard';
@@ -147,7 +146,7 @@ describe('Header', () => {
 
         const rendered = !isEmpty && !loading;
         expect(wrapper.find('.filetree-checkbox-container')).toHaveLength(rendered ? 1 : 0);
-        expect(wrapper.find(Checkbox)).toHaveLength(rendered && hasCheckbox ? 1 : 0);
+        expect(wrapper.find('.checkbox')).toHaveLength(rendered && hasCheckbox ? 1 : 0);
         expect(wrapper.find('.filetree-resource-row')).toHaveLength(rendered ? 1 : 0);
         expect(wrapper.find(FileNodeIcon)).toHaveLength(rendered && showNodeIcon ? 1 : 0);
         expect(wrapper.find('.filetree-file-name')).toHaveLength(rendered && !isDirectory ? 1 : 0);

--- a/packages/components/src/internal/components/files/FileTreeHeader.tsx
+++ b/packages/components/src/internal/components/files/FileTreeHeader.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from 'react';
+import React, { ChangeEvent, FC } from 'react';
 
-import { Checkbox } from 'react-bootstrap';
 import classNames from 'classnames';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
+import { CheckboxLK } from '../../Checkbox';
 
 interface FileNodeIconProps {
     isDirectory: boolean;
@@ -38,7 +38,7 @@ export interface TreeNodeProps {
     onSelect?: () => void; // Callback for selection
     customStyles?: any; // Custom styling object that is applied in addition to the base
     checked?: boolean; // Is check box checked
-    handleCheckbox?: (any) => void; // Callback for checkbox changes
+    handleCheckbox?: (event: ChangeEvent<HTMLInputElement>) => void; // Callback for checkbox changes
     checkboxId?: string; // Id to apply to the checkbox
     emptyDirectoryText?: string; // Text to show if node is a container, but has no contents
 
@@ -97,7 +97,7 @@ export const Header: FC<TreeNodeProps> = props => {
             }
         >
             {handleCheckbox && (
-                <Checkbox id={checkboxId} checked={checked} onChange={handleCheckbox} onClick={checkClick} />
+                <CheckboxLK id={checkboxId} checked={checked} name={node.id} onChange={handleCheckbox} onClick={checkClick} />
             )}
             <div style={style.base} onClick={onSelect}>
                 <div className={activeColor}>

--- a/packages/components/src/internal/components/files/__snapshots__/FileTree.spec.tsx.snap
+++ b/packages/components/src/internal/components/files/__snapshots__/FileTree.spec.tsx.snap
@@ -46,13 +46,13 @@ exports[`FileTree with data 1`] = `
           <div
             className="checkbox"
           >
-            <label
-              title=""
-            >
+            <label>
               <input
                 checked={false}
+                className=""
                 disabled={false}
                 id="filetree-check-root"
+                name="root"
                 onChange={[Function]}
                 onClick={[Function]}
                 type="checkbox"
@@ -134,13 +134,13 @@ exports[`FileTree with data 1`] = `
                 <div
                   className="checkbox"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
                       checked={false}
+                      className=""
                       disabled={false}
                       id="filetree-check-root|parent1"
+                      name="root|parent1"
                       onChange={[Function]}
                       onClick={[Function]}
                       type="checkbox"
@@ -220,13 +220,13 @@ exports[`FileTree with data 1`] = `
                 <div
                   className="checkbox"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
                       checked={false}
+                      className=""
                       disabled={false}
                       id="filetree-check-root|loading parent"
+                      name="root|loading parent"
                       onChange={[Function]}
                       onClick={[Function]}
                       type="checkbox"
@@ -306,13 +306,13 @@ exports[`FileTree with data 1`] = `
                 <div
                   className="checkbox"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
                       checked={false}
+                      className=""
                       disabled={false}
                       id="filetree-check-root|parent2"
+                      name="root|parent2"
                       onChange={[Function]}
                       onClick={[Function]}
                       type="checkbox"
@@ -392,13 +392,13 @@ exports[`FileTree with data 1`] = `
                 <div
                   className="checkbox"
                 >
-                  <label
-                    title=""
-                  >
+                  <label>
                     <input
                       checked={false}
+                      className=""
                       disabled={false}
                       id="filetree-check-root|empty directory"
+                      name="root|empty directory"
                       onChange={[Function]}
                       onClick={[Function]}
                       type="checkbox"

--- a/packages/components/src/internal/components/forms/QueryInfoForm.spec.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.spec.tsx
@@ -17,8 +17,6 @@ import React from 'react';
 
 import { mount, shallow } from 'enzyme';
 
-import { Modal, ModalTitle } from 'react-bootstrap';
-
 import { makeQueryInfo } from '../../test/testHelpers';
 import mixturesQueryInfo from '../../../test/data/mixtures-getQueryDetails.json';
 

--- a/packages/components/src/internal/components/gridbar/ExportModal.tsx
+++ b/packages/components/src/internal/components/gridbar/ExportModal.tsx
@@ -1,9 +1,9 @@
 import React, { FC, memo, useCallback, useState } from 'react';
-import { Checkbox } from 'react-bootstrap';
 
 import { Modal } from '../../Modal';
 
 import { QueryModelMap } from '../../../public/QueryModel/withQueryModels';
+import { CheckboxLK } from '../../Checkbox';
 
 interface ExportModalProperties {
     canExport: boolean;
@@ -37,7 +37,7 @@ export const ExportModal: FC<ExportModalProperties> = memo(props => {
 
     const onChecked = useCallback(
         evt => {
-            const modelId = evt.target.value;
+            const modelId = evt.target.name;
             const draftSelected = new Set(selected);
             if (evt.target.checked) {
                 setSelected(draftSelected.add(modelId));
@@ -76,9 +76,9 @@ export const ExportModal: FC<ExportModalProperties> = memo(props => {
                         return (
                             <tr key={modelId}>
                                 <td>
-                                    <Checkbox checked={selected.has(modelId)} value={modelId} onChange={onChecked}>
+                                    <CheckboxLK checked={selected.has(modelId)} name={modelId} onChange={onChecked}>
                                         {model.title}
-                                    </Checkbox>
+                                    </CheckboxLK>
                                 </td>
                                 <td className="pull-right">{rowCountDisplay}</td>
                                 <td className="view-name">

--- a/packages/components/src/internal/components/labelPrinting/LabelsConfigurationPanel.spec.tsx
+++ b/packages/components/src/internal/components/labelPrinting/LabelsConfigurationPanel.spec.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { FormGroup } from 'react-bootstrap';
-
 import { getTestAPIWrapper } from '../../APIWrapper';
 
 import { mountWithAppServerContext, waitForLifecycle } from '../../test/enzymeTestHelpers';
@@ -151,7 +149,7 @@ describe('LabelTemplateDetails', () => {
 
         // Don't show anything, use Label List's default message
         expect(wrapper.find('.choices-detail__empty-message')).toHaveLength(0);
-        expect(wrapper.find(FormGroup)).toHaveLength(0);
+        expect(wrapper.find('.form-group')).toHaveLength(0);
         expect(wrapper.find('[name="isDefault"]')).toHaveLength(0);
         wrapper.unmount();
     });
@@ -161,7 +159,7 @@ describe('LabelTemplateDetails', () => {
 
         // Show no selection message
         expect(wrapper.find('.choices-detail__empty-message')).toHaveLength(1);
-        expect(wrapper.find(FormGroup)).toHaveLength(0);
+        expect(wrapper.find('.form-group')).toHaveLength(0);
         const defaultInput = wrapper.find('[name="isDefault"]');
         expect(defaultInput).toHaveLength(0);
         wrapper.unmount();
@@ -186,7 +184,7 @@ describe('LabelTemplateDetails', () => {
 
         // Show form w/o default selector
         expect(wrapper.find('.choices-detail__empty-message')).toHaveLength(0);
-        expect(wrapper.find(FormGroup)).toHaveLength(3);
+        expect(wrapper.find('.form-group')).toHaveLength(3);
         const defaultInput = wrapper.find('[name="isDefault"]');
         expect(defaultInput).toHaveLength(0);
         wrapper.unmount();
@@ -214,7 +212,7 @@ describe('LabelTemplateDetails', () => {
 
         // Show form with default selector and default selected
         expect(wrapper.find('.choices-detail__empty-message')).toHaveLength(0);
-        expect(wrapper.find(FormGroup)).toHaveLength(4);
+        expect(wrapper.find('.form-group')).toHaveLength(4);
         const defaultInput = wrapper.find('[name="isDefault"]');
         expect(defaultInput).toHaveLength(1);
         expect(defaultInput.prop('checked')).toBe(true);
@@ -243,7 +241,7 @@ describe('LabelTemplateDetails', () => {
 
         // Show form with default selector and default selected
         expect(wrapper.find('.choices-detail__empty-message')).toHaveLength(0);
-        expect(wrapper.find(FormGroup)).toHaveLength(4);
+        expect(wrapper.find('.form-group')).toHaveLength(4);
         const defaultInput = wrapper.find('[name="isDefault"]');
         expect(defaultInput).toHaveLength(1);
         expect(defaultInput.prop('checked')).toBe(false);

--- a/packages/components/src/internal/components/labelPrinting/LabelsConfigurationPanel.tsx
+++ b/packages/components/src/internal/components/labelPrinting/LabelsConfigurationPanel.tsx
@@ -1,9 +1,5 @@
 import React, { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-
-import { FormGroup } from 'react-bootstrap';
-
 import { List } from 'immutable';
-
 import { getServerContext } from '@labkey/api';
 
 import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
@@ -250,7 +246,7 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
             {updatedTemplate && (
                 <form className="form-horizontal content-form choices-detail__form">
                     {error && <Alert>{error}</Alert>}
-                    <FormGroup>
+                    <div className="form-group">
                         <div className="col-sm-4">
                             <DomainFieldLabel label="Name" required />
                         </div>
@@ -265,8 +261,8 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
                                 value={updatedTemplate.name ?? ''}
                             />
                         </div>
-                    </FormGroup>
-                    <FormGroup>
+                    </div>
+                    <div className="form-group">
                         <div className="col-sm-4">
                             <DomainFieldLabel label="Description" />
                         </div>
@@ -279,8 +275,8 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
                                 value={updatedTemplate.description ?? ''}
                             />
                         </div>
-                    </FormGroup>
-                    <FormGroup>
+                    </div>
+                    <div className="form-group">
                         <div className="col-sm-4">
                             <DomainFieldLabel label="File Path" required />
                             <LabelHelpTip title="BarTender Label Template">
@@ -301,9 +297,9 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
                                 value={updatedTemplate.path ?? ''}
                             />
                         </div>
-                    </FormGroup>
+                    </div>
                     {isDefaultable && (
-                        <FormGroup>
+                        <div className="form-group">
                             <div className="col-sm-4">
                                 <DomainFieldLabel label="Default Template" />
                             </div>
@@ -314,7 +310,7 @@ export const LabelTemplateDetails: FC<LabelTemplateDetailsProps> = memo(props =>
                                 type="checkbox"
                                 onChange={defaultToggleHandler}
                             />
-                        </FormGroup>
+                        </div>
                     )}
                     <div>
                         {!isNew && (

--- a/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { FC, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { Image } from 'react-bootstrap';
 import { getServerContext } from '@labkey/api';
 
 import { User } from '../base/models/User';
@@ -106,7 +105,7 @@ export const UserMenuGroupImpl: FC<UserMenuProps & ImplProps> = props => {
     }
 
     const userToggle = user.avatar ? (
-        <Image src={user.avatar} alt="User Avatar" rounded height={32} width={32} />
+        <img className="img-rounded" src={user.avatar} alt="User Avatar" height={32} width={32} />
     ) : (
         <span className="navbar-item">
             <span className="user-name">

--- a/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
+++ b/packages/components/src/internal/components/ontology/OntologyLookupOptions.tsx
@@ -1,5 +1,4 @@
 import React, { FC, memo, PureComponent, ReactNode } from 'react';
-import { FormControl } from 'react-bootstrap';
 import { List } from 'immutable';
 
 import { ADVANCED_FIELD_EDITOR_TOPIC, HelpLink, ONTOLOGY_LOOKUP_TOPIC } from '../../util/helpLinks';
@@ -195,8 +194,8 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                 </div>
                 <div className="row">
                     <div className="col-xs-5">
-                        <FormControl
-                            componentClass="select"
+                        <select
+                            className="form-control"
                             id={sourceId}
                             key={sourceId}
                             disabled={isFieldFullyLocked(lockType)}
@@ -222,7 +221,7 @@ export class OntologyLookupOptions extends PureComponent<Props, State> {
                                         </option>
                                     );
                                 })}
-                        </FormControl>
+                        </select>
                         <div className="domain-field-label">
                             <OntologyConceptSelectButton
                                 id={createFormInputId(DOMAIN_FIELD_ONTOLOGY_SUBTREE_COL, domainIndex, index)}
@@ -277,8 +276,8 @@ const OntologyTextDomainFieldSelect: FC<OntologyTextDomainFieldSelectProps> = me
     const { domainFields, lockType, field, id, value, filterValue, onFieldChange } = props;
 
     return (
-        <FormControl
-            componentClass="select"
+        <select
+            className="form-control"
             id={id}
             key={id}
             disabled={isFieldFullyLocked(lockType)}
@@ -299,6 +298,6 @@ const OntologyTextDomainFieldSelect: FC<OntologyTextDomainFieldSelectProps> = me
                     </option>
                 );
             })}
-        </FormControl>
+        </select>
     );
 });

--- a/packages/components/src/internal/components/pagination/Pagination.tsx
+++ b/packages/components/src/internal/components/pagination/Pagination.tsx
@@ -1,5 +1,4 @@
 import React, { PureComponent, ReactNode } from 'react';
-import { ButtonGroup } from 'react-bootstrap';
 
 import { LoadingState } from '../../../public/LoadingState';
 
@@ -89,7 +88,7 @@ export class Pagination extends PureComponent<PaginationProps> {
                 />
 
                 {showPaginationButtons && (
-                    <ButtonGroup className="pagination-button-group">
+                    <div className="pagination-button-group btn-group">
                         <PaginationButton
                             className="pagination-button--previous"
                             disabled={disabled || isFirstPage}
@@ -118,7 +117,7 @@ export class Pagination extends PureComponent<PaginationProps> {
                             tooltip="Next Page"
                             onClick={this.onLoadNextPage}
                         />
-                    </ButtonGroup>
+                    </div>
                 )}
             </div>
         );

--- a/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
+++ b/packages/components/src/internal/components/picklist/PicklistEditModal.tsx
@@ -1,6 +1,4 @@
 import React, { ChangeEvent, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Checkbox } from 'react-bootstrap';
-
 import { Utils } from '@labkey/api';
 
 import { Alert } from '../base/Alert';
@@ -14,22 +12,24 @@ import { useNotificationsContext } from '../notifications/NotificationsContext';
 import { setSnapshotSelections } from '../../actions';
 import { Modal } from '../../Modal';
 
+import { CheckboxLK } from '../../Checkbox';
+
 import { Picklist } from './models';
 import { createPicklist, getPicklistUrl, updatePicklist } from './actions';
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
 
 export interface PicklistEditModalProps {
-    sampleIds?: string[];
-    picklist?: Picklist;
+    api?: ComponentsAPIWrapper;
+    currentProductId?: string;
+    metricFeatureArea?: string;
     onCancel: () => void;
     onFinish: (picklist: Picklist) => void;
-    showNotification?: boolean;
-    currentProductId?: string;
+    picklist?: Picklist;
     picklistProductId?: string;
-    metricFeatureArea?: string;
-    api?: ComponentsAPIWrapper;
-    sampleFieldKey?: string;
     queryModel?: QueryModel;
+    sampleFieldKey?: string;
+    sampleIds?: string[];
+    showNotification?: boolean;
 }
 
 export const PicklistEditModal: FC<PicklistEditModalProps> = memo(props => {
@@ -94,9 +94,10 @@ const PicklistEditModalDisplay: FC<PicklistEditModalProps> = memo(props => {
     );
 
     const [shared, setShared] = useState<boolean>(picklist?.isPublic() ?? false);
-    // Using a type for evt here causes difficulties.  It wants a FormEvent<Checkbox> but
-    // then it doesn't recognize checked as a valid field on current target.
-    const onSharedChanged = useCallback(evt => setShared(evt.currentTarget.checked), []);
+    const onSharedChanged = useCallback(
+        (evt: ChangeEvent<HTMLInputElement>) => setShared(evt.currentTarget.checked),
+        []
+    );
 
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
     const [picklistError, setPicklistError] = useState<string>(undefined);
@@ -246,9 +247,9 @@ const PicklistEditModalDisplay: FC<PicklistEditModalProps> = memo(props => {
                         onChange={onDescriptionChange}
                     />
 
-                    <Checkbox checked={shared} onChange={onSharedChanged}>
-                        <span>Share this picklist</span>
-                    </Checkbox>
+                    <CheckboxLK checked={shared} name="shared" onChange={onSharedChanged}>
+                        Share this picklist
+                    </CheckboxLK>
                 </div>
             </form>
         </Modal>

--- a/packages/components/src/internal/components/project/ProjectNameSetting.tsx
+++ b/packages/components/src/internal/components/project/ProjectNameSetting.tsx
@@ -84,6 +84,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                     <input
                         autoComplete="off"
                         className="form-control"
+                        defaultValue={nameIsTitle ? name : defaultTitle}
                         disabled={nameIsTitle}
                         id="project-label"
                         name="title"

--- a/packages/components/src/internal/components/project/ProjectNameSetting.tsx
+++ b/packages/components/src/internal/components/project/ProjectNameSetting.tsx
@@ -1,5 +1,4 @@
 import React, { FC, memo, useCallback, useState } from 'react';
-import { ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
 
 import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 
@@ -41,22 +40,25 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
 
     return (
         <div className="project-name-properties">
-            <FormGroup controlId="project-name-prop-name">
-                <ControlLabel className="col-xs-12 col-sm-2 text-left" required>
+            <div className="form-group">
+                <label className="control-label col-xs-12 col-sm-2 text-left" htmlFor="project-name">
                     Project Name <span className="required-symbol">*</span>
-                </ControlLabel>
+                </label>
 
                 <div className="col-sm-10 col-md-5">
-                    <FormControl
+                    <input
                         autoComplete="off"
                         autoFocus={autoFocus}
+                        className="form-control"
                         defaultValue={defaultName}
+                        id="project-name"
                         name="name"
                         onChange={_onNameChange}
                         required
                         type="text"
                         maxLength={MAX_FOLDER_NAME_LENGTH}
                     />
+
                     <span className="help-block">
                         <label className="checkbox-inline" title={toggleLabel}>
                             <input
@@ -71,33 +73,26 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                         </label>
                     </span>
                 </div>
-            </FormGroup>
+            </div>
 
-            <FormGroup controlId="project-name-prop-title">
-                <ControlLabel className="col-xs-12 col-sm-2 text-left">Project Label</ControlLabel>
+            <div className="form-group">
+                <label className="control-label col-xs-12 col-sm-2 text-left" htmlFor="project-label">
+                    Project Label
+                </label>
 
                 <div className="col-sm-10 col-md-5">
-                    {nameIsTitle ? (
-                        <FormControl
-                            autoComplete="off"
-                            disabled={nameIsTitle}
-                            key="controlled"
-                            name="title"
-                            type="text"
-                            value={nameIsTitle ? name : undefined}
-                        />
-                    ) : (
-                        <FormControl
-                            autoComplete="off"
-                            defaultValue={nameIsTitle ? name : defaultTitle}
-                            key="uncontrolled"
-                            name="title"
-                            onChange={_onTitleChange}
-                            type="text"
-                        />
-                    )}
+                    <input
+                        autoComplete="off"
+                        className="form-control"
+                        disabled={nameIsTitle}
+                        id="project-label"
+                        name="title"
+                        onChange={_onTitleChange}
+                        type="text"
+                        value={nameIsTitle ? name : undefined}
+                    />
                 </div>
-            </FormGroup>
+            </div>
         </div>
     );
 });

--- a/packages/components/src/internal/components/project/ProjectNameSetting.tsx
+++ b/packages/components/src/internal/components/project/ProjectNameSetting.tsx
@@ -41,7 +41,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
     return (
         <div className="project-name-properties">
             <div className="form-group">
-                <label className="control-label col-xs-12 col-sm-2 text-left" htmlFor="project-name">
+                <label className="control-label col-xs-12 col-sm-2 text-left" htmlFor="name">
                     Project Name <span className="required-symbol">*</span>
                 </label>
 
@@ -51,7 +51,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                         autoFocus={autoFocus}
                         className="form-control"
                         defaultValue={defaultName}
-                        id="project-name"
+                        id="name"
                         name="name"
                         onChange={_onNameChange}
                         required
@@ -62,7 +62,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                     <span className="help-block">
                         <label className="checkbox-inline" title={toggleLabel}>
                             <input
-                                id="project-name-prop-nameIsTitle"
+                                id="nameIsTitle"
                                 defaultChecked={nameIsTitle}
                                 style={{ marginRight: '8px' }}
                                 name="nameAsTitle"
@@ -76,7 +76,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
             </div>
 
             <div className="form-group">
-                <label className="control-label col-xs-12 col-sm-2 text-left" htmlFor="project-label">
+                <label className="control-label col-xs-12 col-sm-2 text-left" htmlFor="label">
                     Project Label
                 </label>
 
@@ -86,6 +86,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                             autoComplete="off"
                             className="form-control"
                             disabled
+                            id="label"
                             key="controlled"
                             name="title"
                             type="text"
@@ -97,6 +98,7 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                             autoComplete="off"
                             className="form-control"
                             defaultValue={defaultTitle}
+                            id="label"
                             key="uncontrolled"
                             name="title"
                             onChange={_onTitleChange}

--- a/packages/components/src/internal/components/project/ProjectNameSetting.tsx
+++ b/packages/components/src/internal/components/project/ProjectNameSetting.tsx
@@ -81,17 +81,28 @@ export const ProjectNameSetting: FC<Props> = memo(props => {
                 </label>
 
                 <div className="col-sm-10 col-md-5">
-                    <input
-                        autoComplete="off"
-                        className="form-control"
-                        defaultValue={nameIsTitle ? name : defaultTitle}
-                        disabled={nameIsTitle}
-                        id="project-label"
-                        name="title"
-                        onChange={_onTitleChange}
-                        type="text"
-                        value={nameIsTitle ? name : undefined}
-                    />
+                    {nameIsTitle && (
+                        <input
+                            autoComplete="off"
+                            className="form-control"
+                            disabled
+                            key="controlled"
+                            name="title"
+                            type="text"
+                            value={name ?? ''}
+                        />
+                    )}
+                    {!nameIsTitle && (
+                        <input
+                            autoComplete="off"
+                            className="form-control"
+                            defaultValue={defaultTitle}
+                            key="uncontrolled"
+                            name="title"
+                            onChange={_onTitleChange}
+                            type="text"
+                        />
+                    )}
                 </div>
             </div>
         </div>

--- a/packages/components/src/internal/components/report-list/ReportList.tsx
+++ b/packages/components/src/internal/components/report-list/ReportList.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import React, { PureComponent } from 'react';
-import { Image, Media } from 'react-bootstrap';
 
 import { PreviewGrid } from '../PreviewGrid';
 import { Chart } from '../chart/Chart';
@@ -208,7 +207,7 @@ export class ReportListItem extends PureComponent<ReportListItemProps> {
         const iconSrc = ICONS[type];
         const iconClassName = 'report-list-item__icon';
         const hasCustomIcon = icon.indexOf('reports-thumbnail.view') > -1;
-        let iconEl = <Image className={iconClassName} src={icon} />;
+        let iconEl = <img alt={icon} className={iconClassName} src={icon} />;
 
         if (iconSrc !== undefined && !hasCustomIcon) {
             iconEl = <SVGIcon className={iconClassName} height={null} iconSrc={iconSrc} />;
@@ -223,14 +222,14 @@ export class ReportListItem extends PureComponent<ReportListItemProps> {
         }
 
         return (
-            <Media.ListItem className="report-list-item" onClick={this.onClick}>
-                <Media.Left>{iconEl}</Media.Left>
+            <li className="report-list-item media" onClick={this.onClick}>
+                <div className="media-left">{iconEl}</div>
 
-                <Media.Body>
-                    <Media.Heading className="report-list-item__name">{nameEl}</Media.Heading>
+                <div className="media-body">
+                    <h4 className="report-list-item__name media-heading">{nameEl}</h4>
                     {createdByEl}
-                </Media.Body>
-            </Media.ListItem>
+                </div>
+            </li>
         );
     }
 }
@@ -260,7 +259,7 @@ export class ReportList extends PureComponent<ReportListProps> {
                 return <ReportListItem key={report.runUrl} report={report} onClick={onReportClicked} />;
             });
 
-            body = <Media.List className="report-list__list">{reportEls}</Media.List>;
+            body = <div className="media-list report-list__list">{reportEls}</div>;
         }
 
         return (

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -1,6 +1,4 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-
-import { FormGroup } from 'react-bootstrap';
 import { List } from 'immutable';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
@@ -225,7 +223,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
             {updatedState && (
                 <form className="form-horizontal content-form">
                     {error && <Alert>{error}</Alert>}
-                    <FormGroup>
+                    <div className="form-group">
                         <div className="col-sm-4">
                             <DomainFieldLabel label="Label" required />
                         </div>
@@ -240,8 +238,8 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 value={updatedState.label ?? ''}
                             />
                         </div>
-                    </FormGroup>
-                    <FormGroup>
+                    </div>
+                    <div className="form-group">
                         <div className="col-sm-4">
                             <DomainFieldLabel label="Color" required />
                         </div>
@@ -255,8 +253,8 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 colors={Object.keys(SAMPLE_STATUS_COLORS)}
                             />
                         </div>
-                    </FormGroup>
-                    <FormGroup>
+                    </div>
+                    <div className="form-group">
                         <div className="col-sm-4">
                             <DomainFieldLabel label="Description" />
                         </div>
@@ -269,8 +267,8 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 value={updatedState.description ?? ''}
                             />
                         </div>
-                    </FormGroup>
-                    <FormGroup>
+                    </div>
+                    <div className="form-group">
                         <div className="col-sm-4">
                             <DomainFieldLabel label="Status Type" required />
                         </div>
@@ -286,7 +284,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                                 value={updatedState.stateType}
                             />
                         </div>
-                    </FormGroup>
+                    </div>
                     <div>
                         {!addNew && updatedState.isLocal && (
                             <DisableableButton

--- a/packages/components/src/internal/components/search/FilterExpressionView.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.tsx
@@ -1,6 +1,4 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { FormControl } from 'react-bootstrap';
-
 import { Filter } from '@labkey/api';
 
 import { QueryColumn } from '../../../public/QueryColumn';
@@ -290,7 +288,7 @@ export const FilterExpressionView: FC<Props> = memo(props => {
 
             if (!isMultiValueInput && (jsonType === 'int' || jsonType === 'float')) {
                 return (
-                    <FormControl
+                    <input
                         className="form-control filter-expression__input"
                         step={jsonType === 'int' ? 1 : undefined}
                         name={'field-value-text' + suffix}

--- a/packages/components/src/internal/components/settings/NameIdSettings.spec.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.spec.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { Checkbox } from 'react-bootstrap';
-
 import { mountWithServerContext, waitForLifecycle } from '../../test/enzymeTestHelpers';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
@@ -66,7 +64,7 @@ describe('NameIdSettings', () => {
         const wrapper = mountWithServerContext(<NameIdSettingsForm {...DEFAULT_PROPS} />);
         expect(wrapper.find(LoadingSpinner).length).toEqual(3);
         expect(wrapper.find('.name-id-setting__prefix-field').exists()).toEqual(false);
-        expect(wrapper.find(Checkbox).exists()).toEqual(false);
+        expect(wrapper.find('.checkbox').exists()).toEqual(false);
 
         await waitForLifecycle(wrapper);
 
@@ -75,7 +73,7 @@ describe('NameIdSettings', () => {
         expect(wrapper.find('.name-id-setting__prefix-field')).toHaveLength(1);
         expect(wrapper.find('.sample-counter__setting-section')).toHaveLength(1);
         expect(wrapper.find('.sample-counter__prefix-label')).toHaveLength(2);
-        expect(wrapper.find(Checkbox)).toHaveLength(1);
+        expect(wrapper.find('.checkbox')).toHaveLength(1);
         expect(wrapper.find('.form-control')).toHaveLength(3);
         expect(wrapper.find('button')).toHaveLength(3);
         expect(DEFAULT_PROPS.loadNameExpressionOptions).toHaveBeenCalled();
@@ -95,7 +93,7 @@ describe('NameIdSettings', () => {
         const wrapper = mountWithServerContext(<NameIdSettingsForm {...DEFAULT_PROPS} isAppHome={false} />);
         expect(wrapper.find(LoadingSpinner).length).toEqual(2);
         expect(wrapper.find('.name-id-setting__prefix-field').exists()).toEqual(false);
-        expect(wrapper.find(Checkbox).exists()).toEqual(false);
+        expect(wrapper.find('.checkbox').exists()).toEqual(false);
 
         await waitForLifecycle(wrapper);
 
@@ -104,7 +102,7 @@ describe('NameIdSettings', () => {
         expect(wrapper.find('.name-id-setting__prefix-field')).toHaveLength(1);
         expect(wrapper.find('.sample-counter__setting-section')).toHaveLength(0);
         expect(wrapper.find('.sample-counter__prefix-label')).toHaveLength(0);
-        expect(wrapper.find(Checkbox)).toHaveLength(1);
+        expect(wrapper.find('.checkbox')).toHaveLength(1);
         expect(wrapper.find('.form-control')).toHaveLength(1);
         expect(wrapper.find('button')).toHaveLength(1);
         expect(DEFAULT_PROPS.loadNameExpressionOptions).toHaveBeenCalled();
@@ -181,7 +179,7 @@ describe('NameIdSettings', () => {
 
         expect(wrapper.find('.name-id-setting__setting-section')).toHaveLength(1);
         expect(wrapper.find('.name-id-setting__prefix-field')).toHaveLength(0);
-        expect(wrapper.find(Checkbox)).toHaveLength(1);
+        expect(wrapper.find('.checkbox')).toHaveLength(1);
         expect(wrapper.find('.form-control')).toHaveLength(2);
     });
 

--- a/packages/components/src/internal/components/settings/NameIdSettings.spec.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Checkbox, FormControl } from 'react-bootstrap';
+import { Checkbox } from 'react-bootstrap';
 
 import { mountWithServerContext, waitForLifecycle } from '../../test/enzymeTestHelpers';
 
@@ -76,7 +76,7 @@ describe('NameIdSettings', () => {
         expect(wrapper.find('.sample-counter__setting-section')).toHaveLength(1);
         expect(wrapper.find('.sample-counter__prefix-label')).toHaveLength(2);
         expect(wrapper.find(Checkbox)).toHaveLength(1);
-        expect(wrapper.find(FormControl)).toHaveLength(3);
+        expect(wrapper.find('.form-control')).toHaveLength(3);
         expect(wrapper.find('button')).toHaveLength(3);
         expect(DEFAULT_PROPS.loadNameExpressionOptions).toHaveBeenCalled();
 
@@ -105,7 +105,7 @@ describe('NameIdSettings', () => {
         expect(wrapper.find('.sample-counter__setting-section')).toHaveLength(0);
         expect(wrapper.find('.sample-counter__prefix-label')).toHaveLength(0);
         expect(wrapper.find(Checkbox)).toHaveLength(1);
-        expect(wrapper.find(FormControl)).toHaveLength(1);
+        expect(wrapper.find('.form-control')).toHaveLength(1);
         expect(wrapper.find('button')).toHaveLength(1);
         expect(DEFAULT_PROPS.loadNameExpressionOptions).toHaveBeenCalled();
 
@@ -182,7 +182,7 @@ describe('NameIdSettings', () => {
         expect(wrapper.find('.name-id-setting__setting-section')).toHaveLength(1);
         expect(wrapper.find('.name-id-setting__prefix-field')).toHaveLength(0);
         expect(wrapper.find(Checkbox)).toHaveLength(1);
-        expect(wrapper.find(FormControl)).toHaveLength(2);
+        expect(wrapper.find('.form-control')).toHaveLength(2);
     });
 
     test('With counter, with existing sample', async () => {
@@ -191,7 +191,7 @@ describe('NameIdSettings', () => {
 
         expect(wrapper.find('.sample-counter__setting-section')).toHaveLength(1);
         expect(wrapper.find('.sample-counter__prefix-label')).toHaveLength(2);
-        expect(wrapper.find(FormControl)).toHaveLength(3);
+        expect(wrapper.find('.form-control')).toHaveLength(3);
         const buttons = wrapper.find('button');
         expect(buttons.length).toEqual(3);
 
@@ -212,7 +212,7 @@ describe('NameIdSettings', () => {
 
         expect(wrapper.find('.sample-counter__setting-section')).toHaveLength(1);
         expect(wrapper.find('.sample-counter__prefix-label')).toHaveLength(2);
-        expect(wrapper.find(FormControl)).toHaveLength(3);
+        expect(wrapper.find('.form-control')).toHaveLength(3);
         const buttons = wrapper.find('button');
         expect(buttons.length).toEqual(5);
 

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo, useCallback, useEffect, useReducer } from 'react';
 
 import { PermissionTypes } from '@labkey/api';
-import { Checkbox, FormControl } from 'react-bootstrap';
+import { Checkbox } from 'react-bootstrap';
 
 import { biologicsIsPrimaryApp, sampleManagerIsPrimaryApp } from '../../app/utils';
 
@@ -341,7 +341,8 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                     <div className="name-id-setting__prefix-label"> Prefix: </div>
 
                                     <div className="name-id-setting__prefix-field">
-                                        <FormControl
+                                        <input
+                                            className="form-control"
                                             name="prefix"
                                             type="text"
                                             placeholder="Enter Prefix"
@@ -408,8 +409,8 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         <div className="sample-counter__prefix-label">sampleCount</div>
                                     </div>
                                     <div className="col-sm-2">
-                                        <FormControl
-                                            className="update-samplecount-input "
+                                        <input
+                                            className="form-control update-samplecount-input"
                                             min={sampleCount}
                                             step={1}
                                             name="newSampleCount"
@@ -449,8 +450,8 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         <div className="sample-counter__prefix-label">rootSampleCount</div>
                                     </div>
                                     <div className="col-sm-2">
-                                        <FormControl
-                                            className="update-samplecount-input "
+                                        <input
+                                            className="form-control update-samplecount-input"
                                             min={rootSampleCount}
                                             step={1}
                                             name="newRootSampleCount"

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -1,7 +1,6 @@
 import React, { FC, memo, useCallback, useEffect, useReducer } from 'react';
 
 import { PermissionTypes } from '@labkey/api';
-import { Checkbox } from 'react-bootstrap';
 
 import { biologicsIsPrimaryApp, sampleManagerIsPrimaryApp } from '../../app/utils';
 
@@ -23,6 +22,8 @@ import { HelpLink } from '../../util/helpLinks';
 import { SAMPLE_TYPE_NAME_EXPRESSION_TOPIC } from '../samples/constants';
 
 import { Container } from '../base/models/Container';
+
+import { CheckboxLK } from '../../Checkbox';
 
 import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
 
@@ -303,7 +304,8 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                     {loadingNamingOptions && <LoadingSpinner />}
                     {!loadingNamingOptions && (
                         <form>
-                            <Checkbox
+                            <CheckboxLK
+                                name="allowUserSpecifiedNames"
                                 onChange={saveAllowUserSpecifiedNames}
                                 disabled={savingAllowUserSpecifiedNames}
                                 checked={allowUserSpecifiedNames}
@@ -321,7 +323,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         import will result in an error if a new ID/Name is encountered.
                                     </p>
                                 </LabelHelpTip>
-                            </Checkbox>
+                            </CheckboxLK>
                         </form>
                     )}
                 </div>

--- a/packages/components/src/internal/components/user/CreateUsersModal.tsx
+++ b/packages/components/src/internal/components/user/CreateUsersModal.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from 'react';
-import { FormControl } from 'react-bootstrap';
 import { Security } from '@labkey/api';
 
 import { Modal } from '../../Modal';
@@ -11,11 +10,11 @@ import { Alert } from '../base/Alert';
 interface Props {
     onCancel: () => void;
     onComplete: (response: any, roles: string[]) => void;
-    userLimitSettings?: Partial<UserLimitSettings>;
-
     // optional array of role options, objects with id and label values (i.e. [{id: "org.labkey.api.security.roles.ReaderRole", label: "Reader (default)"}])
     // note that the createNewUser action will not use this value but it will be passed back to the onComplete
     roleOptions?: any[];
+
+    userLimitSettings?: Partial<UserLimitSettings>;
 }
 
 interface State {
@@ -92,11 +91,10 @@ export class CreateUsersModal extends React.Component<Props, State> {
 
         return (
             <>
-                <div className="create-users-label-bottom">
+                <label className="create-users-label-bottom" htmlFor="create-users-email-input">
                     Enter one or more email addresses, each on its own line:
-                </div>
-                <FormControl
-                    componentClass="textarea"
+                </label>
+                <textarea
                     className="form-control"
                     id="create-users-email-input"
                     rows={5}
@@ -110,10 +108,11 @@ export class CreateUsersModal extends React.Component<Props, State> {
                 )}
                 {this.hasRoleOptions() && (
                     <>
-                        <div className="create-users-label-top create-users-label-bottom">Roles:</div>
+                        <label className="create-users-label-top create-users-label-bottom" htmlFor="create-users-role">Roles:</label>
                         <SelectInput
                             containerClass="form-group row"
                             inputClass="col-sm-12"
+                            inputId="create-users-role"
                             name="create-users-role"
                             key="create-users-role-selection"
                             placeholder="Select role..."
@@ -127,9 +126,10 @@ export class CreateUsersModal extends React.Component<Props, State> {
                         />
                     </>
                 )}
-                <div className="create-users-label-bottom">Optional message to send to new users:</div>
-                <FormControl
-                    componentClass="textarea"
+                <label className="create-users-label-bottom" htmlFor="create-users-optionalMessage-input">
+                    Optional message to send to new users:
+                </label>
+                <textarea
                     className="form-control"
                     id="create-users-optionalMessage-input"
                     rows={5}

--- a/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
+++ b/packages/components/src/public/QueryModel/TabbedGridPanel.tsx
@@ -172,7 +172,7 @@ export const TabbedGridPanel: FC<TabbedGridPanelProps & InjectedQueryModels> = m
         [onTabSelect]
     );
 
-    // useNotificationsContext will not always be available depending on if the app wraps the NotificationsContext.Provider
+    // useNotificationsContext is only available if the app uses NotificationsContext, LKS does not
     let _createNotification;
     try {
         _createNotification = useNotificationsContext().createNotification;

--- a/packages/components/src/theme/timeline.scss
+++ b/packages/components/src/theme/timeline.scss
@@ -150,5 +150,5 @@
 }
 
 .timeline-container {
-    overflow-x: scroll;
+    overflow-x: auto;
 }


### PR DESCRIPTION
#### Rationale
This PR removes many usages of react-bootstrap

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1494
- https://github.com/LabKey/labkey-ui-premium/pull/412
- https://github.com/LabKey/limsModules/pull/260
- https://github.com/LabKey/platform/pull/5507
- https://github.com/LabKey/testAutomation/pull/1940

#### Changes
- Remove usages of react-bootstrap
- Add CheckboxLK
  -  To be renamed to Checkbox when we stop using the react-bootstrap version
- No longer make `id` a required prop for `OverlayTrigger`
