### PR TITLE
Storage: separate styling from editable grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.4",
+  "version": "3.53.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.4",
+      "version": "3.53.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.4",
+  "version": "3.53.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.53.5
+*Released*: 18 June 2024
+- Separate storage styling from editable grid
+
 ### version 3.53.4
 *Released*: 18 June 2024
 - Issue 50533: Support passing through a `timezone` prop on `EditInlineField`

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -500,7 +500,6 @@ $table-cell-padding: 4px 2px;
       height: 100%;
 
       .select-input {
-        display: flex;
         height: 100%;
       }
     }

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -253,7 +253,8 @@ $table-cell-padding: 4px 2px;
   }
 
   & > tbody > tr.grid-empty > td {
-      padding: 0 4px;
+    height: 30px;
+    padding: 0 4px;
   }
 
   & > tbody > tr > td {


### PR DESCRIPTION
#### Rationale
This addresses the wonky layout changes introduced by #1514 due to overlapping usage of certain aspects of the styling (i.e. `cellular-display`, `cell-selection`, etc). This also addresses a layout problem that was introduced in the box storage viewer where the dropdowns for lookup cells were appearing offset.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1516
- https://github.com/LabKey/labkey-ui-premium/pull/442
- https://github.com/LabKey/limsModules/pull/370
- https://github.com/LabKey/platform/pull/5592

#### Changes
- Undo height adjustment of empty editable grid row.
- Remove superfluous display setting (this caused the offset dropdowns in storage)
