### PR TITLE
BarTender: supply file export needed for BarTender integration

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.3.0",
+  "version": "4.3.1-fb-barcodeTemplate.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.3.0",
+      "version": "4.3.1-fb-barcodeTemplate.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.0",
+  "version": "4.4.1-fb-barcodeTemplate.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.4.0",
+      "version": "4.4.1-fb-barcodeTemplate.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.1-fb-barcodeTemplate.1",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.4.1-fb-barcodeTemplate.1",
+      "version": "4.4.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.3.1-fb-barcodeTemplate.1",
+  "version": "4.3.1-fb-barcodeTemplate.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.3.1-fb-barcodeTemplate.1",
+      "version": "4.3.1-fb-barcodeTemplate.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.3.0",
+  "version": "4.3.1-fb-barcodeTemplate.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.0",
+  "version": "4.4.1-fb-barcodeTemplate.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.1-fb-barcodeTemplate.1",
+  "version": "4.4.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.3.1-fb-barcodeTemplate.1",
+  "version": "4.3.1-fb-barcodeTemplate.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 4.X
+*Released*: X 2024
+- BarTender: supply file export needed for BarTender integration
+  - Update label and icon for bartender label printing option
+  - Support new "Download template" option for bartender with FieldKey instead of column title
+
 ### version 4.3.0
 *Released*: 25 July 2024
 - Issue 50449: App grid filter to expand icon click area to remove filter value

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -176,6 +176,17 @@ export function getExportParams(
         params.delim = 'COMMA';
     }
 
+    if (type === EXPORT_TYPES.LABEL_TEMPLATE) {
+        params.delim = 'COMMA';
+        params.headerType = 'FieldKey';
+        // don't export aliases if headType is FieldKey
+        Object.keys(params).forEach(param => {
+            if (param.startsWith('exportAlias.'))
+                delete params[param];
+        })
+        incrementClientSideMetricCount('BarTender', 'DownloadTemplateCount');
+    }
+
     if (options) {
         if (options.columns) {
             let columnsString = options.columns;
@@ -255,7 +266,7 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
     });
 
     let controller, action;
-    if (type === EXPORT_TYPES.CSV || type === EXPORT_TYPES.TSV) {
+    if (type === EXPORT_TYPES.CSV || type === EXPORT_TYPES.TSV || type === EXPORT_TYPES.LABEL_TEMPLATE) {
         controller = 'query';
         action = 'exportRowsTsv.post';
     } else if (type === EXPORT_TYPES.EXCEL) {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -181,9 +181,8 @@ export function getExportParams(
         params.headerType = 'FieldKey';
         // don't export aliases if headType is FieldKey
         Object.keys(params).forEach(param => {
-            if (param.startsWith('exportAlias.'))
-                delete params[param];
-        })
+            if (param.startsWith('exportAlias.')) delete params[param];
+        });
         incrementClientSideMetricCount('BarTender', 'DownloadTemplateCount');
     }
 

--- a/packages/components/src/internal/components/samples/utils.tsx
+++ b/packages/components/src/internal/components/samples/utils.tsx
@@ -259,6 +259,12 @@ export function isAllSamplesSchema(schemaQuery: SchemaQuery): boolean {
     )
         return true;
 
