### PR TITLE
Issue 50483, 50608, 50684 & 50023

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.3-fb-bugFixes247X.2",
+  "version": "3.53.3-fb-bugFixes247X.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.3-fb-bugFixes247X.2",
+      "version": "3.53.3-fb-bugFixes247X.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0",
+  "version": "3.53.1-fb-bugFixes247X.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.0",
+      "version": "3.53.1-fb-bugFixes247X.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.3-fb-bugFixes247X.1",
+  "version": "3.53.3-fb-bugFixes247X.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.3-fb-bugFixes247X.1",
+      "version": "3.53.3-fb-bugFixes247X.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.5",
+  "version": "3.53.6-fb-bugFixes247X.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.5",
+      "version": "3.53.6-fb-bugFixes247X.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.2",
+  "version": "3.53.3-fb-bugFixes247X.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.2",
+      "version": "3.53.3-fb-bugFixes247X.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.4-fb-bugFixes247X.2",
+  "version": "3.53.4-fb-bugFixes247X.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.4-fb-bugFixes247X.2",
+      "version": "3.53.4-fb-bugFixes247X.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6-fb-bugFixes247X.1",
+  "version": "3.53.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.6-fb-bugFixes247X.1",
+      "version": "3.53.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.4-fb-bugFixes247X.1",
+  "version": "3.53.4-fb-bugFixes247X.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.4-fb-bugFixes247X.1",
+      "version": "3.53.4-fb-bugFixes247X.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.0",
+  "version": "3.53.1-fb-bugFixes247X.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.2",
+  "version": "3.53.3-fb-bugFixes247X.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.3-fb-bugFixes247X.1",
+  "version": "3.53.3-fb-bugFixes247X.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.4-fb-bugFixes247X.2",
+  "version": "3.53.4-fb-bugFixes247X.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6-fb-bugFixes247X.1",
+  "version": "3.53.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.3-fb-bugFixes247X.2",
+  "version": "3.53.3-fb-bugFixes247X.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.4-fb-bugFixes247X.1",
+  "version": "3.53.4-fb-bugFixes247X.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.X
+*Released*: X June 2024
+- Issue 50483: Creating a required sample-only field after an aliquot field errors on add
+
 ### version 3.53.0
 *Released*: 12 June 2024
 - Issue 50589: Remove option to export editable grid data

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 3.X
 *Released*: X June 2024
 - Issue 50483: Creating a required sample-only field after an aliquot field errors on add
+- Issue 50023 LKSM: Import button on Assay Run page is not enable after creating a new aliquot and adding them to a run result.
 
 ### version 3.53.0
 *Released*: 12 June 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 3.X
 *Released*: X June 2024
 - Issue 50483: Creating a required sample-only field after an aliquot field errors on add
-- Issue 50023 LKSM: Import button on Assay Run page is not enable after creating a new aliquot and adding them to a run result.
+- Issue 50023: Import button on Assay Run page is not enable after creating a new aliquot and adding them to a run result.
+- Issue 50608: View Assay Results from Storage Grid View errors
 
 ### version 3.53.2
 *Released*: 14 June 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version 3.X
-*Released*: X June 2024
+### version 3.53.6
+*Released*: 20 June 2024
 - Issue 50483: Creating a required sample-only field after an aliquot field errors on add
 - Issue 50023: Import button on Assay Run page is not enable after creating a new aliquot and adding them to a run result.
 - Issue 50608: View Assay Results from Storage Grid View errors

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Issue 50483: Creating a required sample-only field after an aliquot field errors on add
 - Issue 50023: Import button on Assay Run page is not enable after creating a new aliquot and adding them to a run result.
 - Issue 50608: View Assay Results from Storage Grid View errors
+- Issue 50684: LKSM: Update descriptions for Source & Sample Type designer
 
 ### version 3.53.3
 *Released*: 18 June 2024

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -229,6 +229,8 @@ import {
     isNegativeFilterType,
     getLegalIdentifier,
     registerFilterType,
+    BOX_SAMPLES_FILTER,
+    LOCATION_SAMPLES_FILTER,
 } from './internal/query/filter';
 import { selectRows } from './internal/query/selectRows';
 import { flattenBrowseDataTreeResponse, loadReports } from './internal/query/reports';
