### PR TITLE
Modal: support custom content in default footer

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.0.6",
+      "version": "4.0.7",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.34.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 4.0.7
+*Released*: 23 July 2024
+- Add `footerContent` prop on `Modal` which is passed through as the `children` of `ModalButtons`.
+Useful for rendering content to the left of the modal confirmation buttons.
+
 ### version 4.0.6
 *Released*: 20 July 2024
 - Issue 50742: Reset/Update genId result in error if samples exists only in child folders

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -616,6 +616,7 @@ import { DataTypeProjectsPanel } from './internal/components/domainproperties/Da
 import { AssayImportPanels } from './internal/components/assay/AssayImportPanels';
 import { AssayDesignEmptyAlert } from './internal/components/assay/AssayDesignEmptyAlert';
 import {
+    AppContextTestProvider,
     makeQueryInfo,
     sleep,
     wrapDraggable,
@@ -1738,6 +1739,7 @@ export {
     BACKGROUND_IMPORT_MIN_ROW_SIZE,
     DATA_IMPORT_FILE_SIZE_LIMITS,
     // Test Helpers
+    AppContextTestProvider,
     sleep,
     createMockWithRouteLeave,
     makeQueryInfo,
@@ -1954,3 +1956,4 @@ export type { ExtraExportMenuOptions } from './public/QueryModel/ExportMenu';
 export type { LabelsAPIWrapper } from './internal/components/labels/APIWrapper';
 export type { InputRendererProps } from './internal/components/forms/input/types';
 export type { InputRenderContext, InputRendererComponent } from './internal/components/forms/input/InputRenderFactory';
+export type { AppContextTestProviderProps } from './internal/test/testHelpers';

--- a/packages/components/src/internal/Modal.tsx
+++ b/packages/components/src/internal/Modal.tsx
@@ -67,6 +67,7 @@ export const ModalHeader: FC<ModalHeaderProps> = ({ title, onCancel }) => {
 ModalHeader.displayName = 'ModalHeader';
 
 export interface ModalProps extends BaseModalProps, ModalButtonsProps {
+    buttonBarContent?: ReactNode;
     // Note: you probably shouldn't use footer, instead use the other props to render the appropriate footer
     footer?: ReactNode;
     title?: ReactNode;
@@ -75,6 +76,7 @@ export interface ModalProps extends BaseModalProps, ModalButtonsProps {
 export const Modal: FC<ModalProps> = memo(props => {
     const {
         actionName,
+        buttonBarContent,
         bsSize,
         cancelText,
         canConfirm,
@@ -111,7 +113,9 @@ export const Modal: FC<ModalProps> = memo(props => {
                     onCommentChange={onCommentChange}
                     onCancel={onCancel}
                     requiresUserComment={requiresUserComment}
-                />
+                >
+                    {buttonBarContent}
+                </ModalButtons>
             )}
 
             {footer && <div className="modal-footer">{footer}</div>}

--- a/packages/components/src/internal/Modal.tsx
+++ b/packages/components/src/internal/Modal.tsx
@@ -67,16 +67,16 @@ export const ModalHeader: FC<ModalHeaderProps> = ({ title, onCancel }) => {
 ModalHeader.displayName = 'ModalHeader';
 
 export interface ModalProps extends BaseModalProps, ModalButtonsProps {
-    buttonBarContent?: ReactNode;
     // Note: you probably shouldn't use footer, instead use the other props to render the appropriate footer
     footer?: ReactNode;
+    // This is partial content of the default footer rendered by the Modal. It is ignored if a "footer" is supplied.
+    footerContent?: ReactNode;
     title?: ReactNode;
 }
 
 export const Modal: FC<ModalProps> = memo(props => {
     const {
         actionName,
-        buttonBarContent,
         bsSize,
         cancelText,
         canConfirm,
@@ -86,6 +86,7 @@ export const Modal: FC<ModalProps> = memo(props => {
         confirmText,
         confirmingText,
         footer,
+        footerContent,
         isConfirming,
         onCancel,
         onCommentChange,
@@ -114,7 +115,7 @@ export const Modal: FC<ModalProps> = memo(props => {
                     onCancel={onCancel}
                     requiresUserComment={requiresUserComment}
                 >
-                    {buttonBarContent}
+                    {footerContent}
                 </ModalButtons>
             )}
 

--- a/packages/components/src/internal/ModalButtons.tsx
+++ b/packages/components/src/internal/ModalButtons.tsx
@@ -6,16 +6,16 @@ import { FormButtons } from './FormButtons';
 import { CommentTextArea } from './components/forms/input/CommentTextArea';
 
 export interface ModalButtonsProps {
-    cancelText?: string;
+    actionName?: string;
     canConfirm?: boolean;
+    cancelText?: string;
     confirmClass?: string;
     confirmText?: string;
     confirmingText?: string;
     isConfirming?: boolean;
     onCancel?: () => void;
-    onConfirm?: () => void;
-    actionName?: string;
     onCommentChange?: (comment: string) => void;
+    onConfirm?: () => void;
     requiresUserComment?: boolean;
 }
 

--- a/packages/components/src/internal/ModalButtons.tsx
+++ b/packages/components/src/internal/ModalButtons.tsx
@@ -24,6 +24,7 @@ export const ModalButtons: FC<ModalButtonsProps> = memo(props => {
         actionName = 'Update',
         cancelText = 'Cancel',
         canConfirm = true,
+        children,
         confirmClass = 'btn-success',
         confirmText = 'Save',
         confirmingText = 'Saving...',
@@ -45,6 +46,7 @@ export const ModalButtons: FC<ModalButtonsProps> = memo(props => {
                         {cancelText}
                     </button>
                 )}
+                {children}
                 {onCommentChange && (
                     <CommentTextArea
                         containerClassName="inline-comment"


### PR DESCRIPTION
#### Rationale
This adds a new `footerContent` prop on `Modal` which supports custom content being rendered in the default footer. This is useful for rendering custom content in the modal's default footer without having to render a fully custom button bar.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1535
- https://github.com/LabKey/labkey-ui-premium/pull/472
- https://github.com/LabKey/platform/pull/5693
- https://github.com/LabKey/limsModules/pull/482

#### Changes
- Add `footerContent` prop on `Modal` which is passed through as the `children` of `ModalButtons`. Useful for rendering content to the left of the modal confirmation buttons.
