### PR TITLE
Fix Issue 51327

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.8",
+  "version": "5.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.8",
+      "version": "5.5.9",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.8",
+  "version": "5.5.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.5.9
+*Released*: 24 September 2024
+- EditableGrid: Fix issue with pasteEvent not working if user pasted more rows than the grid has
+  - Fixes issue 51327
+
 ### version 5.5.8
-*Released*: 18 September 2024
+*Released*: 24 September 2024
 - Fix Issue 51265
     - We now more consistently trim values and use getValidatedEditableGridValue
 - Stop using overflow: scroll

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1299,22 +1299,20 @@ async function insertPastedData(
     const lookupColumnContainerCache = {};
     const { colMin, rowMin } = paste.coordinates;
     let rowIdx = rowMin;
-    let hasReachedRowLimit = false;
 
     for (let r = 0; r < pastedData.size; r++) {
         const row = pastedData.get(r);
-        if (hasReachedRowLimit && lockRowCount) return;
 
         if (readonlyRows) {
             while (rowIdx < rowCount && editorModel.isReadOnlyRow(rowIdx, readonlyRows)) {
                 // Skip over readonly rows
                 rowIdx++;
             }
+        }
 
-            if (rowIdx >= rowCount) {
-                hasReachedRowLimit = true;
-                return;
-            }
+        if (rowIdx >= rowCount && lockRowCount) {
+            // If we've reached the row limit we can short-circuit allowing at least a partial paste.
+            break;
         }
 
         let pkValue = getPkValue(row, editorModel.queryInfo);

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -212,7 +212,7 @@ export class EditorModel
     getFolderValueForRow(rowIdx: number): string {
         const containerCol = this.columnMap.get('folder') ?? this.columnMap.get('container');
         if (!containerCol) return undefined;
-        return this.cellValues.get(genCellKey(containerCol.fieldKey, rowIdx)).get(0).raw;
+        return this.cellValues.get(genCellKey(containerCol.fieldKey, rowIdx))?.get(0)?.raw;
     }
 
     getFolderValueForCell(cellKey: string): string {


### PR DESCRIPTION
#### Rationale
Our code for handling paste is incorrectly handling scenarios where the user pastes more data than there are rows left. See [Issue 51327](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51327).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1587
- https://github.com/LabKey/platform/pull/5881
- https://github.com/LabKey/limsModules/pull/744

#### Changes
- insertPastedData: properly handle when users paste more data than there are rows available.
  - Fixes Issue 51327