@@ -1118,6 +1120,8 @@ export {
     getQueryDetails,
     invalidateQueryDetailsCache,
     registerFilterType,
+    BOX_SAMPLES_FILTER,
+    LOCATION_SAMPLES_FILTER,
     COLUMN_IN_FILTER_TYPE,
     COLUMN_NOT_IN_FILTER_TYPE,
     ANCESTOR_MATCHES_ALL_OF_FILTER_TYPE,

--- a/packages/components/src/internal/components/administration/constants.ts
+++ b/packages/components/src/internal/components/administration/constants.ts
@@ -20,3 +20,6 @@ export const SAMPLE_TYPE_DESIGNER_ROLE = 'org.labkey.experiment.security.SampleT
 export const APPLICATION_ROLES_LABELS = {
     [DATA_CLASS_DESIGNER_ROLE]: 'Source Type Designer',
 };
+export const APPLICATION_ROLES_DESCRIPTIONS = {
+    [DATA_CLASS_DESIGNER_ROLE]: 'Source, Registry & Data Class designers an create and design new data classes or change existing ones',
+};

--- a/packages/components/src/internal/components/administration/constants.ts
+++ b/packages/components/src/internal/components/administration/constants.ts
@@ -21,5 +21,5 @@ export const APPLICATION_ROLES_LABELS = {
     [DATA_CLASS_DESIGNER_ROLE]: 'Source Type Designer',
 };
 export const APPLICATION_ROLES_DESCRIPTIONS = {
-    [DATA_CLASS_DESIGNER_ROLE]: 'Source, Registry & Data Class designers an create and design new data classes or change existing ones.',
+    [DATA_CLASS_DESIGNER_ROLE]: 'Source, Registry & Data Class designers can create and design new data classes or change existing ones.',
 };

--- a/packages/components/src/internal/components/administration/constants.ts
+++ b/packages/components/src/internal/components/administration/constants.ts
@@ -21,5 +21,5 @@ export const APPLICATION_ROLES_LABELS = {
     [DATA_CLASS_DESIGNER_ROLE]: 'Source Type Designer',
 };
 export const APPLICATION_ROLES_DESCRIPTIONS = {
-    [DATA_CLASS_DESIGNER_ROLE]: 'Source, Registry & Data Class designers an create and design new data classes or change existing ones',
+    [DATA_CLASS_DESIGNER_ROLE]: 'Source, Registry & Data Class designers an create and design new data classes or change existing ones.',
 };

--- a/packages/components/src/internal/components/administration/constants.ts
+++ b/packages/components/src/internal/components/administration/constants.ts
@@ -21,5 +21,6 @@ export const APPLICATION_ROLES_LABELS = {
     [DATA_CLASS_DESIGNER_ROLE]: 'Source Type Designer',
 };
 export const APPLICATION_ROLES_DESCRIPTIONS = {
-    [DATA_CLASS_DESIGNER_ROLE]: 'Source, Registry & Data Class designers can create and design new data classes or change existing ones.',
+    [DATA_CLASS_DESIGNER_ROLE]:
+        'Source, Registry & Data Class designers can create and design new data classes or change existing ones.',
 };

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -350,6 +350,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
             runProperties: this.getRunPropertiesMap(),
         };
 
