### PR TITLE
Issue 48439: EditableGrid drops invalid date values when calling insertRows/saveRows

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6-fb-editableGridDates48439.0",
+  "version": "3.53.6-fb-editableGridDates48439.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.6-fb-editableGridDates48439.0",
+      "version": "3.53.6-fb-editableGridDates48439.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6",
+  "version": "3.53.6-fb-editableGridDates48439.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.6",
+      "version": "3.53.6-fb-editableGridDates48439.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6-fb-editableGridDates48439.1",
+  "version": "3.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.6-fb-editableGridDates48439.1",
+      "version": "3.54.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.5",
+  "version": "3.53.5-fb-editableGridDates48439.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.53.5",
+      "version": "3.53.5-fb-editableGridDates48439.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6-fb-editableGridDates48439.1",
+  "version": "3.54.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6",
+  "version": "3.53.6-fb-editableGridDates48439.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.5",
+  "version": "3.53.5-fb-editableGridDates48439.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.53.6-fb-editableGridDates48439.0",
+  "version": "3.53.6-fb-editableGridDates48439.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
-### version TBD
-*Released*: TBD June 2024
+### version 3.54.0
+*Released*: 24 June 2024
 - Issue 48439: EditableGrid drops invalid date values when calling insertRows/saveRows
   - add getValidatedEditableGridValue() to centralize handling of grid data parsing for insert and update case
   - return original date string value when unable to parseDate()

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages.
 
+### version TBD
+*Released*: TBD June 2024
+- Issue 48439: EditableGrid drops invalid date values when calling insertRows/saveRows
+  - add getValidatedEditableGridValue() to centralize handling of grid data parsing for insert and update case
+  - return original date string value when unable to parseDate()
+
 ### version 3.53.5
 *Released*: 18 June 2024
 - Separate storage styling from editable grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Issue 48439: EditableGrid drops invalid date values when calling insertRows/saveRows
   - add getValidatedEditableGridValue() to centralize handling of grid data parsing for insert and update case
   - return original date string value when unable to parseDate()
+- Remove some deprecated code after issue 50589 changes (remove export editable grid option)
 
 ### version 3.53.5
 *Released*: 18 June 2024