+    if (
+        lcSchemaName === SCHEMAS.EXP_TABLES.SCHEMA &&
+        lcQueryName.startsWith('exp_temp_') // Find Sample by ID/Barcode
+    )
+        return true;
+
     if (lcSchemaName === SCHEMAS.SAMPLE_MANAGEMENT.SCHEMA) {
         return (
             lcQueryName === SCHEMAS.SAMPLE_MANAGEMENT.SOURCE_SAMPLES.queryName.toLowerCase() ||

--- a/packages/components/src/internal/constants.ts
+++ b/packages/components/src/internal/constants.ts
@@ -45,7 +45,7 @@ export enum EXPORT_TYPES {
     GENBANK,
     LABEL,
     STORAGE_MAP,
-    LABEL_TEMPLATE
+    LABEL_TEMPLATE,
 }
 
 export enum KEYS {

--- a/packages/components/src/internal/constants.ts
+++ b/packages/components/src/internal/constants.ts
@@ -45,6 +45,7 @@ export enum EXPORT_TYPES {
     GENBANK,
     LABEL,
     STORAGE_MAP,
+    LABEL_TEMPLATE
 }
 
 export enum KEYS {

--- a/packages/components/src/public/QueryModel/ExportMenu.test.tsx
+++ b/packages/components/src/public/QueryModel/ExportMenu.test.tsx
@@ -62,6 +62,42 @@ describe('ExportMenu', () => {
         expect(exportFn).toHaveBeenCalledTimes(1);
     });
 
+    test('supported types, can print template, but not label', () => {
+        const supportedTypes = ImmutableSet.of(EXPORT_TYPES.LABEL_TEMPLATE);
+
+        render(<ExportMenu model={MODEL} supportedTypes={supportedTypes} />);
+
+        expect(document.querySelectorAll('.export-menu-icon').length).toBe(4);
+        expect(document.querySelectorAll('.divider').length).toBe(1);
+    });
+
+    test('supported types, can print label, but not template', () => {
+        const supportedTypes = ImmutableSet.of(EXPORT_TYPES.LABEL);
+
+        render(<ExportMenu model={MODEL} supportedTypes={supportedTypes} />);
+
+        expect(document.querySelectorAll('.export-menu-icon').length).toBe(4);
+        expect(document.querySelectorAll('.divider').length).toBe(1);
+    });
+
+    test('supported types, can print label and template', () => {
+        const supportedTypes = ImmutableSet.of(EXPORT_TYPES.LABEL, EXPORT_TYPES.LABEL_TEMPLATE);
+
+        render(<ExportMenu model={MODEL} supportedTypes={supportedTypes} />);
+
+        expect(document.querySelectorAll('.export-menu-icon').length).toBe(5);
+        expect(document.querySelectorAll('.divider').length).toBe(1);
+    });
+
+    test('supported types: all', () => {
+        const supportedTypes = ImmutableSet.of(EXPORT_TYPES.LABEL, EXPORT_TYPES.LABEL_TEMPLATE, EXPORT_TYPES.STORAGE_MAP);
+
+        render(<ExportMenu model={MODEL} supportedTypes={supportedTypes} />);
+
+        expect(document.querySelectorAll('.export-menu-icon').length).toBe(6);
+        expect(document.querySelectorAll('.divider').length).toBe(2);
+    });
+
     test('extraExportMenuOptions', () => {
         const exportFn = jest.fn();
         const extraOptions = [

--- a/packages/components/src/public/QueryModel/ExportMenu.test.tsx
+++ b/packages/components/src/public/QueryModel/ExportMenu.test.tsx
@@ -90,7 +90,11 @@ describe('ExportMenu', () => {
     });
 
     test('supported types: all', () => {
-        const supportedTypes = ImmutableSet.of(EXPORT_TYPES.LABEL, EXPORT_TYPES.LABEL_TEMPLATE, EXPORT_TYPES.STORAGE_MAP);
+        const supportedTypes = ImmutableSet.of(
+            EXPORT_TYPES.LABEL,
+            EXPORT_TYPES.LABEL_TEMPLATE,
+            EXPORT_TYPES.STORAGE_MAP
+        );
 
         render(<ExportMenu model={MODEL} supportedTypes={supportedTypes} />);
 

--- a/packages/components/src/public/QueryModel/ExportMenu.tsx
+++ b/packages/components/src/public/QueryModel/ExportMenu.tsx
@@ -40,7 +40,8 @@ const exportOptions = [
     { type: EXPORT_TYPES.CSV, icon: 'fa-file-o', label: 'CSV' },
     { type: EXPORT_TYPES.EXCEL, icon: 'fa-file-excel-o', label: 'Excel' },
     { type: EXPORT_TYPES.TSV, icon: 'fa-file-text-o', label: 'TSV' },
-    { type: EXPORT_TYPES.LABEL, icon: 'fa-tag', label: 'Label', hidden: true },
+    { type: EXPORT_TYPES.LABEL, icon: 'fa-print', label: 'Print Label', hidden: true },
+    { type: EXPORT_TYPES.LABEL_TEMPLATE, icon: 'fa-file-o', label: 'Download Template', hidden: true },
     { type: EXPORT_TYPES.STORAGE_MAP, icon: 'fa-file-excel-o', label: 'Storage Map (Excel)', hidden: true },
     // Note: EXPORT_TYPES and exportRows (used in export function below) also include support for FASTA and GENBANK,
     // but they were never used in the QueryGridPanel version of export. We're explicitly not supporting them in
@@ -61,15 +62,15 @@ const ExportMenuItem: FC<ExportMenuItemProps> = ({ hasSelections, onExport, opti
 
     if (option.hidden && !supportedTypes?.includes(option.type)) return null;
 
-    if (option.type === EXPORT_TYPES.LABEL) {
-        const exportAndPrintHeader = 'Export and Print' + (hasSelections ? ' Selected Data' : ' Data');
+    if (option.type === EXPORT_TYPES.LABEL || (option.type === EXPORT_TYPES.LABEL_TEMPLATE && !supportedTypes?.includes(EXPORT_TYPES.LABEL))) {
+        const exportAndPrintHeader = 'Bartender';
         return (
             <React.Fragment key={option.type}>
                 <MenuDivider />
                 <MenuHeader text={exportAndPrintHeader} />
                 <MenuItem onClick={onClick}>
                     <span className={`fa ${option.icon} export-menu-icon`} />
-                    &nbsp; {option.label}
+                    {option.label}
                 </MenuItem>
             </React.Fragment>
         );
@@ -82,7 +83,7 @@ const ExportMenuItem: FC<ExportMenuItemProps> = ({ hasSelections, onExport, opti
                 <MenuHeader text="Export Map" />
                 <MenuItem onClick={onClick}>
                     <span className={`fa ${option.icon} export-menu-icon`} />
-                    &nbsp; {option.label}
+                    {option.label}
                 </MenuItem>
             </React.Fragment>
         );

--- a/packages/components/src/public/QueryModel/ExportMenu.tsx
+++ b/packages/components/src/public/QueryModel/ExportMenu.tsx
@@ -62,7 +62,10 @@ const ExportMenuItem: FC<ExportMenuItemProps> = ({ hasSelections, onExport, opti
 
     if (option.hidden && !supportedTypes?.includes(option.type)) return null;
 
-    if (option.type === EXPORT_TYPES.LABEL || (option.type === EXPORT_TYPES.LABEL_TEMPLATE && !supportedTypes?.includes(EXPORT_TYPES.LABEL))) {
+    if (
+        option.type === EXPORT_TYPES.LABEL ||
+        (option.type === EXPORT_TYPES.LABEL_TEMPLATE && !supportedTypes?.includes(EXPORT_TYPES.LABEL))
+    ) {
         const exportAndPrintHeader = 'Bartender';
         return (
             <React.Fragment key={option.type}>


### PR DESCRIPTION
#### Rationale
This PR adds a new export option to use fieldKey instead of column label as header, which is desired for bartender configuration. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1543
- https://github.com/LabKey/labkey-ui-premium/pull/480
- https://github.com/LabKey/limsModules/pull/512

#### Changes
- Add new EXPORT_TYPES.LABEL_TEMPLATE for bartender templates
- Use fieldKey for LABEL_TEMPLATE exports
- update export menu labels and icons