### PR TITLE
Issue 51254: Limit number of values for multi-valued filter clauses

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.8.1",
+  "version": "5.8.2-limitMultiValueFilters.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.8.1",
+      "version": "5.8.2-limitMultiValueFilters.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.8.1",
+  "version": "5.8.2-limitMultiValueFilters.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51254: Limit number of values for multi-valued filter types
+
 ### version 5.8.1
 *Released*: 30 September 2024
 - Issue 51253: Require saving before testing of BarTender connection

--- a/packages/components/src/internal/components/search/FilterExpressionView.test.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.test.tsx
@@ -16,6 +16,7 @@ import {
 import { FilterExpressionView } from './FilterExpressionView';
 import { userEvent } from '@testing-library/user-event';
 import { render } from '@testing-library/react';
+import { waitFor } from '@testing-library/dom';
 
 const stringField = new QueryColumn({
     name: 'StringField',
@@ -146,7 +147,7 @@ describe('FilterExpressionView', () => {
         if (firstInputValue) {
             expect(filterInputs.item(inputOffset).getAttribute('value')).toEqual(firstInputValue);
             if (disabled) {
-                expect(filterInputs.item(inputOffset).getAttribute('disabled')).toBeInTheDocument();
+                expect(filterInputs.item(inputOffset).getAttribute('disabled')).toBeDefined();
             } else {
                 expect(filterInputs.item(inputOffset).getAttribute('disabled')).toBeFalsy();
             }
@@ -155,7 +156,7 @@ describe('FilterExpressionView', () => {
         if (secondInputValue) {
             expect(filterInputs.item(inputOffset + 1).getAttribute('value')).toEqual(secondInputValue);
             if (disabled) {
-                expect(filterInputs.item(inputOffset + 1).getAttribute('disabled')).toBeInTheDocument();
+                expect(filterInputs.item(inputOffset + 1).getAttribute('disabled')).toBeDefined();
             } else {
                 expect(filterInputs.item(inputOffset + 1).getAttribute('disabled')).toBeFalsy();
             }
@@ -168,10 +169,14 @@ describe('FilterExpressionView', () => {
         selectedOp?: string
     ): Promise<void> {
         const selectInput = document.querySelectorAll('.select-input').item(filterIndex);
-        await act(() => userEvent.click(document.querySelector('.select-input__input')));
+        userEvent.click(document.querySelector('.select-input__input'));
 
-        const options = selectInput.querySelectorAll('.select-input__option');
-        expect(options).toHaveLength(3);
+        let options;
+        await waitFor(() => {
+            options = selectInput.querySelectorAll('.select-input__option');
+            expect(options).toHaveLength(3);
+        });
+
         const selectedFilter = document.querySelector('.filter-expression-field-filter-type');
         if (selectedOp) {
             expect(selectedFilter.getAttribute('value')).toEqual(selectedOp);
@@ -226,7 +231,7 @@ describe('FilterExpressionView', () => {
             />
         );
 
-        validate(Ops, 0, 2, 1, 0, 'gt', 1.23);
+        validate(Ops, 0, 2, 1, 0, 'gt', "1.23");
     });
 
     test('datetime field, not equal', () => {
@@ -267,9 +272,9 @@ describe('FilterExpressionView', () => {
         expect(radios.length).toBe(2);
 
         expect(radios.item(0).getAttribute('value')).toEqual('true');
-        expect(radios.item(0).getAttribute('checked')).toEqual(true);
+        expect(radios.item(0).getAttribute('checked')).toBeDefined();
         expect(radios.item(1).getAttribute('value')).toEqual('false');
-        expect(radios.item(1).getAttribute('checked')).toEqual(false);
+        expect(radios.item(1).getAttribute('checked')).toBeNull();
     });
 
     test('not sole filter, without value', () => {
@@ -321,7 +326,7 @@ describe('FilterExpressionView', () => {
             2,
             0,
             'gt',
-            3.4
+            "3.4"
         );
         const excludedOps = ['gt', 'eq', 'isblank'];
         validate(
@@ -331,7 +336,7 @@ describe('FilterExpressionView', () => {
             2,
             1,
             'lt',
-            8.1
+            "8.1"
         );
     });
 
@@ -353,7 +358,6 @@ describe('FilterExpressionView', () => {
                 disabled={true}
             />
         );
-
         validate(Ops, 0, 2, 2, 0, 'between', '1', '200', true);
     });
 });

--- a/packages/components/src/internal/components/search/FilterExpressionView.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.tsx
@@ -26,8 +26,8 @@ interface Props {
     disabled?: boolean;
     field: QueryColumn;
     fieldFilters: Filter.IFilter[];
-    onFieldFilterUpdate?: (newFilters: Filter.IFilter[], index: number) => void;
     includeAllAncestorFilter?: boolean;
+    onFieldFilterUpdate?: (newFilters: Filter.IFilter[], index: number) => void;
 }
 
 export const FilterExpressionView: FC<Props> = memo(props => {

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -74,7 +74,6 @@ const matchesAllEmptyFilter = {
     jsonType: 'string',
 } as FieldFilter;
 
-
 const containsOneOfBadFilter = {
     fieldKey: 'textField',
     fieldCaption: 'textField',
@@ -82,6 +81,28 @@ const containsOneOfBadFilter = {
         'textField',
         ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'],
         Filter.Types.CONTAINS_ONE_OF
+    ),
+    jsonType: 'string',
+} as FieldFilter;
+
+const containsNoneOfBadFilter = {
+    fieldKey: 'otherTextField',
+    fieldCaption: 'otherTextField',
+    filter: Filter.create(
+        'textField',
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'],
+        Filter.Types.CONTAINS_NONE_OF
+    ),
+    jsonType: 'string',
+} as FieldFilter;
+
+const equalsNoneOfBadFilter = {
+    fieldKey: 'textField',
+    fieldCaption: 'textField',
+    filter: Filter.create(
+        'textField',
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'],
+        Filter.Types.EQUALS_NONE_OF
     ),
     jsonType: 'string',
 } as FieldFilter;
@@ -266,11 +287,52 @@ describe('getFieldFiltersValidationResult', () => {
                 sampleType1: [matchesAllBadFilter, stringBetweenFilter],
                 sampleType2: [intEqFilter],
             })
-        ).toEqual("At most 10 values can be selected for 'Equals All Of' filter type for 'textField'.");
+        ).toEqual("At most 10 values can be selected for 'Equals All Of' filter type for 'textField'. ");
     });
 
     test('exceed max allowed for multi-value', () => {
-        expect("TODO").toEqual("Tests still to be written.");
+        expect(
+            getFieldFiltersValidationResult(
+                {
+                    sampleType1: [containsOneOfBadFilter, stringBetweenFilter],
+                    sampleType2: [intEqFilter],
+                },
+                undefined,
+                4
+            )
+        ).toEqual(
+            "Too many values provided for filters on 'textField'. At most 4 values may be provided for filters of type 'Contains One Of'."
+        );
+    });
+
+    test('exceed max allowed for multi-value and matchesAll', () => {
+        expect(
+            getFieldFiltersValidationResult(
+                {
+                    sampleType1: [containsOneOfBadFilter, matchesAllBadFilter],
+                    sampleType2: [intEqFilter],
+                },
+                undefined,
+                4
+            )
+        ).toEqual(
+            "At most 10 values can be selected for 'Equals All Of' filter type for 'textField'. Too many values provided for filters on 'textField'. At most 4 values may be provided for filters of type 'Contains One Of'."
+        );
+    });
+
+    test('exceed max allowed for multiple multi-value fields', () => {
+        expect(
+            getFieldFiltersValidationResult(
+                {
+                    sampleType1: [containsOneOfBadFilter, equalsNoneOfBadFilter],
+                    sampleType2: [containsNoneOfBadFilter],
+                },
+                undefined,
+                10
+            )
+        ).toEqual(
+            "Too many values provided for filters on 'otherTextField' and 'textField'. At most 10 values may be provided for filters of type 'Contains One Of', 'Does Not Contain Any Of' and 'Does Not Equal Any Of'."
+        );
     });
 });
 

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -74,6 +74,18 @@ const matchesAllEmptyFilter = {
     jsonType: 'string',
 } as FieldFilter;
 
+
+const containsOneOfBadFilter = {
+    fieldKey: 'textField',
+    fieldCaption: 'textField',
+    filter: Filter.create(
+        'textField',
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'],
+        Filter.Types.CONTAINS_ONE_OF
+    ),
+    jsonType: 'string',
+} as FieldFilter;
+
 const intEqFilter = {
     fieldKey: 'intField',
     fieldCaption: 'intField',
@@ -248,13 +260,17 @@ describe('getFieldFiltersValidationResult', () => {
         ).toEqual('Missing filter values for: textField.');
     });
 
-    test('exceed max allowed', () => {
+    test('exceed max allowed, matchesAll', () => {
         expect(
             getFieldFiltersValidationResult({
                 sampleType1: [matchesAllBadFilter, stringBetweenFilter],
                 sampleType2: [intEqFilter],
             })
         ).toEqual("At most 10 values can be selected for 'Equals All Of' filter type for 'textField'.");
+    });
+
+    test('exceed max allowed for multi-value', () => {
+        expect("TODO").toEqual("Tests still to be written.");
     });
 });
 

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -91,7 +91,7 @@ export function isFilterUrlSuffixMatch(suffix: string, filterType: Filter.IFilte
     return suffix === filterType.getURLSuffix();
 }
 
-const MAX_MULTI_VALUE_FILTER_VALUES = 2;
+const MAX_MULTI_VALUE_FILTER_VALUES = 200;
 
 export function getFilterTypePlaceHolder(suffix: string): string {
     if (suffix === 'in' || suffix === 'notin' || suffix === 'containsoneof' || suffix === 'containsnoneof') {
@@ -134,7 +134,8 @@ export function getFilterValuesAsArray(filter: Filter.IFilter, blankValue?: stri
 
 export function getFieldFiltersValidationResult(
     dataTypeFilters: { [key: string]: FieldFilter[] },
-    queryLabels?: { [key: string]: string }
+    queryLabels?: { [key: string]: string },
+    maxMultiValuedValues: number = MAX_MULTI_VALUE_FILTER_VALUES
 ): string {
     const missingValueFields = {};
     let hasMissingError = false;
@@ -171,9 +172,9 @@ export function getFieldFiltersValidationResult(
                         maxMatchAllErrorField = fieldFilter.fieldCaption;
                     }
                 } else if (filter.getFilterType().isMultiValued()) {
-                    if (Array.isArray(value) && value.length > MAX_MULTI_VALUE_FILTER_VALUES) {
-                        multiValueErrorFields.add(fieldFilter.fieldCaption);
-                        multiValueErrorFieldTypes.add(filter.getFilterType().getDisplayText());
+                    if (Array.isArray(value) && value.length > maxMultiValuedValues) {
+                        multiValueErrorFields.add("'" + fieldFilter.fieldCaption + "'");
+                        multiValueErrorFieldTypes.add("'" + filter.getFilterType().getDisplayText() + "'");
                     }
                 }
 
@@ -198,17 +199,16 @@ export function getFieldFiltersValidationResult(
         return 'Missing filter values for: ' + parentMsgs.join('; ') + '.';
     }
 
-    let msg = "";
+    let msg = '';
     if (maxMatchAllErrorField)
-        msg +=
-            "At most 10 values can be selected for 'Equals All Of' filter type for '" + maxMatchAllErrorField + "'.";
+        msg += "At most 10 values can be selected for 'Equals All Of' filter type for '" + maxMatchAllErrorField + "'. ";
 
     if (multiValueErrorFields.size > 0) {
         msg +=
             'Too many values provided for filters on ' +
             makeCommaSeparatedString(Array.from(multiValueErrorFields).sort()) +
             '. At most ' +
-            MAX_MULTI_VALUE_FILTER_VALUES +
+            maxMultiValuedValues +
             ' values may be provided for filters of type ' +
             makeCommaSeparatedString(Array.from(multiValueErrorFieldTypes).sort()) +
             '.';

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -20,6 +20,7 @@ import { REGISTRY_KEY } from '../../app/constants';
 
 import { SearchCategory, SearchScope } from './constants';
 import { FieldFilter, FieldFilterOption, FilterSelection, SearchResultCardData } from './models';
+import { makeCommaSeparatedString } from '../../util/utils';
 
 export const SAMPLE_FILTER_METRIC_AREA = 'sampleFinder';
 
@@ -90,9 +91,14 @@ export function isFilterUrlSuffixMatch(suffix: string, filterType: Filter.IFilte
     return suffix === filterType.getURLSuffix();
 }
 
+const MAX_MULTI_VALUE_FILTER_VALUES = 2;
+
 export function getFilterTypePlaceHolder(suffix: string): string {
     if (suffix === 'in' || suffix === 'notin' || suffix === 'containsoneof' || suffix === 'containsnoneof') {
-        return 'Use new line or semicolon to separate entries';
+        return (
+            'Use new line or semicolon to separate entries. ' +
+            ' Max of ' + MAX_MULTI_VALUE_FILTER_VALUES + ' values.'
+        );
     }
 
     return null;
@@ -130,9 +136,11 @@ export function getFieldFiltersValidationResult(
     dataTypeFilters: { [key: string]: FieldFilter[] },
     queryLabels?: { [key: string]: string }
 ): string {
-    let missingValueFields = {},
-        hasMissingError = false,
-        maxMatchAllErrorField = null;
+    const missingValueFields = {};
+    let hasMissingError = false;
+    let maxMatchAllErrorField = null;
+    const multiValueErrorFields = new Set<string>();
+    const multiValueErrorFieldTypes = new Set<string>();
     Object.keys(dataTypeFilters).forEach(parent => {
         const filters = dataTypeFilters[parent];
         filters.forEach(fieldFilter => {
@@ -162,6 +170,11 @@ export function getFieldFiltersValidationResult(
                     if (!Array.isArray(value) || value.length > 10) {
                         maxMatchAllErrorField = fieldFilter.fieldCaption;
                     }
+                } else if (filter.getFilterType().isMultiValued()) {
+                    if (Array.isArray(value) && value.length > MAX_MULTI_VALUE_FILTER_VALUES) {
+                        multiValueErrorFields.add(fieldFilter.fieldCaption);
+                        multiValueErrorFieldTypes.add(filter.getFilterType().getDisplayText());
+                    }
                 }
 
                 if (missingValueError == true) {
@@ -185,12 +198,22 @@ export function getFieldFiltersValidationResult(
         return 'Missing filter values for: ' + parentMsgs.join('; ') + '.';
     }
 
+    let msg = "";
     if (maxMatchAllErrorField)
-        return (
-            "At most 10 values can be selected for 'Equals All Of' filter type for '" + maxMatchAllErrorField + "'."
-        );
+        msg +=
+            "At most 10 values can be selected for 'Equals All Of' filter type for '" + maxMatchAllErrorField + "'.";
 
-    return null;
+    if (multiValueErrorFields.size > 0) {
+        msg +=
+            'Too many values provided for filters on ' +
+            makeCommaSeparatedString(Array.from(multiValueErrorFields).sort()) +
+            '. At most ' +
+            MAX_MULTI_VALUE_FILTER_VALUES +
+            ' values may be provided for filters of type ' +
+            makeCommaSeparatedString(Array.from(multiValueErrorFieldTypes).sort()) +
+            '.';
+    }
+    return msg.length > 0 ? msg : null;
 }
 
 export function getFilterForFilterSelection(filterSelection: FilterSelection, field: QueryColumn): Filter.IFilter {


### PR DESCRIPTION
#### Rationale
Issue [51254](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51254): in LKS, we limit the number of values you can provide for a multi-value filter type, but we don't currently impose that limit in our applications. Since these values are sometimes passed in the URL, a limit is really wanted.

#### Related Pull Requests

- https://github.com/LabKey/labkey-ui-premium/pull/550
- https://github.com/LabKey/limsModules/pull/768

#### Changes
- Update `getFieldFiltersValidationResult` to check the number of filter values
- Convert test for related `FilterExpressionView` to RTL.
