### PR TITLE
Issues 50640 and 50753: fixing problems with link routing

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.56.2",
+  "version": "3.56.3-misc248seh.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.56.2",
+      "version": "3.56.3-misc248seh.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.57.1-misc248seh.0",
+  "version": "3.57.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.57.1-misc248seh.0",
+      "version": "3.57.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "3.56.3-misc248seh.0",
+  "version": "3.57.1-misc248seh.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "3.56.3-misc248seh.0",
+      "version": "3.57.1-misc248seh.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.56.2",
+  "version": "3.56.3-misc248seh.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "3.57.1-misc248seh.0",
+  "version": "3.57.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - Issue 50640: Update `MenuSectionModel` URL construction to link to `runs` page for assay names
+- Issue 50753: Fix link resolution for sample type names that are numbers
 
 ### version 3.56.2
 *Released*: 28 June 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 50640: Update `MenuSectionModel` URL construction to link to `runs` page for assay names
+
 ### version 3.56.2
 *Released*: 28 June 2024
 - Update MenuSectionItem to accept ReactNode for label attribute

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 3.57.1
+*Released*: 8 July 2024
 - Issue 50640: Update `MenuSectionModel` URL construction to link to `runs` page for assay names
 - Issue 50753: Fix link resolution for sample type names that are numbers
 

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -17,6 +17,7 @@ import { List, Record } from 'immutable';
 import { Ajax, Utils, QueryKey } from '@labkey/api';
 
 import { buildURL, createProductUrl, AppURL, createProductUrlFromPartsWithContainer } from '../../url/AppURL';
+import { ASSAYS_KEY } from '../../app/constants';
 
 export class MenuSectionModel extends Record({
     label: undefined,
@@ -98,6 +99,9 @@ export class MenuItemModel extends Record({
                     .split('/')
                     .filter(val => val !== '')
                     .map(QueryKey.decodePart);
+                if (sectionKey === ASSAYS_KEY && subParts.length > 0) { // Issue 50640. We want to link to 'runs' since we'll get better subnav highlighting
+                    subParts.push('runs');
+                }
 
                 const decoded = subParts.join('/');
                 const decodedKey = rawData.key.replace(rawData.key, () => decoded); // use the functional version to skip any additional pattern substitutions https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -280,16 +280,7 @@ const SAMPLE_TYPE_MAPPERS = [
         }
 
         if (identifier !== undefined) {
-            let url: string[];
-            if (/^\d+$/.test(identifier)) {
-                // numeric -- assume rowId and use resolver
-                url = ['rd', 'samples', identifier];
-            } else {
-                // string -- assume sample set name
-                url = [SAMPLES_KEY, identifier];
-            }
-
-            return AppURL.create(...url);
+            return AppURL.create(SAMPLES_KEY, identifier);
         }
     }),
 


### PR DESCRIPTION
#### Rationale
- Issue [50640](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50640) LKSM/LKB: Assay names with hash marks do not resolve
- Issue [50753](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50753): Sample Manager: Integer like sample type name links to wrong pages

#### Related Pull Requests

- https://github.com/LabKey/labkey-ui-premium/pull/460
- https://github.com/LabKey/limsModules/pull/427

#### Changes
- Issue 50640: Update `MenuSectionModel` URL construction to link to `runs` page for assay names
- Issue 50753: Fix link resolution for sample type names that are numbers