### PR TITLE
Issue 50533: Display dates in server timezone

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.53.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.34.1-fb-timezones.0",
+        "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.1-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
-      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
+      "version": "1.34.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1.tgz",
+      "integrity": "sha512-82dASLsBCq2IGecCIYNqFqbC1x/v/qIpH3rvd8e5S/VsFYjtAn9Xkd13DnDe0eO6+i0r54nSlIfLMtBCBKBchQ=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.3",
+  "version": "3.53.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.3",
+      "version": "3.53.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.53.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@labkey/api": "1.34.0",
+        "@labkey/api": "1.34.1-fb-timezones.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.0.tgz",
-      "integrity": "sha512-YSWDzkdK1ed+t7OtaFz9ZmCb2DEyVr7pdmZfVE7W0ZzBZHgfMiCUo9br0+g/dzqUXqxYBjuNgpJtbJhjObe2UQ=="
+      "version": "1.34.1-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
+      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.34.0",
+    "@labkey/api": "1.34.1-fb-timezones.0",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.3",
+  "version": "3.53.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
-    "@labkey/api": "1.34.1-fb-timezones.0",
+    "@labkey/api": "1.34.1",
     "@testing-library/jest-dom": "~5.17.0",
     "@testing-library/react": "~12.1.5",
     "@testing-library/user-event": "~12.8.3",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version 3.53.4
+*Released*: 18 June 2024
+- Issue 50533: Support passing through a `timezone` prop on `EditInlineField`
+
 ### version 3.53.3
 *Released*: 18 June 2024
 - Add support for Ancestor nodes on All Samples grids

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -66,7 +66,7 @@ export const EditInlineField: FC<Props> = memo(props => {
     const inputType = type === 'int' || type === 'float' ? 'number' : 'text';
     const inputRef = useRef(null);
     const _value = typeof value === 'object' ? value?.value : value;
-    const [dateValue, setDateValue] = useState<Date>(() => isDate && _value ? new Date(_value) : undefined);
+    const [dateValue, setDateValue] = useState<Date>(() => (isDate && _value ? new Date(_value) : undefined));
     const [timeJsonValue, setTimeJsonValue] = useState<string>(undefined);
     const [columnBasedValue, setColumnBasedValue] = useState();
 
@@ -144,14 +144,11 @@ export const EditInlineField: FC<Props> = memo(props => {
         setState({ ignoreBlur: false });
     }, [allowBlank, getInputValue, isDate, onCancel, saveEdit, state.ignoreBlur]);
 
-    const onDateChange = useCallback(
-        (date: Date | string) => {
-            if (date instanceof Array) throw new Error('Unsupported date/time type');
-            if (typeof date === 'string') setTimeJsonValue(date);
-            else setDateValue(date);
-        },
-        []
-    );
+    const onDateChange = useCallback((date: Date | string) => {
+        if (date instanceof Array) throw new Error('Unsupported date/time type');
+        if (typeof date === 'string') setTimeJsonValue(date);
+        else setDateValue(date);
+    }, []);
 
     const onFormsyColumnChange = useCallback(
         (data: Record<string, any>) => {


### PR DESCRIPTION
#### Rationale
For [Issue 50533](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50533) update `EditInlineField` to support displaying dates in alternate timezones.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/177
- https://github.com/LabKey/labkey-ui-components/pull/1517
- https://github.com/LabKey/labkey-ui-premium/pull/444
- https://github.com/LabKey/limsModules/pull/375
- https://github.com/LabKey/platform/pull/5596

#### Changes
- Support passing through a `timezone` prop on `EditInlineField`.
