### PR TITLE
Issue 50998: Add container filter when getting samples from a transaction id

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-crossFolderTransactionGrid.0",
+  "version": "5.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.6-crossFolderTransactionGrid.0",
+      "version": "5.5.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.2",
+  "version": "5.5.3-crossFolderTransactionGrid.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.2",
+      "version": "5.5.3-crossFolderTransactionGrid.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-crossFolderTransactionGrid.0",
+  "version": "5.5.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.2",
+  "version": "5.5.3-crossFolderTransactionGrid.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 5.5.6
+*Released*: 18 September 2024
 - Issue 50998: Add container filter when getting samples from a particular transaction id
 
 ### version 5.5.5

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 50998: Add container filter when getting samples from a particular transaction id
+
 ### version 5.5.2
 *Released*: 16 September 2024
 - Calculated fields issue fixes for 24.10

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -22,7 +22,13 @@ import { Actions } from '../public/QueryModel/withQueryModels';
 
 import { GridResponse } from './components/editable/models';
 
-import { getContainerFilter, invalidateQueryDetailsCache, selectDistinctRows, selectRowsDeprecated } from './query/api';
+import {
+    getContainerFilter,
+    getContainerFilterForFolder,
+    invalidateQueryDetailsCache,
+    selectDistinctRows,
+    selectRowsDeprecated
+} from './query/api';
 import {
     BARTENDER_EXPORT_CONTROLLER,
     EXPORT_TYPES,
@@ -68,16 +74,19 @@ export function selectAll(
     });
 }
 
-export function getGridIdsFromTransactionId(transactionAuditId: number | string, dataType: string): Promise<string[]> {
+export function getGridIdsFromTransactionId(
+    transactionAuditId: number | string,
+    dataType: string,
+    containerPath?: string,
+): Promise<string[]> {
     if (!transactionAuditId) {
         return;
     }
     const failureMsg = 'There was a problem retrieving the ' + dataType + ' from the last action.';
-
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('audit', 'getTransactionRowIds.api'),
-            params: { transactionAuditId, dataType },
+            params: { transactionAuditId, dataType, containerFilter: getContainerFilterForFolder(containerPath) },
             success: Utils.getCallbackWrapper(response => {
                 if (response.success) {
                     resolve(response.rowIds);

--- a/packages/components/src/internal/components/productnavigation/utils.ts
+++ b/packages/components/src/internal/components/productnavigation/utils.ts
@@ -1,5 +1,5 @@
 import { User } from '../base/models/User';
-import { hasPremiumModule, isBiologicsEnabled, isLKSSupportEnabled, resolveModuleContext } from '../../app/utils';
+import { isLKSSupportEnabled, resolveModuleContext } from '../../app/utils';
 import { ModuleContext } from '../base/ServerContext';
 
 /**


### PR DESCRIPTION
#### Rationale
Issue [50998](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50998)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5863
- https://github.com/LabKey/labkey-ui-premium/pull/535
- https://github.com/LabKey/limsModules/pull/717

#### Changes
- Update `getGridIdsFromTransactionId` to take optional `containerPath` and send a container filter to server action
