### PR TITLE
Issue 51425: reprocess lineage node "level" on subsequent traversals

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.1-fb-lineage-level.0",
+  "version": "5.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.13.1-fb-lineage-level.0",
+      "version": "5.13.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.0",
+  "version": "5.13.1-fb-lineage-level.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.13.0",
+      "version": "5.13.1-fb-lineage-level.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.0",
+  "version": "5.13.1-fb-lineage-level.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.13.1-fb-lineage-level.0",
+  "version": "5.13.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,14 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.13.1
+*Released*: 14 October 2024
+- Issue 51425: reprocess lineage node "level" on subsequent traversals
+- Lineage styling:
+    - Set `scaleFactor=0.6` (default is 1) for arrows so they render a bit smaller.
+    - Set `levelSeparation=125` (default is 150) to reduce the space between levels in the graph.
+    - Set `edgeMinimization=false` (default is true) so that all edges are represented in the graph.
+
 ### version 5.13.0
 *Released*: 7 October 2024
 - Issue 47087: Find Derivatives in Sample Finder to include a selection in filters

--- a/packages/components/src/internal/components/lineage/models.test.ts
+++ b/packages/components/src/internal/components/lineage/models.test.ts
@@ -1,160 +1,229 @@
-import { applyLineageOptions, LineageIO } from './models';
+import { applyLineageOptions, generateNodesAndEdges, LineageIO, LineageNode, LineageResult } from './models';
 import { DEFAULT_LINEAGE_OPTIONS } from './constants';
 import { LineageFilter } from './types';
 
-describe('applyLineageOptions', () => {
-    it('use default options', () => {
-        expect(applyLineageOptions()).toStrictEqual(DEFAULT_LINEAGE_OPTIONS);
+describe('lineage model', () => {
+    describe('applyLineageOptions', () => {
+        it('use default options', () => {
+            expect(applyLineageOptions()).toStrictEqual(DEFAULT_LINEAGE_OPTIONS);
+        });
+
+        it('apply lineage options', () => {
+            const filters = [new LineageFilter('someField', ['testValue'])];
+            const filteredOptions = applyLineageOptions({ filters });
+            expect(filteredOptions).toHaveProperty('filters', filters);
+
+            // Check deep copy
+            filters[0].field = 'Jazz';
+            expect(filteredOptions.filters[0].field).toBe('someField');
+        });
+
+        it('apply grouping options', () => {
+            expect(applyLineageOptions({ grouping: { childDepth: 99 } })).toHaveProperty(
+                ['grouping', 'childDepth'],
+                99
+            );
+        });
     });
 
-    it('apply lineage options', () => {
-        const filters = [new LineageFilter('someField', ['testValue'])];
-        const filteredOptions = applyLineageOptions({ filters });
-        expect(filteredOptions).toHaveProperty('filters', filters);
+    describe('LineageIO.applyConfig', () => {
+        const lineageObj = {
+            container: 'container',
+            created: '2022-01-20',
+            createdBy: 'me',
+            modified: '2022-01-21',
+            modifiedBy: 'me',
+            expType: 'type',
+            id: 1,
+            lsid: 'abc:123',
+            name: 'name',
+            pkFilters: [],
+            queryName: 'query',
+            schemaName: 'schema',
+        };
 
-        // Check deep copy
-        filters[0].field = 'Jazz';
-        expect(filteredOptions.filters[0].field).toBe('someField');
+        it('dataInputs', () => {
+            expect(LineageIO.applyConfig({}).dataInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ dataInputs: undefined }).dataInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ dataInputs: [] }).dataInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ dataInputs: [{ ...lineageObj }] }).dataInputs.length).toBe(1);
+        });
+
+        it('dataOutputs', () => {
+            expect(LineageIO.applyConfig({}).dataOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ dataOutputs: undefined }).dataOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ dataOutputs: [] }).dataOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ dataOutputs: [{ ...lineageObj }] }).dataOutputs.length).toBe(1);
+        });
+
+        it('materialInputs', () => {
+            expect(LineageIO.applyConfig({}).materialInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ materialInputs: undefined }).materialInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ materialInputs: [] }).materialInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ materialInputs: [{ ...lineageObj }] }).materialInputs.length).toBe(1);
+        });
+
+        it('materialOutputs', () => {
+            expect(LineageIO.applyConfig({}).materialOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ materialOutputs: undefined }).materialOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ materialOutputs: [] }).materialOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ materialOutputs: [{ ...lineageObj }] }).materialOutputs.length).toBe(1);
+        });
+
+        it('objectInputs', () => {
+            expect(LineageIO.applyConfig({}).objectInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectInputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ provenanceMap: [] }).objectInputs.length).toBe(0);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: undefined,
+                            to: { ...lineageObj },
+                        },
+                    ],
+                }).objectInputs.length
+            ).toBe(0);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: undefined,
+                            to: undefined,
+                        },
+                    ],
+                }).objectInputs.length
+            ).toBe(0);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: { ...lineageObj },
+                            to: undefined,
+                        },
+                    ],
+                }).objectInputs.length
+            ).toBe(1);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: { ...lineageObj },
+                            to: { ...lineageObj },
+                        },
+                    ],
+                }).objectInputs.length
+            ).toBe(1);
+        });
+
+        it('objectOutputs', () => {
+            expect(LineageIO.applyConfig({}).objectOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectOutputs.length).toBe(0);
+            expect(LineageIO.applyConfig({ provenanceMap: [] }).objectOutputs.length).toBe(0);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: undefined,
+                            to: { ...lineageObj },
+                        },
+                    ],
+                }).objectOutputs.length
+            ).toBe(1);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: undefined,
+                            to: undefined,
+                        },
+                    ],
+                }).objectOutputs.length
+            ).toBe(0);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: { ...lineageObj },
+                            to: undefined,
+                        },
+                    ],
+                }).objectOutputs.length
+            ).toBe(0);
+            expect(
+                LineageIO.applyConfig({
+                    provenanceMap: [
+                        {
+                            from: { ...lineageObj },
+                            to: { ...lineageObj },
+                        },
+                    ],
+                }).objectOutputs.length
+            ).toBe(1);
+        });
     });
 
