### PR TITLE
EditableGrid: bulk data resolve public lookups

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.4",
+  "version": "4.0.5-fb-public-lookup.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.4",
+      "version": "4.0.5-fb-public-lookup.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.5-fb-public-lookup.0",
+  "version": "4.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.5-fb-public-lookup.0",
+      "version": "4.0.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.5-fb-public-lookup.0",
+  "version": "4.0.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.4",
+  "version": "4.0.5-fb-public-lookup.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 4.0.5
+*Released*: 17 July 2024
+- EditableGrid: bulk data resolve public lookups
+
 ### version 4.0.4
 *Released*: 12 July 2024
 - Issue 50661: Update `FilterFacetedSelector` to cancel requests as needed while typing

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -324,7 +324,7 @@ async function prepareInsertRowDataFromBulkForm(
         const col = insertColumns.get(colIdx);
         let cv: List<ValueDescriptor>;
 
-        if (data && col && col.isLookup()) {
+        if (data && col && col.isPublicLookup()) {
             cv = List<ValueDescriptor>();
             // value had better be the rowId here, but it may be several in a comma-separated list.
             // If it's the display value, which happens to be a number, much confusion will arise.
@@ -646,7 +646,7 @@ export function removeColumn(
         data,
         queryInfo: queryInfo.mutate({
             columns: queryInfo.columns.filter(col => col.fieldKey.toLowerCase() !== fieldKey.toLowerCase()),
-        }) as QueryInfo,
+        }),
     };
 }
 
@@ -676,7 +676,7 @@ async function prepareUpdateRowDataFromBulkForm(
         }
         let cv: List<ValueDescriptor>;
 
-        if (data && col && col.isLookup()) {
+        if (data && col && col.isPublicLookup()) {
             cv = List<ValueDescriptor>();
             // value had better be the rowId here, but it may be several in a comma-separated list.
             // If it's the display value, which happens to be a number, much confusion will arise.
@@ -969,8 +969,8 @@ export function checkCellReadStatus(
 /**
  * Returns only the newly selected area given an initial selection and a final selection. These are the keys that will
  * be filled with generated data based on the initially selected data.
- * @param initialSelection: The area initially selected
- * @param finalSelection: The final area selected, including the initially selected area
+ * @param initialSelection The area initially selected
+ * @param finalSelection The final area selected, including the initially selected area
  */
 export function generateFillCellKeys(initialSelection: string[], finalSelection: string[]): string[][] {
     const firstInitial = parseCellKey(initialSelection[0]);
@@ -981,8 +981,8 @@ export function generateFillCellKeys(initialSelection: string[], finalSelection:
     const initialMaxRow = lastInitial.rowIdx;
     const finalMinRow = parseCellKey(finalSelection[0]).rowIdx;
     const finalMaxRow = parseCellKey(finalSelection[finalSelection.length - 1]).rowIdx;
-    let start;
-    let end;
+    let start: number;
+    let end: number;
 
     if (finalMaxRow > initialMaxRow) {
         // Final selected area is below the initial selection, so we will be incrementing from the row after
@@ -1076,7 +1076,7 @@ export function parsePastedLookup(
 
 async function getParsedLookup(
     column: QueryColumn,
-    lookupColumnContainerCache: {},
+    lookupColumnContainerCache: Record<string, ValueDescriptor[]>,
     display: any[],
     value: string[] | string,
     cellKey: string,


### PR DESCRIPTION
#### Rationale
This brings the bulk data generation methods for `EditableGrid` into line with the rest of the modeling in that it should only be processing "public" lookups. 

With #1529 I updated the lookup handling for editable grids to allow for string values. This in turn exposed the fact that there are non-public lookups (e.g. the "Alias" field on data classes) which we are then iterating over due to inconsistent processing of lookups. These bulk data transformation methods were asking for `column.isLookup()` rather than `column.isPublicLookup()`. The reason this is important is because only the schema information for public lookups is accessible on the client and thus only public lookups are resolvable by the editable grid.

#### Related Pull Requests
- #1529
- https://github.com/LabKey/limsModules/pull/458

#### Changes
- Use `col.isPublicLookup()` in `prepareInsertRowDataFromBulkForm` and `prepareUpdateRowDataFromBulkForm`
