### PR TITLE
Plate Editor

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.47.0",
+  "version": "3.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.47.0",
+      "version": "3.48.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.47.0",
+  "version": "3.48.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.??.0
+*Released*: ?? May 2024
+- Fix Issue 48377: LKSM/LKB: Editable grid allows pasting into cells that are marked as read-only
+- EditableGrid: add hideReadonlyRows prop
+
 ### version 3.47.0
 *Released*: 30 May 2024
 - Expose `registerInputRenderer` as a way for external package usages of `@labkey/components` to register custom form/grid input renderers.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 3.??.0
 *Released*: ?? May 2024
 - Fix Issue 48377: LKSM/LKB: Editable grid allows pasting into cells that are marked as read-only
+- Fix Issue 48242: LKSM/LKB: Editable Grid - Right clicking a multi-cell selection doesn't work as expected
 - EditableGrid: add hideReadonlyRows prop
 
 ### version 3.47.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ?? May 2024
 - Fix Issue 48377: LKSM/LKB: Editable grid allows pasting into cells that are marked as read-only
 - Fix Issue 48242: LKSM/LKB: Editable Grid - Right clicking a multi-cell selection doesn't work as expected
+- EditableGrid: Fix issue where cut (cmd + x) would delete read only cell values
 - EditableGrid: add hideReadonlyRows prop
 
 ### version 3.47.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.??.0
-*Released*: ?? May 2024
+### version 3.48.0
+*Released*: 4 June 2024
 - Fix Issue 48377: LKSM/LKB: Editable grid allows pasting into cells that are marked as read-only
 - Fix Issue 48242: LKSM/LKB: Editable Grid - Right clicking a multi-cell selection doesn't work as expected
 - EditableGrid: Fix issue where cut (cmd/ctrl + x) would delete read only cell values

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,8 +5,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ?? May 2024
 - Fix Issue 48377: LKSM/LKB: Editable grid allows pasting into cells that are marked as read-only
 - Fix Issue 48242: LKSM/LKB: Editable Grid - Right clicking a multi-cell selection doesn't work as expected
-- EditableGrid: Fix issue where cut (cmd + x) would delete read only cell values
-- EditableGrid: add hideReadonlyRows prop
+- EditableGrid: Fix issue where cut (cmd/ctrl + x) would delete read only cell values
+- EditableGrid: Add hideReadonlyRows prop
+- QueryFormInputs: Remove unused prop componentKey
 
 ### version 3.47.0
 *Released*: 30 May 2024

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -174,6 +174,7 @@ import { ChoicesListItem } from './internal/components/base/ChoicesListItem';
 import { DataTypeSelector } from './internal/components/entities/DataTypeSelector';
 
 import { EditorMode, EditorModel } from './internal/components/editable/models';