-    it('apply grouping options', () => {
-        expect(applyLineageOptions({ grouping: { childDepth: 99 } })).toHaveProperty(['grouping', 'childDepth'], 99);
-    });
-});
+    describe('generateNodesAndEdges', () => {
+        // Regression coverage for Issue 51425
+        it('reprocesses level', () => {
+            // Arrange
+            const childOneLsid = 'child-one-lsid';
+            const childTwoLsid = 'child-two-lsid';
+            const childThreeLsid = 'child-three-lsid';
+            const childFourLsid = 'child-four-lsid';
+            const parentLsid = 'parent-lsid';
 
-describe('LineageIO.applyConfig', () => {
-    const lineageObj = {
-        container: 'container',
-        created: '2022-01-20',
-        createdBy: 'me',
-        modified: '2022-01-21',
-        modifiedBy: 'me',
-        expType: 'type',
-        id: 1,
-        lsid: 'abc:123',
-        name: 'name',
-        pkFilters: [],
-        queryName: 'query',
-        schemaName: 'schema',
-    };
+            const childOneNode = LineageNode.create(childOneLsid, {
+                children: [{ lsid: childFourLsid }],
+                parents: [{ lsid: parentLsid }],
+            });
 
-    it('dataInputs', () => {
-        expect(LineageIO.applyConfig({}).dataInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataInputs: undefined }).dataInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataInputs: [] }).dataInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataInputs: [{ ...lineageObj }] }).dataInputs.length).toBe(1);
-    });
+            const childTwoNode = LineageNode.create(childTwoLsid, {
+                children: [{ lsid: childFourLsid }],
+                parents: [{ lsid: parentLsid }],
+            });
 
-    it('dataOutputs', () => {
-        expect(LineageIO.applyConfig({}).dataOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataOutputs: undefined }).dataOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataOutputs: [] }).dataOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ dataOutputs: [{ ...lineageObj }] }).dataOutputs.length).toBe(1);
-    });
+            const childThreeNode = LineageNode.create(childThreeLsid, {
+                children: [{ lsid: childFourLsid }],
+                parents: [{ lsid: parentLsid }],
+            });
 
-    it('materialInputs', () => {
-        expect(LineageIO.applyConfig({}).materialInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialInputs: undefined }).materialInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialInputs: [] }).materialInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialInputs: [{ ...lineageObj }] }).materialInputs.length).toBe(1);
-    });
+            const childFourNode = LineageNode.create(childFourLsid, {
+                parents: [
+                    { lsid: parentLsid },
+                    { lsid: childOneLsid },
+                    { lsid: childTwoLsid },
+                    { lsid: childThreeLsid },
+                ],
+            });
 