+        let hasValidSamples = false;
         if (sampleColumnData) {
             try {
                 // If the assay has a sample column look up at Batch, Run, or Result level then we want to retrieve
@@ -385,6 +386,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
 
                 modelUpdates.selectedSamples = validSamples;
 
+                hasValidSamples = validSamples.size > 0;
                 if (samples.size > 0) {
                     sampleStatusWarning = getOperationNotAllowedMessage(
                         SampleOperation.AddAssayData,
@@ -402,15 +404,19 @@ class AssayImportPanelsBody extends Component<Props, State> {
                 model: state.model.merge(modelUpdates) as AssayWizardModel,
                 sampleStatusWarning,
             }),
-            this.onInitModelComplete
+            () => this.onInitModelComplete(hasValidSamples)
         );
     };
 
-    onInitModelComplete = async (): Promise<void> => {
+    onInitModelComplete = async (hasSamples?: boolean): Promise<void> => {
+        const { setIsDirty } = this.props;
         const runPropsModel = this.getRunPropsQueryModel();
         const runName = runPropsModel.getRowValue('Name');
         const fileName = getRunPropertiesFileName(runPropsModel.getRow());
         const gridData = await this.state.model.getInitialGridData();
+
+        if (hasSamples)
+            setIsDirty(true);
 
         // Issue 38237: set the runName and comments for the re-import case
         this.setState(state => {
@@ -496,7 +502,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
         }));
     };
 
-    handleRunChange = (fieldValues: any): void => {
+    handleRunChange = (fieldValues: any, isChanged?: boolean): void => {
         const values = { ...this.state.model.runProperties.toObject(), ...fieldValues };
         let { comment, runName } = this.state.model;
 
@@ -512,7 +518,8 @@ class AssayImportPanelsBody extends Component<Props, State> {
             return result;
         }, {});
 
-        this.props.setIsDirty?.(true);
+        if (isChanged)
+            this.props.setIsDirty?.(true);
 
         this.handleChange('runProperties', OrderedMap<string, any>(cleanedValues), () => {
             this.setState(state => ({

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -415,8 +415,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
         const fileName = getRunPropertiesFileName(runPropsModel.getRow());
         const gridData = await this.state.model.getInitialGridData();
 
-        if (hasSamples)
-            setIsDirty(true);
+        if (hasSamples) setIsDirty(true);
 
         // Issue 38237: set the runName and comments for the re-import case
         this.setState(state => {
@@ -518,8 +517,7 @@ class AssayImportPanelsBody extends Component<Props, State> {
             return result;
         }, {});
 
-        if (isChanged)
-            this.props.setIsDirty?.(true);
+        if (isChanged) this.props.setIsDirty?.(true);
 
         this.handleChange('runProperties', OrderedMap<string, any>(cleanedValues), () => {
             this.setState(state => ({

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -348,7 +348,7 @@ export class EditorModel
     validateData(
         queryModel: QueryModel,
         uniqueFieldKey?: string,
-        insertColumns?: QueryColumn[],
+        insertColumns?: QueryColumn[]
     ): {
         missingRequired: Map<string, List<number>>; // map from column caption to row numbers with missing values
         uniqueKeyViolations: Map<string, Map<string, List<number>>>; // map from the column captions (joined by ,) to a map from values that are duplicates to row numbers.

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -347,13 +347,14 @@ export class EditorModel
      */
     validateData(
         queryModel: QueryModel,
-        uniqueFieldKey?: string
+        uniqueFieldKey?: string,
+        insertColumns?: QueryColumn[],
     ): {
         missingRequired: Map<string, List<number>>; // map from column caption to row numbers with missing values
         uniqueKeyViolations: Map<string, Map<string, List<number>>>; // map from the column captions (joined by ,) to a map from values that are duplicates to row numbers.
     } {
         const data = fromJS(queryModel.rows);
-        const columns = queryModel.queryInfo.getInsertColumns();
+        const columns = insertColumns ?? queryModel.queryInfo.getInsertColumns();
         let uniqueFieldCol;
         const keyColumns = columns.filter(column => column.isKeyField);
         let keyValues = Map<number, List<string>>(); // map from row number to list of key values on that row
@@ -436,8 +437,8 @@ export class EditorModel
         };
     }
 
-    getValidationErrors(queryModel: QueryModel, uniqueFieldKey?: string): string[] {
-        const { uniqueKeyViolations, missingRequired } = this.validateData(queryModel, uniqueFieldKey);
+    getValidationErrors(queryModel: QueryModel, uniqueFieldKey?: string, insertColumns?: QueryColumn[]): string[] {
+        const { uniqueKeyViolations, missingRequired } = this.validateData(queryModel, uniqueFieldKey, insertColumns);
         let errors = [];
         if (!uniqueKeyViolations.isEmpty()) {
             const messages = uniqueKeyViolations.reduce((keyMessages, valueMap, fieldNames) => {

--- a/packages/components/src/internal/components/permissions/actions.ts
+++ b/packages/components/src/internal/components/permissions/actions.ts
@@ -20,7 +20,8 @@ export function processGetRolesResponse(rawRoles: any): List<SecurityRole> {
     rawRoles.forEach(roleRaw => {
         const role = roleRaw;
         if (APPLICATION_ROLES_LABELS[role?.uniqueName]) role.displayName = APPLICATION_ROLES_LABELS[role?.uniqueName];
-        if (APPLICATION_ROLES_DESCRIPTIONS[role?.uniqueName]) role.description = APPLICATION_ROLES_DESCRIPTIONS[role?.uniqueName];
+        if (APPLICATION_ROLES_DESCRIPTIONS[role?.uniqueName])
+            role.description = APPLICATION_ROLES_DESCRIPTIONS[role?.uniqueName];
         roles = roles.push(SecurityRole.create(role));
     });
     return roles;

--- a/packages/components/src/internal/components/permissions/actions.ts
+++ b/packages/components/src/internal/components/permissions/actions.ts
@@ -11,7 +11,7 @@ import { ISelectRowsResult, selectRowsDeprecated } from '../../query/api';
 import { Container } from '../base/models/Container';
 import { FetchContainerOptions } from '../security/APIWrapper';
 
-import { APPLICATION_ROLES_LABELS } from '../administration/constants';
+import { APPLICATION_ROLES_LABELS, APPLICATION_ROLES_DESCRIPTIONS } from '../administration/constants';
 
 import { Principal, SecurityPolicy, SecurityRole } from './models';
 
@@ -20,6 +20,7 @@ export function processGetRolesResponse(rawRoles: any): List<SecurityRole> {
     rawRoles.forEach(roleRaw => {
         const role = roleRaw;
         if (APPLICATION_ROLES_LABELS[role?.uniqueName]) role.displayName = APPLICATION_ROLES_LABELS[role?.uniqueName];
+        if (APPLICATION_ROLES_DESCRIPTIONS[role?.uniqueName]) role.description = APPLICATION_ROLES_DESCRIPTIONS[role?.uniqueName];
         roles = roles.push(SecurityRole.create(role));
     });
     return roles;

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -38,6 +38,7 @@ import {
 } from './constants';
 
 import { SampleState, SampleStatus } from './models';
+import { BOX_SAMPLES_FILTER, LOCATION_SAMPLES_FILTER } from '../../query/filter';
 
 export function getOmittedSampleTypeColumns(user: User, moduleContext?: ModuleContext): string[] {
     let cols: string[] = [];
@@ -291,8 +292,9 @@ export function getURLParamsForSampleSelectionKey(
                 const isPicklistFilterType = filterURLSuffix === PICKLIST_SAMPLES_FILTER.getURLSuffix();
                 // and we don't need the LSID LineageOf clause either
                 const isLineageOfFilterType = filterURLSuffix === Filter.Types.EXP_LINEAGE_OF.getURLSuffix();
+                const isSampleInLocationFilterType = filterURLSuffix === LOCATION_SAMPLES_FILTER.getURLSuffix() || filterURLSuffix === BOX_SAMPLES_FILTER.getURLSuffix();
 
-                if (!isPicklistFilterType && !isLineageOfFilterType) {
+                if (!isPicklistFilterType && !isLineageOfFilterType && !isSampleInLocationFilterType) {
                     params[filter.getURLParameterName()] = filter.getURLParameterValue();
                 }
             });

--- a/packages/components/src/internal/query/filter.ts
+++ b/packages/components/src/internal/query/filter.ts
@@ -559,3 +559,12 @@ export const IN_EXP_ANCESTORS_OF_FILTER_TYPE = registerFilterType(
     true,
     undefined
 );
+/**
+ * This implements the filter corresponding to SampleInBoxCompareType. Updates there should also be reflected here.
+ */
+export const BOX_SAMPLES_FILTER = registerFilterType('Sample in box', null, 'sampleinbox', true);
+
+/**
+ * This implements the filter corresponding to SampleInLocationCompareType. Updates there should also be reflected here.
+ */
+export const LOCATION_SAMPLES_FILTER = registerFilterType('Sample in location', null, 'sampleinlocation', true);

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -28,6 +28,7 @@ export const useRouteLeave = (confirmMessage = CONFIRM_MESSAGE): GetSetIsDirty =
     const isDirty = useRef<boolean>(false);
     const setIsDirty = useCallback(
         (dirty: boolean) => {
+            console.log('setDirty');
             isDirty.current = dirty;
         },
         [isDirty]

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -28,7 +28,6 @@ export const useRouteLeave = (confirmMessage = CONFIRM_MESSAGE): GetSetIsDirty =
     const isDirty = useRef<boolean>(false);
     const setIsDirty = useCallback(
         (dirty: boolean) => {
-            console.log('setDirty');
             isDirty.current = dirty;
         },
         [isDirty]


### PR DESCRIPTION
#### Rationale
- Issue 50483: Creating a required sample-only field after an aliquot field errors on add
- Issue 50023 LKSM: Import button on Assay Run page is not enable after creating a new aliquot and adding them to a run result.
- Issue 50608: View Assay Results from Storage Grid View errors
- Issue 50684: LKSM: Update descriptions for Source & Sample Type designer

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1515
- https://github.com/LabKey/labkey-ui-premium/pull/441
- https://github.com/LabKey/platform/pull/5589
- https://github.com/LabKey/limsModules/pull/369

#### Changes
- Set assay import page dirty if there are initialization samples
- Allow insertColumns passed in for validate editable grid data
- exclude storage filters for sample selection