### PR TITLE
AbDisc: create plate from samples, bulk edit fields

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 4.0.3
+*Released*: 12 July 2024
+- getSelectedData: use async implementation, accept columns as `string[]`
+- EditableGrid: action `getLookupDisplayValue()` should support resolving string values
+- BulkUpdateForm: remove `requiredDisplayColumns` prop
+
 ### version 4.0.2
 *Released*: 12 July 2024
 - Editable Grid Improvements: Validation of fields
@@ -10,7 +16,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   - Handle missing required cell value check on Submit
 
 ### version 4.0.1
-*Released*: 10 July 2024
+*Released*: 12 July 2024
 - SelectRows: support optionally requesting metadata
 
 ### version 4.0.0

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -28,7 +28,6 @@ import {
     EXPORT_TYPES,
     FASTA_EXPORT_CONTROLLER,
     GENBANK_EXPORT_CONTROLLER,
-    STORAGE_MAP_EXPORT_CONTROLLER,
     VIEW_NOT_FOUND_EXCEPTION_CLASS,
 } from './constants';
 import { DataViewInfo } from './DataViewInfo';
@@ -375,40 +374,33 @@ export function getSelected(
     });
 }
 
-export function getSelectedData(
+export async function getSelectedData(
     schemaName?: string,
     queryName?: string,
     selections?: string[],
-    columns?: string,
+    columns?: string | string[],
     sorts?: string,
     queryParameters?: Record<string, any>,
     viewName?: string,
     keyColumn = 'RowId'
 ): Promise<GridResponse> {
-    return new Promise((resolve, reject) =>
-        selectRowsDeprecated({
-            schemaName,
-            queryName,
-            viewName,
-            filterArray: [Filter.create(keyColumn, selections, Filter.Types.IN)],
-            parameters: queryParameters,
-            sort: sorts,
-            columns,
-            offset: 0,
-        })
-            .then(response => {
-                const { models, orderedModels } = response;
-                const dataKey = resolveKey(schemaName, queryName);
-                resolve({
-                    data: fromJS(models[dataKey]),
-                    dataIds: List(orderedModels[dataKey]),
-                });
-            })
-            .catch(reason => {
-                console.error(reason);
-                reject(resolveErrorMessage(reason));
-            })
-    );
+    const { models, orderedModels } = await selectRowsDeprecated({
+        schemaName,
+        queryName,
+        viewName,
+        filterArray: [Filter.create(keyColumn, selections, Filter.Types.IN)],
+        parameters: queryParameters,
+        sort: sorts,
+        columns,
+        offset: 0,
+    });
+
+    const dataKey = resolveKey(schemaName, queryName);
+
+    return {
+        data: fromJS(models[dataKey]),
+        dataIds: List(orderedModels[dataKey]),
+    };
 }
 
 export interface SelectResponse {

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -285,7 +285,7 @@ async function getLookupValueDescriptors(
 }
 
 async function getLookupDisplayValue(column: QueryColumn, value: any, containerPath: string): Promise<MessageAndValue> {
-    if (value === undefined || value === null || typeof value === 'string') {
+    if (value === undefined || value === null) {
         return {
             valueDescriptor: {
                 display: value,
@@ -328,8 +328,8 @@ async function prepareInsertRowDataFromBulkForm(
             cv = List<ValueDescriptor>();
             // value had better be the rowId here, but it may be several in a comma-separated list.
             // If it's the display value, which happens to be a number, much confusion will arise.
-            const values = data.toString().split(',');
-            for (const val of values) {
+            const values_ = data.toString().split(',');
+            for (const val of values_) {
                 const { message, valueDescriptor } = await getLookupDisplayValue(
                     col,
                     parseIntIfNumber(val),
@@ -654,9 +654,9 @@ export function removeColumn(
 async function prepareUpdateRowDataFromBulkForm(
     queryInfo: QueryInfo,
     rowData: OrderedMap<string, any>,
-    isIncludedColumn: (col: QueryColumn) => boolean,
-    containerPath: string,
-    altColumns?: string[]
+    isIncludedColumn?: (col: QueryColumn) => boolean,
+    containerPath?: string,
+    altColumns?: string[] // TODO: This should use the same metadata for columns as the rest of the editable grid
 ): Promise<{ messages: OrderedMap<number, CellMessage>; values: OrderedMap<number, List<ValueDescriptor>> }> {
     const columns = queryInfo.getInsertColumns(isIncludedColumn);
     let values = OrderedMap<number, List<ValueDescriptor>>();
@@ -707,9 +707,9 @@ export async function updateGridFromBulkForm(
     queryInfo: QueryInfo,
     rowData: OrderedMap<string, any>,
     dataRowIndexes: List<number>,
-    lockedOrReadonlyRows: number[],
-    isIncludedColumn: (col: QueryColumn) => boolean,
-    containerPath: string,
+    lockedOrReadonlyRows?: number[],
+    isIncludedColumn?: (col: QueryColumn) => boolean,
+    containerPath?: string,
     useEditorModelCols: boolean = false
 ): Promise<Partial<EditorModel>> {
     let cellMessages = editorModel.cellMessages;


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-ui-premium/pull/464 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1529
- https://github.com/LabKey/labkey-ui-premium/pull/464
- https://github.com/LabKey/limsModules/pull/441

#### Changes
- getSelectedData: use async implementation, accept columns as `string[]`
- EditableGrid: action getLookupDisplayValue should support resolving string values
- BulkUpdateForm: remove "requiredDisplayColumns" prop
