### PR TITLE
Issue 51331: Support case-insensitive matching on file extensions

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.10-fb-file-ext-caps.0",
+  "version": "5.5.10-fb-file-ext-caps.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.10-fb-file-ext-caps.0",
+      "version": "5.5.10-fb-file-ext-caps.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.9",
+  "version": "5.5.10-fb-file-ext-caps.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.9",
+      "version": "5.5.10-fb-file-ext-caps.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.10-fb-file-ext-caps.1",
+  "version": "5.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.10-fb-file-ext-caps.1",
+      "version": "5.5.10",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.9",
+  "version": "5.5.10-fb-file-ext-caps.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.10-fb-file-ext-caps.0",
+  "version": "5.5.10-fb-file-ext-caps.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.10-fb-file-ext-caps.1",
+  "version": "5.5.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.5.10
+*Released*: 24 September 2024
+- Update `fileMatchesAcceptedFormat` utility to check file extension casing in a case-insensitive manner. Refactor away from using `Immutable`.
+  - Fixes Issue 51331
+- Update `FileAttachmentContainer` to use native `Set` rather than `Immutable.Set`.
+
 ### version 5.5.9
 *Released*: 24 September 2024
 - EditableGrid: Fix issue with pasteEvent not working if user pasted more rows than the grid has

