### PR TITLE
Issue 49956: Backport of styling update for PreviewOption for QuerySelect

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.12-querySelectStyling.0",
+  "version": "3.24.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.12-querySelectStyling.0",
+      "version": "3.24.12",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.11",
+  "version": "3.24.12-querySelectStyling.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.24.11",
+      "version": "3.24.12-querySelectStyling.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.29.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.11",
+  "version": "3.24.12-querySelectStyling.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.24.12-querySelectStyling.0",
+  "version": "3.24.12",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages.
 
 ### version 3.24.12
-*Released*: TBD
+*Released*: 16 May 2024
 - Issue 49956: Backport of styling update for PreviewOption for QuerySelect
 
 ### version 3.24.11

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.24.12
+*Released*: TBD
+- Issue 49956: Backport of styling update for PreviewOption for QuerySelect
+
 ### version 3.24.11
 *Released*: 8 March 2024
 - Issue 49858: LKSM: Saving grid filter on Storage Status takes 5+ minutes to load grid

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -80,7 +80,7 @@ const PreviewOption: FC<any> = props => {
                         }
 
                         return (
-                            <div key={i} className="text__truncate">
+                            <div key={i}>
                                 {columns.length > 1 && <strong>{column.caption}: </strong>}
                                 <span>{text}</span>
                             </div>
@@ -88,7 +88,7 @@ const PreviewOption: FC<any> = props => {
                     }
 
                     return (
-                        <div key={i} className="text__truncate">
+                        <div key={i}>
                             <span>{label}</span>
                         </div>
                     );


### PR DESCRIPTION
#### Rationale
Issue [49956](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49956)

#### Related Pull Requests
- #1461
- https://github.com/LabKey/labkey-ui-premium/pull/414
- https://github.com/LabKey/limsModules/pull/265

#### Changes
- Remove class from PreviewOptions
