### PR TITLE
Issue 51227: Add metric for number of rows used in editable grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.6.1",
+      "version": "5.6.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.6.1-editableGridMetric.0",
+  "version": "5.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.6.1-editableGridMetric.0",
+      "version": "5.6.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.6.0",
+  "version": "5.6.1-editableGridMetric.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.6.0",
+      "version": "5.6.1-editableGridMetric.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.6.0",
+  "version": "5.6.1-editableGridMetric.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.6.1-editableGridMetric.0",
+  "version": "5.6.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51227: Add metric for number of rows used in editable grid
+
 ### version 5.6.0
 *Released*: 25 September 2024
 - Wire up onBlur for LookupCell

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 5.6.1
+*Released*: 27 September 2024
 - Issue 51227: Add metric for number of rows used in editable grid
 
 ### version 5.6.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -267,6 +267,7 @@ import {
     genCellKey,
     getUpdatedDataFromEditableGrid,
     parseCellKey,
+    incrementRowCountMetric,
 } from './internal/components/editable/utils';
 import { EditableGridTabs } from './internal/components/editable/EditableGrid';
 import { EditableGridPanel } from './internal/components/editable/EditableGridPanel';
@@ -1637,6 +1638,7 @@ export {
     HELP_LINK_REFERRER,
     HelpIcon,
     incrementClientSideMetricCount,
+    incrementRowCountMetric,
     Key,
     useEnterEscape,
     encodePart,

--- a/packages/components/src/internal/components/assay/AssayImportPanels.tsx
+++ b/packages/components/src/internal/components/assay/AssayImportPanels.tsx
@@ -59,7 +59,7 @@ import { getOperationNotAllowedMessage } from '../samples/utils';
 
 import { EditableGridChange } from '../editable/EditableGrid';
 
-import { applyEditorModelChanges } from '../editable/utils';
+import { applyEditorModelChanges, incrementRowCountMetric } from '../editable/utils';
 
 import { CommentTextArea } from '../forms/input/CommentTextArea';
 
@@ -627,6 +627,9 @@ class AssayImportPanelsBody extends Component<BodyProps, State> {
                 auditUserComment: comment,
                 containerPath: container.path,
             });