--- a/packages/components/src/internal/components/assay/AssayDesignUploadPanel.tsx
+++ b/packages/components/src/internal/components/assay/AssayDesignUploadPanel.tsx
@@ -37,7 +37,7 @@ export const AssayDesignUploadPanel: FC<AssayDesignUploadPanelProps> = memo(prop
             <div className="row">
                 <div className="col-xs-12">
                     <FileAttachmentForm
-                        acceptedFormats=".XAR, .XAR.XML, .xar, .xar.xml"
+                        acceptedFormats=".XAR, .XAR.XML"
                         showAcceptedFormats={false}
                         allowDirectories={false}
                         allowMultiple={false}

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -303,6 +303,7 @@ export class RunDataPanel extends PureComponent<Props, State> {
                                         ) : (
                                             <FileAttachmentForm
                                                 key={wizardModel.lastRunId + '-dataFile'} // required for rerender in the "save and import another" case
+                                                acceptedFormats=".xlsx"
                                                 allowDirectories={false}
                                                 allowMultiple={false}
                                                 showLabel={fileColumnNames?.length > 0}

--- a/packages/components/src/internal/components/assay/RunDataPanel.tsx
+++ b/packages/components/src/internal/components/assay/RunDataPanel.tsx
@@ -303,7 +303,6 @@ export class RunDataPanel extends PureComponent<Props, State> {
                                         ) : (
                                             <FileAttachmentForm
                                                 key={wizardModel.lastRunId + '-dataFile'} // required for rerender in the "save and import another" case
-                                                acceptedFormats=".xlsx"
                                                 allowDirectories={false}
                                                 allowMultiple={false}
                                                 showLabel={fileColumnNames?.length > 0}

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -963,7 +963,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         const shouldShowImportExport = this.shouldShowImportExport();
 
         if (shouldShowInferFromFile || shouldShowImportExport) {
-            let acceptedFormats = [];
+            let acceptedFormats: string[] = [];
             if (shouldShowInferFromFile) {
                 acceptedFormats = acceptedFormats.concat(['.csv', '.tsv', '.txt', '.xls', '.xlsx']);
             }
@@ -971,7 +971,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 acceptedFormats = acceptedFormats.concat(['.json']);
             }
 
-            let label;
+            let label: ReactNode;
             if (shouldShowImportExport && shouldShowInferFromFile) {
                 label = 'Import or infer fields from file';
             } else if (shouldShowImportExport) {

--- a/packages/components/src/internal/components/files/FileAttachmentContainer.test.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentContainer.test.tsx
@@ -54,7 +54,7 @@ describe('FileAttachmentContainer', () => {
     test('with multiple files', () => {
         render(
             <FileAttachmentContainer
-                allowMultiple={true}
+                allowMultiple
                 allowDirectories={false}
                 initialFiles={{
                     'file1.txt': new File([], 'file1.txt'),
@@ -75,7 +75,7 @@ describe('FileAttachmentContainer', () => {
     test('with initial file names', () => {
         render(
             <FileAttachmentContainer
-                allowMultiple={true}
+                allowMultiple
                 allowDirectories={false}
                 initialFileNames={['initial1.txt', 'initial2.csv']}
             />
@@ -97,7 +97,7 @@ describe('FileAttachmentContainer', () => {
     test('fileCountSuffix with multiple', () => {
         render(
             <FileAttachmentContainer
-                allowMultiple={true}
+                allowMultiple
                 allowDirectories={false}
                 fileCountSuffix="will be uploaded"
                 initialFiles={{
@@ -116,7 +116,7 @@ describe('FileAttachmentContainer', () => {
     test('fileCountSuffix with single', () => {
         render(
             <FileAttachmentContainer
-                allowMultiple={true}
+                allowMultiple
                 allowDirectories={false}
                 fileCountSuffix="will be uploaded"
                 initialFiles={{

--- a/packages/components/src/internal/components/files/FileAttachmentEntry.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentEntry.tsx
@@ -2,10 +2,10 @@ import React, { PureComponent } from 'react';
 
 interface Props {
     allowDelete?: boolean;
-    onDelete?: (name: string) => void;
-    name: string;
-    downloadUrl?: string;
     deleteTitleText?: string;
+    downloadUrl?: string;
+    name: string;
+    onDelete?: (name: string) => void;
 }
 
 export class FileAttachmentEntry extends PureComponent<Props, any> {

--- a/packages/components/src/internal/components/files/FileAttachmentEntry.tsx
+++ b/packages/components/src/internal/components/files/FileAttachmentEntry.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 
 interface Props {
     allowDelete?: boolean;
-    onDelete?: (name: string) => any;
+    onDelete?: (name: string) => void;
     name: string;
     downloadUrl?: string;
     deleteTitleText?: string;

--- a/packages/components/src/internal/components/files/actions.test.ts
+++ b/packages/components/src/internal/components/files/actions.test.ts
@@ -99,7 +99,7 @@ const FIELDS = fromJS([
     },
 ]);
 
-describe('convertRowDataIntoPreviewData ', () => {
+describe('convertRowDataIntoPreviewData', () => {
     test('empty data object', () => {
         const rows = convertRowDataIntoPreviewData(fromJS([]), 1);
         expect(rows.size).toBe(0);
@@ -157,43 +157,53 @@ describe('getFileExtension', () => {
 
 describe('fileMatchesAcceptedFormat', () => {
     test('not a match', () => {
-        const response = fileMatchesAcceptedFormat('testing.txt', '.csv, .tsv, .xlsx');
-        expect(response.get('extension')).toBe('.txt');
-        expect(response.get('isMatch')).toBeFalsy();
+        let response = fileMatchesAcceptedFormat('testing.txt', '.csv, .tsv, .xlsx');
+        expect(response.extension).toBe('.txt');
+        expect(response.isMatch).toBeFalsy();
+
+        response = fileMatchesAcceptedFormat('testing.xls', '.csv, .tsv, .xlsx');
+        expect(response.extension).toBe('.xls');
+        expect(response.isMatch).toBeFalsy();
     });
 
     test('matches first', () => {
         const response = fileMatchesAcceptedFormat('testing.csv', '.csv, .tsv, .xlsx');
-        expect(response.get('extension')).toBe('.csv');
-        expect(response.get('isMatch')).toBeTruthy();
+        expect(response.extension).toBe('.csv');
+        expect(response.isMatch).toBeTruthy();
     });
 
     test('matches middle', () => {
         const response = fileMatchesAcceptedFormat('testing.tsv', '.csv, .tsv, .xlsx');
-        expect(response.get('extension')).toBe('.tsv');
-        expect(response.get('isMatch')).toBeTruthy();
+        expect(response.extension).toBe('.tsv');
+        expect(response.isMatch).toBeTruthy();
     });
 
     test('matches last', () => {
         const response = fileMatchesAcceptedFormat('testing.xlsx', '.csv, .tsv, .xlsx');
-        expect(response.get('extension')).toBe('.xlsx');
-        expect(response.get('isMatch')).toBeTruthy();
+        expect(response.extension).toBe('.xlsx');
+        expect(response.isMatch).toBeTruthy();
     });
 
     test('no file extension', () => {
         const response = fileMatchesAcceptedFormat('testing', '.csv, .tsv, .xlsx');
-        expect(response.get('extension')).toBe('');
-        expect(response.get('isMatch')).toBeFalsy();
+        expect(response.extension).toBe('');
+        expect(response.isMatch).toBeFalsy();
+    });
+
+    test('case sensitivity', () => {
+        const response = fileMatchesAcceptedFormat('testing.XLSX', '.csv, .tsv, .xlsx');
+        expect(response.extension).toBe('.XLSX');
+        expect(response.isMatch).toBeTruthy();
     });
 
     test('multiple file extension', () => {
         let response = fileMatchesAcceptedFormat('testing.xar.xml', '.xar.xml');
-        expect(response.get('extension')).toBe('.xar.xml');
-        expect(response.get('isMatch')).toBeTruthy();
+        expect(response.extension).toBe('.xar.xml');
+        expect(response.isMatch).toBeTruthy();
 
         response = fileMatchesAcceptedFormat('testing.xar.xml', '.xml');
-        expect(response.get('extension')).toBe('.xml');
-        expect(response.get('isMatch')).toBeTruthy();
+        expect(response.extension).toBe('.xml');
+        expect(response.isMatch).toBeTruthy();
     });
 });
 
@@ -203,9 +213,7 @@ describe('fileSizeLimitCompare', () => {
         type: 'test',
         lastModified: 1,
         name: 'test.text',
-        slice: (start, end, compareType): Blob => {
-            return undefined;
-        },
+        slice: jest.fn(),
         arrayBuffer: undefined,
         stream: undefined,
         text: undefined,

--- a/packages/components/src/internal/components/files/actions.ts
+++ b/packages/components/src/internal/components/files/actions.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { fromJS, List, Map, OrderedMap } from 'immutable';
+import { List, Map, OrderedMap } from 'immutable';
 
 import { parseScientificInt } from '../../util/utils';
 
@@ -25,7 +25,7 @@ export function convertRowDataIntoPreviewData(
     }
 
     // numeric data is imported as Doubles for excel (see org.labkey.api.exp.PropertyType#getFromExcelCell)
-    const integerFieldInds = [];
+    const integerFieldInds: number[] = [];
     if (fields && fields.size > 0) {
         fields.forEach((field, ind) => {
             const rangeURI = field.rangeURI;
@@ -76,21 +76,24 @@ export function getFileExtension(fileName: string, lastIndex = true): string {
     return undefined;
 }
 
-export function fileMatchesAcceptedFormat(fileName: string, formatExtensionStr: string): Map<string, any> {
-    const acceptedFormatArray: string[] = formatExtensionStr.replace(/\s/g, '').split(',');
+export type FileExtensionMatch = {
+    extension: string;
+    isMatch: boolean;
+};
+
+export function fileMatchesAcceptedFormat(fileName: string, formatExtensionStr: string): FileExtensionMatch {
+    // Issue 51331: Support case-insensitive matching on file extensions
+    const acceptedFormatArray = formatExtensionStr.toLowerCase().replace(/\s/g, '').split(',');
     let extension = getFileExtension(fileName);
-    let isMatch = extension?.length > 0 && acceptedFormatArray.indexOf(extension) >= 0;
+    let isMatch = extension?.length > 0 && acceptedFormatArray.indexOf(extension.toLowerCase()) >= 0;
 
     // Issue 42637: some file name extensions may not be based off of the last index of '.' in the file name
     if (!isMatch) {
         extension = getFileExtension(fileName, false);
-        isMatch = extension?.length > 0 && acceptedFormatArray.indexOf(extension) >= 0;
+        isMatch = extension?.length > 0 && acceptedFormatArray.indexOf(extension.toLowerCase()) >= 0;
     }
 
-    return fromJS({
-        extension,
-        isMatch,
-    });
+    return { extension, isMatch };
 }
 
 export interface SizeLimitCheckResult {

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -296,15 +296,11 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
 
     const onChange = useCallback<SelectInputChange>(
         (name_, value_, options_, props_) => {
-            let selectedItems: Map<string, any>;
-            setModel(model_ => {
-                const updatedModel = setSelection(model_, value_);
-                selectedItems = updatedModel.selectedItems;
-                return updatedModel;
-            });
-            onQSChange?.(name_, value_, options_, props_, selectedItems);
+            const model_ = setSelection(model, value_);
+            setModel(model_);
+            onQSChange?.(name_, value_, options_, props_, model_.selectedItems);
         },
-        [onQSChange]
+        [model, onQSChange]
     );
 
     const onFocus = useCallback(async () => {

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -255,7 +255,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
             if (initialLoad) {
                 // If a "defaultInputValue" is supplied and the initial load is an empty search,
                 // then search with the "defaultInputValue"
-                input_ = input ? input : defaultInputValue ?? '';
+                input_ = input ? input : (defaultInputValue ?? '');
                 setInitialLoad(false);
             } else {
                 input_ = input;


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51331](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51331) by making the file extension check case-insensitive. The original file name and extension casing are preserved.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1589
- https://github.com/LabKey/platform/pull/5885
- https://github.com/LabKey/limsModules/pull/749

#### Changes
- Update `fileMatchesAcceptedFormat` utility to check file extension casing in a case-insensitive manner. Refactor away from using `Immutable`.
- Update `FileAttachmentContainer` to use native `Set` rather than `Immutable.Set`.
- Remove side effect of call to `setModel()` in `QuerySelect`. Hoping to address intermittent test failure where `selectedItems` is undefined (which it never should be).
