### PR TITLE
Convert usages of OverlayTrigger off of react-bootstrap

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0",
+  "version": "3.53.0-fb-overlayConverts.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.0",
+      "version": "3.53.0-fb-overlayConverts.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0-fb-overlayConverts.1",
+  "version": "3.53.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.0-fb-overlayConverts.1",
+      "version": "3.53.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0-fb-overlayConverts.0",
+  "version": "3.53.0-fb-overlayConverts.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.0-fb-overlayConverts.0",
+      "version": "3.53.0-fb-overlayConverts.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0-fb-overlayConverts.1",
+  "version": "3.53.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0-fb-overlayConverts.0",
+  "version": "3.53.0-fb-overlayConverts.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0",
+  "version": "3.53.0-fb-overlayConverts.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD June 2024
+### version 3.53.1
+*Released*: 13 June 2024
 - Convert usages of OverlayTrigger off of react-bootstrap
 
 ### version 3.53.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD June 2024
+- Convert usages of OverlayTrigger off of react-bootstrap
+
 ### version 3.53.0
 *Released*: 12 June 2024
 - Issue 50589: Remove option to export editable grid data

--- a/packages/components/src/internal/components/HelpIcon.tsx
+++ b/packages/components/src/internal/components/HelpIcon.tsx
@@ -1,24 +1,24 @@
-import React, { FC, memo, MouseEvent, useCallback, useMemo } from 'react';
-import { OverlayTrigger, Popover } from 'react-bootstrap';
+import React, { FC, memo, useMemo } from 'react';
 
 import { generateId } from '../util/utils';
