### PR TITLE
Fix Issue 50455

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.46.2",
+  "version": "3.46.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.46.2",
+      "version": "3.46.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.46.2",
+  "version": "3.46.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.46.3
+*Released*: 21 May 2024
+- Fix Issue 50455
+
 ### version 3.46.2
 *Released*: 21 May 2024
 - Issue 50347 LKSM: Data Field Name in Naming Pattern Causing Error

--- a/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.spec.tsx
@@ -119,7 +119,7 @@ describe('ColumnSelectionModal', () => {
         }
 
         function validate(wrapper: ReactWrapper, column: QueryColumn, dragDisabled: boolean): void {
-            const fieldName = wrapper.find('.field-name');
+            const fieldName = wrapper.find('.field-name span');
             expect(fieldName.text()).toBe(column.caption);
             const removeIcon = wrapper.find('.fa-times');
             expect(removeIcon.exists()).toBeTruthy();
@@ -189,8 +189,8 @@ describe('ColumnSelectionModal', () => {
     describe('FieldLabelDisplay', () => {
         test('not lookup', () => {
             const wrapper = mount(<FieldLabelDisplay column={QUERY_COL} includeFieldKey />);
-            expect(wrapper.find('.field-name')).toHaveLength(1);
-            expect(wrapper.find('.field-name').text()).toBe(QUERY_COL.caption);
+            expect(wrapper.find('.field-name span')).toHaveLength(1);
+            expect(wrapper.find('.field-name span').text()).toBe(QUERY_COL.caption);
             expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
             expect(wrapper.find('input')).toHaveLength(0);
             wrapper.unmount();
@@ -198,7 +198,7 @@ describe('ColumnSelectionModal', () => {
 
         test('is lookup', () => {
             const wrapper = mount(<FieldLabelDisplay column={QUERY_COL_LOOKUP} includeFieldKey />);
-            expect(wrapper.find('.field-name')).toHaveLength(1);
+            expect(wrapper.find('.field-name span')).toHaveLength(1);
             expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
             expect(wrapper.find('input')).toHaveLength(0);
             wrapper.unmount();

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -74,8 +74,8 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
     }
 
     return (
-        <OverlayTrigger overlay={popover}>
-            <div className="field-name">{initialTitle}</div>
+        <OverlayTrigger className="field-name" overlay={popover}>
+            <span>{initialTitle}</span>
         </OverlayTrigger>
     );
 });

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.spec.tsx
@@ -173,13 +173,13 @@ describe('CustomizeGridViewModal', () => {
         expect(colsInView.at(1).prop('selected')).toBe(true);
 
         // clicking a new column should change the selected index
-        colsInView.at(0).find('.field-name').simulate('click');
+        colsInView.at(0).find('.field-name span').simulate('click');
         colsInView = wrapper.find(ColumnInView);
         expect(colsInView.at(0).prop('selected')).toBe(true);
         expect(colsInView.at(1).prop('selected')).toBe(false);
 
         // clicking on the same column should unselect
-        colsInView.at(0).find('.field-name').simulate('click');
+        colsInView.at(0).find('.field-name span').simulate('click');
         colsInView = wrapper.find(ColumnInView);
         expect(colsInView.at(0).prop('selected')).toBe(false);
         expect(colsInView.at(1).prop('selected')).toBe(false);


### PR DESCRIPTION
#### Rationale
My previous react-bootstrap related PR introduced a bug with the column selection modal's layout.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1499
- https://github.com/LabKey/limsModules/pull/281

#### Changes
- Fix [Issue 50455](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50455)
