### PR TITLE
Issue 49966: Allow attaching a label to a box created during import

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.6.0",
+  "version": "4.6.1-inventoryImport.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.6.0",
+      "version": "4.6.1-inventoryImport.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.6.1-inventoryImport.0",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.6.1-inventoryImport.0",
+      "version": "4.7.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.6.1-inventoryImport.0",
+  "version": "4.7.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.6.0",
+  "version": "4.6.1-inventoryImport.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 4.6.1
+*Released*: 12 August 2024
 - Issue 49966: Add new `StorageUnitLabel` column as a known column to allow attaching a label to a box created during import
 
 ### version 4.6.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 49966: Add new `StorageUnitLabel` column as a known column to allow attaching a label to a box created during import
+
 ### version 4.6.0
 *Released*: 8 August 2024
 - Issue 50833: Renaming a project doesn't get fully reloaded until page refresh

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 4.6.1
+### version 4.7.0
 *Released*: 12 August 2024
 - Issue 49966: Add new `StorageUnitLabel` column as a known column to allow attaching a label to a box created during import
 

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -180,6 +180,7 @@ export const SAMPLE_STORAGE_COLUMNS = [
     'StorageRow',
     'StorageCol',
     'StorageUnit',
+    'StorageUnitLabel',
     'RawAmount',
     'RawUnits',
     'FreezeThawCount',


### PR DESCRIPTION
#### Rationale
Issue [49966](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49966)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/554

#### Changes
- Update `SAMPLE_STORAGE_COLUMNS` to include new column for labeling a new storage unit