--- a/packages/components/src/internal/components/assay/AssayWizardModel.ts
+++ b/packages/components/src/internal/components/assay/AssayWizardModel.ts
@@ -198,7 +198,7 @@ export class AssayWizardModel
         } else if (this.isGridTab(currentStep)) {
             // need to get the EditorModel for the data to use in the import
             assayData.dataRows = editorModel
-                .getRawDataFromModel(queryModel)
+                .getRawDataFromModel(queryModel, false, false)
                 .valueSeq()
                 .map(row => row.filter(v => v !== undefined && v !== null && ('' + v).trim() !== ''))
                 .toList()

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
@@ -1,32 +1,25 @@
 import React from 'react';
 import { List, Map } from 'immutable';
-import { shallow } from 'enzyme';
+
+import { act } from '@testing-library/react';
+
+import userEvent from '@testing-library/user-event';
 
 import { PROPERTIES_PANEL_ERROR_MSG } from '../constants';
-import DomainForm from '../DomainForm';
 
 import { DomainDetails } from '../models';
-
-import { mountWithAppServerContext, waitForLifecycle } from '../../../test/enzymeTestHelpers';
-
-import { FileAttachmentForm } from '../../../../public/files/FileAttachmentForm';
-
-import { Alert } from '../../base/Alert';
 
 import { getTestAPIWrapper } from '../../../APIWrapper';
 
 import { getEntityTestAPIWrapper } from '../../entities/APIWrapper';
 
-import { SampleTypePropertiesPanel } from './SampleTypePropertiesPanel';
-import { SampleTypeDesigner, SampleTypeDesignerImpl } from './SampleTypeDesigner';
-import { act } from '@testing-library/react';
 import { renderWithAppContext } from '../../../test/reactTestLibraryHelpers';
-import userEvent from '@testing-library/user-event';
 
+import { SampleTypeDesigner, SampleTypeDesignerImpl } from './SampleTypeDesigner';
 
 const SERVER_CONTEXT = {
     moduleContext: {
-        query: { hasProductProjects: true}
+        query: { hasProductProjects: true },
     },
 };
 
@@ -102,7 +95,7 @@ describe('SampleTypeDesigner', () => {
         await act(async () => {
             renderWithAppContext(form, {
                 serverContext: SERVER_CONTEXT,
-            })
+            });
         });
 
         expect(document.getElementsByClassName('domain-form-panel')).toHaveLength(2);
@@ -130,7 +123,7 @@ describe('SampleTypeDesigner', () => {
         await act(async () => {
             renderWithAppContext(form, {
                 serverContext: SERVER_CONTEXT,
-            })
+            });
         });
 
         expect(document.getElementsByClassName('domain-form-panel')).toHaveLength(3);
@@ -169,10 +162,10 @@ describe('SampleTypeDesigner', () => {
         await act(async () => {
             renderWithAppContext(form, {
                 serverContext: SERVER_CONTEXT,
-            })
+            });
         });
 
-        //expect(wrapped.find(SampleTypePropertiesPanel)).toHaveLength(1);
+        // expect(wrapped.find(SampleTypePropertiesPanel)).toHaveLength(1);
         const panels = document.querySelectorAll('.domain-form-panel');
         expect(panels).toHaveLength(2);
         const panelTitles = document.querySelectorAll('.domain-panel-title');
@@ -185,13 +178,15 @@ describe('SampleTypeDesigner', () => {
         await act(async () => {
             renderWithAppContext(<SampleTypeDesigner {...BASE_PROPS} />, {
                 serverContext: SERVER_CONTEXT,
-            })
+            });
         });
 
         const panelHeader = document.querySelector('div#domain-header');
         expect(panelHeader.getAttribute('class')).toContain('domain-panel-header-collapsed');
         userEvent.click(panelHeader);
-        expect(document.querySelector('#domain-header').getAttribute('class')).toContain('domain-panel-header-expanded');
+        expect(document.querySelector('#domain-header').getAttribute('class')).toContain(
+            'domain-panel-header-expanded'
+        );
         expect(document.getElementsByClassName('translator--toggle__wizard')).toHaveLength(1);
 
         const alerts = document.getElementsByClassName('alert');
@@ -205,7 +200,7 @@ describe('SampleTypeDesigner', () => {
         await act(async () => {
             renderWithAppContext(<SampleTypeDesigner {...BASE_PROPS} />, {
                 serverContext: SERVER_CONTEXT,
-            })
+            });
         });
 
         const panelHeader = document.querySelector('div#domain-header');

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
@@ -165,7 +165,6 @@ describe('SampleTypeDesigner', () => {
             });
         });
 
-        // expect(wrapped.find(SampleTypePropertiesPanel)).toHaveLength(1);
         const panels = document.querySelectorAll('.domain-form-panel');
         expect(panels).toHaveLength(2);
         const panelTitles = document.querySelectorAll('.domain-panel-title');

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -27,11 +27,10 @@ import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { GridData } from '../../models';
 
 import { getQueryColumnRenderers } from '../../global';
-import { getColDateFormat, getJsonDateTimeFormatString, parseDate } from '../../util/Date';
 import { caseInsensitive, quoteValueWithDelimiters } from '../../util/utils';
 
 import { CellCoordinates, EditableGridEvent } from './constants';
