### PR TITLE
Add back calculated fields experimental feature flag

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.2-fb-calcFields2410ExpFlag.0",
+  "version": "5.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.2-fb-calcFields2410ExpFlag.0",
+      "version": "5.5.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.2",
+  "version": "5.5.2-fb-calcFields2410ExpFlag.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.2",
+      "version": "5.5.2-fb-calcFields2410ExpFlag.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.2",
+  "version": "5.5.2-fb-calcFields2410ExpFlag.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.2-fb-calcFields2410ExpFlag.0",
+  "version": "5.5.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD September 2024
+- Add back calculated fields experimental feature flag
+
 ### version 5.5.2
 *Released*: 16 September 2024
 - Calculated fields issue fixes for 24.10

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD September 2024
+### version 5.5.3
+*Released*: 17 September 2024
 - Add back calculated fields experimental feature flag
 
 ### version 5.5.2

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -116,6 +116,7 @@ export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu'
 export const EXPERIMENTAL_CHART_BUILDER = 'experimental-biologics-chart-builder';
 export const EXPERIMENTAL_IDENTIFYING_FIELDS = 'experimental-identifying-fields';
 export const EXPERIMENTAL_SAMPLE_ALIQUOT_SELECTOR = 'experimental-sample-aliquot-selector';
+export const EXPERIMENTAL_CALCULATED_FIELDS = 'experimental-calculated-fields';
 
 export const PROJECT_DATA_TYPE_EXCLUSIONS = 'dataTypeExclusions';
 

