### PR TITLE
Issue 50742, 50709, 50650, 50607 and 42183

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6-fb-248XBugFixes.3",
+  "version": "4.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.6-fb-248XBugFixes.3",
+      "version": "4.0.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.4",
+  "version": "4.0.5-fb-248XBugFixes.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.4",
+      "version": "4.0.5-fb-248XBugFixes.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6-fb-248XBugFixes.1",
+  "version": "4.0.6-fb-248XBugFixes.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.6-fb-248XBugFixes.1",
+      "version": "4.0.6-fb-248XBugFixes.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6-fb-248XBugFixes.2",
+  "version": "4.0.6-fb-248XBugFixes.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.6-fb-248XBugFixes.2",
+      "version": "4.0.6-fb-248XBugFixes.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.5-fb-248XBugFixes.1",
+  "version": "4.0.5-fb-248XBugFixes.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.5-fb-248XBugFixes.1",
+      "version": "4.0.5-fb-248XBugFixes.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6-fb-248XBugFixes.2",
+  "version": "4.0.6-fb-248XBugFixes.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6-fb-248XBugFixes.3",
+  "version": "4.0.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.5-fb-248XBugFixes.1",
+  "version": "4.0.5-fb-248XBugFixes.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6-fb-248XBugFixes.1",
+  "version": "4.0.6-fb-248XBugFixes.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.4",
+  "version": "4.0.5-fb-248XBugFixes.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 4.X
-*Released*: X July 2024
+### version 4.0.6
+*Released*: 20 July 2024
 - Issue 50742: Reset/Update genId result in error if samples exists only in child folders
 - Issue 50709: LKSM: Pasting in editable grid when an aliquot field is between two sample fields doesn't work
 - Issue 50650: LKSM: SampleFinder doesn't show ancestor column data if default view also contains the same ancestors

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Issue 50709: LKSM: Pasting in editable grid when an aliquot field is between two sample fields doesn't work
 - Issue 50650: LKSM: SampleFinder doesn't show ancestor column data if default view also contains the same ancestors
 - Issue 42183: SM: Need better indication that comment in a workflow task has not been saved.
+- Issue 50607: Updated field labels are not shown in the grid
 
 ### version 4.0.4
 *Released*: 12 July 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Issue 50742: Reset/Update genId result in error if samples exists only in child folders
 - Issue 50709: LKSM: Pasting in editable grid when an aliquot field is between two sample fields doesn't work
 - Issue 50650: LKSM: SampleFinder doesn't show ancestor column data if default view also contains the same ancestors
+- Issue 42183: SM: Need better indication that comment in a workflow task has not been saved.
 
 ### version 4.0.4
 *Released*: 12 July 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 4.X
+*Released*: X July 2024
+- Issue 50742: Reset/Update genId result in error if samples exists only in child folders
+- Issue 50709: LKSM: Pasting in editable grid when an aliquot field is between two sample fields doesn't work
+- Issue 50650: LKSM: SampleFinder doesn't show ancestor column data if default view also contains the same ancestors
+
 ### version 4.0.4
 *Released*: 12 July 2024
 - Issue 50661: Update `FilterFacetedSelector` to cancel requests as needed while typing