-import { genCellKey, parseCellKey } from './utils';
+import { genCellKey, getValidatedEditableGridValue, parseCellKey } from './utils';
 
 export interface EditableColumnMetadata {
     align?: string;
@@ -313,14 +312,8 @@ export class EditorModel
                 } else if (col.jsonType === 'time') {
                     row = row.set(col.name, values.size === 1 ? values.first().raw : undefined);
                 } else if (col.jsonType === 'date' && !displayValues) {
-                    let dateVal;
-                    if (values.size === 1) {
-                        dateVal = values.first().raw;
-                        dateVal = parseDate(dateVal, getColDateFormat(col));
-                    }
-
-                    // Issue 44398: match JSON dateTime format provided by LK server when submitting date values back for insert/update
-                    row = row.set(col.name, getJsonDateTimeFormatString(dateVal));
+                    const val = values.size === 1 ? values.first().raw : undefined;
+                    row = row.set(col.name, getValidatedEditableGridValue(val, col).value);
                 } else {
                     row = row.set(col.name, values.size === 1 ? values.first().raw?.toString().trim() : undefined);
                 }

--- a/packages/components/src/internal/components/editable/utils.test.ts
+++ b/packages/components/src/internal/components/editable/utils.test.ts
@@ -2,7 +2,6 @@ import { fromJS, List, Map } from 'immutable';
 
 import { ExtendedMap } from '../../../public/ExtendedMap';
 
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
 import { LoadingState } from '../../../public/LoadingState';
 
 import { ASSAY_WIZARD_MODEL } from '../../../test/data/constants';
@@ -15,17 +14,8 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { BOOLEAN_TYPE, DATE_TYPE, INTEGER_TYPE, TEXT_TYPE, TIME_TYPE } from '../domainproperties/PropDescType';
 
 import { initEditableGridModel } from './actions';