--- a/packages/components/src/internal/app/utils.test.ts
+++ b/packages/components/src/internal/app/utils.test.ts
@@ -967,18 +967,26 @@ describe('utils', () => {
 
     test('isCalculatedFieldsEnabled', () => {
         expect(isCalculatedFieldsEnabled()).toBeFalsy();
-        expect(isCalculatedFieldsEnabled({ api: { moduleNames: [] } })).toBeFalsy(); // community
+        expect(isCalculatedFieldsEnabled({ core: { 'experimental-calculated-fields': false } })).toBeFalsy();
+        expect(isCalculatedFieldsEnabled({ core: { 'experimental-calculated-fields': true } })).toBeFalsy();
+        expect(
+            isCalculatedFieldsEnabled({ core: { 'experimental-calculated-fields': true }, api: { moduleNames: [] } })
+        ).toBeFalsy(); // community
         expect(
             isCalculatedFieldsEnabled({
+                core: { 'experimental-calculated-fields': true },
                 api: { moduleNames: ['premium'] },
             })
         ).toBeTruthy(); // LKS Prof
 
         window.history.pushState({}, 'Test Title', '/samplemanager-app.view#'); // isApp()
-        expect(isCalculatedFieldsEnabled({ core: { productFeatures: [] } })).toBeFalsy();
+        expect(isCalculatedFieldsEnabled({ core: { 'experimental-calculated-fields': true } })).toBeFalsy();
+        expect(
+            isCalculatedFieldsEnabled({ core: { 'experimental-calculated-fields': true, productFeatures: [] } })
+        ).toBeFalsy();
         expect(
             isCalculatedFieldsEnabled({
-                core: { productFeatures: [ProductFeature.CalculatedFields] },
+                core: { 'experimental-calculated-fields': true, productFeatures: [ProductFeature.CalculatedFields] },
             })
         ).toBeTruthy();
     });

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -21,6 +21,7 @@ import {
     ASSAYS_KEY,
     BIOLOGICS_APP_PROPERTIES,
     EXPERIMENTAL_APP_PLATE_SUPPORT,
+    EXPERIMENTAL_CALCULATED_FIELDS,
     EXPERIMENTAL_CHART_BUILDER,
     EXPERIMENTAL_IDENTIFYING_FIELDS,
     EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS,
@@ -457,6 +458,10 @@ export function isDataChangeCommentRequirementFeatureEnabled(moduleContext?: Mod
 }
 
 export function isCalculatedFieldsEnabled(moduleContext?: ModuleContext): boolean {
+    if (resolveModuleContext(moduleContext)?.core?.[EXPERIMENTAL_CALCULATED_FIELDS] !== true) {
+        return false;
+    }
+
     return isApp()
         ? isFeatureEnabled(ProductFeature.CalculatedFields, moduleContext)
         : !isCommunityDistribution(moduleContext);

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -145,13 +145,11 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
 
     getDetails = (): ReactNode => {
         const { field, fieldDetailsInfo, fieldError, index, expanded, domainIndex } = this.props;
-        // eslint-disable-next-line no-warning-comments
-        // FIXME: Pushing these ReactNodes (of which many are strings) into an array requires that each be marked with a "key" prop.
         const details = field.getDetailsArray(fieldDetailsInfo);
 
         if (fieldError) {
             details.push(details.length > 0 ? '. ' : '');
-            details.push(<DomainRowWarning fieldError={fieldError} />);
+            details.push(<DomainRowWarning key="domain-row-field-error" fieldError={fieldError} />);
         }
 
         return (

--- a/packages/components/src/internal/components/domainproperties/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.test.ts
@@ -348,6 +348,7 @@ describe('domain properties actions', () => {
 
     test('getAvailableTypes, all optional allowed', () => {
         LABKEY.moduleContext = { ...TEST_LKS_STARTER_MODULE_CONTEXT };
+        LABKEY.moduleContext.core['experimental-calculated-fields'] = true;
         const domain = DomainDesign.create({
             allowFlagProperties: true,
             allowFileLinkProperties: true,
@@ -375,6 +376,7 @@ describe('domain properties actions', () => {
 
     test('getAvailableTypes, no optional allowed', () => {
         LABKEY.moduleContext = { ...TEST_LKS_STARTER_MODULE_CONTEXT };
+        LABKEY.moduleContext.core['experimental-calculated-fields'] = true;
         const domain = DomainDesign.create({
             allowFlagProperties: false,
             allowFileLinkProperties: false,
@@ -403,6 +405,7 @@ describe('domain properties actions', () => {
     test('getAvailableTypes calculated fields, LKSM Starter', () => {
         window.history.pushState({}, 'Test Title', '/samplemanager-app.view#');
         LABKEY.moduleContext = { ...TEST_LKSM_STARTER_MODULE_CONTEXT };
+        LABKEY.moduleContext.core['experimental-calculated-fields'] = true;
         const domain = DomainDesign.create({
             allowCalculatedFields: true,
         });
@@ -413,6 +416,7 @@ describe('domain properties actions', () => {
     test('getAvailableTypes calculated fields, LKSM Professional', () => {
         window.history.pushState({}, 'Test Title', '/samplemanager-app.view#');
         LABKEY.moduleContext = { ...TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT };
+        LABKEY.moduleContext.core['experimental-calculated-fields'] = true;
         const domain = DomainDesign.create({
             allowCalculatedFields: true,
         });
@@ -460,6 +464,7 @@ describe('domain properties actions', () => {
 
     test('getAvailableTypes, sampleType Premium', () => {
         LABKEY.moduleContext.api = { moduleNames: ['premium'] };
+        LABKEY.moduleContext.core = { 'experimental-calculated-fields': true };
         const domain = DomainDesign.create({
             domainKindName: Domain.KINDS.SAMPLE_TYPE,
             allowCalculatedFields: true,
@@ -471,6 +476,7 @@ describe('domain properties actions', () => {
 
     test('getAvailableTypes, sampleType community', () => {
         LABKEY.moduleContext.api = { moduleNames: ['api', 'core'] };
+        LABKEY.moduleContext.core = { 'experimental-calculated-fields': true };
         const domain = DomainDesign.create({
             domainKindName: Domain.KINDS.SAMPLE_TYPE,
             allowCalculatedFields: true,

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1363,7 +1363,7 @@ export class DomainField
                         message: FIELD_EMPTY_TEXT_CHOICE_WARNING_MSG,
                         severity: SEVERITY_LEVEL_WARN,
                     });
-                    details.push(<DomainRowWarning fieldError={fieldError} />);
+                    details.push(<DomainRowWarning key="domain-row-text-choice-error" fieldError={fieldError} />);
                 }
             }
             period = '. ';


### PR DESCRIPTION
#### Rationale
We'd like to do a little better job of error handling in the app for invalid calc field expressions before we fully enable this feature. This PR puts back the optional feature flag.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1580
- https://github.com/LabKey/labkey-ui-premium/pull/533
- https://github.com/LabKey/limsModules/pull/714
- https://github.com/LabKey/platform/pull/5860
- https://github.com/LabKey/testAutomation/pull/2052

#### Changes
- Add back calculated fields experimental feature flag and related test fixes
