### PR TITLE
Fix issue 51265

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.7",
+      "version": "5.5.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 5.?.?
+### version 5.5.8
 *Released*: 18 September 2024
 - Fix Issue 51265
     - We now more consistently trim values and use getValidatedEditableGridValue

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.?.?
+*Released*: 18 September 2024
+- Fix Issue 51265
+    - We now more consistently trim values and use getValidatedEditableGridValue
+
 ### version 5.5.7
 *Released*: 20 September 2024
 - Issue 50389: Casing of aliased (parent) sample or source type name can be changed in the editable grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 18 September 2024
 - Fix Issue 51265
     - We now more consistently trim values and use getValidatedEditableGridValue
+- Stop using overflow: scroll
 
 ### version 5.5.7
 *Released*: 20 September 2024

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -335,6 +335,8 @@ export class EditorModel
                     if (values.size === 1) val = values.first()?.raw;
                     row = row.set(col.name, val);
                 }
+            } else if (col.jsonType === 'time' || col.jsonType === 'date') {
+                row = row.set(col.name, values.size === 1 ? values.first().raw : undefined);
             } else {
                 const val = values.size === 1 ? values.first().raw?.toString().trim() : undefined;
                 row = row.set(col.name, getValidatedEditableGridValue(val, col).value);
@@ -345,7 +347,7 @@ export class EditorModel
     }
 
     /**
-     * This method formats the EditorModel data so we can upload the data to LKS via insert/updateRows
+     * This method formats the EditorModel data, so we can upload the data to LKS via insert/updateRows
      * @param displayValues
      */
     getDataForServerUpload(displayValues = true): List<Map<string, any>> {

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -332,10 +332,10 @@ export class EditorModel
                     );
                 } else {
                     let val;
-                    if (values.size === 1) val = values.first()?.raw?.toString().trim();
+                    if (values.size === 1) val = values.first()?.raw;
                     row = row.set(col.name, val);
                 }
-            }  else {
+            } else {
                 const val = values.size === 1 ? values.first().raw?.toString().trim() : undefined;
                 row = row.set(col.name, getValidatedEditableGridValue(val, col).value);
             }

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -335,12 +335,14 @@ export class EditorModel
                     if (values.size === 1) val = values.first()?.raw;
                     row = row.set(col.name, val);
                 }
-            } else if (col.jsonType === 'time' || col.jsonType === 'date') {
+            } else if (col.jsonType === 'time') {
                 row = row.set(col.name, values.size === 1 ? values.first().raw : undefined);
+            } else if (col.jsonType === 'date') {
+                row = row.set(col.name, values.size === 1 ? values.first().raw?.toString().trim() : undefined);
             } else {
-                let val = values.size === 1 ? values.first().raw?.toString().trim() : undefined;
-                if (displayValues) val = getValidatedEditableGridValue(val, col).value;
-                row = row.set(col.name, getValidatedEditableGridValue(val, col).value);
+                let val = values.size === 1 ? values.first().raw : undefined;
+                if (!displayValues) val = getValidatedEditableGridValue(val?.toString().trim(), col).value;
+                row = row.set(col.name, val);
             }
         });
 

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -338,7 +338,8 @@ export class EditorModel
             } else if (col.jsonType === 'time' || col.jsonType === 'date') {
                 row = row.set(col.name, values.size === 1 ? values.first().raw : undefined);
             } else {
-                const val = values.size === 1 ? values.first().raw?.toString().trim() : undefined;
+                let val = values.size === 1 ? values.first().raw?.toString().trim() : undefined;
+                if (displayValues) val = getValidatedEditableGridValue(val, col).value;
                 row = row.set(col.name, getValidatedEditableGridValue(val, col).value);
             }
         });

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -332,16 +332,12 @@ export class EditorModel
                     );
                 } else {
                     let val;
-                    if (values.size === 1) val = values.first()?.raw;
+                    if (values.size === 1) val = values.first()?.raw?.toString().trim();
                     row = row.set(col.name, val);
                 }
-            } else if (col.jsonType === 'time') {
-                row = row.set(col.name, values.size === 1 ? values.first().raw : undefined);
-            } else if (col.jsonType !== 'date' || !displayValues) {
-                const val = values.size === 1 ? values.first().raw : undefined;
+            }  else {
+                const val = values.size === 1 ? values.first().raw?.toString().trim() : undefined;
                 row = row.set(col.name, getValidatedEditableGridValue(val, col).value);
-            } else {
-                row = row.set(col.name, values.size === 1 ? values.first().raw?.toString().trim() : undefined);
             }
         });
 

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -190,6 +190,10 @@ export function getUpdatedDataFromGrid(
                     // erase an existing value we set the value to null in our update data
                     value = value === undefined ? null : value;
 
+                    // TODO: Verify that it is ok for us to not use getValidatedEditableGridValue here like we were.
+                    //  It should be fine, because editorRows comes from  getDataForServerUpload which uses
+                    //  EditorModel.getRowValue, which uses getValidatedEditableGridValue for most, but not all column
+                    //  types. This comment will be removed when tests pass.
                     row[key] = value;
                 }
                 return row;

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -188,13 +188,7 @@ export function getUpdatedDataFromGrid(
 
                     // if the value is 'undefined', it will be removed from the update rows, so in order to
                     // erase an existing value we set the value to null in our update data
-                    value = value === undefined ? null : value;
-
-                    // TODO: Verify that it is ok for us to not use getValidatedEditableGridValue here like we were.
-                    //  It should be fine, because editorRows comes from  getDataForServerUpload which uses
-                    //  EditorModel.getRowValue, which uses getValidatedEditableGridValue for most, but not all column
-                    //  types. This comment will be removed when tests pass.
-                    row[key] = value;
+                    row[key] = value === undefined ? null : value;
                 }
                 return row;
             }, {});

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -128,7 +128,7 @@ export function getUpdatedDataFromGrid(
                 // We can skip the idField for the diff check, that will be added to the updated rows later
                 if (key === idField) return row;
 
-                let originalValue = originalRow.has(key) ? originalRow.get(key) : undefined;
+                let originalValue = originalRow.get(key, undefined);
                 const col = queryInfo.getColumn(key);
 
                 // Convert empty cell to null
@@ -190,7 +190,7 @@ export function getUpdatedDataFromGrid(
                     // erase an existing value we set the value to null in our update data
                     value = value === undefined ? null : value;
 
-                    row[key] = getValidatedEditableGridValue(value, col).value;
+                    row[key] = value;
                 }
                 return row;
             }, {});

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -246,5 +246,5 @@
 }
 
 .svg-chart__chart {
-    overflow: scroll;
+    overflow: auto;
 }

--- a/packages/components/src/theme/fileupload.scss
+++ b/packages/components/src/theme/fileupload.scss
@@ -220,7 +220,7 @@
 
 .file-upload--file-entry-listing {
     max-height: 160px;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin-bottom: 0;
 }
 .file-upload--file-entry-listing.well {


### PR DESCRIPTION
#### Rationale
In some cases our EditableGrid isn't trimming values, which is causing insertRows to return a 400 error (see [Issue 51265](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51265)). While we should probably not throw a validation error in these cases, we should probably also be trimming values we send to the server.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1583
- https://github.com/LabKey/platform/pull/5867
- https://github.com/LabKey/limsModules/pull/724

#### Changes
- EditorModel: trim values more consistently
- Stop using overflow: scroll
