### PR TITLE
@labkey/build to allow for entryPoints.js props to set requiresLogin and requiresNoPermission

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.4.0-fb-buildRequireLogin.0",
+  "version": "7.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.4.0-fb-buildRequireLogin.0",
+      "version": "7.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.24.9",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.4.0",
+  "version": "7.4.0-fb-buildRequireLogin.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.4.0",
+      "version": "7.4.0-fb-buildRequireLogin.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.24.9",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.4.0-fb-buildRequireLogin.0",
+  "version": "7.5.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.4.0",
+  "version": "7.4.0-fb-buildRequireLogin.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,9 @@
 # @labkey/build
 
+### version TBD
+*Released*: TBD
+- Add option to add requiresLogin and requiresNoPermission to entry points
+
 ### version 7.4.0
 *Released*: 24 July 2024
 - Package updates

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,7 +1,7 @@
 # @labkey/build
 
-### version TBD
-*Released*: TBD
+### version 7.5.0
+*Released*: 27 July 2024
 - Add option to add requiresLogin and requiresNoPermission to entry points
 
 ### version 7.4.0

--- a/packages/build/webpack/app.view.template.xml
+++ b/packages/build/webpack/app.view.template.xml
@@ -21,6 +21,12 @@
         <% }); %>
     </permissionClasses>
     <% } %>
+    <% if (htmlWebpackPlugin.options.requiresLogin) { %>
+    <requiresLogin/>
+    <% } %>
+    <% if (htmlWebpackPlugin.options.requiresNoPermission) { %>
+    <requiresNoPermission/>
+    <% } %>
     <dependencies>
         <dependency path="clientapi"/>
         <dependency path="passwordGauge.js"/>

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -315,6 +315,8 @@ module.exports = {
                         title: app.title,
                         permission: app.permission, // deprecated
                         permissionClasses: app.permissionClasses,
+                        requiresLogin: app.requiresLogin,
+                        requiresNoPermission: app.requiresNoPermission,
                         viewTemplate: app.template,
                         filename: '../../views/gen/' + app.name + '.view.xml',
                         template: 'node_modules/@labkey/build/webpack/app.view.template.xml',
@@ -334,6 +336,8 @@ module.exports = {
                         title: app.title,
                         permission: app.permission, // deprecated
                         permissionClasses: app.permissionClasses,
+                        requiresLogin: app.requiresLogin,
+                        requiresNoPermission: app.requiresNoPermission,
                         viewTemplate: app.template,
                         filename: '../../views/gen/' + app.name + 'Dev.view.xml',
                         template: 'node_modules/@labkey/build/webpack/app.view.template.xml',


### PR DESCRIPTION
#### Rationale
Add support in entryPoints.js props to set requiresLogin and requiresNoPermission (see related PR for further info).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5701
- https://github.com/LabKey/wnprc-modules/pull/626

#### Changes
- Add option to add requiresLogin and requiresNoPermission to entry points
