### PR TITLE
Issue 51337: LKSM: Can't edit samples where source ID has a comma

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.9",
+  "version": "5.5.10-fb-issue51337.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.9",
+      "version": "5.5.10-fb-issue51337.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.10",
+  "version": "5.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.5.10",
+      "version": "5.5.11",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.5.9",
+  "version": "5.5.10-fb-issue51337.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.X
+*Released*: X September 2024
+- Issue 51337: LKSM: Can't edit samples where source ID has a comma
+  - Check quoted parent value with comma before calling JSON.parse, which would remove the quotes
+
 ### version 5.5.9
 *Released*: 24 September 2024
 - EditableGrid: Fix issue with pasteEvent not working if user pasted more rows than the grid has

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -20,7 +20,7 @@ import { getQueryColumnRenderers } from '../../global';
 
 import { QuerySelectOwnProps } from '../forms/QuerySelect';
 
-import { isBoolean, isFloat, isInteger } from '../../util/utils';
+import { isBoolean, isFloat, isInteger, isQuotedWithDelimiters } from '../../util/utils';
 
 import { SchemaQuery } from '../../../public/SchemaQuery';
 
@@ -153,7 +153,8 @@ export function getUpdatedDataFromGrid(
                 // updated values. This is not the final type check.
                 if (typeof originalValue === 'number' || typeof originalValue === 'boolean') {
                     try {
-                        value = JSON.parse(value);
+                        if (!isQuotedWithDelimiters(value, ','))
+                            value = JSON.parse(value);
                     } catch (e) {
                         // Incorrect types are handled by API and user feedback created from that response. Don't need
                         // to handle that here.

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -42,6 +42,7 @@ import {
     withTransformedKeys,
     getValueFromRow,
     isBoolean,
+    isQuotedWithDelimiters,
 } from './utils';
 
 const emptyList = List<string>();
@@ -1290,6 +1291,10 @@ describe('quoteValueWithDelimiters', () => {
         expect(quoteValueWithDelimiters(undefined, ',')).toBeUndefined();
         expect(quoteValueWithDelimiters(null, ';')).toBeNull();
         expect(quoteValueWithDelimiters('', ' ')).toBe('');
+
+        expect(isQuotedWithDelimiters(undefined, ',')).toBeFalsy();
+        expect(isQuotedWithDelimiters(null, ';')).toBeFalsy();
+        expect(isQuotedWithDelimiters('', ' ')).toBeFalsy();
     });
 
     test('non-string value', () => {
@@ -1297,28 +1302,47 @@ describe('quoteValueWithDelimiters', () => {
         expect(quoteValueWithDelimiters(4, undefined)).toBe(4);
         expect(quoteValueWithDelimiters({ value: '4,5' }, undefined)).toStrictEqual({ value: '4,5' });
         expect(quoteValueWithDelimiters([4, 5, 6], ',')).toStrictEqual([4, 5, 6]);
+
+        expect(isQuotedWithDelimiters(4, ',')).toBeFalsy();
+        expect(isQuotedWithDelimiters(4, undefined)).toBeFalsy();
+        expect(isQuotedWithDelimiters({ value: '4,5' }, undefined)).toBeFalsy();
+        expect(isQuotedWithDelimiters([4, 5, 6], ',')).toBeFalsy();
     });
 
     test('invalid delimiter', () => {
         expect(() => quoteValueWithDelimiters('value', undefined)).toThrow('Delimiter is required.');
         expect(() => quoteValueWithDelimiters('value', null)).toThrow('Delimiter is required.');
         expect(() => quoteValueWithDelimiters('value', '')).toThrow('Delimiter is required.');
+
+        expect(() => isQuotedWithDelimiters('value', undefined)).toThrow('Delimiter is required.');
+        expect(() => isQuotedWithDelimiters('value', null)).toThrow('Delimiter is required.');
+        expect(() => isQuotedWithDelimiters('value', '')).toThrow('Delimiter is required.');
     });
 
     test('without delimiter in value', () => {
         expect(quoteValueWithDelimiters('abc d', ',')).toBe('abc d');
         expect(quoteValueWithDelimiters('a', ';')).toBe('a');
+
+        expect(isQuotedWithDelimiters('abc d', ',')).toBeFalsy();
+        expect(isQuotedWithDelimiters('a', ';')).toBeFalsy();
     });
 
     test('with delimiter', () => {
         expect(quoteValueWithDelimiters('abc,d', ',')).toBe('"abc,d"');
         expect(quoteValueWithDelimiters('ab "cd,e"', ',')).toBe('"ab ""cd,e"""');
         expect(quoteValueWithDelimiters('ab, "cd,e"', ',')).toBe('"ab, ""cd,e"""');
+
+        expect(isQuotedWithDelimiters('"abc,d"', ',')).toBeTruthy();
+        expect(isQuotedWithDelimiters('"ab ""cd,e"""', ',')).toBeTruthy();
+        expect(isQuotedWithDelimiters('"ab, ""cd,e"""', ',')).toBeTruthy();
     });
 
     test('round trip', () => {
         const initialString = 'ab "cd,e"';
         expect(parseCsvString(quoteValueWithDelimiters(initialString, ','), ',', true)).toStrictEqual([initialString]);
+
+        expect(isQuotedWithDelimiters(quoteValueWithDelimiters(initialString, ','), ',')).toBeTruthy();
+
     });
 });
 

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -729,6 +729,20 @@ export function quoteValueWithDelimiters(value: any, delimiter: string) {
     return '"' + value + '"';
 }
 
+export function isQuotedWithDelimiters(value: any, delimiter: string) : boolean {
+    if (!value || !Utils.isString(value)) {
+        return false;
+    }
+    if (!delimiter) {
+        throw 'Delimiter is required.';
+    }
+
+    const strVal = value + '';
+    if (strVal.indexOf(delimiter) === -1) return false;
+
+    return strVal.startsWith('"') && strVal.endsWith('"');
+}
+
 export function arrayEquals(a: string[], b: string[], ignoreOrder = true, caseInsensitive?: boolean): boolean {
     if (a === b) return true;
     if (a == null && b == null) return true;


### PR DESCRIPTION
#### Rationale
When a parent sample/data name contains comma, the parent value should be quoted so it can be parsed correctly and distinguished from multi parent inputs. The util to getUpdatedDataFromGrid for editable grid calls JSON.parse on those quoted values, if existing lineages are present. This removes the quotes that are needed. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1590
- https://github.com/LabKey/limsModules/pull/752

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
