### PR TITLE
Plate Rollup View

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.54.0",
+  "version": "3.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.54.0",
+      "version": "3.55.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.54.0",
+  "version": "3.55.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,5 +1,11 @@
 # @labkey/components
-Components, models, actions, and utility functions for LabKey applications and pages.
+Components, models, actions, and utility functions for LabKey applications and pages
+
+### version 3.??.?
+*Released*: ?? June 2024
+- Grid: improve styling for sticky headers
+  - No longer compute height via JS
+  - Use max-height, set via CSS
 
 ### version 3.54.0
 *Released*: 24 June 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 3.??.?
-*Released*: ?? June 2024
+### version 3.55.0
+*Released*: 25 June 2024
 - Grid: improve styling for sticky headers
   - No longer compute height via JS
   - Use max-height, set via CSS

--- a/packages/components/src/internal/components/assay/__snapshots__/RunDataPanel.test.tsx.snap
+++ b/packages/components/src/internal/components/assay/__snapshots__/RunDataPanel.test.tsx.snap
@@ -48,7 +48,9 @@ exports[`RunDataPanel assay model with results File field types 1`] = `
           <div
             class="form-step"
           >
-            <div>
+            <div
+              class="editable-grid-wrapper"
+            >
               <div
                 class="row editable-grid-buttons"
               >
@@ -91,7 +93,7 @@ exports[`RunDataPanel assay model with results File field types 1`] = `
                 class="editable-grid__container grid-panel__lock-left"
               >
                 <div
-                  class="table-responsive"
+                  class="table-responsive table-responsive--max-height"
                 >
                   <div
                     class="grid-messages"

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -380,15 +380,6 @@ export const Grid: FC<GridProps> = memo(props => {
     } = props;
     const gridData = processData(data);
     const gridColumns = columns !== undefined ? processColumns(columns) : resolveColumns(gridData);
-
-    const divRef = useRef<HTMLDivElement>();
-    useEffect(() => {
-        if (!fixedHeight) return;
-        const maxHeight = window.innerHeight * 0.7;
-        divRef.current.style.height =
-            divRef.current.lastElementChild?.clientHeight < maxHeight ? 'unset' : maxHeight + 'px';
-    }, [fixedHeight, gridData.size]); // dep on gridData.size to recalculate div height on each grid row count change
-
     const headerProps: GridHeaderProps = {
         calcWidths,
         columns: gridColumns,
@@ -417,10 +408,12 @@ export const Grid: FC<GridProps> = memo(props => {
 
     const wrapperClasses = classNames({
         'table-responsive': responsive,
+        // fixedHeight is a misnomer, we used to set a fixed height, but now we use a max-height set via css
+        'table-responsive--max-height': fixedHeight,
     });
 
     return (
-        <div className={wrapperClasses} data-gridid={gridId} ref={divRef}>
+        <div className={wrapperClasses} data-gridid={gridId}>
             <GridMessages messages={messages} />
 
             <table className={tableClasses} ref={tableRef}>

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1854,7 +1854,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         }
 
         return (
-            <div>
+            <div className="editable-grid-wrapper">
                 {tabBtnProps?.placement === 'top' && this.renderButtons()}
                 {gridContent}
                 {error && <Alert className="margin-top">{error}</Alert>}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -48,10 +48,6 @@ export interface QueryFormInputsProps {
     // (e.g., if you want to generate a set of samples with common properties but need to provide the individual, unique ids)
     checkRequiredFields?: boolean;
     columnFilter?: (col?: QueryColumn) => boolean;
-    // isIncludedColumn can be used when you want to keep certain columns always filtered out (e.g., aliquot- or
-    // sample-only columns). Note: This props is never used by QueryFormInputs, but is needed because this interface is
-    // shared with other components. We should probably move this particular prop to a more appropriate place.
-    isIncludedColumn?: (col: QueryColumn) => boolean;
     /** A container filter that will be applied to all query-based inputs in this form */
     containerFilter?: Query.ContainerFilter;
     containerPath?: string;
@@ -60,11 +56,15 @@ export interface QueryFormInputsProps {
     fireQSChangeOnInit?: boolean;
     includeLabelField?: boolean;
     initiallyDisableFields?: boolean;
+    // isIncludedColumn can be used when you want to keep certain columns always filtered out (e.g., aliquot- or
+    // sample-only columns). Note: This props is never used by QueryFormInputs, but is needed because this interface is
+    // shared with other components. We should probably move this particular prop to a more appropriate place.
+    isIncludedColumn?: (col: QueryColumn) => boolean;
     lookups?: Map<string, number>;
     onAdditionalFormDataChange?: (name: string, value: any) => void;
     onFieldsEnabledChange?: (numEnabled: number) => void;
-    operation?: Operation;
     onSelectChange?: SelectInputChange;
+    operation?: Operation;
     pluralNoun?: string;
     preventCrossFolderEnable?: boolean;
     queryColumns?: ExtendedMap<string, QueryColumn>;

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -48,7 +48,9 @@ export interface QueryFormInputsProps {
     // (e.g., if you want to generate a set of samples with common properties but need to provide the individual, unique ids)
     checkRequiredFields?: boolean;
     columnFilter?: (col?: QueryColumn) => boolean;
-    // this can be used when you want to keep certain columns always filtered out (e.g., aliquot- or sample-only columns)
+    // isIncludedColumn can be used when you want to keep certain columns always filtered out (e.g., aliquot- or
+    // sample-only columns). Note: This props is never used by QueryFormInputs, but is needed because this interface is
+    // shared with other components. We should probably move this particular prop to a more appropriate place.
     isIncludedColumn?: (col: QueryColumn) => boolean;
     /** A container filter that will be applied to all query-based inputs in this form */
     containerFilter?: Query.ContainerFilter;

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -13,8 +13,6 @@ import { FileInput } from '../../internal/components/forms/input/FileInput';
 import { resolveErrorMessage } from '../../internal/util/messaging';
 import { Alert } from '../../internal/components/base/Alert';
 
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../internal/APIWrapper';
-
 import { useDataChangeCommentsRequired } from '../../internal/components/forms/input/useDataChangeCommentsRequired';
 import { CommentTextArea } from '../../internal/components/forms/input/CommentTextArea';
 import { QueryModel } from './QueryModel';

--- a/packages/components/src/theme/query-model.scss
+++ b/packages/components/src/theme/query-model.scss
@@ -194,6 +194,10 @@
     }
 }
 
+.table-responsive.table-responsive--max-height {
+    max-height: 70vh;
+}
+
 /* Grid sticky/locked column headers on vertical scroll */
 .grid-panel__grid .table-responsive,
 .editable-grid__container .table-responsive {


### PR DESCRIPTION
#### Rationale
This PR alters how we set the height on our grids, which is used to enable sticky headers.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1512
- https://github.com/LabKey/labkey-ui-premium/pull/439
- https://github.com/LabKey/limsModules/pull/367

#### Changes
- Grid: Set max-height via CSS
  -  No longer set height via JS
  - This enables us to easily override this setting via other selectors (needed in our Plate Viewer)
- EditableGrid: Add class name to outermost div
  -  Needed to override styles in our Plate Viewer