### PR TITLE
Fix sample timeline event with parent name starting with quotes

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.6.0",
+  "version": "4.6.1-fb-issue50924.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.6.0",
+      "version": "4.6.1-fb-issue50924.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.6.0",
+  "version": "4.6.1-fb-issue50924.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 4.5.X
+*Released*: X August 2024
+- Issue 50924: Sample timeline event details throws error if the parent sample name starts with double quote
+
 ### version 4.6.0
 *Released*: 8 August 2024
 - Issue 50833: Renaming a project doesn't get fully reloaded until page refresh

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -1276,11 +1276,12 @@ describe('parseCsvString', () => {
     test('remove quotes', () => {
         expect(parseCsvString('a,"b","c,d"', ',', true)).toStrictEqual(['a', 'b', 'c,d']);
         expect(parseCsvString(',"b","c,d"', ',', true)).toStrictEqual(['', 'b', 'c,d']);
-        expect(parseCsvString('a,"b","c', ',', true)).toStrictEqual(['a', 'b', 'c']);
+        expect(parseCsvString('a,"b","c', ',', true)).toStrictEqual(['a', 'b', '"c']);
         expect(parseCsvString('a,"b",c"', ',', true)).toStrictEqual(['a', 'b', 'c"']);
         expect(parseCsvString('"b"', ',', true)).toStrictEqual(['b']);
         expect(parseCsvString('a,"b""b2","c,d"', ',', true)).toStrictEqual(['a', 'b"b2', 'c,d']);
         expect(parseCsvString('"b""b2""b3"""', ',', true)).toStrictEqual(['b"b2"b3"']);
+        expect(parseCsvString('"a,123', ',', true)).toStrictEqual(['"a', '123']);
     });
 });
 

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -683,16 +683,21 @@ export function parseCsvString(value: string, delimiter: string, removeQuotes?: 
             while (true) {
                 // find the end of the quoted value
                 end = value.indexOf('"', end + 1);
-                if (end === -1) {
-                    // no ending quote
-                    end = value.length;
+                if (end === -1)
                     break;
-                }
                 if (end === value.length - 1 || value[end + 1] !== '"') {
                     // end quote at end of string or without double quote
                     break;
                 }
                 end++; // skip double ""
+            }
+            // if no ending quote, don't remove quotes;
+            if (end === -1){
+                end = value.indexOf(delimiter, start);
+                if (end === -1) end = value.length;
+                parsedValues.push(value.substring(start, end));
+                start = end + delimiter.length;
+                continue;
             }
             let parsedValue = removeQuotes ? value.substring(start + 1, end) : value.substring(start, end + 1); // start is at the quote
             if (removeQuotes && parsedValue.indexOf('""') !== -1) {


### PR DESCRIPTION
#### Rationale
This issue is revealed after adding a test case to check sample timeline with parent samples containing special characters. When a parent sample name starts with ", (for example "S1), the parseCsvString util returns null for the parsed parent name. This is causing sample timeline page to throw js error. When an ending quotes is not found, the starting quote should be treated a regular character and parsed as such.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1548
- https://github.com/LabKey/platform/pull/5732
- https://github.com/LabKey/testAutomation/pull/2007
- https://github.com/LabKey/limsModules/pull/537

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
