### PR TITLE
Calculated fields validation of expression in Field Editor

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.9.0",
+  "version": "4.9.0-fb-calcFieldsValidation.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.9.0",
+      "version": "4.9.0-fb-calcFieldsValidation.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.3",
+  "version": "4.7.3-fb-calcFieldsValidation.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.3",
+      "version": "4.7.3-fb-calcFieldsValidation.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.9.0-fb-calcFieldsValidation.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.9.0-fb-calcFieldsValidation.0",
+      "version": "4.10.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.8.0",
+  "version": "4.8.0-fb-calcFieldsValidation.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.8.0",
+      "version": "4.8.0-fb-calcFieldsValidation.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.2",
+  "version": "4.7.2-fb-calcFieldsValidation.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.2",
+      "version": "4.7.2-fb-calcFieldsValidation.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.2-fb-calcFieldsValidation.0",
+  "version": "4.7.2-fb-calcFieldsValidation.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.2-fb-calcFieldsValidation.0",
+      "version": "4.7.2-fb-calcFieldsValidation.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0-fb-calcFieldsValidation.1",
+  "version": "4.7.0-fb-calcFieldsValidation.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.0-fb-calcFieldsValidation.1",
+      "version": "4.7.0-fb-calcFieldsValidation.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0",
+  "version": "4.7.0-fb-calcFieldsValidation.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.0",
+      "version": "4.7.0-fb-calcFieldsValidation.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0-fb-calcFieldsValidation.2",
+  "version": "4.7.0-fb-calcFieldsValidation.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.0-fb-calcFieldsValidation.2",
+      "version": "4.7.0-fb-calcFieldsValidation.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0-fb-calcFieldsValidation.0",
+  "version": "4.7.0-fb-calcFieldsValidation.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.7.0-fb-calcFieldsValidation.0",
+      "version": "4.7.0-fb-calcFieldsValidation.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0-fb-calcFieldsValidation.1",
+  "version": "4.7.0-fb-calcFieldsValidation.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0",
+  "version": "4.7.0-fb-calcFieldsValidation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0-fb-calcFieldsValidation.2",
+  "version": "4.7.0-fb-calcFieldsValidation.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.2-fb-calcFieldsValidation.0",
+  "version": "4.7.2-fb-calcFieldsValidation.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.8.0",
+  "version": "4.8.0-fb-calcFieldsValidation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.3",
+  "version": "4.7.3-fb-calcFieldsValidation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.0-fb-calcFieldsValidation.0",
+  "version": "4.7.0-fb-calcFieldsValidation.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.9.0-fb-calcFieldsValidation.0",
+  "version": "4.10.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.9.0",
+  "version": "4.9.0-fb-calcFieldsValidation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.7.2",
+  "version": "4.7.2-fb-calcFieldsValidation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,7 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD August 2024
 - Calculated fields validation of value expression
-  - update tooltip text and examples for Expression textaread label
+  - update tooltip text and examples for Expression textarea label
   - validate expression on component mount and on text area blur
   - display validation message or error in textarea footer and set domain row warning state
   - SampleTypeDesigner uniqueId field addition warning modal button change

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   - update tooltip text and examples
   - validate expression on component mount and on text area blur
   - display validation message or error in textarea footer
+  - SampleTypeDesigner uniqueId field addition warning modal button change
 
 ### version 4.7.0
 *Released*: 12 August 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD August 2024
+- Calculated fields validation of value expression
+  - update tooltip text and examples
+  - validate expression on component mount and on text area blur
+  - display validation message or error in textarea footer
+
 ### version 4.7.0
 *Released*: 12 August 2024
 - Issue 49966: Add new `StorageUnitLabel` column as a known column to allow attaching a label to a box created during import

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,9 +4,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD August 2024
 - Calculated fields validation of value expression
-  - update tooltip text and examples
+  - update tooltip text and examples for Expression textaread label
   - validate expression on component mount and on text area blur
-  - display validation message or error in textarea footer
+  - display validation message or error in textarea footer and set domain row warning state
   - SampleTypeDesigner uniqueId field addition warning modal button change
 
 ### version 4.7.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD August 2024
+### version 4.10.0
+*Released*: 20 August 2024
 - Calculated fields validation of value expression
   - update tooltip text and examples for Expression textarea label
   - validate expression on component mount and on text area blur

--- a/packages/components/src/internal/app/utils.test.ts
+++ b/packages/components/src/internal/app/utils.test.ts
@@ -63,6 +63,7 @@ import {
     userCanEditStorageData,
     userCanReadGroupDetails,
     userCanReadUserDetails,
+    isQueryMetadataEditor,
 } from './utils';
 import {
     ASSAYS_KEY,
@@ -947,6 +948,16 @@ describe('utils', () => {
                 core: { 'experimental-calculated-fields': true, productFeatures: [ProductFeature.CalculatedFields] },
             })
         ).toBeTruthy();
+    });
+
+    test('isQueryMetadataEditor', () => {
+        expect(isQueryMetadataEditor()).toBe(false);
+        window.history.pushState({}, 'Test Title', '/query-metadataQuery.view#');
+        expect(isQueryMetadataEditor()).toBe(true);
+        window.history.pushState({}, 'Test Title', '/samplemanager-app.view#');
+        expect(isQueryMetadataEditor()).toBe(false);
+        window.history.pushState({}, 'Test Title', '/core-queryMetadataEditorDev.view#');
+        expect(isQueryMetadataEditor()).toBe(true);
     });
 });
 

--- a/packages/components/src/internal/app/utils.test.ts
+++ b/packages/components/src/internal/app/utils.test.ts
@@ -210,7 +210,12 @@ describe('getMenuSectionConfigs', () => {
                 productId: BIOLOGICS_APP_PROPERTIES.productId,
             },
             core: {
-                productFeatures: [ProductFeature.Workflow, ProductFeature.Assay, ProductFeature.ELN, ProductFeature.BiologicsRegistry],
+                productFeatures: [
+                    ProductFeature.Workflow,
+                    ProductFeature.Assay,
+                    ProductFeature.ELN,
+                    ProductFeature.BiologicsRegistry,
+                ],
             },
         };
 