--- a/packages/components/src/internal/announcements/Discussions.tsx
+++ b/packages/components/src/internal/announcements/Discussions.tsx
@@ -18,6 +18,7 @@ interface Props {
     nounSingular?: string;
     readOnly?: boolean;
     user: UserWithPermissions;
+    setHasPendingChanges?: (hasPendingChanges: boolean) => void;
 }
 
 export const Discussions: FC<Props> = memo(props => {
@@ -31,11 +32,13 @@ export const Discussions: FC<Props> = memo(props => {
         nounSingular,
         readOnly,
         user,
+        setHasPendingChanges
     } = props;
     const { canInsert } = user;
     const [error, setError] = useState<string>(undefined);
     const [discussions, setDiscussions] = useState<AnnouncementModel[]>([]);
     const [showEditor, setShowEditor] = useState(false);
+    const [pendingChanges, setPendingChanges] = useState<Set<number>>(new Set());
 
     const allowCreateThread = !readOnly && canInsert;
     const hasError = error !== undefined;
@@ -61,6 +64,16 @@ export const Discussions: FC<Props> = memo(props => {
     const onShow = useCallback(() => {
         setShowEditor(true);
     }, []);
+
+    const updatePendingThread = useCallback((threadId: number, hasPendingChange: boolean) => {
+        const updatedPendingChanges = new Set(pendingChanges);
+        if (hasPendingChange)
+            updatedPendingChanges.add(threadId);
+        else
+            updatedPendingChanges.delete(threadId);
+        setPendingChanges(updatedPendingChanges);
+        setHasPendingChanges?.(updatedPendingChanges.size > 0);
+    }, [pendingChanges]);
 
     useEffect(() => {
         if (autoLoad) loadDiscussions();
@@ -95,6 +108,7 @@ export const Discussions: FC<Props> = memo(props => {
                     readOnly={readOnly}
                     thread={thread}
                     user={user}
+                    setPendingChange={updatePendingThread}
                 />
             ))}
 
@@ -115,6 +129,7 @@ export const Discussions: FC<Props> = memo(props => {
                     nounSingular={nounSingular}
                     onCancel={onCancel}
                     onCreate={onCreate}
+                    setPendingChange={updatePendingThread}
                 />
             )}
         </div>

--- a/packages/components/src/internal/announcements/Discussions.tsx
+++ b/packages/components/src/internal/announcements/Discussions.tsx
@@ -17,8 +17,8 @@ interface Props {
     nounPlural?: string;
     nounSingular?: string;
     readOnly?: boolean;
-    user: UserWithPermissions;
     setHasPendingChanges?: (hasPendingChanges: boolean) => void;
+    user: UserWithPermissions;
 }
 
 export const Discussions: FC<Props> = memo(props => {
@@ -32,7 +32,7 @@ export const Discussions: FC<Props> = memo(props => {
         nounSingular,
         readOnly,
         user,
-        setHasPendingChanges
+        setHasPendingChanges,
     } = props;
     const { canInsert } = user;
     const [error, setError] = useState<string>(undefined);
@@ -65,15 +65,16 @@ export const Discussions: FC<Props> = memo(props => {
         setShowEditor(true);
     }, []);
 
-    const updatePendingThread = useCallback((threadId: number, hasPendingChange: boolean) => {
-        const updatedPendingChanges = new Set(pendingChanges);
-        if (hasPendingChange)
-            updatedPendingChanges.add(threadId);
-        else
-            updatedPendingChanges.delete(threadId);
-        setPendingChanges(updatedPendingChanges);
-        setHasPendingChanges?.(updatedPendingChanges.size > 0);
-    }, [pendingChanges]);
+    const updatePendingThread = useCallback(
+        (threadId: number, hasPendingChange: boolean) => {
+            const updatedPendingChanges = new Set(pendingChanges);
+            if (hasPendingChange) updatedPendingChanges.add(threadId);
+            else updatedPendingChanges.delete(threadId);
+            setPendingChanges(updatedPendingChanges);
+            setHasPendingChanges?.(updatedPendingChanges.size > 0);
+        },
+        [pendingChanges]
+    );
 
     useEffect(() => {
         if (autoLoad) loadDiscussions();

--- a/packages/components/src/internal/announcements/ThreadBlock.tsx
+++ b/packages/components/src/internal/announcements/ThreadBlock.tsx
@@ -130,6 +130,7 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
         showResponses,
         thread,
         user,
+        setPendingChange,
     } = props;
     const [editing, setEditing] = useState(false);
     const [error, setError] = useState<string>(undefined);
@@ -235,6 +236,7 @@ export const ThreadBlock: FC<ThreadBlockProps> = props => {
                         onCreate={onReplied}
                         parent={thread.parent ?? thread.entityId}
                         thread={undefined}
+                        setPendingChange={setPendingChange}
                     />
                 </div>
             )}

--- a/packages/components/src/internal/announcements/ThreadEditor.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.tsx
@@ -253,6 +253,7 @@ export interface ThreadEditorProps {
     onUpdate?: (updatedThread: AnnouncementModel) => void;
     parent?: string;
     thread?: AnnouncementModel;
+    setPendingChange?: (threadId: number, hasPendingChange: boolean) => void;
 }
 
 export const ThreadEditor: FC<ThreadEditorProps> = props => {
@@ -267,6 +268,7 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         onUpdate,
         parent,
         thread,
+        setPendingChange,
     } = props;
     const bodyInputRef = useRef<HTMLTextAreaElement>(null);
     const [error, setError] = useState<string>(undefined);
@@ -417,9 +419,15 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         (event: ChangeEvent<HTMLTextAreaElement>) => {
             setError(undefined);
             setBody(event.target.value);
+            setPendingChange?.(thread?.rowId ?? -1, !!event.target.value);
         },
         [setBody]
     );
+
+    const handleCancel = useCallback(() => {
+        onCancel?.();
+        setPendingChange?.(thread?.rowId ?? -1, false);
+    }, [thread?.rowId, onCancel, setPendingChange]);
 
     const onSubmit = useCallback(() => {
         if (submitting) return;
@@ -429,6 +437,7 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         } else {
             updateThread();
         }
+        setPendingChange?.(thread?.rowId ?? -1, false);
     }, [createThread, isCreate, setSubmitting, submitting, updateThread]);
 
     const onKeyDown = useCallback(
@@ -494,7 +503,7 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
                 <input multiple onChange={onFileInputChange} type="file" />
             </label>
 
-            <span className="clickable-text thread-editor__cancel-btn" onClick={onCancel}>
+            <span className="clickable-text thread-editor__cancel-btn" onClick={handleCancel}>
                 Cancel
             </span>
 

--- a/packages/components/src/internal/announcements/ThreadEditor.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.tsx
@@ -416,9 +416,12 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         [model]
     );
 
-    const handlePendingChange = useCallback((hasPendingChange = false) => {
-        setPendingChange?.(thread?.rowId ?? -1, hasPendingChange);
-    }, [setPendingChange, thread?.rowId]);
+    const handlePendingChange = useCallback(
+        (hasPendingChange = false) => {
+            setPendingChange?.(thread?.rowId ?? -1, hasPendingChange);
+        },
+        [setPendingChange, thread?.rowId]
+    );
 
     const onBodyChange = useCallback(
         (event: ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/components/src/internal/announcements/ThreadEditor.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.tsx
@@ -416,19 +416,23 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         [model]
     );
 
+    const handlePendingChange = useCallback((hasPendingChange = false) => {
+        setPendingChange?.(thread?.rowId ?? -1, hasPendingChange);
+    }, [setPendingChange, thread?.rowId]);
+
     const onBodyChange = useCallback(
         (event: ChangeEvent<HTMLTextAreaElement>) => {
             setError(undefined);
             setBody(event.target.value);
-            setPendingChange?.(thread?.rowId ?? -1, !!event.target.value);
+            handlePendingChange(!!event.target.value);
         },
-        [setBody]
+        [setBody, handlePendingChange]
     );
 
     const handleCancel = useCallback(() => {
         onCancel?.();
-        setPendingChange?.(thread?.rowId ?? -1, false);
-    }, [thread?.rowId, onCancel, setPendingChange]);
+        handlePendingChange();
+    }, [thread?.rowId, onCancel, handlePendingChange]);
 
     const onSubmit = useCallback(() => {
         if (submitting) return;
@@ -438,8 +442,8 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
         } else {
             updateThread();
         }
-        setPendingChange?.(thread?.rowId ?? -1, false);
-    }, [createThread, isCreate, setSubmitting, submitting, updateThread]);
+        handlePendingChange();
+    }, [createThread, isCreate, setSubmitting, submitting, updateThread, handlePendingChange]);
 
     const onKeyDown = useCallback(
         (evt: KeyboardEvent) => {

--- a/packages/components/src/internal/announcements/ThreadEditor.tsx
+++ b/packages/components/src/internal/announcements/ThreadEditor.tsx
@@ -18,11 +18,12 @@ import { resolveErrorMessage } from '../util/messaging';
 import { LoadingSpinner } from '../components/base/LoadingSpinner';
 import { Key } from '../../public/useEnterEscape';
 
+import { DropdownAnchor, MenuItem } from '../dropdowns';
+
 import { AnnouncementsAPIWrapper } from './APIWrapper';
 
 import { RemoveAttachmentModal, ThreadAttachments } from './ThreadAttachments';
 import { Attachment, AnnouncementModel } from './model';
-import { DropdownAnchor, MenuItem } from '../dropdowns';
 
 // Check if a line starts with any spaces, a number, followed by a period and a space.
 const orderedBulletRe = /^\s*\d+. /;
@@ -252,8 +253,8 @@ export interface ThreadEditorProps {
     onCreate?: (newThread: AnnouncementModel) => void;
     onUpdate?: (updatedThread: AnnouncementModel) => void;
     parent?: string;
-    thread?: AnnouncementModel;
     setPendingChange?: (threadId: number, hasPendingChange: boolean) => void;
+    thread?: AnnouncementModel;
 }
 
 export const ThreadEditor: FC<ThreadEditorProps> = props => {
@@ -487,7 +488,12 @@ export const ThreadEditor: FC<ThreadEditorProps> = props => {
                 <Preview containerPath={containerPath} content={model.body} renderContent={api.renderContent} />
             )}
 
-            <ThreadAttachments attachments={attachments} error={attachmentError} onRemove={openRemoveModal} containerPath={containerPath}/>
+            <ThreadAttachments
+                attachments={attachments}
+                error={attachmentError}
+                onRemove={openRemoveModal}
+                containerPath={containerPath}
+            />
 
             <button
                 type="button"

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -33,6 +33,7 @@ import { GRID_SELECTION_INDEX, GRID_HEADER_CELL_BODY } from '../../constants';
 
 import { LabelHelpTip } from './LabelHelpTip';
 import { GridColumn } from './models/GridColumn';
+import { caseInsensitive } from '../../util/utils';
 
 function processColumns(columns: List<any>): List<GridColumn> {
     return columns
@@ -257,6 +258,7 @@ interface GridRowProps {
 const GridRow: FC<GridRowProps> = memo(({ columns, highlight, row, rowIdx }) => {
     // style cast to "any" type due to @types/react@16.3.14 switch to csstype package usage which does not declare
     // "textAlign" property correctly for <td> elements.
+    const rowObj = row.toObject();
     return (
         <tr
             className={classNames({
@@ -270,7 +272,7 @@ const GridRow: FC<GridRowProps> = memo(({ columns, highlight, row, rowIdx }) => 
                     <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, rowIdx, c)}</Fragment>
                 ) : (
                     <td key={column.index} style={{ textAlign: column.align || 'left' } as any}>
-                        {column.cell(row.get(column.index), row, column, rowIdx, c)}
+                        {column.cell(caseInsensitive(rowObj, column.index), row, column, rowIdx, c)}
                     </td>
                 )
             )}

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -31,8 +31,6 @@ import { HelpTipRenderer } from '../forms/HelpTipRenderer';
 
 import { GRID_SELECTION_INDEX, GRID_HEADER_CELL_BODY } from '../../constants';
 
-import { caseInsensitive } from '../../util/utils';
-
 import { LabelHelpTip } from './LabelHelpTip';
 import { GridColumn } from './models/GridColumn';
 
@@ -259,7 +257,6 @@ interface GridRowProps {
 const GridRow: FC<GridRowProps> = memo(({ columns, highlight, row, rowIdx }) => {
     // style cast to "any" type due to @types/react@16.3.14 switch to csstype package usage which does not declare
     // "textAlign" property correctly for <td> elements.
-    const rowObj = row.toObject();
     return (
         <tr
             className={classNames({
@@ -273,7 +270,7 @@ const GridRow: FC<GridRowProps> = memo(({ columns, highlight, row, rowIdx }) => 
                     <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, rowIdx, c)}</Fragment>
                 ) : (
                     <td key={column.index} style={{ textAlign: column.align || 'left' } as any}>
-                        {column.cell(caseInsensitive(rowObj, column.index), row, column, rowIdx, c)}
+                        {column.cell(row.get(column.index), row, column, rowIdx, c)}
                     </td>
                 )
             )}

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -31,9 +31,10 @@ import { HelpTipRenderer } from '../forms/HelpTipRenderer';
 
 import { GRID_SELECTION_INDEX, GRID_HEADER_CELL_BODY } from '../../constants';
 
+import { caseInsensitive } from '../../util/utils';
+
 import { LabelHelpTip } from './LabelHelpTip';
 import { GridColumn } from './models/GridColumn';
-import { caseInsensitive } from '../../util/utils';
 
 function processColumns(columns: List<any>): List<GridColumn> {
     return columns

--- a/packages/components/src/internal/components/domainproperties/APIWrapper.ts
+++ b/packages/components/src/internal/components/domainproperties/APIWrapper.ts
@@ -9,7 +9,6 @@ import {
     validateDomainNameExpressions,
     getGenId,
     setGenId,
-    hasExistingDomainData,
     fetchDomainDetails,
     FetchDomainDetailsOptions,
     getMaxPhiLevel,
@@ -30,12 +29,6 @@ export interface DomainPropertiesAPIWrapper {
     getGenId: (rowId: number, kindName: 'SampleSet' | 'DataClass', containerPath?: string) => Promise<number>;
     getMaxPhiLevel: (containerPath?: string) => Promise<string>;
     getValidPublishTargets: (containerPath?: string) => Promise<Container[]>;
-    hasExistingDomainData: (
-        kindName: 'SampleSet' | 'DataClass',
-        dataTypeLSID?: string,
-        rowId?: number,
-        containerPath?: string
-    ) => Promise<boolean>;
     saveDomain: (options: SaveDomainOptions) => Promise<DomainDesign>;
     setGenId: (
         rowId: number,
@@ -59,7 +52,6 @@ export class DomainPropertiesAPIWrapper implements DomainPropertiesAPIWrapper {
     getGenId = getGenId;
     getMaxPhiLevel = getMaxPhiLevel;
     getValidPublishTargets = getValidPublishTargets;
-    hasExistingDomainData = hasExistingDomainData;
     saveDomain = saveDomain;
     setGenId = setGenId;
     validateDomainNameExpressions = validateDomainNameExpressions;
@@ -83,8 +75,7 @@ export function getDomainPropertiesTestAPIWrapper(
         // probably make Jest an explicit dependency since we are actually exporting test utilities.
         getMaxPhiLevel: () => Promise.resolve(PHILEVEL_FULL_PHI),
         getValidPublishTargets: mockFn(),
-        hasExistingDomainData: mockFn(),
-        saveDomain: mockFn(),
+         saveDomain: mockFn(),
         setGenId: mockFn(),
         validateDomainNameExpressions: mockFn(),
         ...overrides,

--- a/packages/components/src/internal/components/domainproperties/APIWrapper.ts
+++ b/packages/components/src/internal/components/domainproperties/APIWrapper.ts
@@ -75,7 +75,7 @@ export function getDomainPropertiesTestAPIWrapper(
         // probably make Jest an explicit dependency since we are actually exporting test utilities.
         getMaxPhiLevel: () => Promise.resolve(PHILEVEL_FULL_PHI),
         getValidPublishTargets: mockFn(),
-         saveDomain: mockFn(),
+        saveDomain: mockFn(),
         setGenId: mockFn(),
         validateDomainNameExpressions: mockFn(),
         ...overrides,

--- a/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.spec.tsx
@@ -22,10 +22,10 @@ describe('NameExpressionGenIdBanner', () => {
                     kindName="DataClass"
                     api={getTestAPIWrapper(jest.fn, {
                         domain: getDomainPropertiesTestAPIWrapper(jest.fn, {
-                            getGenId: () => Promise.resolve(123),
+                            getGenId: jest.fn().mockResolvedValue(123),
                         }),
                         entity: getEntityTestAPIWrapper(jest.fn, {
-                            isDataTypeEmpty: () => Promise.resolve(false),
+                            isDataTypeEmpty: jest.fn().mockResolvedValue(false),
                         }),
                     })}
                 />
@@ -46,10 +46,10 @@ describe('NameExpressionGenIdBanner', () => {
                     kindName="DataClass"
                     api={getTestAPIWrapper(jest.fn, {
                         domain: getDomainPropertiesTestAPIWrapper(jest.fn, {
-                            getGenId: () => Promise.resolve(0),
+                            getGenId: jest.fn().mockResolvedValue(0),
                         }),
                         entity: getEntityTestAPIWrapper(jest.fn, {
-                            isDataTypeEmpty: () => Promise.resolve(true),
+                            isDataTypeEmpty: jest.fn().mockResolvedValue(true),
                         }),
                     })}
                 />
@@ -70,10 +70,10 @@ describe('NameExpressionGenIdBanner', () => {
                     kindName="DataClass"
                     api={getTestAPIWrapper(jest.fn, {
                         domain: getDomainPropertiesTestAPIWrapper(jest.fn, {
-                            getGenId: () => Promise.resolve(123),
+                            getGenId: jest.fn().mockResolvedValue(123),
                         }),
                         entity: getEntityTestAPIWrapper(jest.fn, {
-                            isDataTypeEmpty: () => Promise.resolve(true),
+                            isDataTypeEmpty: jest.fn().mockResolvedValue(true),
                         }),
                     })}
                 />

--- a/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.spec.tsx
@@ -7,9 +7,10 @@ import { getTestAPIWrapper } from '../../APIWrapper';
 
 import { NotificationsContextProvider } from '../notifications/NotificationsContext';
 
+import { getEntityTestAPIWrapper } from '../entities/APIWrapper';
+
 import { NameExpressionGenIdBanner } from './NameExpressionGenIdBanner';
 import { getDomainPropertiesTestAPIWrapper } from './APIWrapper';
-import { getEntityTestAPIWrapper } from '../entities/APIWrapper';
 
 describe('NameExpressionGenIdBanner', () => {
     test('with existing data', async () => {
@@ -25,7 +26,7 @@ describe('NameExpressionGenIdBanner', () => {
                         }),
                         entity: getEntityTestAPIWrapper(jest.fn, {
                             isDataTypeEmpty: () => Promise.resolve(false),
-                        })
+                        }),
                     })}
                 />
             </NotificationsContextProvider>
@@ -49,7 +50,7 @@ describe('NameExpressionGenIdBanner', () => {
                         }),
                         entity: getEntityTestAPIWrapper(jest.fn, {
                             isDataTypeEmpty: () => Promise.resolve(true),
-                        })
+                        }),
                     })}
                 />
             </NotificationsContextProvider>
@@ -73,7 +74,7 @@ describe('NameExpressionGenIdBanner', () => {
                         }),
                         entity: getEntityTestAPIWrapper(jest.fn, {
                             isDataTypeEmpty: () => Promise.resolve(true),
-                        })
+                        }),
                     })}
                 />
             </NotificationsContextProvider>

--- a/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.spec.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.spec.tsx
@@ -9,6 +9,7 @@ import { NotificationsContextProvider } from '../notifications/NotificationsCont
 
 import { NameExpressionGenIdBanner } from './NameExpressionGenIdBanner';
 import { getDomainPropertiesTestAPIWrapper } from './APIWrapper';
+import { getEntityTestAPIWrapper } from '../entities/APIWrapper';
 
 describe('NameExpressionGenIdBanner', () => {
     test('with existing data', async () => {
@@ -20,9 +21,11 @@ describe('NameExpressionGenIdBanner', () => {
                     kindName="DataClass"
                     api={getTestAPIWrapper(jest.fn, {
                         domain: getDomainPropertiesTestAPIWrapper(jest.fn, {
-                            hasExistingDomainData: () => Promise.resolve(true),
                             getGenId: () => Promise.resolve(123),
                         }),
+                        entity: getEntityTestAPIWrapper(jest.fn, {
+                            isDataTypeEmpty: () => Promise.resolve(false),
+                        })
                     })}
                 />
             </NotificationsContextProvider>
@@ -42,9 +45,11 @@ describe('NameExpressionGenIdBanner', () => {
                     kindName="DataClass"
                     api={getTestAPIWrapper(jest.fn, {
                         domain: getDomainPropertiesTestAPIWrapper(jest.fn, {
-                            hasExistingDomainData: () => Promise.resolve(false),
                             getGenId: () => Promise.resolve(0),
                         }),
+                        entity: getEntityTestAPIWrapper(jest.fn, {
+                            isDataTypeEmpty: () => Promise.resolve(true),
+                        })
                     })}
                 />
             </NotificationsContextProvider>
@@ -64,9 +69,11 @@ describe('NameExpressionGenIdBanner', () => {
                     kindName="DataClass"
                     api={getTestAPIWrapper(jest.fn, {
                         domain: getDomainPropertiesTestAPIWrapper(jest.fn, {
-                            hasExistingDomainData: () => Promise.resolve(false),
                             getGenId: () => Promise.resolve(123),
                         }),
+                        entity: getEntityTestAPIWrapper(jest.fn, {
+                            isDataTypeEmpty: () => Promise.resolve(true),
+                        })
                     })}
                 />
             </NotificationsContextProvider>

--- a/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.tsx
@@ -39,7 +39,12 @@ export const NameExpressionGenIdBanner: FC<NameExpressionGenIdProps> = props => 
     const init = async () => {
         if (rowId && kindName) {
             try {
-                const canResetGen = await api.entity.isDataTypeEmpty(kindName === 'DataClass' ? 'DataClass' : 'SampleType', dataTypeLSID, rowId, containerPath);
+                const canResetGen = await api.entity.isDataTypeEmpty(
+                    kindName === 'DataClass' ? 'DataClass' : 'SampleType',
+                    dataTypeLSID,
+                    rowId,
+                    containerPath
+                );
                 setCanReset(canResetGen);
 
                 try {

--- a/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.tsx
+++ b/packages/components/src/internal/components/domainproperties/NameExpressionGenIdBanner.tsx
@@ -39,8 +39,7 @@ export const NameExpressionGenIdBanner: FC<NameExpressionGenIdProps> = props => 
     const init = async () => {
         if (rowId && kindName) {
             try {
-                const hasData = await api.domain.hasExistingDomainData(kindName, dataTypeLSID, rowId, containerPath);
-                const canResetGen = !hasData;
+                const canResetGen = await api.entity.isDataTypeEmpty(kindName === 'DataClass' ? 'DataClass' : 'SampleType', dataTypeLSID, rowId, containerPath);
                 setCanReset(canResetGen);
 
                 try {

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -1239,35 +1239,6 @@ export function getGenId(rowId: number, kindName: 'SampleSet' | 'DataClass', con
     });
 }
 
-export function hasExistingDomainData(
-    kindName: 'SampleSet' | 'DataClass',
-    dataTypeLSID?: string,
-    rowId?: number,
-    containerPath?: string
-): Promise<boolean> {
-    let dataCountSql = 'SELECT COUNT(*) AS DataCount FROM ';
-
-    if (kindName === 'SampleSet') {
-        dataCountSql += "materials WHERE sampleset = '" + dataTypeLSID + "'";
-    } else {
-        dataCountSql += 'data WHERE dataclass = ' + rowId;
-    }
-
-    return new Promise((resolve, reject) => {
-        Query.executeSql({
-            containerPath,
-            schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
-            sql: dataCountSql,
-            success: data => {
-                resolve(data.rows[0].DataCount !== 0);
-            },
-            failure: error => {
-                reject(error);
-            },
-        });
-    });
-}
-
 export function setGenId(
     rowId: number,
     kindName: 'SampleSet' | 'DataClass',

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1522,7 +1522,9 @@ async function insertPastedData(
             }
         }
 
-        const pkValue = getPkValue(row, queryInfo);
+        let pkValue = getPkValue(row, queryInfo);
+        if (!pkValue)
+            pkValue = dataKeys.get(rowIdx);
 
         for (let cn = 0; cn < row.size; cn++) {
             const val = row.get(cn);

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1523,8 +1523,7 @@ async function insertPastedData(
         }
 
         let pkValue = getPkValue(row, queryInfo);
-        if (!pkValue)
-            pkValue = dataKeys.get(rowIdx);
+        if (!pkValue) pkValue = dataKeys.get(rowIdx);
 
         for (let cn = 0; cn < row.size; cn++) {
             const val = row.get(cn);

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -68,7 +68,7 @@ export const CustomizeGridViewModal: FC<Props> = memo(props => {
                 const viewInfo = model.currentView.mutate({
                     columns: selectedColumns.map(col => ({
                         fieldKey: col.fieldKeyPath /* Issue 46256: use encoded fieldKeyPath */,
-                        title: col.customViewTitle,
+                        title: model.getCustomViewTitleOverride(col),
                     })),
                 });
                 await saveAsSessionView(model.schemaQuery, model.containerPath, viewInfo);

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -740,7 +740,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 .filter(column => column.index !== columnToHide.index)
                 .map(col => ({
                     fieldKey: col.fieldKeyPath /* 46256: use encoded fieldKeyPath */,
-                    title: col.customViewTitle,
+                    title: model.getCustomViewTitleOverride(col),
                 })),
         });
     };
@@ -758,28 +758,29 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
     updateColumnTitle = (updatedCol: QueryColumn): void => {
         const { model } = this.props;
-        this.saveAsSessionView({
-            columns: model.displayColumns.map(col => {
-                if (col.index === updatedCol.index) {
+        this.saveAsSessionView({}, updatedCol);
+        this.setState({ disableColumnDrag: false });
+    };
+
+    saveAsSessionView = (updates: Partial<ViewInfo>, updatedCol?: QueryColumn): void => {
+        const { model } = this.props;
+        const { schemaQuery, containerPath } = model;
+        const changedFilters = updates.filters && !filterArraysEqual(updates.filters, model.currentView.filters);
+        if (!updates.columns) {
+            updates.columns = model.displayColumns.map(col => {
+                if (updatedCol && col.index === updatedCol.index) {
                     return {
                         fieldKey: updatedCol.fieldKeyPath /* 46256: use encoded fieldKeyPath */,
-                        title: updatedCol.customViewTitle,
+                        title: model.getCustomViewTitleOverride(updatedCol),
                     };
                 } else {
                     return {
                         fieldKey: col.fieldKeyPath /* 46256: use encoded fieldKeyPath */,
-                        title: col.customViewTitle,
+                        title: model.getCustomViewTitleOverride(col),
                     };
                 }
-            }),
-        });
-        this.setState({ disableColumnDrag: false });
-    };
-
-    saveAsSessionView = (updates: Partial<ViewInfo>): void => {
-        const { model } = this.props;
-        const { schemaQuery, containerPath } = model;
-        const changedFilters = updates.filters && !filterArraysEqual(updates.filters, model.currentView.filters);
+            })
+        }
         const viewInfo = model.currentView.mutate(updates);
 
         saveAsSessionView(schemaQuery, containerPath, viewInfo)
@@ -853,6 +854,12 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 // update/set sorts and filters to combine view and user-defined items
                 filters: model.filterArray.concat(view.filters),
                 sorts: model.sorts.concat(view.sorts),
+                columns: model.displayColumns.map(col => {
+                    return {
+                        fieldKey: col.fieldKeyPath /* 46256: use encoded fieldKeyPath */,
+                        title: model.getCustomViewTitleOverride(col),
+                    }
+                })
             });
 
             if (view.session) {
@@ -981,7 +988,8 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
     };
 
     onColumnDrop = (source: string, target: string): void => {
-        const { displayColumns } = this.props.model;
+        const { model } = this.props;
+        const { displayColumns } = model;
 
         const sourceIndex = displayColumns.findIndex(col => col.index === source);
         const colInMotion = displayColumns.find(col => col.index === source);
@@ -998,7 +1006,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 this.saveAsSessionView({
                     columns: updatedColumns.map(col => ({
                         fieldKey: col.fieldKeyPath /* 46256: use encoded fieldKeyPath */,
-                        title: col.customViewTitle,
+                        title: model.getCustomViewTitleOverride(col),
                     })),
                 });
 

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -49,6 +49,8 @@ import { User } from '../../internal/components/base/models/User';
 
 import { MenuItem, SplitButton } from '../../internal/dropdowns';
 
+import { DOMAIN_FIELD } from '../../internal/components/forms/DomainFieldHelpTipContents';
+
 import { ActionValue } from './grid/actions/Action';
 import { FilterAction } from './grid/actions/Filter';
 import { SearchAction } from './grid/actions/Search';
@@ -73,7 +75,6 @@ import { CustomizeGridViewModal } from './CustomizeGridViewModal';
 import { ManageViewsModal } from './ManageViewsModal';
 import { Actions, InjectedQueryModels, RequiresModelAndActions, withQueryModels } from './withQueryModels';
 import { ChartPanel } from './ChartPanel';
-import { DOMAIN_FIELD } from '../../internal/components/forms/DomainFieldHelpTipContents';
 
 export interface GridPanelProps<ButtonsComponentProps> {
     ButtonsComponent?: ComponentType<ButtonsComponentProps & RequiresModelAndActions>;
@@ -779,7 +780,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                         title: model.getCustomViewTitleOverride(col),
                     };
                 }
-            })
+            });
         }
         const viewInfo = model.currentView.mutate(updates);
 
@@ -858,8 +859,8 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                     return {
                         fieldKey: col.fieldKeyPath /* 46256: use encoded fieldKeyPath */,
                         title: model.getCustomViewTitleOverride(col),
-                    }
-                })
+                    };
+                }),
             });
 
             if (view.session) {

--- a/packages/components/src/public/QueryModel/QueryModel.test.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.test.ts
@@ -129,7 +129,7 @@ describe('QueryModel', () => {
         model = model.mutate({ queryInfo: QUERY_INFO });
         expect(model.columnString).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime,extraTestColumn');
         model = model.mutate({ requiredColumns: ['Name'] });
-        expect(model.columnString).toEqual('Name,RowId,Flag,mixtureTypeId,expirationTime,extraTestColumn');
+        expect(model.columnString).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime,extraTestColumn');
         expect(model.keyColumns).toEqual([cols.get('rowid')]);
         let expectedDisplayCols = [
             cols.get('name'),
@@ -158,7 +158,7 @@ describe('QueryModel', () => {
             cols.get('expirationtime'),
         ];
         expect(model.displayColumns).toEqual(expectedDisplayCols);
-        expect(model.columnString).toEqual('Name,RowId,Flag,mixtureTypeId,expirationTime');
+        expect(model.columnString).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime');
     });
 
     test('SelectedState', () => {

--- a/packages/components/src/public/QueryModel/QueryModel.test.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.test.ts
@@ -161,9 +161,15 @@ describe('QueryModel', () => {
         expect(model.columnString).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime');
 
         expect(model.getRequestColumnsString(['nAME'])).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime');
-        expect(model.getRequestColumnsString(['OtherField'])).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime,OtherField');
-        expect(model.getRequestColumnsString(['nAME', 'OtherField'])).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime,OtherField');
-        expect(model.getRequestColumnsString(['OtherField', 'Name'], ['mixtureTypeId'])).toEqual('RowId,Name,Flag,expirationTime,OtherField');
+        expect(model.getRequestColumnsString(['OtherField'])).toEqual(
+            'RowId,Name,Flag,mixtureTypeId,expirationTime,OtherField'
+        );
+        expect(model.getRequestColumnsString(['nAME', 'OtherField'])).toEqual(
+            'RowId,Name,Flag,mixtureTypeId,expirationTime,OtherField'
+        );
+        expect(model.getRequestColumnsString(['OtherField', 'Name'], ['mixtureTypeId'])).toEqual(
+            'RowId,Name,Flag,expirationTime,OtherField'
+        );
     });
 
     test('SelectedState', () => {

--- a/packages/components/src/public/QueryModel/QueryModel.test.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.test.ts
@@ -159,6 +159,11 @@ describe('QueryModel', () => {
         ];
         expect(model.displayColumns).toEqual(expectedDisplayCols);
         expect(model.columnString).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime');
+
+        expect(model.getRequestColumnsString(['nAME'])).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime');
+        expect(model.getRequestColumnsString(['OtherField'])).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime,OtherField');
+        expect(model.getRequestColumnsString(['nAME', 'OtherField'])).toEqual('RowId,Name,Flag,mixtureTypeId,expirationTime,OtherField');
+        expect(model.getRequestColumnsString(['OtherField', 'Name'], ['mixtureTypeId'])).toEqual('RowId,Name,Flag,expirationTime,OtherField');
     });
 
     test('SelectedState', () => {

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -687,13 +687,14 @@ export class QueryModel {
         }
 
         // remove duplicate
-        const fieldKeysLc = [], fieldKeysCleaned = [];
+        const fieldKeysLc = [],
+            fieldKeysCleaned = [];
         fieldKeys.forEach(fieldKey => {
             if (fieldKeysLc.indexOf(fieldKey.toLowerCase()) === -1) {
                 fieldKeysCleaned.push(fieldKey);
                 fieldKeysLc.push(fieldKey.toLowerCase());
             }
-        })
+        });
 
         return fieldKeysCleaned.join(',');
     }

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -543,8 +543,7 @@ export class QueryModel {
     getCustomViewTitleOverride(column: QueryColumn): string {
         const label = column.customViewTitle;
         const originalCol = this.queryInfo.getColumn(column.fieldKey);
-        if (!originalCol || (originalCol.caption !== label))
-            return label;
+        if (!originalCol || originalCol.caption !== label) return label;
         return '';
     }
 
@@ -676,7 +675,7 @@ export class QueryModel {
         const _omittedColumns = omittedColumns ?? this.omittedColumns;
 
         // Note: ES6 Set is being used here, not Immutable Set
-        const uniqueFieldKeys : Set<string> = new Set();
+        const uniqueFieldKeys: Set<string> = new Set();
         this.keyColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
 
         this.uniqueIdColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -542,7 +542,7 @@ export class QueryModel {
     // Issue 50607: Updated field labels are not shown in the grid if the default grid view has been changed.
     getCustomViewTitleOverride(column: QueryColumn): string {
         const label = column.customViewTitle;
-        const originalCol = this.queryInfo.columns.get(column.fieldKey.toLowerCase());
+        const originalCol = this.queryInfo.getColumn(column.fieldKey);
         if (!originalCol || (originalCol.caption !== label))
             return label;
         return '';
@@ -696,12 +696,12 @@ export class QueryModel {
         }
 
         // remove duplicate
-        const fieldKeysLc = [],
+        const fieldKeysLc = new Set(),
             fieldKeysCleaned = [];
         fieldKeys.forEach(fieldKey => {
-            if (fieldKeysLc.indexOf(fieldKey.toLowerCase()) === -1) {
+            if (!fieldKeysLc.has(fieldKey.toLowerCase())) {
                 fieldKeysCleaned.push(fieldKey);
-                fieldKeysLc.push(fieldKey.toLowerCase());
+                fieldKeysLc.add(fieldKey.toLowerCase());
             }
         });
 

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -539,6 +539,15 @@ export class QueryModel {
         return this.queryInfo?.getDisplayColumns(this.viewName, this.omittedColumns);
     }
 
+    // Issue 50607: Updated field labels are not shown in the grid if the default grid view has been changed.
+    getCustomViewTitleOverride(column: QueryColumn): string {
+        const label = column.customViewTitle;
+        const originalCol = this.queryInfo.columns.get(column.fieldKey.toLowerCase());
+        if (!originalCol || (originalCol.caption !== label))
+            return label;
+        return '';
+    }
+
     /**
      * Array of all [[QueryColumn]] objects from the [[QueryInfo]] view. This will exclude those columns listed
      * in omittedColumns.

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -686,7 +686,16 @@ export class QueryModel {
             fieldKeys = fieldKeys.filter(fieldKey => !lowerOmit.has(fieldKey.toLowerCase()));
         }
 
-        return fieldKeys.join(',');
+        // remove duplicate
+        const fieldKeysLc = [], fieldKeysCleaned = [];
+        fieldKeys.forEach(fieldKey => {
+            if (fieldKeysLc.indexOf(fieldKey.toLowerCase()) === -1) {
+                fieldKeysCleaned.push(fieldKey);
+                fieldKeysLc.push(fieldKey.toLowerCase());
+            }
+        })
+
+        return fieldKeysCleaned.join(',');
     }
 
     /**

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -676,7 +676,7 @@ export class QueryModel {
         const _omittedColumns = omittedColumns ?? this.omittedColumns;
 
         // Note: ES6 Set is being used here, not Immutable Set
-        const uniqueFieldKeys = new Set(_requiredColumns);
+        const uniqueFieldKeys : Set<string> = new Set();
         this.keyColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
 
         this.uniqueIdColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
@@ -687,6 +687,10 @@ export class QueryModel {
         } else {
             this.displayColumns.forEach(col => uniqueFieldKeys.add(col.fieldKey));
         }
+
+        // add requiredColumns last so fieldKeys from QueryColumns are preferred, when there is a case difference
+        // For example, choose Ancestors/RegistryAndSources/Participant (from displayColumns) over Ancestors/RegistryAndSources/participant (from requiredColumns)
+        requiredColumns?.forEach(col => uniqueFieldKeys.add(col));
 
         let fieldKeys = Array.from(uniqueFieldKeys);
 

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -690,7 +690,7 @@ export class QueryModel {
 
         // add requiredColumns last so fieldKeys from QueryColumns are preferred, when there is a case difference
         // For example, choose Ancestors/RegistryAndSources/Participant (from displayColumns) over Ancestors/RegistryAndSources/participant (from requiredColumns)
-        requiredColumns?.forEach(col => uniqueFieldKeys.add(col));
+        _requiredColumns?.forEach(col => uniqueFieldKeys.add(col));
 
         let fieldKeys = Array.from(uniqueFieldKeys);
 


### PR DESCRIPTION
#### Rationale
- Issue 50742: Reset/Update genId result in error if samples exists only in child folders
- Issue 50709: LKSM: Pasting in editable grid when an aliquot field is between two sample fields doesn't work
- Issue 50650: LKSM: SampleFinder doesn't show ancestor column data if default view also contains the same ancestors
- Issue 42183: SM: Need better indication that comment in a workflow task has not been saved.
- Issue 50607: Updated field labels are not shown in the grid

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1533
- https://github.com/LabKey/labkey-ui-premium/pull/469
- https://github.com/LabKey/limsModules/pull/468

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
