### PR TITLE
Improve Types

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.48.1",
+  "version": "3.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.48.1",
+      "version": "3.49.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.48.1",
+  "version": "3.49.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ? June 2024
 - getSelectionLineageData: make selection `Set<string>` instead of `List<any>`
   - It's always sourced from QueryModel.selections
+- SamplesEditableGridProps: remove displayQueryModel
 
 ### version 3.48.1
 *Released*: 4 June 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+###  version 3.??.?
+*Released*: ? June 2024
+- getSelectionLineageData: make selection `string[]` instead of `List<any>`
+  - It's always sourced from QueryModel.selections, so it's safe to make it `string[]`
+
 ### version 3.48.1
 *Released*: 4 June 2024
 - Issue 41718: Domain Designer Field Imports should observe auto-increment fields

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-###  version 3.??.?
-*Released*: ? June 2024
+###  version 3.49.0
+*Released*: 6 June 2024
 - getSelectionLineageData: make selection `Set<string>` instead of `List<any>`
   - It's always sourced from QueryModel.selections
 - SamplesEditableGridProps: remove displayQueryModel

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,8 +3,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ###  version 3.??.?
 *Released*: ? June 2024
-- getSelectionLineageData: make selection `string[]` instead of `List<any>`
-  - It's always sourced from QueryModel.selections, so it's safe to make it `string[]`
+- getSelectionLineageData: make selection `Set<string>` instead of `List<any>`
+  - It's always sourced from QueryModel.selections
 
 ### version 3.48.1
 *Released*: 4 June 2024

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -74,7 +74,7 @@ export interface SamplesAPIWrapper {
     ) => Promise<DomainDetails>;
 
     getSelectionLineageData: (
-        selection: List<any>,
+        selection: string[],
         schema: string,
         query: string,
         viewName: string,

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -74,7 +74,7 @@ export interface SamplesAPIWrapper {
     ) => Promise<DomainDetails>;
 
     getSelectionLineageData: (
-        selection: string[],
+        selection: Set<string>,
         schema: string,
         query: string,
         viewName: string,

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -280,26 +280,16 @@ export async function getSampleStorageId(sampleRowId: number): Promise<number> {
     return caseInsensitive(result.rows[0], 'RowId').value;
 }
 
-function getRowIdsFromSelection(selection: List<any>): number[] {
-    const rowIds = [];
-    if (selection && !selection.isEmpty()) {
-        selection.forEach(sel => rowIds.push(parseInt(sel, 10)));
-    }
-    return rowIds;
-}
-
 // Used for samples and dataclasses
 export function getSelectionLineageData(
-    selection: List<any>,
+    selection: string[],
     schema: string,
     query: string,
     viewName: string,
     columns?: string[]
 ): Promise<ISelectRowsResult> {
-    const rowIds = getRowIdsFromSelection(selection);
-    if (rowIds.length === 0) {
-        return Promise.reject('No data is selected.');
-    }
+    if (selection?.length === 0) return Promise.reject('No data is selected.');
+    const rowIds = selection.map(s => parseInt(s, 10));
 
     return selectRowsDeprecated({
         schemaName: schema,

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -282,14 +282,14 @@ export async function getSampleStorageId(sampleRowId: number): Promise<number> {
 
 // Used for samples and dataclasses
 export function getSelectionLineageData(
-    selection: string[],
+    selections: Set<string>,
     schema: string,
     query: string,
     viewName: string,
     columns?: string[]
 ): Promise<ISelectRowsResult> {
-    if (selection?.length === 0) return Promise.reject('No data is selected.');
-    const rowIds = selection.map(s => parseInt(s, 10));
+    if (selections?.size === 0) return Promise.reject('No data is selected.');
+    const rowIds = Array.from(selections).map(s => parseInt(s, 10));
 
     return selectRowsDeprecated({
         schemaName: schema,

--- a/packages/components/src/internal/sampleModels.ts
+++ b/packages/components/src/internal/sampleModels.ts
@@ -67,7 +67,6 @@ export type SampleGridButton = ComponentType<SampleGridButtonProps & RequiresMod
 export interface SamplesEditableGridProps {
     api?: ComponentsAPIWrapper;
     combineParentTypes?: boolean;
-    displayQueryModel: QueryModel;
     editableGridUpdateData?: OrderedMap<string, any>;
     getIsDirty?: () => boolean;
     invalidateSampleQueries?: (schemaQuery: SchemaQuery) => void;


### PR DESCRIPTION
#### Rationale
This PR converts GridBody to FC and updates some types to match those on QueryModel

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1508
- https://github.com/LabKey/labkey-ui-premium/pull/431
- https://github.com/LabKey/limsModules/pull/334

#### Changes
- Convert GridBody to FC
- Update `getSelectionLineageData` to use `Set<string>` for selections
- Remove `displayQueryModel` from `SamplesEditableGridProps`
  - the query model has been moved to a different interface that is more appropriate

