### PR TITLE
Issue 50657: Use default view when sending request to BarTender from a sample details page

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.1-printLabelsDefaultView.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.1-printLabelsDefaultView.0",
+      "version": "4.7.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0",
+  "version": "4.7.1-printLabelsDefaultView.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.0",
+      "version": "4.7.1-printLabelsDefaultView.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.1-printLabelsDefaultView.0",
+  "version": "4.7.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0",
+  "version": "4.7.1-printLabelsDefaultView.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 50657: Use default view when printing labels from a sample's details page
+
 ### version 4.7.0
 *Released*: 12 August 2024
 - Issue 49966: Add new `StorageUnitLabel` column as a known column to allow attaching a label to a box created during import

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 4.7.1
+*Released*: 13 August 2024
 - Issue 50657: Use default view when printing labels from a sample's details page
 
 ### version 4.7.0


### PR DESCRIPTION
#### Rationale
[Issue 50657: LKSM: BarTender won't recognize Ancestor data from a specific sample's page](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50657)

#### Related Pull Requests

- https://github.com/LabKey/labkey-ui-premium/pull/490
- https://github.com/LabKey/limsModules/pull/564


#### Changes
- Update `PrintLabelsModal` to use the default view if starting with the details view