+import { EditableGridEvent } from './internal/components/editable/constants';
 import {
     clearSelected,
     getGridIdsFromTransactionId,
@@ -1137,6 +1138,7 @@ export {
     EditableGridTabs,
     EditorModel,
     EditorMode,
+    EditableGridEvent,
     cancelEvent,
     // url and location related items
     AppURL,
@@ -1917,7 +1919,6 @@ export type { EditableDetailPanelProps } from './public/QueryModel/EditableDetai
 export type { ComponentsAPIWrapper } from './internal/APIWrapper';
 export type { GetParentTypeDataForLineage } from './internal/components/entities/actions';
 export type { URLMapper } from './internal/url/URLResolver';
-export type { EditableGridEvent } from './internal/components/editable/constants';
 export type { PlacementType } from './internal/components/editable/Controls';
 export type { EditableGridChange } from './internal/components/editable/EditableGrid';
 export type { GetAssayDefinitionsOptions, GetProtocolOptions } from './internal/components/assay/actions';

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -111,7 +111,6 @@ interface GridHeaderProps {
     headerCell?: any;
     onColumnDrop?: (sourceIndex: string, targetIndex: string) => void;
     showHeader?: boolean;
-    transpose?: boolean;
 }
 
 interface State {
@@ -157,10 +156,10 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
     };
 
     render() {
-        const { calcWidths, columns, headerCell, showHeader, transpose, onColumnDrop } = this.props;
+        const { calcWidths, columns, headerCell, showHeader, onColumnDrop } = this.props;
         const { dragTarget } = this.state;
 
-        if (transpose || !showHeader) {
+        if (!showHeader) {
             // returning null here causes <noscript/> to render which is not expected
             return <thead style={{ display: 'none' }} />;
         }
@@ -239,6 +238,7 @@ const GridMessages: FC<GridMessagesProps> = memo(({ messages }) => (
     <div className="grid-messages">
         {messages.map((message: Map<string, string>, i) => {
             return (
+                // eslint-disable-next-line react/no-array-index-key
                 <div className="grid-message" key={i}>
                     {message.get('content')}
                 </div>
@@ -255,18 +255,10 @@ interface GridBodyProps {
     isLoading: boolean;
     loadingText: ReactNode;
     rowKey: any;
-    transpose: boolean;
 }
 
 class GridBody extends PureComponent<GridBodyProps> {
-    constructor(props: GridBodyProps) {
-        super(props);
-
-        this.renderRow = this.renderRow.bind(this);
-        this.renderRowTranspose = this.renderRowTranspose.bind(this);
-    }
-
-    renderDefaultRow() {
+    renderDefaultRow(): ReactNode {
         const { columns, emptyText, isLoading, loadingText } = this.props;
 
         return (
@@ -276,7 +268,7 @@ class GridBody extends PureComponent<GridBodyProps> {
         );
     }
 
-    renderRow(row: any, r: number, highlight?: boolean): any {
+    renderRow = (row: any, r: number, highlight?: boolean): ReactNode => {
         const { columns, rowKey } = this.props;
         const key = rowKey ? row.get(rowKey) : r;
 
@@ -302,32 +294,15 @@ class GridBody extends PureComponent<GridBodyProps> {
                 )}
             </tr>
         );
-    }
+    };
 
-    renderRowTranspose(row: any, r: number): any {
-        const { columns, rowKey } = this.props;
-        let counter = 0;
-        const key = rowKey ? row.get(rowKey) : r;
-
-        return columns
-            .map((column: GridColumn, c: number) => (
-                <tr key={[key, counter++].join('_')} style={c === 0 ? { backgroundColor: '#eee' } : undefined}>
-                    <td>{column.title}</td>
-                    <td>{column.cell(row.get(column.index), row, column, r, c)}</td>
-                </tr>
-            ))
-            .toArray();
-    }
-
-    render() {
-        const { data, transpose, highlightRowIndexes } = this.props;
+    render(): ReactNode {
+        const { data, highlightRowIndexes } = this.props;
 
         return (
             <tbody>
                 {data.count() > 0
                     ? data.map((row, ind) => {
-                          if (transpose) return this.renderRowTranspose(row, ind);
-
                           const highlight = highlightRowIndexes && highlightRowIndexes.contains(ind);
                           return this.renderRow(row, ind, highlight);
                       })
@@ -364,7 +339,6 @@ export interface GridProps {
     showHeader?: boolean;
     striped?: boolean;
     tableRef?: RefObject<HTMLTableElement>;
-    transpose?: boolean;
 }
 
 export const Grid: FC<GridProps> = memo(props => {
@@ -382,7 +356,6 @@ export const Grid: FC<GridProps> = memo(props => {
         showHeader = true,
         striped = true,
         tableRef = undefined,
-        transpose = false,
         fixedHeight = false,
         columns,
         headerCell,
@@ -408,7 +381,6 @@ export const Grid: FC<GridProps> = memo(props => {
         headerCell,
         onColumnDrop,
         showHeader,
-        transpose,
     };
 
     const bodyProps: GridBodyProps = {
@@ -418,7 +390,6 @@ export const Grid: FC<GridProps> = memo(props => {
         isLoading,
         loadingText,
         rowKey,
-        transpose,
         highlightRowIndexes,
     };
 

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -258,7 +258,7 @@ interface GridBodyProps {
 }
 
 class GridBody extends PureComponent<GridBodyProps> {
-    renderDefaultRow(): ReactNode {
+    renderDefaultRow = (): ReactNode => {
         const { columns, emptyText, isLoading, loadingText } = this.props;
 
         return (

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -333,6 +333,9 @@ export class Cell extends React.PureComponent<CellProps, State> {
     };
 
     handleSelect: React.MouseEventHandler<HTMLDivElement> = (event): void => {
+        // Only handle event if the left mouse button is clicked
+        if (event.buttons !== 1) return;
+
         const { cellActions, colIdx, rowIdx, selected } = this.props;
         const { selectCell } = cellActions;
 

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1023,6 +1023,9 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     beginDrag = (event: GridMouseEvent): void => {
+        // Only handle event if the left mouse button is clicked
+        if (event.buttons !== 1) return;
+
         const { disabled, editorModel } = this.props;
         if (this.handleDrag(event) && !disabled) {
             clearTimeout(this.dragDelay);

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -726,7 +726,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
      * Given a colIdx/rowIdx returns true if a cell is read only. Use this in event handlers to prevent modifying read
      * only cells (e.g. during delete).
      */
-    isReadOnly(colIdx: number, rowIdx: number): boolean {
+    isReadOnly(cellKey: string): boolean {
+        const { colIdx, rowIdx } = parseCellKey(cellKey);
         const { dataKeys, lockedRows, readonlyRows } = this.props;
         const cellValueDataKey = dataKeys.get(rowIdx);
 
@@ -738,7 +739,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const loweredColumnMetadata = this.getLoweredColumnMetadata();
         const metadata = loweredColumnMetadata[queryCol.fieldKey.toLowerCase()];
 
-        return metadata && (metadata.readOnly || metadata.isReadOnlyCell(cellValueDataKey));
+        return metadata && (metadata.readOnly || metadata.isReadOnlyCell?.(cellValueDataKey));
     }
 
     modifyCell = (colIdx: number, rowIdx: number, newValues: ValueDescriptor[], mod: MODIFICATION_TYPES): void => {
@@ -776,14 +777,14 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 changes.cellValues = editorModel.cellValues.reduce((result, value, key) => {
                     // Take no action if a cell is read only. Users can select an area that includes read only rows and
                     // cells
-                    const isReadOnly = this.isReadOnly(colIdx, rowIdx);
+                    const isReadOnly = this.isReadOnly(key);
                     if (!isReadOnly && editorModel.selectionCells.includes(key)) {
                         return result.set(key, List());
                     }
                     return result.set(key, value);
                 }, Map<string, List<ValueDescriptor>>());
                 changes.cellMessages = editorModel.cellMessages.reduce((result, value, key) => {
-                    const isReadOnly = this.isReadOnly(colIdx, rowIdx);
+                    const isReadOnly = this.isReadOnly(key);
                     if (!isReadOnly && editorModel.selectionCells.includes(key)) {
                         return result.remove(key);
                     }

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -893,6 +893,12 @@ function inferSelectionIncrement(
     };
 }
 
+/**
+ * Gets the string representation of the primary key for a given row. It needs to be a string because it will be
+ * compared against the values coming from QueryModel.orderedRows, which are string representations of PK values.
+ * @param row
+ * @param queryInfo
+ */
 function getPkValue(row: any, queryInfo: QueryInfo): string {
     const keyCols = queryInfo.getPkCols();
     let key;
@@ -903,7 +909,8 @@ function getPkValue(row: any, queryInfo: QueryInfo): string {
         if (typeof key === 'object') key = key.value;
     }
 
-    return key;
+    // The key may be anything (often it's a number because it's RowId), so we coerce it to a string
+    return key?.toString();
 }
 
 interface CellReadStatus {
@@ -922,9 +929,7 @@ export function checkCellReadStatus(
     if (readonlyRows || columnMetadata?.isReadOnlyCell || lockedRows) {
         const keyCols = queryInfo.getPkCols();
         if (keyCols.length === 1) {
-            // Coerce PK Value to string because it could be anything, but readonlyRows and lockedRows are string[], and
-            // isReadOnlyCell expects a string
-            const key = getPkValue(row, queryInfo)?.toString();
+            const key = getPkValue(row, queryInfo);
             return {
                 isReadonlyRow: readonlyRows && key ? readonlyRows.includes(key) : false,
                 isReadonlyCell: columnMetadata?.isReadOnlyCell ? columnMetadata.isReadOnlyCell(key) : false,

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -922,8 +922,9 @@ export function checkCellReadStatus(
     if (readonlyRows || columnMetadata?.isReadOnlyCell || lockedRows) {
         const keyCols = queryInfo.getPkCols();
         if (keyCols.length === 1) {
-            const key = getPkValue(row, queryInfo);
-
+            // Coerce PK Value to string because it could be anything, but readonlyRows and lockedRows are string[], and
+            // isReadOnlyCell expects a string
+            const key = getPkValue(row, queryInfo)?.toString();
             return {
                 isReadonlyRow: readonlyRows && key ? readonlyRows.includes(key) : false,
                 isReadonlyCell: columnMetadata?.isReadOnlyCell ? columnMetadata.isReadOnlyCell(key) : false,
@@ -1399,7 +1400,8 @@ function parsePastedLookup(descriptors: ValueDescriptor[], value: string[] | str
 
 function isReadonlyRow(row: Map<string, any>, pkCols: QueryColumn[], readonlyRows: string[]): boolean {
     if (pkCols.length === 1 && row) {
-        const pkValue = caseInsensitive(row.toJS(), pkCols[0].fieldKey);
+        // Coerce pkValue to string because it may actually be a number or other type, and readonlyRows is string[]
+        const pkValue = caseInsensitive(row.toJS(), pkCols[0].fieldKey)?.toString();
         return readonlyRows.includes(pkValue);
     }
 

--- a/packages/components/src/internal/components/editable/constants.ts
+++ b/packages/components/src/internal/components/editable/constants.ts
@@ -33,7 +33,7 @@ export interface CellCoordinates {
     rowIdx: number;
 }
 
-export enum EditableGridEvent {
+export const enum EditableGridEvent {
     ADD_ROWS = 'ADD_ROWS',
     BULK_ADD = 'BULK_ADD',
     BULK_UPDATE = 'BULK_UPDATE',

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -213,7 +213,6 @@ export class EditorModel
         return columns.filter(col => !col.isFileInput);
     }
 
-    // TODO: Look into using this for the PlateViewer
     getColumnValues(columnName: string): List<List<ValueDescriptor>> {
         const colIdx = this.columns.findIndex(colName => colName === columnName);
         if (colIdx === -1) {

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -105,7 +105,6 @@ const DATA_CHANGE_EVENTS: EditableGridEvent[] = [
     EditableGridEvent.ADD_ROWS,
     EditableGridEvent.BULK_ADD,
     EditableGridEvent.BULK_UPDATE,
-    EditableGridEvent.BULK_UPDATE,
     EditableGridEvent.DRAG_FILL,
     EditableGridEvent.FILL_TEXT,
     EditableGridEvent.MODIFY_CELL,
@@ -214,6 +213,7 @@ export class EditorModel
         return columns.filter(col => !col.isFileInput);
     }
 
+    // TODO: Look into using this for the PlateViewer
     getColumnValues(columnName: string): List<List<ValueDescriptor>> {
         const colIdx = this.columns.findIndex(colName => colName === columnName);
         if (colIdx === -1) {

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -50,8 +50,6 @@ export interface QueryFormInputsProps {
     columnFilter?: (col?: QueryColumn) => boolean;
     // this can be used when you want to keep certain columns always filtered out (e.g., aliquot- or sample-only columns)
     isIncludedColumn?: (col: QueryColumn) => boolean;
-    componentKey?: string;
-    // unique key to add to QuerySelect to avoid duplication w/ transpose
     /** A container filter that will be applied to all query-based inputs in this form */
     containerFilter?: Query.ContainerFilter;
     containerPath?: string;

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -794,11 +794,11 @@ export function withQueryModels<Props>(
 
         /**
          * Helper for various actions that may want to trigger loadQueryInfo, loadRows, or loadSelections.
-         * @param id: The id of the QueryModel you want to load
-         * @param loadQueryInfo: boolean, if true will load the QueryInfo before loading the model's rows.
-         * @param loadRows: boolean, if true will load the model's rows.
-         * @param loadSelections: boolean, if true will load selections after loading QueryInfo.
-         * @param reloadTotalCount: boolean, if true will reload totalCount after loading QueryInfo.
+         * @param id The id of the QueryModel you want to load
+         * @param loadQueryInfo boolean, if true will load the QueryInfo before loading the model's rows.
+         * @param loadRows boolean, if true will load the model's rows.
+         * @param loadSelections boolean, if true will load selections after loading QueryInfo.
+         * @param reloadTotalCount boolean, if true will reload totalCount after loading QueryInfo.
          */
         maybeLoad = (
             id: string,
@@ -813,10 +813,7 @@ export function withQueryModels<Props>(
             } else {
                 if (loadRows) {
                     this.loadRows(id, loadSelections);
-
-                    if (this.state.queryModels[id].includeTotalCount) {
-                        this.loadTotalCount(id, reloadTotalCount);
-                    }
+                    this.loadTotalCount(id, reloadTotalCount);
                 } else if (loadSelections) {
                     this.loadSelections(id);
                 }


### PR DESCRIPTION
#### Rationale
We need the ability to hide read only rows in the EditableGrid so we can display a subset of all rows.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1506
- https://github.com/LabKey/labkey-ui-premium/pull/425
- https://github.com/LabKey/limsModules/pull/321

#### Changes
- Fix Issue 48377: LKSM/LKB: Editable grid allows pasting into cells that are marked as read-only
- EditableGrid: add hideReadonlyRows prop
- Export EditableGridEvent as a const enum
