### PR TITLE
Editable Grid: Support multi-line cells

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.1",
+  "version": "3.53.2-fb-multiline-grid.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.1",
+      "version": "3.53.2-fb-multiline-grid.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.2-fb-multiline-grid.0",
+  "version": "3.53.2-fb-multiline-grid.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.2-fb-multiline-grid.0",
+      "version": "3.53.2-fb-multiline-grid.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.2-fb-multiline-grid.1",
+  "version": "3.53.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.2-fb-multiline-grid.1",
+      "version": "3.53.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.1",
+  "version": "3.53.2-fb-multiline-grid.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.2-fb-multiline-grid.1",
+  "version": "3.53.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.2-fb-multiline-grid.0",
+  "version": "3.53.2-fb-multiline-grid.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.53.2
+*Released*: 14 June 2024
+- Feature Request 50121: Support multi-line cells in editable grid
+
 ### version 3.53.1
 *Released*: 13 June 2024
 - Convert usages of OverlayTrigger off of react-bootstrap

--- a/packages/components/src/internal/components/editable/Cell.spec.tsx
+++ b/packages/components/src/internal/components/editable/Cell.spec.tsx
@@ -56,7 +56,7 @@ describe('Cell', () => {
 
     test('default props', () => {
         const cell = mount(<Cell {...defaultProps()} />);
-        expect(cell.find('div')).toHaveLength(1);
+        expect(cell.find('div')).toHaveLength(2);
         expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
@@ -73,8 +73,8 @@ describe('Cell', () => {
             <Cell {...defaultProps()} col={queryColumn} colIdx={2} placeholder="placeholder text" rowIdx={3} />
         );
         const div = cell.find('div');
-        expect(div).toHaveLength(1);
-        expect(div.text()).toBe('placeholder text');
+        expect(div).toHaveLength(2);
+        expect(div.at(0).text()).toBe('placeholder text');
         expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
@@ -100,7 +100,7 @@ describe('Cell', () => {
 
     test('readOnly property', () => {
         const cell = mount(<Cell {...defaultProps()} colIdx={3} readOnly rowIdx={3} />);
-        expect(cell.find('div')).toHaveLength(1);
+        expect(cell.find('div')).toHaveLength(2);
         expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
@@ -108,7 +108,7 @@ describe('Cell', () => {
     test('column is readOnly', () => {
         const roColumn = new QueryColumn({ readOnly: true, name: 'roColumn' });
         const cell = mount(<Cell {...defaultProps()} col={roColumn} colIdx={4} readOnly={false} rowIdx={3} />);
-        expect(cell.find('div')).toHaveLength(1);
+        expect(cell.find('div')).toHaveLength(2);
         expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
@@ -119,15 +119,15 @@ describe('Cell', () => {
         );
 
         const div = cell.find('div');
-        expect(div).toHaveLength(1);
-        expect(div.text()).toBe('readOnly placeholder');
+        expect(div).toHaveLength(2);
+        expect(div.at(0).text()).toBe('readOnly placeholder');
         expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
     test('col is lookup, not public', () => {
         const cell = mount(<Cell {...defaultProps()} col={lookupCol} colIdx={1} rowIdx={2} />);
-        expect(cell.find('div')).toHaveLength(1);
+        expect(cell.find('div')).toHaveLength(2);
         expect(cell.find('.cell-menu')).toHaveLength(0);
         expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
@@ -179,7 +179,7 @@ describe('Cell', () => {
 
     test('cell renderDragHandle', () => {
         const cell = mount(<Cell {...defaultProps()} col={validValuesCol} renderDragHandle />);
-        expect(cell.find('div')).toHaveLength(2);
+        expect(cell.find('div')).toHaveLength(3);
         expect(cell.find('.cell-menu')).toHaveLength(1);
         expect(cell.find('.cell-menu-value')).toHaveLength(1);
         expect(cell.find('.cell-menu-selector')).toHaveLength(1);

--- a/packages/components/src/internal/components/editable/Cell.spec.tsx
+++ b/packages/components/src/internal/components/editable/Cell.spec.tsx
@@ -41,6 +41,7 @@ describe('Cell', () => {
             cellActions: {
                 clearSelection: jest.fn(),
                 fillDown: jest.fn(),
+                fillText: jest.fn(),
                 focusCell: jest.fn(),
                 inDrag: jest.fn(),
                 modifyCell: jest.fn(),
@@ -56,14 +57,14 @@ describe('Cell', () => {
     test('default props', () => {
         const cell = mount(<Cell {...defaultProps()} />);
         expect(cell.find('div')).toHaveLength(1);
-        expect(cell.find('input')).toHaveLength(0);
+        expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
     test('with focus', () => {
         const cell = mount(<Cell {...defaultProps()} focused selected />);
         expect(cell.find('div')).toHaveLength(0);
-        expect(cell.find('input')).toHaveLength(1);
+        expect(cell.find('textarea')).toHaveLength(1);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
@@ -74,7 +75,7 @@ describe('Cell', () => {
         const div = cell.find('div');
         expect(div).toHaveLength(1);
         expect(div.text()).toBe('placeholder text');
-        expect(cell.find('input')).toHaveLength(0);
+        expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
@@ -92,7 +93,7 @@ describe('Cell', () => {
         );
         expect(cell.find('div')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
-        const input = cell.find('input');
+        const input = cell.find('textarea');
         expect(input).toHaveLength(1);
         expect(input.prop('placeholder')).toBe('placeholder text');
     });
@@ -100,7 +101,7 @@ describe('Cell', () => {
     test('readOnly property', () => {
         const cell = mount(<Cell {...defaultProps()} colIdx={3} readOnly rowIdx={3} />);
         expect(cell.find('div')).toHaveLength(1);
-        expect(cell.find('input')).toHaveLength(0);
+        expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
@@ -108,7 +109,7 @@ describe('Cell', () => {
         const roColumn = new QueryColumn({ readOnly: true, name: 'roColumn' });
         const cell = mount(<Cell {...defaultProps()} col={roColumn} colIdx={4} readOnly={false} rowIdx={3} />);
         expect(cell.find('div')).toHaveLength(1);
-        expect(cell.find('input')).toHaveLength(0);
+        expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
@@ -120,7 +121,7 @@ describe('Cell', () => {
         const div = cell.find('div');
         expect(div).toHaveLength(1);
         expect(div.text()).toBe('readOnly placeholder');
-        expect(cell.find('input')).toHaveLength(0);
+        expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
@@ -128,17 +129,14 @@ describe('Cell', () => {
         const cell = mount(<Cell {...defaultProps()} col={lookupCol} colIdx={1} rowIdx={2} />);
         expect(cell.find('div')).toHaveLength(1);
         expect(cell.find('.cell-menu')).toHaveLength(0);
-        expect(cell.find('input')).toHaveLength(0);
+        expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
     const expectLookup = (cell: ReactWrapper, focused = false, readOnly = false): void => {
-        expect(cell.find('div')).toHaveLength(focused ? 9 : 2);
         expect(cell.find('.cell-menu')).toHaveLength(focused ? 0 : 1);
-        expect(cell.find('.cell-menu-value')).toHaveLength(focused ? 0 : 1);
         expect(cell.find('.cell-menu-selector')).toHaveLength(focused || readOnly ? 0 : 1);
         expect(cell.find('.' + CELL_SELECTION_HANDLE_CLASSNAME)).toHaveLength(0);
-        expect(cell.find('input')).toHaveLength(focused ? 1 : 0);
         expect(cell.find(LookupCell)).toHaveLength(focused ? 1 : 0);
     };
 
@@ -186,7 +184,7 @@ describe('Cell', () => {
         expect(cell.find('.cell-menu-value')).toHaveLength(1);
         expect(cell.find('.cell-menu-selector')).toHaveLength(1);
         expect(cell.find('.' + CELL_SELECTION_HANDLE_CLASSNAME)).toHaveLength(1);
-        expect(cell.find('input')).toHaveLength(0);
+        expect(cell.find('textarea')).toHaveLength(0);
         expect(cell.find(LookupCell)).toHaveLength(0);
     });
 
@@ -197,7 +195,9 @@ describe('Cell', () => {
             if (focused) {
                 expect(cell.find(DateInputCell).prop('defaultValue')).toEqual(rawValue);
                 expect(cell.find('input.date-input-cell').prop('value')).toEqual(value);
-            } else expect(cell.find('.cellular-display').text()).toEqual(value);
+            } else {
+                expect(cell.find('.cellular-display').text()).toEqual(value);
+            }
         }
     };
 

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -33,7 +33,7 @@ import { SelectInputChange } from '../forms/input/SelectInput';
 import { CellMessage, ValueDescriptor } from './models';
 
 import { CellActions, MODIFICATION_TYPES, SELECTION_TYPES } from './constants';
-import { gridCellSelectInputProps, onCellSelectChange } from './utils';
+import { EDIT_GRID_INPUT_CELL_CLASS, gridCellSelectInputProps, onCellSelectChange } from './utils';
 import { LookupCell } from './LookupCell';
 import { DateInputCell } from './DateInputCell';
 
@@ -547,7 +547,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
             );
         }
 
-        let style: React.CSSProperties = undefined;
+        let style: React.CSSProperties;
         if (this.preFocusDOMRect.current) {
             const { height, width } = this.preFocusDOMRect.current;
             style = {
@@ -561,7 +561,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
         return (
             <textarea
                 autoFocus
-                className={classNames('cellular-input', {
+                className={classNames(`${EDIT_GRID_INPUT_CELL_CLASS} cellular-input`, {
                     'cellular-input-align-right': alignRight,
                     'cellular-input-multiline': this.isMultiline,
                 })}

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -446,18 +446,20 @@ export class Cell extends React.PureComponent<CellProps, State> {
             if (showMenu && !this.isReadOnly) {
                 cell = (
                     <div {...displayProps}>
-                        <span className="cell-content">
+                        <div className="cell-content">
                             <div className="cell-menu-value">{valueDisplay}</div>
                             <span className="cell-menu-selector" onClick={this.handleDblClick}>
                                 <i className="fa fa-chevron-down" />
                             </span>
-                        </span>
+                        </div>
                     </div>
                 );
             } else {
                 cell = (
                     <div {...displayProps}>
-                        <span className="cell-content">{valueDisplay}</span>
+                        <div className="cell-content">
+                            <span className="cell-content-value">{valueDisplay}</span>
+                        </div>
                     </div>
                 );
             }

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -378,6 +378,13 @@ export class Cell extends React.PureComponent<CellProps, State> {
         onCellSelectChange(cellActions, colIdx, rowIdx, selectedOptions, props_.multiple);
     };
 
+    onFocusCapture: React.FocusEventHandler<HTMLTextAreaElement> = (event): void => {
+        // Move the cursor the end of the input value upon focus
+        if (event.target.value) {
+            event.target.selectionStart = event.target.selectionEnd = event.target.value.length;
+        }
+    };
+
     render() {
         const {
             borderMaskBottom,
@@ -571,6 +578,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
                 disabled={this.isReadOnly}
                 onBlur={this.handleBlur}
                 onChange={this.handleChange}
+                onFocusCapture={this.onFocusCapture}
                 onKeyDown={this.handleKeys}
                 placeholder={placeholder}
                 style={style}

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -416,6 +416,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
                     'cell-menu': showMenu,
                     'cell-placeholder': valueDisplay.length === 0 && placeholder !== undefined,
                     'cell-read-only': this.isReadOnly,
+                    'cell-align-right': col.align === 'right',
                     'cell-selected': selected,
                     'cell-selection': selection,
                     'cell-warning': message !== undefined,
@@ -534,15 +535,12 @@ export class Cell extends React.PureComponent<CellProps, State> {
             );
         }
 
-        // TODO: Need to trim text values upon save
-        // TODO: This should only apply to text-based fields. Not numeric fields.
-        // TODO: Need to fix the loading state of select inputs so it does not jump
-        // TODO: Need to see about supporting multi-line value copy within a cell to another cell. Normally, this resolves as a multi-cell copy.
-        // console.log(col.jsonType);
         return (
             <textarea
                 autoFocus
-                className={classNames('cellular-input', { 'cellular-input-multiline': col.inputType === 'textarea' })}
+                className={classNames('cellular-input', {
+                    'cellular-input-multiline': col.inputType === 'textarea',
+                })}
                 defaultValue={
                     values.size === 0 ? '' : values.first().display !== undefined ? values.first().display : ''
                 }
@@ -551,9 +549,20 @@ export class Cell extends React.PureComponent<CellProps, State> {
                 onChange={this.handleChange}
                 onKeyDown={this.handleKeys}
                 placeholder={placeholder}
-                style={{ height: `${this._preFocusDOMRect.height}px`, minHeight: `${this._preFocusDOMRect.height}px`, minWidth: `${this._preFocusDOMRect.width}px`, width: `${this._preFocusDOMRect.width}px` }}
+                style={{
+                    height: `${this._preFocusDOMRect.height}px`,
+                    minHeight: `${this._preFocusDOMRect.height}px`,
+                    minWidth: `${this._preFocusDOMRect.width}px`,
+                    width: `${this._preFocusDOMRect.width}px`,
+                    textAlign: col.align === 'right' ? 'right' : undefined,
+                }}
                 tabIndex={-1}
             />
         );
+
+        // TODO: Support cmd+enter in addition or instead of shift+enter?
+        // TODO: Need to trim text values upon save
+        // TODO: Need to see about supporting multi-line value copy within a cell to another cell. Normally, this resolves as a multi-cell copy.
+            // -- This is supported via quotations being wrapped around the content in the clipboard
     }
 }

--- a/packages/components/src/internal/components/editable/DateInputCell.tsx
+++ b/packages/components/src/internal/components/editable/DateInputCell.tsx
@@ -7,7 +7,7 @@ import { formatDate, formatDateTime, isDateTimeCol } from '../../util/Date';
 
 import { MODIFICATION_TYPES, SELECTION_TYPES } from './constants';
 import { ValueDescriptor } from './models';
-import { genCellKey } from './utils';
+import { EDIT_GRID_INPUT_CELL_CLASS, genCellKey } from './utils';
 
 export interface DateInputCellProps {
     col: QueryColumn;
@@ -48,7 +48,7 @@ export const DateInputCell: FC<DateInputCellProps> = memo(props => {
             autoFocus
             disabled={disabled}
             formsy={false}
-            inputClassName="date-input-cell"
+            inputClassName={`date-input-cell ${EDIT_GRID_INPUT_CELL_CLASS}`}
             inputWrapperClassName=""
             isClearable={false}
             isFormInput={false}

--- a/packages/components/src/internal/components/editable/DateInputCell.tsx
+++ b/packages/components/src/internal/components/editable/DateInputCell.tsx
@@ -48,7 +48,7 @@ export const DateInputCell: FC<DateInputCellProps> = memo(props => {
             autoFocus
             disabled={disabled}
             formsy={false}
-            inputClassName="date-input-cell cellular-input"
+            inputClassName="date-input-cell"
             inputWrapperClassName=""
             isClearable={false}
             isFormInput={false}

--- a/packages/components/src/internal/components/editable/LookupCell.spec.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.spec.tsx
@@ -26,6 +26,7 @@ describe('LookupCell', () => {
             colIdx: 0,
             forUpdate: false,
             modifyCell: jest.fn(),
+            row: undefined,
             rowIdx: 0,
             select: jest.fn(),
             values: List.of({ raw: 'a' } as ValueDescriptor, { raw: 'b' } as ValueDescriptor, {} as ValueDescriptor),

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -35,7 +35,7 @@ import { getValueFromRow } from '../../util/utils';
 import { MODIFICATION_TYPES, SELECTION_TYPES } from './constants';
 import { ValueDescriptor } from './models';
 
-import { getLookupFilters, gridCellSelectInputProps, onCellSelectChange } from './utils';
+import { getLookupFilters, gridCellQuerySelectProps, gridCellSelectInputProps, onCellSelectChange } from './utils';
 
 export interface LookupCellProps {
     col: QueryColumn;
@@ -109,7 +109,7 @@ const QueryLookupCell: FC<QueryLookupCellProps> = memo(props => {
 
     return (
         <QuerySelect
-            {...gridCellSelectInputProps}
+            {...gridCellQuerySelectProps}
             containerFilter={lookup.containerFilter ?? containerFilter ?? getContainerFilterForLookups()}
             containerPath={lookup.containerPath ?? containerPath}
             defaultInputValue={defaultInputValue}

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -17,6 +17,7 @@ import { getQueryColumnRenderers } from '../../global';
 
 import { EditorModel, EditorModelProps, EditableGridModels } from './models';
 import { CellActions, CellCoordinates, MODIFICATION_TYPES } from './constants';
+import { QuerySelectOwnProps } from '../forms/QuerySelect';
 
 export const applyEditableGridChangesToModels = (
     dataModels: QueryModel[],
@@ -498,6 +499,11 @@ export const gridCellSelectInputProps: Partial<SelectInputProps> = {
     placeholder: '',
     showIndicatorSeparator: false,
     showLabel: false,
+};
+
+export const gridCellQuerySelectProps: Partial<QuerySelectOwnProps> = {
+    ...gridCellSelectInputProps,
+    showLoading: false,
 };
 
 /**

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -454,6 +454,8 @@ export function getLookupFilters(
     return filters;
 }
 
+export const EDIT_GRID_INPUT_CELL_CLASS = 'eg-input-cell';
+
 export const gridCellSelectInputProps: Partial<SelectInputProps> = {
     autoFocus: true,
     containerClass: 'select-input-cell-container',
@@ -493,7 +495,7 @@ export const gridCellSelectInputProps: Partial<SelectInputProps> = {
             baseUnit: 2,
         },
     }),
-    inputClass: 'select-input-cell',
+    inputClass: `select-input-cell ${EDIT_GRID_INPUT_CELL_CLASS}`,
     menuPosition: 'fixed',
     openMenuOnFocus: true,
     placeholder: '',

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -15,9 +15,10 @@ import { SelectInputOption, SelectInputProps } from '../forms/input/SelectInput'
 
 import { getQueryColumnRenderers } from '../../global';
 
+import { QuerySelectOwnProps } from '../forms/QuerySelect';
+
 import { EditorModel, EditorModelProps, EditableGridModels } from './models';
 import { CellActions, CellCoordinates, MODIFICATION_TYPES } from './constants';
-import { QuerySelectOwnProps } from '../forms/QuerySelect';
 
 export const applyEditableGridChangesToModels = (
     dataModels: QueryModel[],

--- a/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SampleStatusInput.tsx
@@ -115,6 +115,7 @@ export const SampleStatusInput: FC<SampleStatusInputProps> = memo(props => {
                 name={col.fieldKey}
                 openMenuOnFocus={!col.isJunctionLookup()}
                 required={col.required}
+                showLoading={false}
                 {...querySelectProps}
                 containerFilter={getSampleStatusContainerFilter()}
                 onQSChange={onChange}

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -1,8 +1,6 @@
 // #Grids
 // Grid Styling
-
-
-.form-horizontal .control-label.text-left{
+.form-horizontal .control-label.text-left {
   text-align: left;
 }
 
@@ -243,6 +241,8 @@ $table-cell-border: $table-cell-border-width solid transparent;
 $table-cell-selected-border: $table-cell-border-width solid #2980b9;
 $table-cell-selected-box-shadow: 0 3px 3px darkgrey;
 $table-cell-selection-bg-color: #EDF3FF;
+$table-cell-max-height: 200px;
+$table-cell-max-width: 600px;
 
 .table-cellular {
   border-collapse: collapse;
@@ -252,13 +252,12 @@ $table-cell-selection-bg-color: #EDF3FF;
   }
 
   & > tbody > tr.grid-empty > td {
-      height: 30px;
       padding: 0 4px;
   }
 
   & > tbody > tr > td {
     border: 1px solid #dadada;
-    line-height: 1;
+    height: 1px;
 
     &.cellular-count {
       background-color: #f3f3f3;
@@ -269,7 +268,10 @@ $table-cell-selection-bg-color: #EDF3FF;
 
       .cellular-count-content {
         position: absolute;
-        top: 0; bottom: 0; right: 0; left: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        top: 0;
         margin-top: 6px;
       }
 
@@ -281,11 +283,14 @@ $table-cell-selection-bg-color: #EDF3FF;
     .cellular-display {
       border: $table-cell-border;
       cursor: default;
+      display: flex;
+      height: 100%;
+      max-height: $table-cell-max-height;
+      max-width: $table-cell-max-width;
       outline: none;
       overflow: hidden;
       padding: 7px 1px 2px 2px;
-      height: 30px;
-      white-space: nowrap;
+      white-space: pre;
 
         &.cell-selection {
             border: $table-cell-border-width solid $table-cell-selection-bg-color;
@@ -313,6 +318,15 @@ $table-cell-selection-bg-color: #EDF3FF;
         &.cell-border-left {
             border-left: $table-cell-selected-border;
         }
+
+        .cell-content-wrapper {
+          display: flex;
+          height: 100%;
+        }
+
+        .cell-content {
+          align-self: flex-end;
+        }
     }
 
     .cell-selection-handle {
@@ -327,15 +341,23 @@ $table-cell-selection-bg-color: #EDF3FF;
 
     .cellular-input {
       border: $table-cell-selected-border;
+      display: block;
+      height: 100%;
+      max-height: $table-cell-max-height;
+      max-width: 400px;
       outline: none;
-      padding: 6px 2px;
+      padding: 7px 1px 2px 2px;
+      resize: none;
       width: 100%;
-      min-width: 200px;
 
       &:focus {
         border: $table-cell-selected-border;
         outline: none;
       }
+    }
+
+    .cellular-input-multiline {
+      resize: both;
     }
 
     .cell-warning {
@@ -380,11 +402,11 @@ $table-cell-selection-bg-color: #EDF3FF;
 
     .cell-menu-selector {
         position: absolute;
+        bottom: -8px;
         color: $light-gray;
         min-height: 30px;
         font-size: 12px;
         right: 7px;
-        top: 8px;
 
         .fa {
             font-size: 14px;
@@ -415,6 +437,29 @@ $table-cell-selection-bg-color: #EDF3FF;
        }
     }
 
+    .react-datepicker-wrapper {
+      background-color: $white;
+      border: $table-cell-selected-border;
+      display: block;
+      height: 100%;
+
+      .date-input-cell {
+        outline: none;
+        padding: 7px 1px 2px 2px;
+      }
+    }
+  }
+
+  @-moz-document url-prefix() {
+    & > tbody > tr > td {
+      height: 100%;
+
+      .cellular-display {
+        display: inline-table;
+        min-height: 30px;
+        width: 100%;
+      }
+    }
   }
 }
 
@@ -427,15 +472,26 @@ $table-cell-selection-bg-color: #EDF3FF;
 }
 
 .select-input-cell .select-input__control, .date-input-cell {
+    align-content: flex-end;
     border-style: none;
-    min-height: 30px;
+    height: 100%;
     width: 100%;
     min-width: 200px;
 }
 
 .select-input-cell-container, .date-input-cell-container {
+    height: 100%;
     margin-bottom: 0;
     border-style: none;
+
+    .select-input-cell {
+      height: 100%;
+
+      .select-input {
+        display: flex;
+        height: 100%;
+      }
+    }
 }
 
 // https://codepen.io/quanon/pen/WjXmWe
@@ -487,11 +543,6 @@ $table-cell-selection-bg-color: #EDF3FF;
   .input-group-btn {
     width: unset
   }
-}
-
-// Grid selection banner
-.QueryGrid-right-spacing {
-  padding-right: 15px;
 }
 
 .gridbar-button-spacer {

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -243,6 +243,7 @@ $table-cell-selected-box-shadow: 0 3px 3px darkgrey;
 $table-cell-selection-bg-color: #EDF3FF;
 $table-cell-max-height: 200px;
 $table-cell-max-width: 600px;
+$table-cell-padding: 4px 2px;
 
 .table-cellular {
   border-collapse: collapse;
@@ -285,11 +286,9 @@ $table-cell-max-width: 600px;
       cursor: default;
       display: flex;
       height: 100%;
-      max-height: $table-cell-max-height;
-      max-width: $table-cell-max-width;
       outline: none;
       overflow: hidden;
-      padding: 7px 1px 2px 2px;
+      padding: $table-cell-padding;
       white-space: pre;
 
         &.cell-selection {
@@ -321,6 +320,9 @@ $table-cell-max-width: 600px;
 
         .cell-content {
           align-self: flex-end;
+          max-height: $table-cell-max-height;
+          max-width: $table-cell-max-width;
+          overflow: auto;
         }
     }
 
@@ -341,7 +343,7 @@ $table-cell-max-width: 600px;
       max-height: $table-cell-max-height;
       max-width: 400px;
       outline: none;
-      padding: 7px 1px 2px 2px;
+      padding: $table-cell-padding;
       resize: none;
       width: 100%;
 
@@ -448,7 +450,7 @@ $table-cell-max-width: 600px;
 
       .date-input-cell {
         outline: none;
-        padding: 7px 1px 2px 2px;
+        padding: $table-cell-padding;
       }
     }
   }
@@ -464,14 +466,9 @@ $table-cell-max-width: 600px;
         width: 100%;
       }
 
-      .cell-content {
-        max-height: $table-cell-max-height - 15px;
-        overflow: auto;
-      }
-
       .cell-content-value, .cell-menu-value {
         display: inline-block;
-        padding: 4px 2px;
+        padding: $table-cell-padding;
       }
     }
   }

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -319,11 +319,6 @@ $table-cell-max-width: 600px;
             border-left: $table-cell-selected-border;
         }
 
-        .cell-content-wrapper {
-          display: flex;
-          height: 100%;
-        }
-
         .cell-content {
           align-self: flex-end;
         }
@@ -466,6 +461,11 @@ $table-cell-max-width: 600px;
         display: inline-table;
         min-height: 30px;
         width: 100%;
+      }
+
+      .cell-content-value, .cell-menu-value {
+        display: inline-block;
+        padding: 4px 2px;
       }
     }
   }

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -464,6 +464,11 @@ $table-cell-max-width: 600px;
         width: 100%;
       }
 
+      .cell-content {
+        max-height: $table-cell-max-height - 15px;
+        overflow: auto;
+      }
+
       .cell-content-value, .cell-menu-value {
         display: inline-block;
         padding: 4px 2px;

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -453,6 +453,7 @@ $table-cell-max-width: 600px;
     }
   }
 
+  // Specific styling for Firefox (hence the "@-moz...") to support multi-line cells.
   @-moz-document url-prefix() {
     & > tbody > tr > td {
       height: 100%;

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -360,6 +360,10 @@ $table-cell-max-width: 600px;
       resize: both;
     }
 
+    .cell-align-right {
+      justify-content: flex-end;
+    }
+
     .cell-warning {
       position: relative;
 

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -356,6 +356,10 @@ $table-cell-max-width: 600px;
       }
     }
 
+    .cellular-input-align-right {
+      text-align: right;
+    }
+
     .cellular-input-multiline {
       resize: both;
     }


### PR DESCRIPTION
#### Rationale
This introduces support for multi-line cells in the editable grid to fulfill [Feature Request 50121](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50121).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1514
- https://github.com/LabKey/labkey-ui-premium/pull/440
- https://github.com/LabKey/limsModules/pull/361
- https://github.com/LabKey/platform/pull/5586
- https://github.com/LabKey/testAutomation/pull/1963

#### Changes
- Focused cells now render a textarea, instead of an input, which can then be manually resized or scrolled when editing.
- When a cell is rendered that contains a value with multiple lines the cell now renders up to a height of 200px.
- When a multi-line cell transitions to a focused state the dimensions of the cell are maintained to reduce jumping.
- Typing Shift+Enter in a focused textarea starts a new line rather than ending focus.
- Cells now have a maximum width of 600px.
- Column text alignment is now respected when editing input-based cells.
