### PR TITLE
Remove usage of MaterialLookupColumnRenderer

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.56.0",
+  "version": "3.56.1-fb-render-50730.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.56.0",
+      "version": "3.56.1-fb-render-50730.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.56.1-fb-render-50730.0",
+  "version": "3.56.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.56.1-fb-render-50730.0",
+      "version": "3.56.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.56.0",
+  "version": "3.56.1-fb-render-50730.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.56.1-fb-render-50730.0",
+  "version": "3.56.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 3.56.1
+*Released*: 28 June 2024
+- Remove reference to `MaterialLookupColumnRenderer`
+
 ### version 3.56.0
 *Released*: 27 June 2024
 - Use `LabelOverlay` in headers for grids

--- a/packages/components/src/internal/renderers/ImportAliasRenderer.tsx
+++ b/packages/components/src/internal/renderers/ImportAliasRenderer.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { PureComponent, FC, memo, ReactNode } from 'react';
+import React, { FC, memo, useMemo } from 'react';
 import { Map } from 'immutable';
 
 import { AppURL } from '../url/AppURL';
@@ -22,18 +22,6 @@ import { DATA_CLASS_IMPORT_PREFIX, SAMPLE_SET_IMPORT_PREFIX } from '../component
 
 interface Props {
     data: Map<any, any>;
-}
-
-export class SampleTypeImportAliasRenderer extends PureComponent<Props> {
-    render(): ReactNode {
-        return <ImportAliasRenderer appRouteMap={{ [SAMPLE_SET_IMPORT_PREFIX]: SAMPLES_KEY }} data={this.props.data} />;
-    }
-}
-
-export class SourceTypeImportAliasRenderer extends PureComponent<Props> {
-    render(): ReactNode {
-        return <ImportAliasRenderer appRouteMap={{ [DATA_CLASS_IMPORT_PREFIX]: SOURCES_KEY }} data={this.props.data} />;
-    }
 }
 
 interface RendererProps extends Props {
@@ -69,4 +57,14 @@ export const ImportAliasRenderer: FC<RendererProps> = memo(props => {
                 })}
         </>
     );
+});
+
+export const SampleTypeImportAliasRenderer: FC<Props> = memo(props => {
+    const appRouteMap = useMemo(() => ({ [SAMPLE_SET_IMPORT_PREFIX]: SAMPLES_KEY }), []);
+    return <ImportAliasRenderer appRouteMap={appRouteMap} data={props.data} />;
+});
+
+export const SourceTypeImportAliasRenderer: FC<Props> = memo(props => {
+    const appRouteMap = useMemo(() => ({ [DATA_CLASS_IMPORT_PREFIX]: SOURCES_KEY }), []);
+    return <ImportAliasRenderer appRouteMap={appRouteMap} data={props.data} />;
 });


### PR DESCRIPTION
#### Rationale
The `MaterialLookupColumnRenderer` is an outdated column renderer that is no longer used.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1522
- https://github.com/LabKey/limsModules/pull/410
- https://github.com/LabKey/platform/pull/5634

#### Changes
- Remove reference to `MaterialLookupColumnRenderer`