-    it('materialOutputs', () => {
-        expect(LineageIO.applyConfig({}).materialOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialOutputs: undefined }).materialOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialOutputs: [] }).materialOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ materialOutputs: [{ ...lineageObj }] }).materialOutputs.length).toBe(1);
-    });
+            const parentNode = LineageNode.create(parentLsid, {
+                children: [{ lsid: childOneLsid }, { lsid: childTwoLsid }, { lsid: childThreeLsid }],
+            });
 
-    it('objectInputs', () => {
-        expect(LineageIO.applyConfig({}).objectInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectInputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [] }).objectInputs.length).toBe(0);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: undefined,
-                        to: { ...lineageObj },
-                    },
-                ],
-            }).objectInputs.length
-        ).toBe(0);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: undefined,
-                        to: undefined,
-                    },
-                ],
-            }).objectInputs.length
-        ).toBe(0);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: { ...lineageObj },
-                        to: undefined,
-                    },
-                ],
-            }).objectInputs.length
-        ).toBe(1);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: { ...lineageObj },
-                        to: { ...lineageObj },
-                    },
-                ],
-            }).objectInputs.length
-        ).toBe(1);
-    });
+            const result = LineageResult.create({
+                nodes: {
+                    [parentNode.lsid]: parentNode,
+                    [childOneNode.lsid]: childOneNode,
+                    [childTwoNode.lsid]: childTwoNode,
+                    [childThreeNode.lsid]: childThreeNode,
+                    [childFourNode.lsid]: childFourNode,
+                },
+                seed: childFourNode.lsid,
+            });
 
-    it('objectOutputs', () => {
-        expect(LineageIO.applyConfig({}).objectOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: undefined }).objectOutputs.length).toBe(0);
-        expect(LineageIO.applyConfig({ provenanceMap: [] }).objectOutputs.length).toBe(0);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: undefined,
-                        to: { ...lineageObj },
-                    },
-                ],
-            }).objectOutputs.length
-        ).toBe(1);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: undefined,
-                        to: undefined,
-                    },
-                ],
-            }).objectOutputs.length
-        ).toBe(0);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: { ...lineageObj },
-                        to: undefined,
-                    },
-                ],
-            }).objectOutputs.length
-        ).toBe(0);
-        expect(
-            LineageIO.applyConfig({
-                provenanceMap: [
-                    {
-                        from: { ...lineageObj },
-                        to: { ...lineageObj },
-                    },
-                ],
-            }).objectOutputs.length
-        ).toBe(1);
+            // Act
+            const { edges, nodes } = generateNodesAndEdges(result);
+
+            // Assert
+            expect(Object.keys(edges).length).toEqual(7);
+            expect(Object.keys(nodes).length).toEqual(5);
+
+            expect(nodes[parentNode.lsid].level).toEqual(-2);
+            expect(nodes[childOneNode.lsid].level).toEqual(-1);
+            expect(nodes[childTwoNode.lsid].level).toEqual(-1);
+            expect(nodes[childThreeNode.lsid].level).toEqual(-1);
+            expect(nodes[childFourNode.lsid].level).toEqual(0);
+        });
     });
 });

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -1245,7 +1245,7 @@ function reprocessLevel(visNode: VisGraphNode | VisGraphCombinedNode, dir: LINEA
  *   - if there are less than {combineSize} edges, create a basic node
  *     - create edges from the node to all edge targets
  */
-export function processNodes(
+function processNodes(
     seed: string,
     lsid: string,
     nodes: LineageNodesRecord,


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51425](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51425) by reprocessing lineage nodes on subsequent traversals to recalculate their `level` property. The `level` tells vis.js where to place the node in the hierarchy. As a result, the graph layout is more consistent and not subject to differences of the node processing order.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/820

#### Changes
- Introduce a `reprocessLevel()` utility that is called for each subsequent traversal of a node after the first traversal. This adjusts the level of the node given the processing depth if neccessary.
- Styling:
  - Set `scaleFactor=0.6` (default is 1) for arrows so they render a bit smaller.
  - Set `levelSeparation=125` (default is 150) to reduce the space between levels in the graph
  - Set `edgeMinimization=false` (default is true) so that all edges are represented in the graph
- Stop returning `-0` for `level` because it is not useful and just makes things confusing (no functional difference).
- Factor out `generateNodesAndEdges()` to make it easier to test node generation.
- Add regression tests.
