### PR TITLE
Issue 49882: App editable grid support for locking column header and left columns on scroll

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.0",
+  "version": "3.49.0-fb-editableGridLock49882.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.49.0-fb-editableGridLock49882.0",
+      "version": "3.49.0-fb-editableGridLock49882.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.48.1",
+  "version": "3.48.1-fb-editableGridLock49882.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.48.1",
+      "version": "3.48.1-fb-editableGridLock49882.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0",
+  "version": "3.49.0-fb-editableGridLock49882.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.49.0",
+      "version": "3.49.0-fb-editableGridLock49882.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.3",
+  "version": "3.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.49.0-fb-editableGridLock49882.3",
+      "version": "3.50.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.1",
+  "version": "3.49.0-fb-editableGridLock49882.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.49.0-fb-editableGridLock49882.1",
+      "version": "3.49.0-fb-editableGridLock49882.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.2",
+  "version": "3.49.0-fb-editableGridLock49882.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.49.0-fb-editableGridLock49882.2",
+      "version": "3.49.0-fb-editableGridLock49882.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.33.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.0",
+  "version": "3.49.0-fb-editableGridLock49882.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.3",
+  "version": "3.50.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.1",
+  "version": "3.49.0-fb-editableGridLock49882.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.48.1",
+  "version": "3.48.1-fb-editableGridLock49882.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0",
+  "version": "3.49.0-fb-editableGridLock49882.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.49.0-fb-editableGridLock49882.2",
+  "version": "3.49.0-fb-editableGridLock49882.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD June 2024
+- Issue 49882: App editable grid support for locking column header and left columns on scroll
+
 ### version 3.48.1
 *Released*: 4 June 2024
 - Issue 41718: Domain Designer Field Imports should observe auto-increment fields

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD June 2024
+###  version 3.50.0
+*Released*: 10 June 2024
 - Issue 49882: App editable grid support for locking column header and left columns on scroll
 
 ###  version 3.49.0

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -272,6 +272,7 @@ export class RunDataPanel extends PureComponent<Props, State> {
                                             editorModel={editorModel}
                                             emptyGridMsg="Start by adding the quantity of assay data rows you want to create."
                                             isSubmitting={wizardModel.isSubmitting}
+                                            lockLeftOnScroll={false}
                                             maxRows={this.props.maxRows}
                                             metricFeatureArea="assayResultsEditableGrid"
                                             model={queryModel}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -316,6 +316,7 @@ export interface SharedEditableGridProps {
     emptyGridMsg?: string;
     exportColFilter?: (col: QueryColumn) => boolean;
     extraExportColumns?: Array<Partial<QueryColumn>>;
+    fixedHeight?: boolean;
     forUpdate?: boolean;
     gridTabHeaderComponent?: ReactNode;
     hideCheckboxCol?: boolean;
@@ -421,6 +422,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         bulkUpdateText: 'Bulk Update',
         columnMetadata: Map<string, EditableColumnMetadata>(),
         notDeletable: List<any>(),
+        fixedHeight: true,
         condensed: false,
         disabled: false,
         isSubmitting: false,
@@ -892,7 +894,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 title: '&nbsp;',
                 cell: (selected: boolean, row) => (
                     <input
-                        style={{ margin: '0 8px' }}
+                        className="grid-panel__checkbox"
                         checked={this.state.selected.contains(row.get(GRID_EDIT_INDEX))}
                         type="checkbox"
                         onChange={this.select.bind(this, row)}
@@ -1006,7 +1008,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const { queryInfo } = this.props;
 
         if (col.index.toLowerCase() === GRID_SELECTION_INDEX && this.showSelectionCheckboxes()) {
-            return headerSelectionCell(this.selectAll, this.state.selectedState, false);
+            return headerSelectionCell(this.selectAll, this.state.selectedState, false, 'grid-panel__checkbox');
         }
 
         const qColumn = queryInfo.getColumn(col.index);
@@ -1780,6 +1782,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             error,
             bordered,
             condensed,
+            fixedHeight,
             emptyGridMsg,
             striped,
             allowBulkUpdate,
@@ -1789,15 +1792,23 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             hideTopControls,
             tabContainerCls,
             gridTabHeaderComponent,
+            hideCountCol,
         } = this.props;
         const { showBulkAdd, showBulkUpdate, showMask, activeEditTab, selected } = this.state;
+        const showCheckboxes = this.showSelectionCheckboxes();
+        const showCountCol = !hideCountCol;
 
         const gridContent = (
             <>
                 {!hideTopControls && this.renderTopControls()}
                 {gridTabHeaderComponent}
                 <div
-                    className={classNames(EDITABLE_GRID_CONTAINER_CLS, { 'loading-mask': showMask })}
+                    className={classNames(EDITABLE_GRID_CONTAINER_CLS, 'grid-panel__lock-left', {
+                        'grid-panel__lock-left-with-checkboxes': showCheckboxes,
+                        'grid-panel__lock-left-with-countcol': showCountCol && !showCheckboxes,
+                        'grid-panel__lock-left-with-checkboxes-and-countcol': showCountCol && showCheckboxes,
+                        'loading-mask': showMask,
+                    })}
                     onKeyDown={this.onKeyDown}
                     onMouseDown={this.beginDrag}
                     onMouseUp={this.onMouseUp}
@@ -1810,8 +1821,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                         condensed={condensed}
                         data={this.getGridData()}
                         emptyText={emptyGridMsg}
+                        fixedHeight={fixedHeight}
                         headerCell={this.headerCell}
-                        responsive={false}
                         rowKey={GRID_EDIT_INDEX}
                         striped={striped}
                     />

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -325,6 +325,7 @@ export interface SharedEditableGridProps {
     hideTopControls?: boolean;
     insertColumns?: QueryColumn[];
     isSubmitting?: boolean;
+    lockLeftOnScroll?: boolean; // lock the left columns when scrolling horizontally
     lockedRows?: string[]; // list of key values for rows that are locked. locked rows are readonly but might have a different display from readonly rows
     maxRows?: number;
     metricFeatureArea?: string;
@@ -423,6 +424,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         columnMetadata: Map<string, EditableColumnMetadata>(),
         notDeletable: List<any>(),
         fixedHeight: true,
+        lockLeftOnScroll: true,
         condensed: false,
         disabled: false,
         isSubmitting: false,
@@ -1793,6 +1795,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             tabContainerCls,
             gridTabHeaderComponent,
             hideCountCol,
+            lockLeftOnScroll,
         } = this.props;
         const { showBulkAdd, showBulkUpdate, showMask, activeEditTab, selected } = this.state;
         const showCheckboxes = this.showSelectionCheckboxes();
@@ -1803,10 +1806,11 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 {!hideTopControls && this.renderTopControls()}
                 {gridTabHeaderComponent}
                 <div
-                    className={classNames(EDITABLE_GRID_CONTAINER_CLS, 'grid-panel__lock-left', {
-                        'grid-panel__lock-left-with-checkboxes': showCheckboxes,
-                        'grid-panel__lock-left-with-countcol': showCountCol && !showCheckboxes,
-                        'grid-panel__lock-left-with-checkboxes-and-countcol': showCountCol && showCheckboxes,
+                    className={classNames(EDITABLE_GRID_CONTAINER_CLS, {
+                        'grid-panel__lock-left': lockLeftOnScroll,
+                        'grid-panel__lock-left-with-checkboxes': lockLeftOnScroll && showCheckboxes,
+                        'grid-panel__lock-left-with-countcol': lockLeftOnScroll && showCountCol && !showCheckboxes,
+                        'grid-panel__lock-left-with-checkboxes-and-countcol': lockLeftOnScroll && showCountCol && showCheckboxes,
                         'loading-mask': showMask,
                     })}
                     onKeyDown={this.onKeyDown}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1806,9 +1806,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 {!hideTopControls && this.renderTopControls()}
                 {gridTabHeaderComponent}
                 <div
-                    className={classNames(EDITABLE_GRID_CONTAINER_CLS, {
-                        'grid-panel__lock-left': lockLeftOnScroll,
-                        'grid-panel__lock-left-with-checkboxes': lockLeftOnScroll && showCheckboxes,
+                    className={classNames(EDITABLE_GRID_CONTAINER_CLS, 'grid-panel__lock-left', {
+                        'grid-panel__lock-left-with-checkboxes': showCheckboxes,
                         'grid-panel__lock-left-with-countcol': lockLeftOnScroll && showCountCol && !showCheckboxes,
                         'grid-panel__lock-left-with-checkboxes-and-countcol': lockLeftOnScroll && showCountCol && showCheckboxes,
                         'loading-mask': showMask,

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1809,7 +1809,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                     className={classNames(EDITABLE_GRID_CONTAINER_CLS, 'grid-panel__lock-left', {
                         'grid-panel__lock-left-with-checkboxes': showCheckboxes,
                         'grid-panel__lock-left-with-countcol': lockLeftOnScroll && showCountCol && !showCheckboxes,
-                        'grid-panel__lock-left-with-checkboxes-and-countcol': lockLeftOnScroll && showCountCol && showCheckboxes,
+                        'grid-panel__lock-left-with-checkboxes-and-countcol':
+                            lockLeftOnScroll && showCountCol && showCheckboxes,
                         'loading-mask': showMask,
                     })}
                     onKeyDown={this.onKeyDown}

--- a/packages/components/src/internal/components/editable/EditableGridPanel.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanel.tsx
@@ -188,7 +188,7 @@ export const EditableGridPanel: FC<EditableGridPanelProps> = memo(props => {
     return (
         <div className={`panel ${bsStyle === 'info' ? 'panel-info' : 'panel-default'} ${className}`}>
             <div className="panel-heading">{title}</div>
-            <div className="panel-body table-responsive">
+            <div className="panel-body">
                 {hasTabs && (
                     <ul className="nav nav-tabs">
                         {models.map((tabModel, index) => {

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -1147,7 +1147,6 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                         <div
                             className={classNames('grid-panel__grid ', 'grid-panel__lock-left', {
                                 'grid-panel__lock-left-with-checkboxes': allowSelections,
-                                'grid-panel__lock-left-without-checkboxes': !allowSelections,
                             })}
                         >
                             {hasError && <Alert>{errorMsg || queryInfoError || rowsError || selectionsError}</Alert>}

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -179,8 +179,24 @@
     }
 }
 
+.grid-panel__checkbox {
+    margin: 0 8px !important;
+}
+
+.grid-panel__grid .table-responsive thead th {
+    // Cancel the padding set by .table-condensed, see padding on .grid-header-cell__body below.
+    padding: 0;
+
+    &#__selection__,
+    .grid-header-cell__body {
+        // re-add the padding to the .grid-header-cell__body, this makes it so the entire th area is clickable
+        padding: $table-condensed-cell-padding;
+    }
+}
+
 /* Grid sticky/locked column headers on vertical scroll */
-.grid-panel__grid .table-responsive {
+.grid-panel__grid .table-responsive,
+.editable-grid__container .table-responsive {
     overflow-y: auto;
 
     thead {
@@ -190,26 +206,30 @@
 
         th {
             background-color: $white;
-            // Cancel the padding set by .table-condensed, see padding on .grid-header-cell__body below.
-            padding: 0;
 
             /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
             background-clip: padding-box;
-
-            &#__selection__,
-            .grid-header-cell__body {
-                // re-add the padding to the .grid-header-cell__body, this makes it so the entire th area is clickable
-                padding: $table-condensed-cell-padding;
-            }
         }
     }
 }
 
 /* Grid sticky/locked left most column on horizontal scroll */
-.grid-panel__grid.grid-panel__lock-left .table-responsive {
+.grid-panel__grid.grid-panel__lock-left .table-responsive,
+.editable-grid__container.grid-panel__lock-left .table-responsive {
     thead th:nth-child(1), tr td:nth-child(1) {
         position: sticky;
+        z-index: 1;
         left: -1px;
+
+        /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
+        background-clip: padding-box;
+    }
+}
+.grid-panel__grid.grid-panel__lock-left-with-checkboxes .table-responsive,
+.editable-grid__container.grid-panel__lock-left-with-checkboxes .table-responsive,
+.editable-grid__container.grid-panel__lock-left-with-countcol .table-responsive {
+    thead th:nth-child(2), tr td:nth-child(2) {
+        position: sticky;
         z-index: 1;
 
         /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
@@ -218,9 +238,30 @@
 }
 .grid-panel__grid.grid-panel__lock-left-with-checkboxes .table-responsive {
     thead th:nth-child(2), tr td:nth-child(2) {
-        position: sticky;
         left: 22px;
+    }
+}
+.editable-grid__container.grid-panel__lock-left-with-checkboxes .table-responsive {
+    thead th:nth-child(1), tr td:nth-child(1) {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    thead th:nth-child(2), tr td:nth-child(2) {
+        left: 28px;
+    }
+}
+.editable-grid__container.grid-panel__lock-left-with-countcol .table-responsive {
+    thead th:nth-child(2), tr td:nth-child(2) {
+        left: 43px;
+    }
+}
+
+.editable-grid__container.grid-panel__lock-left-with-checkboxes-and-countcol .table-responsive {
+    thead th:nth-child(3), tr td:nth-child(3) {
+        position: sticky;
         z-index: 1;
+        left: 71px;
 
         /* fix for weird FF behavior, described in https://stackoverflow.com/questions/7517127/ */
         background-clip: padding-box;


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49882

Our app grids have supported header and left column locking for awhile now. This PR adds that same functionality to the EditableGrid. It shares much of the same styling to handle the sticky bits. The main difference is that there is a couple cases where the Editable grid wants to lock 3 left columns instead of 2 (i.e. checkbox column, row number column, first data column).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1509
- https://github.com/LabKey/labkey-ui-premium/pull/434
- https://github.com/LabKey/limsModules/pull/336 

#### Changes
- Add fixedHeight prop to EditableGrid
- Add grid-panel__lock-left-with-... classes to EditableGrid based on checks for showCheckboxes and showCountCol
- Refactor grid panel `position: sticky` css to be shared between GridPanel and EditableGrid