+import { Placement } from '../useOverlayPositioning';
+import { Popover } from '../Popover';
+import { OverlayTrigger } from '../OverlayTrigger';
 
 interface Props {
-    placement?: 'top' | 'right' | 'bottom' | 'left';
+    placement?: Placement;
 }
 
 export const HelpIcon: FC<Props> = memo(({ children, placement = 'bottom' }) => {
     const id = useMemo(() => generateId(), []);
-    const overlayContent = <Popover id={id}>{children}</Popover>;
-    const onClick = useCallback((event: MouseEvent<HTMLSpanElement>) => {
-        // We need to preventDefault and stopPropagation here so we can use HelpIcon inside of <label> elements. If we
-        // cancel the event the popover will not render.
-        event.preventDefault();
-        event.stopPropagation();
-    }, []);
+    const overlayContent = (
+        <Popover id={id} placement={placement}>
+            {children}
+        </Popover>
+    );
     return (
-        <span className="help-icon" onClick={onClick}>
-            <OverlayTrigger overlay={overlayContent} placement={placement} rootClose trigger="click">
+        <span className="help-icon">
+            <OverlayTrigger overlay={overlayContent}>
                 <i className="fa fa-question-circle" />
             </OverlayTrigger>
         </span>

--- a/packages/components/src/internal/components/base/LockIcon.tsx
+++ b/packages/components/src/internal/components/base/LockIcon.tsx
@@ -1,27 +1,34 @@
 import React, { ReactNode, FC, memo } from 'react';
-import { OverlayTrigger, Popover } from 'react-bootstrap';
+
+import { OverlayTrigger } from '../../OverlayTrigger';
+import { Popover } from '../../Popover';
+import { Placement } from '../../useOverlayPositioning';
 
 interface Props {
     body: ReactNode;
+    className?: string;
     iconCls?: string;
     id: string;
+    placement?: Placement;
     title: string;
     unlocked?: boolean;
 }
 
-export const LockIcon: FC<Props> = memo(({ id, title, iconCls, body, unlocked = false }) => {
-    return (
-        <OverlayTrigger
-            placement="bottom"
-            overlay={
-                <Popover id={id} title={title}>
-                    {body}
-                </Popover>
-            }
-        >
-            <span className={'domain-field-lock-icon' + (iconCls ? ' ' + iconCls : '')}>
-                <span className={`fa fa-${unlocked ? 'unlock' : 'lock'}`} />
-            </span>
-        </OverlayTrigger>
-    );
-});
+export const LockIcon: FC<Props> = memo(
+    ({ id, title, iconCls, body, className, unlocked = false, placement = 'bottom' }) => {
+        return (
+            <OverlayTrigger
+                className={className}
+                overlay={
+                    <Popover id={id} title={title} placement={placement}>
+                        {body}
+                    </Popover>
+                }
+            >
+                <span className={'domain-field-lock-icon' + (iconCls ? ' ' + iconCls : '')}>
+                    <span className={`fa fa-${unlocked ? 'unlock' : 'lock'}`} />
+                </span>
+            </OverlayTrigger>
+        );
+    }
+);

--- a/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceOptions.tsx
@@ -28,7 +28,8 @@ const IN_USE_TITLE = 'Text Choice In Use';
 const IN_USE_TIP = 'This text choice value cannot be deleted because it is in use.';
 const VALUE_IN_USE = (
     <LockIcon
-        iconCls="pull-right choices-list__locked"
+        className="pull-right"
+        iconCls="choices-list__locked"
         body={IN_USE_TIP}
         id="text-choice-value-lock-icon"
         title={IN_USE_TITLE}
@@ -40,7 +41,8 @@ const LOCKED_TIP =
     'This text choice value cannot be deleted because it is in use and cannot be edited because one or more usages are for read-only items.';
 const VALUE_LOCKED = (
     <LockIcon
-        iconCls="pull-right choices-list__locked"
+        className="pull-right"
+        iconCls="choices-list__locked"
         body={LOCKED_TIP}
         id="text-choice-value-lock-icon"
         title={LOCKED_TITLE}

--- a/packages/components/src/internal/components/forms/DisableableInput.tsx
+++ b/packages/components/src/internal/components/forms/DisableableInput.tsx
@@ -1,13 +1,15 @@
 import React, { FC, memo, useMemo } from 'react';
-import { OverlayTrigger, Popover } from 'react-bootstrap';
+
 import { generateId } from '../../util/utils';
+import { OverlayTrigger } from '../../OverlayTrigger';
+import { Popover } from '../../Popover';
 
 interface Props {
     className?: string;
     disabledMsg?: string;
     name: string;
-    placeholder?: string;
     onChange: (evt: any) => void;
+    placeholder?: string;
     title?: string;
     value: string;
 }
@@ -19,7 +21,14 @@ export const DisableableInput: FC<Props> = memo(props => {
     return (
         <>
             {disabledMsg ? (
-                <OverlayTrigger placement="bottom" overlay={<Popover id={id} title={title}>{disabledMsg}</Popover>}>
+                <OverlayTrigger
+                    style={{ display: 'inline' }}
+                    overlay={
+                        <Popover id={id} title={title} placement="bottom">
+                            {disabledMsg}
+                        </Popover>
+                    }
+                >
                     <div className="disabled-button-with-tooltip full-width">
                         <input {...inputProps} type="text" disabled />
                     </div>

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -375,7 +375,8 @@ export const SampleStatusesList: FC<SampleStatusesListProps> = memo(props => {
                                     componentRight={
                                         (state.inUse || !state.isLocal) && (
                                             <LockIcon
-                                                iconCls="pull-right choices-list__locked"
+                                                className="pull-right"
+                                                iconCls="choices-list__locked"
                                                 body={getSampleStatusLockedMessage(state, false)}
                                                 id="sample-state-lock-icon"
                                                 title={SAMPLE_STATUS_LOCKED_TITLE}

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -25,12 +25,14 @@ import { useAppContext } from '../../AppContext';
 
 import { Container } from '../base/models/Container';
 
+import { ColorPickerInput } from '../forms/input/ColorPickerInput';
+
+import { LabelHelpTip } from '../base/LabelHelpTip';
+
 import { SampleState } from './models';
 import { getSampleStatusColor, getSampleStatusLockedMessage } from './utils';
-import { ColorPickerInput } from '../forms/input/ColorPickerInput';
 import { SampleStatusTag } from './SampleStatusTag';
 import { SAMPLE_STATUS_COLORS, SampleStateType } from './constants';
-import { LabelHelpTip } from '../base/LabelHelpTip';
 
 const TITLE = 'Manage Sample Statuses';
 const STATE_TYPE_SQ = new SchemaQuery('exp', 'SampleStateType');

--- a/packages/components/src/public/QueryModel/ManageViewsModal.tsx
+++ b/packages/components/src/public/QueryModel/ManageViewsModal.tsx
@@ -1,6 +1,4 @@
 import React, { FC, Fragment, memo, useCallback, useEffect, useState } from 'react';
-import { OverlayTrigger, Popover } from 'react-bootstrap';
-
 import { PermissionTypes } from '@labkey/api';
 
 import { ViewInfo } from '../../internal/ViewInfo';
@@ -15,6 +13,9 @@ import { RequiresPermission } from '../../internal/components/base/Permissions';
 
 import { userCanEditSharedViews } from '../../internal/app/utils';
 import { Modal } from '../../internal/Modal';
+
+import { OverlayTrigger } from '../../internal/OverlayTrigger';
+import { Popover } from '../../internal/Popover';
 
 import { ViewNameInput } from './SaveViewModal';
 
@@ -223,9 +224,8 @@ export const ManageViewsModal: FC<Props> = memo(props => {
                                     <RequiresPermission perms={PermissionTypes.Admin}>
                                         {isDefault && !isRenaming && (
                                             <OverlayTrigger
-                                                placement="top"
                                                 overlay={
-                                                    <Popover id="disabled-button-popover">
+                                                    <Popover id="disabled-button-popover" placement="top">
                                                         Revert back to the system default view.
                                                     </Popover>
                                                 }

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -190,9 +190,13 @@
     margin-bottom: 15px;
   }
 
-    .react-datepicker__triangle {
-        left: -10px !important;
-    }
+  .react-datepicker__triangle {
+    left: -10px !important;
+  }
+
+  .overlay-trigger {
+    display: inline;
+  }
 }
 
 .editable-grid__bulk-header {

--- a/packages/components/src/theme/section.scss
+++ b/packages/components/src/theme/section.scss
@@ -109,10 +109,7 @@
     font-size: $font-size-large;
 }
 
+// TODO usages of this can be replace with text-danger
 .error-msg {
     color: $brand-danger;
-}
-
-.success-msg {
-    color: $brand-success;
 }

--- a/packages/components/src/theme/section.scss
+++ b/packages/components/src/theme/section.scss
@@ -112,3 +112,7 @@
 .error-msg {
     color: $brand-danger;
 }
+
+.success-msg {
+    color: $brand-success;
+}


### PR DESCRIPTION
#### Rationale
As part of converting usages of components from the react-bootstrap packages, this PR converts several OverlayTrigger/Popover usages to the ui-components internal implementation.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1513
- https://github.com/LabKey/labkey-ui-premium/pull/438
- https://github.com/LabKey/limsModules/pull/357
- https://github.com/LabKey/platform/pull/5585

#### Changes
- mostly just converting over to new components and moving the placement prop from OverlayTrigger to the Popover
- a few usages had to override the overlay-trigger style for display: inline-block and set it back to inline
- a few usages had to move other styles up from the child component to apply to the new wrapping div (i.e. pull-right)
