### PR TITLE
Misc 24.10 fixes

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6",
+  "version": "5.5.6-fb-can2410Fixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.6",
+      "version": "5.5.6-fb-can2410Fixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-fb-can2410Fixes.2",
+  "version": "5.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.6-fb-can2410Fixes.2",
+      "version": "5.5.7",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-fb-can2410Fixes.0",
+  "version": "5.5.6-fb-can2410Fixes.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.6-fb-can2410Fixes.0",
+      "version": "5.5.6-fb-can2410Fixes.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-fb-can2410Fixes.1",
+  "version": "5.5.6-fb-can2410Fixes.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.6-fb-can2410Fixes.1",
+      "version": "5.5.6-fb-can2410Fixes.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-fb-can2410Fixes.0",
+  "version": "5.5.6-fb-can2410Fixes.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6",
+  "version": "5.5.6-fb-can2410Fixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-fb-can2410Fixes.1",
+  "version": "5.5.6-fb-can2410Fixes.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.6-fb-can2410Fixes.2",
+  "version": "5.5.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD September 2024
+### version 5.5.7
+*Released*: 20 September 2024
 - Issue 50389: Casing of aliased (parent) sample or source type name can be changed in the editable grid
 
 ### version 5.5.6

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD September 2024
+- Issue 50389: Casing of aliased (parent) sample or source type name can be changed in the editable grid
+
 ### version 5.5.6
 *Released*: 18 September 2024
 - Issue 50998: Add container filter when getting samples from a particular transaction id

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -289,6 +289,7 @@ function resolveSampleParentTypes(
                 index,
                 schema: 'samples',
                 query: sampleType?.toLowerCase(),
+                label: sampleType,
                 value: List<DisplayObject>(data.sort(_getEntitySort(orderedRowIds))),
                 isAliquotParent,
             })

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -244,6 +244,8 @@ async function getSelectedParents(
     const columns = ['LSID', 'Name', 'RowId'];
     if (isSampleParent) {
         columns.push('SampleSet');
+    } else {
+        columns.push('DataClass');
     }
 
     const response = await selectRows({ columns, filterArray, schemaQuery });
@@ -401,11 +403,16 @@ function resolveEntityParentTypeFromIds(
         .map(({ label, rowId }) => ({ displayValue: label, value: rowId }));
     if (orderedRowIds?.length > 1) data = data.sort(_getEntitySort(orderedRowIds));
 
+    // Issue 50389: use the data class display name if available
+    const dataClass =
+        response.rows.length > 0 ? caseInsensitive(response.rows[0], 'DataClass')?.displayValue : undefined;
+
     return List<EntityParentType>([
         EntityParentType.create({
             index: 1,
             schema: schemaQuery.schemaName,
             query: schemaQuery.queryName,
+            label: dataClass,
             value: List(data),
             isAliquotParent,
         }),

--- a/packages/components/src/internal/components/entities/models.test.ts
+++ b/packages/components/src/internal/components/entities/models.test.ts
@@ -41,11 +41,12 @@ describe('EntityParentType', () => {
         );
         expect(col.caption).toBe('Sampletype Parents');
 
-        col = EntityParentType.create({ schema: SCHEMAS.SAMPLE_SETS.SCHEMA, query: 'sampletype' }).generateColumn(
-            'Display Column',
-            SCHEMAS.SAMPLE_SETS.SCHEMA
-        );
-        expect(col.caption).toBe('Sampletype Parents');
+        col = EntityParentType.create({
+            schema: SCHEMAS.SAMPLE_SETS.SCHEMA,
+            query: 'sampletype',
+            label: 'Sample Type Label',
+        }).generateColumn('Display Column', SCHEMAS.SAMPLE_SETS.SCHEMA);
+        expect(col.caption).toBe('Sample Type Label Parents');
     });
 
     test('generateColumn isAliquotParent', () => {

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -74,6 +74,7 @@ export interface DisplayObject {
 export class EntityParentType extends Record({
     index: undefined,
     key: undefined,
+    label: undefined,
     query: undefined,
     schema: undefined,
     value: undefined,
@@ -82,6 +83,7 @@ export class EntityParentType extends Record({
 }) {
     declare index: number;
     declare key: string;
+    declare label: string;
     declare query: string;
     declare schema: string;
     declare value: List<DisplayObject>;
@@ -121,8 +123,7 @@ export class EntityParentType extends Record({
 
     // TODO: We should stop generating this on the client and retrieve the actual ColumnInfo from the server
     generateColumn(displayColumn: string, targetSchema: string): QueryColumn {
-        const parentInputType = this.getInputType();
-        const formattedQueryName = capitalizeFirstChar(this.query);
+        const formattedQueryName = this.label ?? capitalizeFirstChar(this.query);
         const parentColName = this.generateFieldKey();
 
         // Issue 40233: SM app allows for two types of parents, sources and samples, and its confusing if both use


### PR DESCRIPTION
#### Rationale
Issue [50389](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50389): Casing of aliased (parent) sample or source type name can be changed in the editable grid

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1586
- https://github.com/LabKey/labkey-ui-premium/pull/540
- https://github.com/LabKey/limsModules/pull/733

#### Changes
- retain sample type / data class parent type name casing via label 