@@ -278,7 +283,12 @@ describe('getMenuSectionConfigs', () => {
                 [EXPERIMENTAL_REQUESTS_MENU]: true,
             },
             core: {
-                productFeatures: [ProductFeature.Workflow, ProductFeature.Assay, ProductFeature.ELN, ProductFeature.BiologicsRegistry],
+                productFeatures: [
+                    ProductFeature.Workflow,
+                    ProductFeature.Assay,
+                    ProductFeature.ELN,
+                    ProductFeature.BiologicsRegistry,
+                ],
             },
         };
 
@@ -674,13 +684,12 @@ describe('utils', () => {
                 core: { productFeatures: [ProductFeature.TransformScripts] },
             })
         ).toBe(true);
-
     });
 
     test('isLKSSupportEnabled', () => {
         expect(isLKSSupportEnabled({})).toBe(false);
         expect(isLKSSupportEnabled({ inventory: {} })).toBe(false);
-        expect(isLKSSupportEnabled({ api: { moduleNames: ['premium'] }, })).toBe(true);
+        expect(isLKSSupportEnabled({ api: { moduleNames: ['premium'] } })).toBe(true);
         expect(isLKSSupportEnabled({ samplemanagement: {} })).toBe(false);
         expect(
             isLKSSupportEnabled({
@@ -918,10 +927,8 @@ describe('utils', () => {
             BIOLOGICS_APP_PROPERTIES
         );
         LABKEY.container = { folderType: 'LIMS' };
-        expect(getPrimaryAppProperties({ inventory: {}, samplemanagement: {} })).toStrictEqual(
-            LIMS_APP_PROPERTIES
-        );
-        LABKEY.container = { };
+        expect(getPrimaryAppProperties({ inventory: {}, samplemanagement: {} })).toStrictEqual(LIMS_APP_PROPERTIES);
+        LABKEY.container = {};
     });
 
     test('isCalculatedFieldsEnabled', () => {

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -255,7 +255,8 @@ export function isSampleStatusEnabled(moduleContext?: ModuleContext): boolean {
 }
 
 export function isQueryMetadataEditor(): boolean {
-    return ActionURL.getAction()?.toLowerCase().startsWith('querymetadataeditor');
+    const action = ActionURL.getAction()?.toLowerCase() || '';
+    return action === 'metadataquery' || action.startsWith('querymetadataeditor');
 }
 
 export function getCurrentAppProperties(): AppProperties {

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.test.tsx
@@ -99,13 +99,15 @@ describe('CalculatedFieldOptions', () => {
             getColumnTypeMap(
                 List.of(
                     { name: 'b', dataType: { name: 'text' } } as DomainField,
-                    { name: 'c', dataType: { name: 'calculation' } } as DomainField
+                    { name: 'c', dataType: { name: 'calculation' } } as DomainField,
+                    { name: 'd', dataType: { name: 'INT' } } as DomainField
                 ),
                 [{ Name: 'a', DataType: 'integer' } as SystemField]
             )
         ).toEqual({
             a: 'INTEGER',
             b: 'TEXT',
+            d: 'INTEGER',
         });
     });
 });

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.test.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import { act } from 'react-dom/test-utils';
 
+import { List } from 'immutable';
+
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 
-import { CalculatedFieldOptions } from './CalculatedFieldOptions';
-import { DomainField } from './models';
+import { CalculatedFieldOptions, getColumnTypeMap, typeToDisplay } from './CalculatedFieldOptions';
+import { DomainField, SystemField } from './models';
 import { DOMAIN_FIELD_PARTIALLY_LOCKED, INT_RANGE_URI, STRING_RANGE_URI } from './constants';
 
 describe('CalculatedFieldOptions', () => {
@@ -63,5 +65,45 @@ describe('CalculatedFieldOptions', () => {
         expect(document.querySelectorAll('.form-control')).toHaveLength(1);
         expect(document.querySelector('textarea').textContent).toBe('1=0');
         expect(document.querySelector('textarea').getAttribute('disabled')).toBe('');
+    });
+
+    test('typeToDisplay', () => {
+        expect(typeToDisplay(undefined)).toBe('Unknown');
+        expect(typeToDisplay(null)).toBe('Unknown');
+        expect(typeToDisplay('')).toBe('Unknown');
+        expect(typeToDisplay('Other')).toBe('Unknown');
+        expect(typeToDisplay('int')).toBe('Integer');
+        expect(typeToDisplay('Integer')).toBe('Integer');
+        expect(typeToDisplay('double')).toBe('Decimal (floating point)');
+        expect(typeToDisplay('Decimal')).toBe('Decimal (floating point)');
+        expect(typeToDisplay('VARCHAR')).toBe('Text');
+        expect(typeToDisplay('varchar')).toBe('Text');
+        expect(typeToDisplay('Date')).toBe('Date Time');
+        expect(typeToDisplay('Bogus')).toBe('Bogus');
+    });
+
+    test('getColumnTypeMap', () => {
+        expect(getColumnTypeMap(undefined, undefined)).toEqual({});
+        expect(getColumnTypeMap(List.of(), [])).toEqual({});
+        expect(
+            getColumnTypeMap(List.of({ name: 'b', dataType: { name: 'text' } } as DomainField), [
+                { Name: 'a', DataType: 'integer' } as SystemField,
+            ])
+        ).toEqual({
+            a: 'INTEGER',
+            b: 'TEXT',
+        });
+        expect(
+            getColumnTypeMap(
+                List.of(
+                    { name: 'b', dataType: { name: 'text' } } as DomainField,
+                    { name: 'c', dataType: { name: 'calculation' } } as DomainField
+                ),
+                [{ Name: 'a', DataType: 'integer' } as SystemField]
+            )
+        ).toEqual({
+            a: 'INTEGER',
+            b: 'TEXT',
+        });
     });
 });

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { act } from 'react-dom/test-utils';
-
 import { List } from 'immutable';
+
+import { act } from '@testing-library/react';
 
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 
@@ -26,6 +26,7 @@ describe('CalculatedFieldOptions', () => {
         expect(document.querySelector('.domain-field-section-heading').textContent).toBe('Expression');
         expect(document.querySelectorAll('.margin-bottom')).toHaveLength(0);
         expect(document.querySelectorAll('.form-control')).toHaveLength(1);
+        expect(document.querySelectorAll('.domain-field-calc-footer')).toHaveLength(1);
         expect(document.querySelector('textarea').textContent).toBe('');
         expect(document.querySelector('textarea').getAttribute('disabled')).toBe(null);
     });
@@ -45,6 +46,7 @@ describe('CalculatedFieldOptions', () => {
         expect(document.querySelector('.domain-field-section-heading').textContent).toBe('Expression');
         expect(document.querySelectorAll('.margin-bottom')).toHaveLength(1);
         expect(document.querySelectorAll('.form-control')).toHaveLength(1);
+        expect(document.querySelectorAll('.domain-field-calc-footer')).toHaveLength(1);
         expect(document.querySelector('textarea').textContent).toBe('1=0');
         expect(document.querySelector('textarea').getAttribute('disabled')).toBe(null);
     });

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
@@ -15,8 +15,9 @@ import { isFieldFullyLocked, isFieldPartiallyLocked } from './propertiesUtil';
 import { CALCULATED_TYPE, PropDescType } from './PropDescType';
 import { parseCalculatedColumn } from './actions';
 
-const typeToDisplay = (type: string): string => {
-    if (type.toLowerCase() === 'other') {
+// export for jest testing
+export const typeToDisplay = (type: string): string => {
+    if (!type || type.toLowerCase() === 'other') {
         return 'Unknown';
     } else if (type.toLowerCase() === 'int' || type.toLowerCase() === 'integer') {
         return 'Integer';
@@ -30,7 +31,11 @@ const typeToDisplay = (type: string): string => {
     return type;
 };
 
-const getColumnTypeMap = (domainFields: List<DomainField>, systemFields: SystemField[]): Record<string, string> => {
+// export for jest testing
+export const getColumnTypeMap = (
+    domainFields: List<DomainField>,
+    systemFields: SystemField[]
+): Record<string, string> => {
     const colTypeMap = {};
     systemFields?.forEach(df => {
         colTypeMap[df.Name] = df.DataType.toUpperCase();

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
@@ -65,7 +65,7 @@ interface Props {
     field: DomainField;
     getDomainFields: () => { domainFields: List<DomainField>; systemFields: SystemField[] };
     index: number;
-    onChange: (string, any) => void;
+    onChange: (fieldId: string, value: any, index?: number, expand?: boolean, skipDirtyCheck?: boolean) => void;
 }
 
 export const CalculatedFieldOptions: FC<Props> = memo(props => {
@@ -103,9 +103,9 @@ export const CalculatedFieldOptions: FC<Props> = memo(props => {
                         severity: SEVERITY_LEVEL_WARN,
                         rowIndexes: List<number>([index]),
                     });
-                    onChange(warningId, domainFieldWarning);
+                    onChange(warningId, domainFieldWarning, index, false, true);
                 } else {
-                    onChange(warningId, undefined);
+                    onChange(warningId, undefined, index, false, true);
                 }
             } catch (e) {
                 setError(resolveErrorMessage(e) ?? 'Failed to validate expression.');

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
@@ -32,10 +32,10 @@ const typeToDisplay = (type: string): string => {
 
 const getColumnTypeMap = (domainFields: List<DomainField>, systemFields: SystemField[]): Record<string, string> => {
     const colTypeMap = {};
-    systemFields.forEach(df => {
+    systemFields?.forEach(df => {
         colTypeMap[df.Name] = df.DataType.toUpperCase();
     });
-    domainFields.forEach(df => {
+    domainFields?.forEach(df => {
         if (df.dataType.name !== CALCULATED_TYPE.name) {
             colTypeMap[df.name] = df.dataType.name === 'int' ? 'INTEGER' : df.dataType.name.toUpperCase();
         }

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
@@ -1,64 +1,116 @@
-import React, { FC, memo, PureComponent, ReactNode, useCallback } from 'react';
+import React, {FC, memo, useCallback, useEffect, useMemo, useState} from 'react';
 import classNames from 'classnames';
 
-import { HelpLink, LABKEY_SQL_TOPIC } from '../../util/helpLinks';
+import { List } from 'immutable';
+
+import { FIELD_EDITOR_CALC_COLS_TOPIC, HelpLink, LABKEY_SQL_TOPIC } from '../../util/helpLinks';
+
+import { LoadingSpinner } from '../base/LoadingSpinner';
 
 import { createFormInputId, createFormInputName } from './utils';
 import { DOMAIN_FIELD_VALUE_EXPRESSION } from './constants';
-import { DomainField } from './models';
+import {DomainField, SystemField} from './models';
 import { SectionHeading } from './SectionHeading';
 import { isFieldFullyLocked, isFieldPartiallyLocked } from './propertiesUtil';
-import { PropDescType } from './PropDescType';
+import {CALCULATED_TYPE, PropDescType} from './PropDescType';
+import { parseCalculatedColumn } from './actions';
+
+const typeToDisplay = (type: string): string => {
+    if (type.toLowerCase() === 'other') {
+        return 'Unknown';
+    } else if (type.toLowerCase() === 'int' || type.toLowerCase() === 'integer') {
+        return 'Integer';
+    } else if (type.toLowerCase() === 'double' || type.toLowerCase() === 'decimal') {
+        return 'Decimal (floating point)';
+    } else if (type.toLowerCase() === 'varchar') {
+        return 'Text';
+    } else if (type.toLowerCase() === 'date') {
+        return 'Date Time';
+    }
+    return type;
+};
+
+const getColumnTypeMap = (domainFields: List<DomainField>, systemFields: SystemField[]): Record<string, string> => {
+    const colTypeMap = {};
+    systemFields.forEach(df => {
+        colTypeMap[df.Name] = df.DataType.toUpperCase();
+    });
+    domainFields.forEach(df => {
+        if (df.dataType.name !== CALCULATED_TYPE.name) {
+            colTypeMap[df.name] = df.dataType.name === 'int' ? 'INTEGER' : df.dataType.name.toUpperCase();
+        }
+    });
+    return colTypeMap;
+};
 
 const HELP_TIP_BODY = (
-    <>
+    <div className="domain-field-fixed-tooltip">
+        <p>Define the SQL expression to use for this calculated field.</p>
         <p>
-            Define the SQL expression to use for this calculated field. This definition can perform some type of
-            calculation for the given data row.
+            The expression must be valid LabKey SQL and can use the default system fields, custom fields, constants, and
+            operators. Learn more: <HelpLink topic={LABKEY_SQL_TOPIC}>LabKey SQL Reference</HelpLink>
         </p>
-        <p>
-            The expression must be valid LabKey SQL and can use the default system fields, custom fields, and SQL
-            functions as defined in the <HelpLink topic={LABKEY_SQL_TOPIC}>LabKey SQL Reference</HelpLink>{' '}
-            documentation.
-        </p>
-        <p>
-            Examples:
-            <ul>
-                <li>
-                    <code>numericField1 / numericField2 * 100</code>
-                </li>
-                <li>
-                    <code>CURDATE()</code>
-                </li>
-                <li>
-                    <code>TIMESTAMPDIFF( 'SQL_TSI_DAY', CURDATE(), TIMESTAMPADD( 'SQL_TSI_MONTH', 6, dateField))</code>
-                </li>
-                <li>
-                    <code>
-                        CASE WHEN age_in_months(dateField, CURDATE()) &lt;= 6 AND FreezeThawCount &lt; 2 THEN 'Viable'
-                        ELSE 'Questionable' END
-                    </code>
-                </li>
-            </ul>
-        </p>
-    </>
+        Examples:
+        <pre>
+            <p>numericField1 / numericField2 * 100</p>
+            <p>CURDATE()</p>
+            <p>CASE WHEN FreezeThawCount &lt; 2 THEN 'Viable' ELSE 'Questionable' END</p>
+        </pre>
+        <HelpLink topic={FIELD_EDITOR_CALC_COLS_TOPIC}>Click for more examples</HelpLink>
+    </div>
 );
 
 interface Props {
     domainIndex: number;
     field: DomainField;
+    getDomainFields: () => { domainFields: List<DomainField>, systemFields: SystemField[] };
     index: number;
     onChange: (string, any) => void;
 }
 
 export const CalculatedFieldOptions: FC<Props> = memo(props => {
-    const { index, field, domainIndex, onChange } = props;
+    const { index, field, domainIndex, onChange, getDomainFields } = props;
+    const [error, setError] = useState<string>(undefined);
+    const [parsedType, setParsedType] = useState<string>(undefined);
+    const isNew = useMemo(() => field.isNew(), [field]);
 
     const handleChange = useCallback(
         (evt: any): void => {
             onChange(evt.target.id, evt.target.value);
         },
         [onChange]
+    );
+
+    const validateExpression = useCallback(
+        async (value: string): Promise<void> => {
+            setError(undefined);
+            setParsedType(undefined);
+            const { domainFields, systemFields } = getDomainFields();
+            const colTypeMap = getColumnTypeMap(domainFields, systemFields);
+            const response = await parseCalculatedColumn(value, colTypeMap);
+            setError(response.error);
+            setParsedType(response.type);
+        },
+        [getDomainFields]
+    );
+
+    const handleBlur = useCallback(
+        (evt: any): void => {
+            const value = evt.target.value;
+            validateExpression(value);
+        },
+        [validateExpression]
+    );
+
+    useEffect(
+        () => {
+            if (!isNew) {
+                validateExpression(field.valueExpression);
+            }
+        },
+        [
+            /* on mount only */
+        ]
     );
 
     return (
@@ -81,8 +133,14 @@ export const CalculatedFieldOptions: FC<Props> = memo(props => {
                         id={createFormInputId(DOMAIN_FIELD_VALUE_EXPRESSION, domainIndex, index)}
                         name={createFormInputName(DOMAIN_FIELD_VALUE_EXPRESSION)}
                         onChange={handleChange}
+                        onBlur={handleBlur}
                         disabled={isFieldPartiallyLocked(field.lockType) || isFieldFullyLocked(field.lockType)}
                     />
+                    <div className="domain-field-calc-footer">
+                        {error && <div className="error">{error}</div>}
+                        {!error && parsedType && <div className="validated">Validated. Calculated data type is "{typeToDisplay(parsedType)}".</div>}
+                        {!isNew && !error && !parsedType && <LoadingSpinner msg="Validating expression..." />}
+                    </div>
                 </div>
             </div>
         </div>

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
@@ -42,7 +42,7 @@ export const getColumnTypeMap = (
     });
     domainFields?.forEach(df => {
         if (df.dataType.name !== CALCULATED_TYPE.name) {
-            colTypeMap[df.name] = df.dataType.name === 'int' ? 'INTEGER' : df.dataType.name.toUpperCase();
+            colTypeMap[df.name] = df.dataType.name.toLowerCase() === 'int' ? 'INTEGER' : df.dataType.name.toUpperCase();
         }
     });
     return colTypeMap;

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1050,8 +1050,11 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         return !collapsed;
     };
 
-    getDomainFields = (): List<DomainField> => {
-        return this.props.domain.fields;
+    getDomainFields = (): { domainFields: List<DomainField>, systemFields: SystemField[] } => {
+        return {
+            domainFields: this.props.domain.fields,
+            systemFields: this.props.systemFields,
+        };
     };
 
     scrollFunction = (i: number): void => {

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1135,7 +1135,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                 {domain.fields.map((field, i) => {
                                     // use the propertyId in the row key for saved fields (helps with issues 49481 and 50076)
                                     let key = 'domain-row-key-new' + i;
-                                    if (!field.isNew() && !field.isCalculatedField()) {
+                                    if (!field.isNew() && !field.isCalculatedField() && field.propertyId > 0) {
                                         key = 'domain-row-key-prop' + field.propertyId;
                                     }
 

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -596,12 +596,13 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         this.onDomainChange(handleSystemFieldUpdates(domain, field, enable));
     };
 
-    onFieldsChange = (changes: List<IFieldChange>, index: number, expand: boolean): void => {
+    onFieldsChange = (changes: List<IFieldChange>, index: number, expand: boolean, skipDirtyCheck = false): void => {
         const { domain } = this.props;
         const firstChange = changes.get(0);
         const rowSelectedChange = getNameFromId(firstChange?.id) === 'selected';
+        const dirty = skipDirtyCheck ? false : !rowSelectedChange;
 
-        this.onDomainChange(handleDomainUpdates(domain, changes), !rowSelectedChange);
+        this.onDomainChange(handleDomainUpdates(domain, changes), dirty);
 
         if (rowSelectedChange) {
             this.setState(

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -846,7 +846,10 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 confirmClass="btn-danger"
                 confirmText="Yes, Remove Field"
             >
-                <div>Are you sure you want to remove {fieldName}? All of its data will be deleted as well.</div>
+                <div>
+                    Are you sure you want to remove {fieldName}?{' '}
+                    {!field.isCalculatedField() && 'All of its data will be deleted as well.'}
+                </div>
             </Modal>
         );
     }

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -1054,7 +1054,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         return !collapsed;
     };
 
-    getDomainFields = (): { domainFields: List<DomainField>, systemFields: SystemField[] } => {
+    getDomainFields = (): { domainFields: List<DomainField>; systemFields: SystemField[] } => {
         return {
             domainFields: this.props.domain.fields,
             systemFields: this.props.systemFields,

--- a/packages/components/src/internal/components/domainproperties/DomainRow.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.test.tsx
@@ -20,9 +20,11 @@ import { act } from 'react-dom/test-utils';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
+
 import { DomainField, DomainFieldError } from './models';
 import {
-    ATTACHMENT_TYPE, CALCULATED_TYPE,
+    ATTACHMENT_TYPE,
+    CALCULATED_TYPE,
     DATETIME_TYPE,
     DOUBLE_TYPE,
     PARTICIPANT_TYPE,
@@ -45,7 +47,8 @@ import {
     DOMAIN_LAST_ENTERED_DEFAULT,
     DOMAIN_NON_EDITABLE_DEFAULT,
     FIELD_NAME_CHAR_WARNING_INFO,
-    FIELD_NAME_CHAR_WARNING_MSG, INT_RANGE_URI,
+    FIELD_NAME_CHAR_WARNING_MSG,
+    INT_RANGE_URI,
     PHILEVEL_RESTRICTED_PHI,
     SEVERITY_LEVEL_ERROR,
     SEVERITY_LEVEL_WARN,
@@ -85,6 +88,9 @@ describe('DomainRow', () => {
             dragging: false,
             expanded: false,
             field: DomainField.create({}),
+            getDomainFields: () => {
+                return {};
+            },
             helpNoun: 'domain',
             index: 1,
             maxPhiLevel: PHILEVEL_RESTRICTED_PHI,
@@ -119,7 +125,9 @@ describe('DomainRow', () => {
         let container;
         await act(async () => {
             container = renderWithAppContext(
-                wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
+                wrapDraggable(
+                    <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />
+                )
             ).container;
         });
 
@@ -153,7 +161,9 @@ describe('DomainRow', () => {
         let container;
         await act(async () => {
             container = renderWithAppContext(
-                wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
+                wrapDraggable(
+                    <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />
+                )
             ).container;
         });
 
@@ -187,7 +197,9 @@ describe('DomainRow', () => {
         let container;
         await act(async () => {
             container = renderWithAppContext(
-                wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
+                wrapDraggable(
+                    <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />
+                )
             ).container;
         });
 
@@ -221,7 +233,9 @@ describe('DomainRow', () => {
         let container;
         await act(async () => {
             container = renderWithAppContext(
-                wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
+                wrapDraggable(
+                    <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />
+                )
             ).container;
         });
 
@@ -236,10 +250,14 @@ describe('DomainRow', () => {
         expect(req.length).toEqual(1);
 
         // Verify not expanded
-        const expandButton = document.querySelectorAll('#' + createFormInputId(DOMAIN_FIELD_EXPAND, _domainIndex, _index));
+        const expandButton = document.querySelectorAll(
+            '#' + createFormInputId(DOMAIN_FIELD_EXPAND, _domainIndex, _index)
+        );
         expect(expandButton.length).toEqual(1);
 
-        const deleteButton = document.querySelectorAll('#' + createFormInputId(DOMAIN_FIELD_DELETE, _domainIndex, _index));
+        const deleteButton = document.querySelectorAll(
+            '#' + createFormInputId(DOMAIN_FIELD_DELETE, _domainIndex, _index)
+        );
         expect(deleteButton.length).toEqual(1);
 
         const advButton = document.querySelectorAll('#' + createFormInputId(DOMAIN_FIELD_ADV, _domainIndex, _index));
@@ -267,7 +285,13 @@ describe('DomainRow', () => {
         await act(async () => {
             renderWithAppContext(
                 wrapDraggable(
-                    <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} expanded />
+                    <DomainRow
+                        {...getDefaultProps()}
+                        index={_index}
+                        domainIndex={_domainIndex}
+                        field={field}
+                        expanded
+                    />
                 )
             );
         });
@@ -283,10 +307,14 @@ describe('DomainRow', () => {
         expect(req.length).toEqual(1);
 
         // Verify expanded
-        const expandButton = document.querySelectorAll('#' + createFormInputId(DOMAIN_FIELD_EXPAND, _domainIndex, _index));
+        const expandButton = document.querySelectorAll(
+            '#' + createFormInputId(DOMAIN_FIELD_EXPAND, _domainIndex, _index)
+        );
         expect(expandButton.length).toEqual(1);
 
-        const deleteButton = document.querySelectorAll('#' + createFormInputId(DOMAIN_FIELD_DELETE, _domainIndex, _index));
+        const deleteButton = document.querySelectorAll(
+            '#' + createFormInputId(DOMAIN_FIELD_DELETE, _domainIndex, _index)
+        );
         expect(deleteButton.length).toEqual(1);
 
         const advButton = document.querySelectorAll('#' + createFormInputId(DOMAIN_FIELD_ADV, _domainIndex, _index));
@@ -314,7 +342,9 @@ describe('DomainRow', () => {
         let container;
         await act(async () => {
             container = renderWithAppContext(
-                wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
+                wrapDraggable(
+                    <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />
+                )
             ).container;
         });
 
@@ -348,7 +378,9 @@ describe('DomainRow', () => {
         let container;
         await act(async () => {
             container = renderWithAppContext(
-                wrapDraggable(<DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />)
+                wrapDraggable(
+                    <DomainRow {...getDefaultProps()} index={_index} domainIndex={_domainIndex} field={field} />
+                )
             ).container;
         });
 

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -54,7 +54,7 @@ import {
     DomainOnChange,
     IDomainFormDisplayOptions,
     IFieldChange,
-    resolveAvailableTypes,
+    resolveAvailableTypes, SystemField,
 } from './models';
 import { PropDescType } from './PropDescType';
 import { getCheckedValue } from './actions';
@@ -87,7 +87,7 @@ export interface DomainRowProps {
     field: DomainField;
     fieldDetailsInfo?: Record<string, string>;
     fieldError?: DomainFieldError;
-    getDomainFields?: () => List<DomainField>;
+    getDomainFields?: () => { domainFields: List<DomainField>, systemFields: SystemField[] };
     helpNoun: string;
     index: number;
     isDragDisabled?: boolean;

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -54,7 +54,8 @@ import {
     DomainOnChange,
     IDomainFormDisplayOptions,
     IFieldChange,
-    resolveAvailableTypes, SystemField,
+    resolveAvailableTypes,
+    SystemField,
 } from './models';
 import { PropDescType } from './PropDescType';
 import { getCheckedValue } from './actions';
@@ -87,7 +88,7 @@ export interface DomainRowProps {
     field: DomainField;
     fieldDetailsInfo?: Record<string, string>;
     fieldError?: DomainFieldError;
-    getDomainFields?: () => { domainFields: List<DomainField>, systemFields: SystemField[] };
+    getDomainFields?: () => { domainFields: List<DomainField>; systemFields: SystemField[] };
     helpNoun: string;
     index: number;
     isDragDisabled?: boolean;
@@ -208,7 +209,13 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
         this.onSingleFieldChange(evt.target.id, value, index, expand);
     };
 
-    onSingleFieldChange = (id: string, value: any, index?: number, expand?: boolean, skipDirtyCheck?: boolean): void => {
+    onSingleFieldChange = (
+        id: string,
+        value: any,
+        index?: number,
+        expand?: boolean,
+        skipDirtyCheck?: boolean
+    ): void => {
         const changes = List([{ id, value } as IFieldChange]);
         this.props.onChange(changes, index, expand === true, skipDirtyCheck);
     };

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -208,9 +208,9 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
         this.onSingleFieldChange(evt.target.id, value, index, expand);
     };
 
-    onSingleFieldChange = (id: string, value: any, index?: number, expand?: boolean): void => {
+    onSingleFieldChange = (id: string, value: any, index?: number, expand?: boolean, skipDirtyCheck?: boolean): void => {
         const changes = List([{ id, value } as IFieldChange]);
-        this.props.onChange(changes, index, expand === true);
+        this.props.onChange(changes, index, expand === true, skipDirtyCheck);
     };
 
     onMultiFieldChange = (changes: List<IFieldChange>): void => {

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -236,16 +236,13 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
                 value: undefined,
             });
         } else {
-            const fieldName = value;
-            const severity = SEVERITY_LEVEL_WARN;
-            const indexes = List<number>([index]);
             const domainFieldError = new DomainFieldError({
                 message: FIELD_NAME_CHAR_WARNING_MSG,
                 extraInfo: FIELD_NAME_CHAR_WARNING_INFO,
-                fieldName,
+                fieldName: value,
                 propertyId: undefined,
-                severity,
-                rowIndexes: indexes,
+                severity: SEVERITY_LEVEL_WARN,
+                rowIndexes: List<number>([index]),
             });
 
             // set value for field error

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -19,7 +19,7 @@ import { List } from 'immutable';
 
 import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
 
-import {DomainField, IDomainFormDisplayOptions, IFieldChange, SystemField} from './models';
+import { DomainField, IDomainFormDisplayOptions, IFieldChange, SystemField } from './models';
 import { NameAndLinkingOptions } from './NameAndLinkingOptions';
 import { TextFieldOptions } from './TextFieldOptions';
 import { BooleanFieldOptions } from './BooleanFieldOptions';
@@ -33,7 +33,7 @@ import { DerivationDataScopeFieldOptions } from './DerivationDataScopeFieldOptio
 import { TextChoiceOptions } from './TextChoiceOptions';
 import { FileAttachmentOptions } from './FileAttachmentOptions';
 import { CalculatedFieldOptions } from './CalculatedFieldOptions';
-import {CALCULATED_TYPE} from "./PropDescType";
+import { CALCULATED_TYPE } from './PropDescType';
 
 interface Props {
     appPropertiesOnly?: boolean;
@@ -41,7 +41,7 @@ interface Props {
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
     domainIndex: number;
     field: DomainField;
-    getDomainFields?: () => { domainFields: List<DomainField>, systemFields: SystemField[] };
+    getDomainFields?: () => { domainFields: List<DomainField>; systemFields: SystemField[] };
     index: number;
     onChange: (fieldId: string, value: any, index?: number, expand?: boolean, skipDirtyCheck?: boolean) => void;
     onMultiChange: (changes: List<IFieldChange>) => void;
@@ -260,8 +260,16 @@ export class DomainRowExpandedOptions extends React.Component<Props> {
     };
 
     render() {
-        const { field, index, onChange, showingModal, appPropertiesOnly, domainIndex, domainFormDisplayOptions, getDomainFields } =
-            this.props;
+        const {
+            field,
+            index,
+            onChange,
+            showingModal,
+            appPropertiesOnly,
+            domainIndex,
+            domainFormDisplayOptions,
+            getDomainFields,
+        } = this.props;
 
         return (
             <div className="domain-row-container">

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -43,7 +43,7 @@ interface Props {
     field: DomainField;
     getDomainFields?: () => { domainFields: List<DomainField>, systemFields: SystemField[] };
     index: number;
-    onChange: (fieldId: string, value: any, index?: number, expand?: boolean) => void;
+    onChange: (fieldId: string, value: any, index?: number, expand?: boolean, skipDirtyCheck?: boolean) => void;
     onMultiChange: (changes: List<IFieldChange>) => void;
     queryName?: string;
     schemaName?: string;

--- a/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRowExpandedOptions.tsx
@@ -19,7 +19,7 @@ import { List } from 'immutable';
 
 import { OntologyLookupOptions } from '../ontology/OntologyLookupOptions';
 
-import { DomainField, IDomainFormDisplayOptions, IFieldChange } from './models';
+import {DomainField, IDomainFormDisplayOptions, IFieldChange, SystemField} from './models';
 import { NameAndLinkingOptions } from './NameAndLinkingOptions';
 import { TextFieldOptions } from './TextFieldOptions';
 import { BooleanFieldOptions } from './BooleanFieldOptions';
@@ -33,6 +33,7 @@ import { DerivationDataScopeFieldOptions } from './DerivationDataScopeFieldOptio
 import { TextChoiceOptions } from './TextChoiceOptions';
 import { FileAttachmentOptions } from './FileAttachmentOptions';
 import { CalculatedFieldOptions } from './CalculatedFieldOptions';
+import {CALCULATED_TYPE} from "./PropDescType";
 
 interface Props {
     appPropertiesOnly?: boolean;
@@ -40,7 +41,7 @@ interface Props {
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
     domainIndex: number;
     field: DomainField;
-    getDomainFields?: () => List<DomainField>;
+    getDomainFields?: () => { domainFields: List<DomainField>, systemFields: SystemField[] };
     index: number;
     onChange: (fieldId: string, value: any, index?: number, expand?: boolean) => void;
     onMultiChange: (changes: List<IFieldChange>) => void;
@@ -68,7 +69,7 @@ export class DomainRowExpandedOptions extends React.Component<Props> {
         // In most cases we will use the selected data type to determine which field options to show,
         // however in the calculated field data type case, we need to use the rangeURI.
         let dataTypeName = field.dataType.name;
-        if (dataTypeName === 'calculation' && field?.rangeURI) {
+        if (dataTypeName === CALCULATED_TYPE.name && field?.rangeURI) {
             dataTypeName = field?.rangeURI.substring(field?.rangeURI.lastIndexOf('#') + 1);
         }
 
@@ -205,7 +206,7 @@ export class DomainRowExpandedOptions extends React.Component<Props> {
                     />
                 );
             case 'ontologyLookup':
-                const domainFields = getDomainFields ? getDomainFields() : List<DomainField>();
+                const domainFields = getDomainFields ? getDomainFields().domainFields : List<DomainField>();
 
                 return (
                     <OntologyLookupOptions
@@ -259,7 +260,7 @@ export class DomainRowExpandedOptions extends React.Component<Props> {
     };
 
     render() {
-        const { field, index, onChange, showingModal, appPropertiesOnly, domainIndex, domainFormDisplayOptions } =
+        const { field, index, onChange, showingModal, appPropertiesOnly, domainIndex, domainFormDisplayOptions, getDomainFields } =
             this.props;
 
         return (
@@ -287,6 +288,7 @@ export class DomainRowExpandedOptions extends React.Component<Props> {
                             <CalculatedFieldOptions
                                 domainIndex={domainIndex}
                                 field={field}
+                                getDomainFields={getDomainFields}
                                 index={index}
                                 onChange={onChange}
                             />

--- a/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/__snapshots__/DomainRow.test.tsx.snap
@@ -222,6 +222,15 @@ exports[`DomainRow Calculated Field 1`] = `
                         name="domainpropertiesrow-valueExpression"
                         rows="4"
                       />
+                      <div
+                        class="domain-field-calc-footer"
+                      >
+                        <div
+                          class="error"
+                        >
+                          Error: an expression value is required.
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -41,6 +41,8 @@ import { getQueryDetails } from '../../query/api';
 
 import { selectRows } from '../../query/selectRows';
 
+import { resolveErrorMessage } from '../../util/messaging';
+
 import {
     DOMAIN_ERROR_ID,
     DOMAIN_FIELD_CLIENT_SIDE_ERROR,
@@ -97,7 +99,6 @@ import {
 } from './models';
 import { createFormInputId, createFormInputName, getIndexFromId, getNameFromId } from './utils';
 import { DomainPropertiesAPIWrapper } from './APIWrapper';
-import {resolveErrorMessage} from "../../util/messaging";
 
 let sharedCache = Map<string, Promise<any>>();
 

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -97,6 +97,7 @@ import {
 } from './models';
 import { createFormInputId, createFormInputName, getIndexFromId, getNameFromId } from './utils';
 import { DomainPropertiesAPIWrapper } from './APIWrapper';
+import {resolveErrorMessage} from "../../util/messaging";
 
 let sharedCache = Map<string, Promise<any>>();
 
@@ -362,6 +363,36 @@ export function getMaxPhiLevel(containerPath?: string): Promise<string> {
                 resolve(response.maxPhiLevel);
             }),
             failure: handleRequestFailure(reject),
+        });
+    });
+}
+
+export function parseCalculatedColumn(
+    expression: string,
+    columnMap: Record<string, string>,
+    containerPath?: string
+): Promise<{ error: string; type: string }> {
+    return new Promise((resolve, reject) => {
+        if (!expression || expression?.trim()?.length === 0) {
+            resolve({ error: 'Error: an expression value is required.', type: undefined });
+            return;
+        }
+
+        Ajax.request({
+            url: buildURL('query', 'parseCalculatedColumn.api', undefined, { container: containerPath }),
+            jsonData: {
+                expression,
+                columnMap,
+            },
+            success: Utils.getCallbackWrapper(response => {
+                const type = response.jdbcType;
+                const error = response.errors?.[0].msg;
+                resolve({ error, type });
+            }),
+            failure: Utils.getCallbackWrapper(response => {
+                console.error(response);
+                reject(resolveErrorMessage(response));
+            }),
         });
     });
 }

--- a/packages/components/src/internal/components/domainproperties/models.test.ts
+++ b/packages/components/src/internal/components/domainproperties/models.test.ts
@@ -832,6 +832,20 @@ describe('DomainField', () => {
         expect(f2.isSaved()).toBeFalsy();
         const f3 = DomainField.create({ name: 'foo', rangeURI: TEXT_TYPE.rangeURI, propertyId: 1 });
         expect(f3.isSaved()).toBeTruthy();
+        const f4 = DomainField.create({
+            name: 'foo',
+            conceptURI: CALCULATED_CONCEPT_URI,
+            rangeURI: undefined,
+            propertyId: 0,
+        });
+        expect(f4.isSaved()).toBeFalsy();
+        const f5 = DomainField.create({
+            name: 'foo',
+            conceptURI: CALCULATED_CONCEPT_URI,
+            rangeURI: TEXT_TYPE.rangeURI,
+            propertyId: 0,
+        });
+        expect(f5.isSaved()).toBeTruthy();
     });
 
     test('isPHI', () => {
@@ -940,6 +954,24 @@ describe('DomainField', () => {
                 rangeURI: STRING_RANGE_URI,
                 conceptURI: CONCEPT_CODE_CONCEPT_URI,
                 sourceOntology: 'test1',
+            }).getErrors()
+        ).toBe(FieldErrors.NONE);
+
+        expect(
+            DomainField.create({
+                name: 'test',
+                rangeURI: STRING_RANGE_URI,
+                conceptURI: CALCULATED_CONCEPT_URI,
+                valueExpression: '  ',
+            }).getErrors()
+        ).toBe(FieldErrors.MISSING_CALCULATION_EXPRESSION);
+
+        expect(
+            DomainField.create({
+                name: 'test',
+                rangeURI: STRING_RANGE_URI,
+                conceptURI: CALCULATED_CONCEPT_URI,
+                valueExpression: ' 1+1 ',
             }).getErrors()
         ).toBe(FieldErrors.NONE);
     });

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -104,7 +104,7 @@ export interface IFieldChange {
     value: any;
 }
 
-export type DomainOnChange = (changes: List<IFieldChange>, index?: number, expand?: boolean) => void;
+export type DomainOnChange = (changes: List<IFieldChange>, index?: number, expand?: boolean, skipDirtyCheck?: boolean) => void;
 
 export interface IBannerMessage {
     message: string;

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1475,7 +1475,9 @@ function isFieldNew(field: Partial<IDomainField>): boolean {
 }
 
 function isFieldSaved(field: Partial<IDomainField>): boolean {
-    return !isFieldNew(field) && field.propertyId !== 0;
+    // calculated fields that are saved will have a rangeURI
+    const isSavedCalcField = field.conceptURI === CALCULATED_CONCEPT_URI && field.rangeURI !== undefined;
+    return !isFieldNew(field) && (field.propertyId !== 0 || isSavedCalcField);
 }
 
 export function resolveAvailableTypes(

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -104,7 +104,12 @@ export interface IFieldChange {
     value: any;
 }
 
-export type DomainOnChange = (changes: List<IFieldChange>, index?: number, expand?: boolean, skipDirtyCheck?: boolean) => void;
+export type DomainOnChange = (
+    changes: List<IFieldChange>,
+    index?: number,
+    expand?: boolean,
+    skipDirtyCheck?: boolean
+) => void;
 
 export interface IBannerMessage {
     message: string;

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -587,6 +587,7 @@ export class DomainIndex
 export enum FieldErrors {
     ALIQUOT_ONLY_REQUIRED = "Fields that are 'Editable for aliquots only' cannot be 'Required'.",
     INVALID_LOOKUP = 'Lookup target table does not exist.',
+    MISSING_CALCULATION_EXPRESSION = 'Please provide an expression value for each calculated field.',
     MISSING_DATA_TYPE = 'Please provide a data type for each field.',
     MISSING_FIELD_NAME = 'Please provide a name for each field.',
     MISSING_ONTOLOGY_PROPERTIES = 'Missing required ontology source or label field property.',
@@ -1209,6 +1210,10 @@ export class DomainField
         // Issue 46733: Editable for aliquots only/Required Field: Adding Samples gives error
         if (this.derivationDataScope === DERIVATION_DATA_SCOPES.CHILD_ONLY && this.required) {
             return FieldErrors.ALIQUOT_ONLY_REQUIRED;
+        }
+
+        if (this.isCalculatedField() && (!this.valueExpression || this.valueExpression.trim().length === 0)) {
+            return FieldErrors.MISSING_CALCULATION_EXPRESSION;
         }
 
         return FieldErrors.NONE;

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -183,10 +183,10 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                 'sampleset-parent-import-alias-',
                 this.formatLabel
             );
-            this.setState({
-                model: model.merge({ parentAliases }) as SampleTypeModel,
+            this.setState(state => ({
+                model: state.model.merge({ parentAliases }) as SampleTypeModel,
                 parentOptions,
-            });
+            }));
         } catch (error) {
             setSubmitting(false, () => {
                 this.setState({ error: resolveErrorMessage(error) });
@@ -302,7 +302,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
     };
 
     onUniqueIdConfirm = (): void => {
-        this.setState({ uniqueIdsConfirmed: true }, this.onFinish);
+        this.setState({ showUniqueIdConfirmation: false, uniqueIdsConfirmed: true }, this.onFinish);
     };
 
     onNameExpressionWarningCancel = (): void => {
@@ -766,10 +766,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                         }
                         onCancel={this.onUniqueIdCancel}
                         onConfirm={this.onUniqueIdConfirm}
-                        confirmText={
-                            submitting ? 'Finishing ...' : 'Finish Updating ' + SampleTypeDataType.typeNounSingular
-                        }
-                        isConfirming={submitting}
+                        confirmText="Continue"
                     >
                         {confirmModalMessage}
                     </Modal>

--- a/packages/components/src/internal/util/helpLinks.tsx
+++ b/packages/components/src/internal/util/helpLinks.tsx
@@ -12,6 +12,7 @@ export const PROPERTY_FIELDS_TOPIC = 'propertyFields';
 export const FIELD_EDITOR_TOPIC = 'fieldEditor';
 export const ADVANCED_FIELD_EDITOR_TOPIC = FIELD_EDITOR_TOPIC + '#advanced';
 export const FIELD_EDITOR_SAMPLE_TYPES_TOPIC = PROPERTY_FIELDS_TOPIC + '#samp';
+export const FIELD_EDITOR_CALC_COLS_TOPIC = PROPERTY_FIELDS_TOPIC + '#calc';
 export const DATE_FORMATS_TOPIC = 'dateFormats#date';
 export const NUMBER_FORMATS_TOPIC = 'dateFormats#number';
 export const ONTOLOGY_LOOKUP_TOPIC = 'ontologyLookup';

--- a/packages/components/src/theme/domainproperties.scss
+++ b/packages/components/src/theme/domainproperties.scss
@@ -900,3 +900,18 @@
     display: inline-block;
     padding-right: 10px;
 }
+
+.domain-field-fixed-tooltip {
+    width: 575px;
+}
+.lk-popover:has( .domain-field-fixed-tooltip) {
+    max-width: 600px;
+}
+
+.domain-field-calc-footer div,
+.domain-field-calc-footer span {
+    font-size: 12px;
+}
+.domain-field-calc-footer .error {
+    color: $brand-danger;
+}


### PR DESCRIPTION
#### Rationale
Previous PRs added calculated fields to the field editor for supported data types. This PR adds validation of the expression value to warn user about invalid syntax, etc. It also shows query warnings in the schema browser.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1532
- https://github.com/LabKey/labkey-ui-components/pull/1552
- https://github.com/LabKey/labkey-ui-premium/pull/493
- https://github.com/LabKey/platform/pull/5777
- https://github.com/LabKey/limsModules/pull/581
- https://github.com/LabKey/premiumModules/pull/31

#### Changes
- update tooltip text and examples for Expression textarea label
- validate expression on component mount and on text area blur
- display validation message or error in textarea footer and set domain row warning state
- SampleTypeDesigner uniqueId field addition warning modal button change
- fix query metadata editor for calc fields and wrapped fields
