### PR TITLE
renderWithAppContext: Use generics

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.3.1",
+      "version": "5.4.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/src/internal/test/reactTestLibraryHelpers.tsx
+++ b/packages/components/src/internal/test/reactTestLibraryHelpers.tsx
@@ -11,14 +11,14 @@ import { AppContextTestProvider, AppContextTestProviderProps } from './testHelpe
  * @param contexts The contexts to be provided to the underlying React Context providers.
  * @param options Additional `RenderOptions` to supply to the `render()` method.
  */
-export const renderWithAppContext = (
+export function renderWithAppContext<A>(
     node: ReactElement,
-    contexts?: AppContextTestProviderProps,
+    contexts?: AppContextTestProviderProps<A>,
     options?: Omit<RenderOptions, 'wrapper'>
-): RenderResult => {
+): RenderResult {
     // https://github.com/testing-library/react-testing-library/issues/780
     return render(node, {
         wrapper: _props => <AppContextTestProvider {..._props} {...(contexts as AppContextTestProviderProps)} />,
         ...options,
     });
-};
+}


### PR DESCRIPTION
#### Rationale
Some of our tests rely on extended versions of our AppContext (e.g. ELN unit tests rely on ELNAppContext), this PR updates renderWithAppContext to allow consumers to specify what AppContext they'll be using.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1577
- https://github.com/LabKey/labkey-ui-premium/pull/529
 
#### Changes
- renderWithAppContext: Use generics so consumers can set custom AppContext types