-import { EditorMode, EditorModel, EditableGridLoader, ValueDescriptor } from './models';
-import {
-    computeRangeChange,
-    genCellKey,
-    getEditorExportData,
-    getUpdatedDataFromGrid,
-    parseCellKey,
-    sortCellKeys,
-} from './utils';
-
-const MODEL_ID_LOADED = 'loaded';
+import { EditorMode, EditorModel, EditableGridLoader } from './models';
+import { computeRangeChange, genCellKey, getUpdatedDataFromGrid, parseCellKey, sortCellKeys } from './utils';
 
 class MockEditableGridLoader implements EditableGridLoader {
     columns: QueryColumn[];
@@ -47,80 +37,6 @@ class MockEditableGridLoader implements EditableGridLoader {
 }
 
 describe('Editable Grids Utils', () => {
-    test('getEditorExportData', () => {
-        // Arrange
-        const { queryInfo } = ASSAY_WIZARD_MODEL;
-        const queryModel = new QueryModel({
-            id: MODEL_ID_LOADED,
-            schemaQuery: queryInfo.schemaQuery,
-        }).mutate({
-            rows: {
-                '7197': {
-                    ParticipantID: { displayValue: 'p1234', value: 'p1234' },
-                    RowId: { value: 7197 },
-                    SampleID: { displayValue: 'Sample 1', value: 'Sample 1' },
-                    VisitID: { displayValue: 'Visit 1', value: 1 },
-                },
-                '8192': {
-                    ParticipantID: { displayValue: 'p4567', value: 'p4567' },
-                    RowId: { value: 8192 },
-                    SampleID: { displayValue: 'Sample 8192', value: 'Sample 8192' },
-                    VisitID: { value: null },
-                    'Run/Batch/batch_dbl_field': { value: 4.35 },
-                },
-            },
-            orderedRows: ['7197', '8192'],
-            rowsLoadingState: LoadingState.LOADED,
-            queryInfoLoadingState: LoadingState.LOADED,
-            queryInfo,
-        });
-        const editorModel = new EditorModel({
-            cellValues: Map<string, List<ValueDescriptor>>({
-                // 7197
-                '0-0': List([{ display: 'Sample 1', raw: 'Sample 1' }]),
-                '1-0': List([{ display: 'p1234', raw: 'p1234' }]),
-                '2-0': List([{ display: 'Visit 1', raw: 'Visit 1' }]),
-                '3-0': List([{ display: '11/22/22', raw: '11/22/22' }]),
-
-                // 8192
-                '0-1': List([{ display: 'Sample 8192-1', raw: 'Sample 8192-1' }]),
-                '1-1': List([{ display: 'p4567', raw: 'p4567' }]),
-                '2-2': List([]),
-                '3-1': List([]),
-            }),
-            columns: List(['SampleID', 'ParticipantID', 'VisitID', 'Date']),
-            id: MODEL_ID_LOADED,
-        });
-        const extraColumns = [
-            { caption: 'Row ID', fieldKey: 'RowId' },
-            { caption: 'Batch Double Field', fieldKey: 'Run/Batch/batch_dbl_field' },
-        ];
-
-        // Act
-        const exportData = getEditorExportData(
-            [editorModel],
-            [queryModel],
-            undefined,
-            undefined,
-            undefined,
-            true,
-            extraColumns
-        );
-
-        // Assert
-        expect(exportData.length).toEqual(3);
-        expect(exportData[0]).toEqual([
-            'SampleID',
-            'Participant ID',
-            'Visit ID',
-            'Date',
-            'Row ID',
-            'Batch Double Field',
-        ]);
-        expect(exportData[1]).toEqual(['Sample 1', 'p1234', 'Visit 1', '11/22/22', 7197, undefined]);
-        expect(exportData[2]).toEqual(['Sample 8192-1', 'p4567', undefined, undefined, 8192, 4.35]);
-    });
-
     describe('initEditableGridModel', () => {
         const { queryInfo } = ASSAY_WIZARD_MODEL;
         const dataModel = makeTestQueryModel(queryInfo.schemaQuery, queryInfo);

--- a/packages/components/src/internal/components/editable/utils.test.ts
+++ b/packages/components/src/internal/components/editable/utils.test.ts
@@ -575,7 +575,7 @@ describe('getUpdatedDataFromGrid', () => {
                 Map<string, any>({
                     RowId: 448,
                     Date: '2020-12-23 14:35',
-                    Time: '01:10:00',
+                    Time: '01:10:01',
                 }),
             ],
             'RowId',
@@ -583,6 +583,7 @@ describe('getUpdatedDataFromGrid', () => {
         );
         expect(updatedData[0]).toStrictEqual({
             Date: '2020-12-23 14:35',
+            Time: '01:10:01',
             RowId: 448,
         });
 
@@ -598,7 +599,7 @@ describe('getUpdatedDataFromGrid', () => {
                 Map<string, any>({
                     RowId: 448,
                     Date: '2020-12-24 14:34',
-                    Time: '01:10:00',
+                    Time: '01:11:00',
                 }),
             ],
             'RowId',
@@ -606,6 +607,7 @@ describe('getUpdatedDataFromGrid', () => {
         );
         expect(updatedData[0]).toStrictEqual({
             Date: '2020-12-24 14:34',
+            Time: '01:11:00',
             RowId: 448,
         });
 
@@ -621,7 +623,7 @@ describe('getUpdatedDataFromGrid', () => {
                 Map<string, any>({
                     RowId: 448,
                     Date: '2020-12-INVALID 14:34',
-                    Time: '01:10:00',
+                    Time: '01:INVALID:00',
                 }),
             ],
             'RowId',
@@ -629,6 +631,7 @@ describe('getUpdatedDataFromGrid', () => {
         );
         expect(updatedData[0]).toStrictEqual({
             Date: '2020-12-INVALID 14:34',
+            Time: '01:INVALID:00',
             RowId: 448,
         });
 
@@ -660,8 +663,11 @@ describe('getUpdatedDataFromGrid', () => {
 describe('getValidatedEditableGridValue', () => {
     const dateCol = new QueryColumn({ jsonType: 'date', rangeURI: DATE_RANGE_URI });
     const dateTimeCol = new QueryColumn({ jsonType: 'date' });
+    const timeCol = new QueryColumn({ jsonType: 'time' });
     const intCol = new QueryColumn({ jsonType: 'int' });
     const floatCol = new QueryColumn({ jsonType: 'float' });
+    const boolCol = new QueryColumn({ jsonType: 'boolean' });
+    const textCol = new QueryColumn({ jsonType: 'string' });
 
     test('no column', () => {
         expect(getValidatedEditableGridValue('2020-12-23', undefined)).toStrictEqual({
@@ -753,21 +759,13 @@ describe('getValidatedEditableGridValue', () => {
     });
 
     test('non-date columns', () => {
-        expect(getValidatedEditableGridValue('2020-12-23', intCol)).toStrictEqual({
-            message: undefined,
-            value: '2020-12-23',
+        const colTypes = [intCol, floatCol, timeCol, boolCol, textCol];
+        const values = ['2020-12-23', 'Bogus', true, 13, 2.99];
+        colTypes.forEach(col => {
+            values.forEach(value => {
+                expect(getValidatedEditableGridValue(value, col)).toStrictEqual({ message: undefined, value });
+            });
         });
-        expect(getValidatedEditableGridValue('Bogus', intCol)).toStrictEqual({ message: undefined, value: 'Bogus' });
-        expect(getValidatedEditableGridValue(true, intCol)).toStrictEqual({ message: undefined, value: true });
-        expect(getValidatedEditableGridValue(13, intCol)).toStrictEqual({ message: undefined, value: 13 });
-
-        expect(getValidatedEditableGridValue('2020-12-23', floatCol)).toStrictEqual({
-            message: undefined,
-            value: '2020-12-23',
-        });
-        expect(getValidatedEditableGridValue('Bogus', floatCol)).toStrictEqual({ message: undefined, value: 'Bogus' });
-        expect(getValidatedEditableGridValue(true, floatCol)).toStrictEqual({ message: undefined, value: true });
-        expect(getValidatedEditableGridValue(13, floatCol)).toStrictEqual({ message: undefined, value: 13 });
     });
 });
 

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -56,8 +56,8 @@ export const applyEditableGridChangesToModels = (
 };
 
 export const getValidatedEditableGridValue = (origValue: any, col: QueryColumn): { message: string, value: any } => {
-    const isDateTimeType = col.jsonType === 'date';
-    const isDateType = isDateTimeType && col.isDateOnlyColumn;
+    const isDateTimeType = col?.jsonType === 'date';
+    const isDateType = isDateTimeType && col?.isDateOnlyColumn;
     let message;
     let value = origValue;
 

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -55,7 +55,7 @@ export const applyEditableGridChangesToModels = (
     };
 };
 
-export const getValidatedEditableGridValue = (origValue: any, col: QueryColumn): { message: string, value: any } => {
+export const getValidatedEditableGridValue = (origValue: any, col: QueryColumn): { message: string; value: any } => {
     const isDateTimeType = col?.jsonType === 'date';
     const isDateType = isDateTimeType && col?.isDateOnlyColumn;
     let message;

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -267,7 +267,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
                 autoFocus={autoFocus}
                 className={inputClassName}
                 dateFormat={dateFormat}
-                disabled={isDisabled || invalid}
+                disabled={isDisabled}
                 id={queryColumn.fieldKey}
                 isClearable={isClearable}
                 name={name ? name : queryColumn.fieldKey}
@@ -278,7 +278,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputProps, 
                 onMonthChange={this.onChange}
                 placeholderText={placeholderText ?? `Select ${queryColumn.caption.toLowerCase()}`}
                 selected={selectedDate}
-                showTimeSelect={!hideTime && (isDateTimeCol(queryColumn) || isTimeOnly)}
+                showTimeSelect={!hideTime && (isDateTimeCol(queryColumn) || isTimeOnly) && !invalid}
                 showTimeSelectOnly={!hideTime && isTimeOnly}
                 timeIntervals={isTimeOnly ? 10 : 30}
                 timeFormat={timeFormat}


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48439

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1518
- https://github.com/LabKey/labkey-ui-premium/pull/447
- https://github.com/LabKey/limsModules/pull/388

#### Changes
- add getValidatedEditableGridValue() to centralize handling of grid data parsing for insert and update case
- return original date string value when unable to parseDate()
- Remove some deprecated code after issue 50589 changes (remove export editable grid option)