+            if (data.dataRows?.length) {
+                incrementRowCountMetric('assayData', data.dataRows?.length, false);
+            }
 
             this.props.setIsDirty?.(false);
             if (importAgain && onSave) {

--- a/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridPanelForUpdate.tsx
@@ -25,7 +25,7 @@ import { EditorModel, EditableGridLoader, EditableColumnMetadata } from './model
 
 import { EditableGridPanel, EditableGridPanelProps } from './EditableGridPanel';
 import { initEditorModel } from './actions';
-import { applyEditorModelChanges, getUpdatedDataFromEditableGrid } from './utils';
+import { applyEditorModelChanges, getUpdatedDataFromEditableGrid, incrementRowCountMetric } from './utils';
 import { EditableGridChange } from './EditableGrid';
 
 const ERROR_ALERT_ID = 'editable-grid-error';
@@ -39,6 +39,7 @@ interface EditableGridPanelForUpdateProps extends InheritedEditableGridPanelProp
     columnMetadata?: Map<string, EditableColumnMetadata>;
     editStatusData?: OperationConfirmationData;
     loader: EditableGridLoader;
+    metricFeatureArea?: string;
     onCancel: () => void;
     onComplete: () => void;
     pluralNoun: string;
@@ -60,6 +61,7 @@ export const EditableGridPanelForUpdate: FC<EditableGridPanelForUpdateProps> = p
         columnMetadata,
         editStatusData,
         loader,
+        metricFeatureArea,
         onCancel,
         onComplete,
         pluralNoun,
@@ -121,6 +123,7 @@ export const EditableGridPanelForUpdate: FC<EditableGridPanelForUpdateProps> = p
         try {
             // TODO: I suspect we can skip passing originalRows since getDataForServerUpload appends folder/container
             await updateRows(gridData.schemaQuery, gridData.updatedRows, comment, gridData.originalRows);
+            incrementRowCountMetric(metricFeatureArea, editorModel.rowCount, true);
             setIsSubmitting(false);
             onComplete();
         } catch (e) {

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -26,6 +26,7 @@ import { SchemaQuery } from '../../../public/SchemaQuery';
 
 import { EditorModel, CellMessage } from './models';
 import { CellActions, MODIFICATION_TYPES } from './constants';
+import { incrementClientSideMetricCount } from '../../actions';
 
 export function applyEditorModelChanges(
     models: EditorModel[],
@@ -470,4 +471,17 @@ export function computeRangeChange(selectedIdx: number, min: number, max: number
     }
 
     return [Math.max(0, min), max];
+}
+
+export function incrementRowCountMetric(dataType: string, rowCount: number, isUpdate: boolean): void {
+    const metricFeatureArea = isUpdate ? 'gridUpdateCounts' : 'gridInsertCounts';
+    if (rowCount > 0 && rowCount <= 50) {
+        incrementClientSideMetricCount(metricFeatureArea, dataType + '1To50');
+    } else if (rowCount <= 100) {
+        incrementClientSideMetricCount(metricFeatureArea, dataType + '51To100');
+    } else if (rowCount <= 250) {
+        incrementClientSideMetricCount(metricFeatureArea, dataType + '101To250');
+    } else {
+        incrementClientSideMetricCount(metricFeatureArea, dataType + 'GT250');
+    }
 }

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -474,8 +474,10 @@ export function computeRangeChange(selectedIdx: number, min: number, max: number
 }
 
 export function incrementRowCountMetric(dataType: string, rowCount: number, isUpdate: boolean): void {
+    if (!rowCount) return;
+
     const metricFeatureArea = isUpdate ? 'gridUpdateCounts' : 'gridInsertCounts';
-    if (rowCount > 0 && rowCount <= 50) {
+    if (rowCount <= 50) {
         incrementClientSideMetricCount(metricFeatureArea, dataType + '1To50');
     } else if (rowCount <= 100) {
         incrementClientSideMetricCount(metricFeatureArea, dataType + '51To100');

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -55,6 +55,7 @@ import {
     UpdateRowsOptions,
 } from './api';
 import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows';
+import { incrementRowCountMetric } from '../components/editable/utils';
 
 export interface QueryAPIWrapper {
     clearSelected: (options: ClearSelectedOptions) => Promise<SelectResponse>;
@@ -93,6 +94,7 @@ export interface QueryAPIWrapper {
     getServerDate: () => Promise<Date>;
     getSnapshotSelections: (key: string, containerPath?: string) => Promise<GetSelectedResponse>;
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
+    incrementRowCountMetric: (featureArea: string, rowCount: number, isUpdate: boolean) => void;
     insertRows: (options: InsertRowsOptions) => Promise<QueryCommandResponse>;
     renameGridView: (
         schemaQuery: SchemaQuery,
@@ -158,6 +160,7 @@ export class QueryServerAPIWrapper implements QueryAPIWrapper {
     getSnapshotSelections = getSnapshotSelections;
     getServerDate = getServerDate;
     incrementClientSideMetricCount = incrementClientSideMetricCount;
+    incrementRowCountMetric = incrementRowCountMetric;
     insertRows = insertRows;
     renameGridView = renameGridView;
     replaceSelected = replaceSelected;
@@ -194,6 +197,7 @@ export function getQueryTestAPIWrapper(
         getSnapshotSelections: mockFn(),
         getServerDate: () => Promise.resolve(new Date()),
         incrementClientSideMetricCount: mockFn(),
+        incrementRowCountMetric: mockFn(),
         insertRows: mockFn(),
         renameGridView: mockFn(),
         replaceSelected: mockFn(),


### PR DESCRIPTION
#### Rationale
Issue [51227](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51227): We want to understand how many rows people are using our editable grids to understand if reducing the maximum number would be problematic or not.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/763
- https://github.com/LabKey/labkey-ui-premium/pull/548

#### Changes
- Add `incrementRowCountMetric` utility method
