### PR TITLE
Issue 51056: Cannot pool samples with single double quotes in the name 

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.0",
+  "version": "5.13.1-fb-bugFix2411X.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.13.0",
+      "version": "5.13.1-fb-bugFix2411X.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.2-fb-bugFix2411X.1",
+  "version": "5.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.13.2-fb-bugFix2411X.1",
+      "version": "5.13.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.1-fb-bugFix2411X.1",
+  "version": "5.13.1-fb-bugFix2411X.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.13.1-fb-bugFix2411X.1",
+      "version": "5.13.1-fb-bugFix2411X.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.1",
+  "version": "5.13.2-fb-bugFix2411X.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.13.1",
+      "version": "5.13.2-fb-bugFix2411X.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.1-fb-bugFix2411X.1",
+  "version": "5.13.1-fb-bugFix2411X.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.0",
+  "version": "5.13.1-fb-bugFix2411X.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.2-fb-bugFix2411X.1",
+  "version": "5.13.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.X
+*Released*: X October 2024
+- Issue 51056 Samples with single double quotes in the name will not resolve if added as parent samples.
+
 ### version 5.13.0
 *Released*: 7 October 2024
 - Issue 47087: Find Derivatives in Sample Finder to include a selection in filters

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 5.X
-*Released*: X October 2024
+### version 5.13.2
+*Released*: 14 October 2024
 - Issue 51056 Samples with single double quotes in the name will not resolve if added as parent samples.
 - Issue 51433 Unhandled client side exception when using a parent field in editable grid after clearing the field.
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 5.X
 *Released*: X October 2024
 - Issue 51056 Samples with single double quotes in the name will not resolve if added as parent samples.
+- Issue 51433 Unhandled client side exception when using a parent field in editable grid after clearing the field.
 
 ### version 5.13.0
 *Released*: 7 October 2024

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -527,7 +527,7 @@ export class EditorModel
 
     getValueForCellKey(cellKey: string): List<ValueDescriptor> {
         if (this.cellValues.has(cellKey)) {
-            return this.cellValues.get(cellKey);
+            return this.cellValues.get(cellKey) ?? List<ValueDescriptor>();
         }
 
         return List<ValueDescriptor>();

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -1285,6 +1285,9 @@ describe('parseCsvString', () => {
         expect(parseCsvString('a,"b""b2","c,d"', ',', true)).toStrictEqual(['a', 'b"b2', 'c,d']);
         expect(parseCsvString('"b""b2""b3"""', ',', true)).toStrictEqual(['b"b2"b3"']);
         expect(parseCsvString('"a,123', ',', true)).toStrictEqual(['"a', '123']);
+        expect(parseCsvString('"a,"123', ',', true)).toStrictEqual(['"a', '"123']);
+        expect(parseCsvString('"a,"123', ', ', true)).toStrictEqual(['"a,"123']);
+        expect(parseCsvString('"a, "123', ',', true)).toStrictEqual(['"a', ' "123']);
     });
 });
 

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -689,14 +689,14 @@ export function parseCsvString(value: string, delimiter: string, removeQuotes?: 
             }
             // if no ending quote, don't remove quotes;
             if (end === -1 || end !== value.length - 1) {
-                let isNextDelimiterOrQuote = true;
+                let isCurrentDelimiterOrQuote = true;
                 if (end > -1) {
                     const nextChar = value[end + 1];
                     // Issue 51056: "a, "b should be parsed to ["a, "b], not [a, ]
-                    isNextDelimiterOrQuote = nextChar === '"' || nextChar === delimiter;
+                    isCurrentDelimiterOrQuote = nextChar === '"' || nextChar === delimiter;
                 }
 
-                if (end === -1 || !isNextDelimiterOrQuote) {
+                if (end === -1 || !isCurrentDelimiterOrQuote) {
                     end = value.indexOf(delimiter, start);
                     if (end === -1) end = value.length;
                     parsedValues.push(value.substring(start, end));

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -688,12 +688,21 @@ export function parseCsvString(value: string, delimiter: string, removeQuotes?: 
                 end++; // skip double ""
             }
             // if no ending quote, don't remove quotes;
-            if (end === -1) {
-                end = value.indexOf(delimiter, start);
-                if (end === -1) end = value.length;
-                parsedValues.push(value.substring(start, end));
-                start = end + delimiter.length;
-                continue;
+            if (end === -1 || end !== value.length - 1) {
+                let isNextDelimiterOrQuote = true;
+                if (end > -1) {
+                    const nextChar = value[end + 1];
+                    // Issue 51056: "a, "b should be parsed to ["a, "b], not [a, ]
+                    isNextDelimiterOrQuote = nextChar === '"' || nextChar === delimiter;
+                }
+
+                if (end === -1 || !isNextDelimiterOrQuote) {
+                    end = value.indexOf(delimiter, start);
+                    if (end === -1) end = value.length;
+                    parsedValues.push(value.substring(start, end));
+                    start = end + delimiter.length;
+                    continue;
+                }
             }
             let parsedValue = removeQuotes ? value.substring(start + 1, end) : value.substring(start, end + 1); // start is at the quote
             if (removeQuotes && parsedValue.indexOf('""') !== -1) {


### PR DESCRIPTION
#### Rationale
Issue 51056 Samples with single double quotes in the name will not resolve if added as parent samples.
Issue 51433 Unhandled client side exception when using a parent field in editable grid after clearing the field.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1604
- https://github.com/LabKey/labkey-ui-premium/pull/559
- https://github.com/LabKey/platform/pull/5926
- https://github.com/LabKey/limsModules/pull/807
- https://github.com/LabKey/testAutomation/pull/2085

#### Changes
- modify parseCsvString to only remove quotes if it's a paired quote
- modify getValueForCellKey to never return null
