### PR TITLE
SelectRows: support optionally requesting metadata

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.1-fb-include-metadata.1",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.1-fb-include-metadata.1",
+      "version": "4.0.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.1-fb-include-metadata.0",
+  "version": "4.0.1-fb-include-metadata.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.1-fb-include-metadata.0",
+      "version": "4.0.1-fb-include-metadata.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.0",
+  "version": "4.0.1-fb-include-metadata.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.0",
+      "version": "4.0.1-fb-include-metadata.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.1-fb-include-metadata.0",
+  "version": "4.0.1-fb-include-metadata.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.0",
+  "version": "4.0.1-fb-include-metadata.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.1-fb-include-metadata.1",
+  "version": "4.0.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 4.0.1
+*Released*: 10 July 2024
+- SelectRows: support optionally requesting metadata
+
 ### version 4.0.0
 *Released*: 10 July 2024
 - Remove usages of react-bootstrap

--- a/packages/components/src/internal/query/api.test.ts
+++ b/packages/components/src/internal/query/api.test.ts
@@ -14,7 +14,9 @@ import {
     getContainerFilter,
     getContainerFilterForFolder,
     getContainerFilterForLookups,
+    includesLookupColumns,
     ISelectRowsResult,
+    isSelectRowMetadataRequired,
     quoteValueColumnWithDelimiters,
     Renderers,
     splitRowsByContainer,
@@ -198,5 +200,39 @@ describe('api', () => {
             a: [{ container: 'a' }],
             b: [{ container: 'b' }, { container: 'b' }],
         });
+    });
+
+    test('includesLookupColumns', () => {
+        expect(includesLookupColumns(undefined)).toBe(false);
+        expect(includesLookupColumns(null)).toBe(false);
+        expect(includesLookupColumns('')).toBe(false);
+        expect(includesLookupColumns('/')).toBe(true);
+        expect(includesLookupColumns('a')).toBe(false);
+        expect(includesLookupColumns('a, b')).toBe(false);
+        expect(includesLookupColumns('a/')).toBe(true);
+        expect(includesLookupColumns('a/b')).toBe(true);
+        expect(includesLookupColumns(['a'])).toBe(false);
+        expect(includesLookupColumns(['a', 'b'])).toBe(false);
+        expect(includesLookupColumns(['a/b'])).toBe(true);
+    });
+
+    test('isSelectRowMetadataRequired', () => {
+        // Should default to true -- same as selectRows itself does
+        expect(isSelectRowMetadataRequired()).toBe(true);
+        expect(isSelectRowMetadataRequired(null)).toBe(true);
+
+        // Should respect explicitly set includeMetadata parameter
+        expect(isSelectRowMetadataRequired(true, 'RowId')).toBe(true);
+        expect(isSelectRowMetadataRequired(false, 'RowId')).toBe(false);
+
+        expect(isSelectRowMetadataRequired(undefined, '')).toBe(true);
+        expect(isSelectRowMetadataRequired(undefined, 'RowId')).toBe(false);
+        expect(isSelectRowMetadataRequired(undefined, 'RowId, Name')).toBe(false);
+        expect(isSelectRowMetadataRequired(undefined, 'RowId, Name, Some/Lookup')).toBe(true);
+
+        expect(isSelectRowMetadataRequired(undefined, [])).toBe(true);
+        expect(isSelectRowMetadataRequired(undefined, ['RowId'])).toBe(false);
+        expect(isSelectRowMetadataRequired(undefined, ['RowId', 'Name'])).toBe(false);
+        expect(isSelectRowMetadataRequired(undefined, ['RowId', 'Name', 'Some/Lookup'])).toBe(true);
     });
 });

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -611,7 +611,10 @@ export function handleSelectRowsResponse(response: Query.Response, queryInfo: Qu
         // If metaData is present, then use its "id" value regardless of presence of a queryInfo
         metadataKey = resolved.metaData.id;
     } else if (queryInfo) {
-        metadataKey = queryInfo.pkCols[0];
+        // Match ApiQueryResponse logic for determining "metaData.id"
+        if (queryInfo.pkCols.length === 1) {
+            metadataKey = queryInfo.pkCols[0];
+        }
     }
     const modelKey = resolveKeyFromJson(resolved);
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -606,7 +606,13 @@ export function handleSelectRowsResponse(response: Query.Response, queryInfo: Qu
         qsKey = 'queries',
         rowCount = response.rowCount || 0;
 
-    const metadataKey = resolved.metaData?.id ?? queryInfo.pkCols[0];
+    let metadataKey: string;
+    if (resolved.metaData) {
+        // If metaData is present, then use its "id" value regardless of presence of a queryInfo
+        metadataKey = resolved.metaData.id;
+    } else if (queryInfo) {
+        metadataKey = queryInfo.pkCols[0];
+    }
     const modelKey = resolveKeyFromJson(resolved);
 
     // ensure id -- unfortunately, with normalizr 3.x there doesn't seem to be a way to generate the id

--- a/packages/components/src/internal/test/testHelpers.tsx
+++ b/packages/components/src/internal/test/testHelpers.tsx
@@ -62,7 +62,7 @@ export const parseQueryResponse = (getQueryResponse): Partial<ISelectRowsResult>
     // Hack: need to stringify and parse the query response object because Query.Response modifies the object in place,
     // which causes errors if you try to use the same response object twice.
     const response = new Query.Response(JSON.parse(JSON.stringify(getQueryResponse)));
-    return handleSelectRowsResponse(response);
+    return handleSelectRowsResponse(response, new QueryInfo({}));
 };
 
 export const makeTestISelectRowsResult = (getQueryResponse, getQueryDetailsResponse): ISelectRowsResult => {

--- a/packages/components/src/internal/url/AppURLResolver.test.ts
+++ b/packages/components/src/internal/url/AppURLResolver.test.ts
@@ -17,6 +17,8 @@ import { fromJS, Map } from 'immutable';
 
 import { registerDefaultURLMappers } from '../test/testHelpers';
 
+import { QueryInfo } from '../../public/QueryInfo';
+
 import { ExperimentRunResolver, ListResolver } from './AppURLResolver';
 import { URLResolver } from './URLResolver';
 import { AppURL } from './AppURL';
@@ -237,7 +239,7 @@ describe('URL Resolvers', () => {
         // avoid false positives by defining number of assertions in a test
         expect.assertions(9);
 
-        const result = resolver.resolveSelectRows(selectRowsResult);
+        const result = resolver.resolveSelectRows(selectRowsResult, new QueryInfo({}));
         const newResult = fromJS(result);
 
         // validate ActionMapper('experiment', 'showDataClass') -- no lookup
@@ -279,7 +281,7 @@ describe('URL Resolvers', () => {
         // avoid false positives by defining number of assertions in a test
         expect.assertions(9);
 
-        const result = resolver.resolveSelectRows(selectRowsResult);
+        const result = resolver.resolveSelectRows(selectRowsResult, new QueryInfo({}));
         const newResult = fromJS(result);
 
         // validate ActionMapper('experiment', 'showDataClass') -- no lookup
@@ -333,7 +335,7 @@ describe('URL Resolvers', () => {
         // avoid false positives by defining number of assertions in a test
         expect.assertions(9);
 
-        const result = resolver.resolveSelectRows(selectRowsResult);
+        const result = resolver.resolveSelectRows(selectRowsResult, new QueryInfo({}));
         const newResult = fromJS(result);
 
         // validate ActionMapper('experiment', 'showDataClass') -- no lookup
@@ -375,7 +377,7 @@ describe('URL Resolvers', () => {
         // avoid false positives by defining number of assertions in a test
         expect.assertions(9);
 
-        const result = resolver.resolveSelectRows(selectRowsResult);
+        const result = resolver.resolveSelectRows(selectRowsResult, new QueryInfo({}));
         const newResult = fromJS(result);
 
         // validate ActionMapper('experiment', 'showDataClass') -- no lookup

--- a/packages/components/src/internal/url/URLResolver.test.ts
+++ b/packages/components/src/internal/url/URLResolver.test.ts
@@ -6,6 +6,8 @@ import { LineageResult } from '../components/lineage/models';
 
 import { registerDefaultURLMappers } from '../test/testHelpers';
 
+import { QueryColumn, QueryLookup } from '../../public/QueryColumn';
+
 import { LookupMapper, URLResolver } from './URLResolver';
 import { AppURL } from './AppURL';
 
@@ -21,10 +23,7 @@ beforeAll(() => {
 
 describe('resolveSearchUsingIndex', () => {
     test('resolve Sample Set url', () => {
-        const resolver = new URLResolver();
-
-        const testJson = fromJS(entitiesJSON);
-        const resolved = resolver.resolveSearchUsingIndex(testJson);
+        const resolved = new URLResolver().resolveSearchUsingIndex(entitiesJSON);
         expect(resolved).toHaveProperty(['hits']);
         expect(resolved).toHaveProperty(['hits', 0]);
         expect(resolved).toHaveProperty(['hits', 0, 'url'], '#/samples/Molecule');
@@ -38,7 +37,9 @@ describe('LookupMapper', () => {
         const resolved = mapper.resolve(
             '#/list/a',
             fromJS({ value: 1 }),
-            fromJS({ lookup: { schemaName: 'list', queryName: 'testing' } })
+            new QueryColumn({ lookup: new QueryLookup({ schemaName: 'list', queryName: 'testing' }) }),
+            undefined,
+            undefined
         );
         expect(resolved).toStrictEqual(AppURL.create('test', 'list', 'testing', 1));
     });
@@ -48,7 +49,15 @@ describe('LookupMapper', () => {
         const resolved = mapper.resolve(
             '#/list/a',
             fromJS({ value: 1 }),
-            fromJS({ lookup: { schemaName: 'list', queryName: 'testing', containerPath: LABKEY.container.path } })
+            new QueryColumn({
+                lookup: new QueryLookup({
+                    schemaName: 'list',
+                    queryName: 'testing',
+                    containerPath: LABKEY.container.path,
+                }),
+            }),
+            undefined,
+            undefined
         );
         expect(resolved).toStrictEqual(AppURL.create('test', 'list', 'testing', 1));
     });
@@ -58,7 +67,11 @@ describe('LookupMapper', () => {
         const resolved = mapper.resolve(
             '#/list/a',
             fromJS({ value: 1 }),
-            fromJS({ lookup: { schemaName: 'list', queryName: 'testing', containerPath: '/other/path' } })
+            new QueryColumn({
+                lookup: new QueryLookup({ schemaName: 'list', queryName: 'testing', containerPath: '/other/path' }),
+            }),
+            undefined,
+            undefined
         );
         expect(resolved).toBeUndefined();
     });

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -703,7 +703,7 @@ export class URLResolver {
 
                     // TODO: add reroute for assays/runs when pages and URLs are decided
                     if (row.has('data') && row.hasIn(['data', 'dataClass'])) {
-                        query = row.getIn(['data', 'dataClass', 'name']); // dataClass is a nested Map/Object inside 'data' return
+                        query = row.getIn(['data', 'dataClass', 'name']);
                         url = url.substring(0, url.indexOf('&')); // URL includes documentID value, this will split off at the start of the docID
                         return row.set('url', this.mapURL({ url, row, query }));
                     } else if (id.indexOf('dataClass') >= 0) {


### PR DESCRIPTION
#### Rationale
Our applications rely heavily on query metadata to understand how queries and their associated columns are configured. To support this we rely on the `QueryInfo` (sourced from `query-getQueryDetails.api`) to supply us with almost all of this metadata. However, for select rows requests (sourced from `query-getQuery.api`) we also support, and default to, including metadata about the request (the flag `includeMetadata` defaults to true). Often times, this select rows metadata has significant overlap with the metadata that is included in `QueryInfo` so it results in our applications requesting a good amount of redundant metadata.

I took a look at where we make use of this select rows `Query.Response.metaData` and it is used in two places:
1. To provide the `metaData.id` field for the results.
2. To provide as the `metaData.fields` metadata in `URLResolver`.

For the `metaData.id` we can source this from the `QueryInfo.pkCols`. The `metaData.fields` are a bit more nuanced. For columns that are directly on the query we can source these from `QueryInfo.columns`. For columns that are on a different query we'll still need to rely on the select rows metadata. What this means is that we can inspect the `columns` property to determine if we need to include select rows metadata by checking for columns that have a non-singular path.

- `columns = *`: Specifying `*` requests only columns directly on the query. No additional metadata necessary.
- `columns = A, B, C`: All of these are singular path columns (i.e. directly on the query). No additional metadata necessary.
- `columns = A, B/D, C`: The column `B/D` is not a singular path and thus requires additional metadata be included.

In practice, this results in a lot of queries not needing to include the additional select rows metadata as we already have all the information for the requested columns in the associated `QueryInfo`. The payoff is reduced payload sizes and reduced processing time.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/442

#### Changes
- For both `selectRows` and `selectRowsDeprecated` the `includeMetadata` flag is now set according to the value of `isSelectRowMetadataRequired()` when not explicitly set by the caller. Note, the `executeSql` variant of `selectRowsDeprecated` continues to always default to `includeMetadata=true`.
- Update `URLMapper.resolve()` to specify the `column` parameter is of type `QueryColumn`.
- Update `URLResolver.resolveSelectRows()` to furnish only `QueryColumn` instances to the resolvers.
- Update `URLResolver.resolveSelectRows()` to accept a `QueryInfo` which can be used as a fallback source for columns.
- Update `URLResolver.resolveSearchUsingIndex()` to not specify a `column` since it doesn't have a way to source these from search results.
- Consolidate and clarify typings around `URLResolver`.