### PR TITLE
Fix Issue 50700

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "4.15.0",
+      "version": "4.15.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@labkey/api": "1.35.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1481,7 +1481,7 @@ function getCellCopyValue(valueDescriptors: List<ValueDescriptor>): string {
     return value;
 }
 
-function getCopyValue(model: EditorModel): string {
+function getCopyValue(model: EditorModel, hideReadOnlyRows: boolean, readonlyRows: string[]): string {
     let copyValue = '';
     const EOL = '\n';
     const selectionCells = [...model.selectionCells];
@@ -1491,6 +1491,11 @@ function getCopyValue(model: EditorModel): string {
     for (let rn = 0; rn < model.rowCount; rn++) {
         let cellSep = '';
         let inSelection = false;
+
+        // Do not include hidden rows in copy values
+        if (hideReadOnlyRows && readonlyRows) {
+            if (model.isReadOnlyRow(rn, readonlyRows)) continue;
+        }
 
         model.orderedColumns.forEach(fieldKey => {
             const cellKey = genCellKey(fieldKey, rn);
@@ -1514,10 +1519,10 @@ function getCopyValue(model: EditorModel): string {
     return copyValue;
 }
 
-export function copyEvent(editorModel: EditorModel, event: any): boolean {
+export function copyEvent(editorModel: EditorModel, event: any, hideReadOnlyRows: boolean, readonlyRows: string[]): boolean {
     if (editorModel && !editorModel.hasFocus && editorModel.hasSelection && !editorModel.isSparseSelection) {
         cancelEvent(event);
-        setCopyValue(event, getCopyValue(editorModel));
+        setCopyValue(event, getCopyValue(editorModel, hideReadOnlyRows, readonlyRows));
         return true;
     }
 

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -225,7 +225,9 @@ export class EditorModel
         startCol: number,
         startRow: number,
         predicate: (value: List<ValueDescriptor>, colIdx: number, rowIdx: number) => boolean,
-        advance: (colIdx: number, rowIdx: number) => CellCoordinates // TODO: make advance take fieldKey
+        advance: (colIdx: number, rowIdx: number) => CellCoordinates, // TODO: make advance take fieldKey
+        hideReadonlyRows: boolean,
+        readonlyRows: string[]
     ): { colIdx: number; rowIdx: number; value: List<ValueDescriptor> } {
         let colIdx = startCol,
             rowIdx = startRow;
@@ -233,6 +235,8 @@ export class EditorModel
         while (true) {
             ({ colIdx, rowIdx } = advance(colIdx, rowIdx));
             if (!this.isInBounds(colIdx, rowIdx)) break;
+
+            if (hideReadonlyRows && readonlyRows && this.isReadOnlyRow(rowIdx, readonlyRows)) continue;
 
             const fieldKey = this.getFieldKeyByIndex(colIdx);
             const value = this.getValue(fieldKey, rowIdx);


### PR DESCRIPTION
#### Rationale
This PR fixes [Issue 50700](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50700) by taking in to account hidden/readonly rows during certain actions such as cut, copy, and cell selection via keyboard

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1571
- https://github.com/LabKey/limsModules/pull/666

#### Changes
- Account for readonlyRows and hideReadonlyRows when performing EditableGrid actions
