### PR TITLE
Fix check for enabling transform scripts

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.1",
+  "version": "4.4.2-enabledTransformScripts.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.4.1",
+      "version": "4.4.2-enabledTransformScripts.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.2-enabledTransformScripts.0",
+  "version": "4.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.4.2-enabledTransformScripts.0",
+      "version": "4.4.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.2-enabledTransformScripts.0",
+  "version": "4.4.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.4.1",
+  "version": "4.4.2-enabledTransformScripts.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Fix `isTransformScriptsEnabled` check
+
 ### version 4.4.1
 *Released*: 30 July 2024
 - BarTender: supply file export needed for BarTender integration

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 4.4.2
+*Released*: 31 July 2024
 - Fix `isTransformScriptsEnabled` check
 
 ### version 4.4.1

--- a/packages/components/src/internal/app/utils.test.ts
+++ b/packages/components/src/internal/app/utils.test.ts
@@ -639,10 +639,17 @@ describe('utils', () => {
     });
 
     test('isTransformScriptsEnabled', () => {
-        expect(isTransformScriptsEnabled({})).toBe(false);
-        expect(isTransformScriptsEnabled({ inventory: {} })).toBe(false);
-        expect(isTransformScriptsEnabled({ api: { moduleNames: ['premium'] }, })).toBe(true);
+        expect(isTransformScriptsEnabled({})).toBe(true);
+        expect(isTransformScriptsEnabled({ api: { moduleNames: ['premium'] } })).toBe(true);
+
         expect(isTransformScriptsEnabled({ samplemanagement: {} })).toBe(false);
+        expect(
+            isTransformScriptsEnabled({
+                samplemanagement: {},
+                core: { productFeatures: [ProductFeature.TransformScripts] },
+            })
+        ).toBe(true);
+
         expect(
             isTransformScriptsEnabled({
                 samplemanagement: {},
@@ -659,6 +666,7 @@ describe('utils', () => {
         ).toBe(true);
         expect(
             isTransformScriptsEnabled({
+                samplemanagement: {},
                 biologics: {},
             })
         ).toBe(false);

--- a/packages/components/src/internal/app/utils.test.ts
+++ b/packages/components/src/internal/app/utils.test.ts
@@ -641,14 +641,7 @@ describe('utils', () => {
     test('isTransformScriptsEnabled', () => {
         expect(isTransformScriptsEnabled({})).toBe(true);
         expect(isTransformScriptsEnabled({ api: { moduleNames: ['premium'] } })).toBe(true);
-
-        expect(isTransformScriptsEnabled({ samplemanagement: {} })).toBe(false);
-        expect(
-            isTransformScriptsEnabled({
-                samplemanagement: {},
-                core: { productFeatures: [ProductFeature.TransformScripts] },
-            })
-        ).toBe(true);
+        expect(isTransformScriptsEnabled({ samplemanagement: {} })).toBe(true);
 
         expect(
             isTransformScriptsEnabled({
@@ -661,15 +654,26 @@ describe('utils', () => {
             isTransformScriptsEnabled({
                 samplemanagement: {},
                 biologics: {},
+            })
+        ).toBe(true);
+
+        window.history.pushState({}, 'isApp', '/lims-app.view#'); // isApp()
+        expect(
+            isTransformScriptsEnabled({
+                samplemanagement: {},
                 core: { productFeatures: [ProductFeature.TransformScripts] },
             })
         ).toBe(true);
+
+        window.history.pushState({}, 'isApp', '/samplemanager-app.view#'); // isApp()
         expect(
             isTransformScriptsEnabled({
                 samplemanagement: {},
                 biologics: {},
+                core: { productFeatures: [ProductFeature.TransformScripts] },
             })
-        ).toBe(false);
+        ).toBe(true);
+
     });
 
     test('isLKSSupportEnabled', () => {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -384,9 +384,11 @@ export function isChartBuilderEnabled(moduleContext?: ModuleContext): boolean {
     );
 }
 
-// Should be enabled for LKS Starter, which won't have any product features
+// Should be enabled for LKS Community & LKS Starter, but in the apps only if the feature is enabled
 export function isTransformScriptsEnabled(moduleContext?: ModuleContext): boolean {
-    return isFeatureEnabled(ProductFeature.TransformScripts, moduleContext) || hasPremiumModule(moduleContext);
+    return isApp()
+        ? isFeatureEnabled(ProductFeature.TransformScripts, moduleContext)
+        : true;
 }
 
 export function isRReportsEnabled(moduleContext?: ModuleContext): boolean {


### PR DESCRIPTION
#### Rationale
Transform scripts should be enabled for LKS Community and Starter, but not for LKSM Starter or Professional. The original implementation assumed it should not be enabled for LKS Community.

#### Related Pull Requests
- #1542 
- https://github.com/LabKey/labkey-ui-premium/pull/481
- https://github.com/LabKey/limsModules/pull/522
- https://github.com/LabKey/platform/pull/5725

#### Changes
- Update `isTransformScriptsEnabled` logic
