### PR TITLE
Plates: Importing assay runs for plates with replicates

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.3",
+  "version": "5.17.4-fb-assay-plate-import-ux.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.3",
+      "version": "5.17.4-fb-assay-plate-import-ux.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.4-fb-assay-plate-import-ux.0",
+  "version": "5.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.4-fb-assay-plate-import-ux.0",
+      "version": "5.17.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.3",
+  "version": "5.17.4-fb-assay-plate-import-ux.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.4-fb-assay-plate-import-ux.0",
+  "version": "5.17.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.17.4
+*Released*: 25 October 2024
+- Add `SchemaQuery` properties on `AssayDefinitionModel`.
+- Refactor `AssayDefinitionModel` to use `ExtendedMap`.
+
 ### version 5.17.3
 *Released*: 23 October 2024
 - Issue 39332: Make sure export started messages shows before export starts in TabbedGridPanel exportTabs case

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -961,6 +961,7 @@ const App = {
     hasPremiumModule,
     hasProductFolders,
     hasModule,
+    generateNameWithTimestamp,
     getContainerFormats,
     getDateFormat,
     getDateTimeFormat,

--- a/packages/components/src/internal/AssayDefinitionModel.test.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.test.ts
@@ -1,6 +1,3 @@
-import { List } from 'immutable';
-import { Filter } from '@labkey/api';
-
 import assayDefJSON from '../test/data/assayDefinitionModel.json';
 import assayDefNoSampleIdJSON from '../test/data/assayDefinitionModelNoSampleId.json';
 
@@ -21,13 +18,13 @@ describe('AssayDefinitionModel', () => {
     test('without getSampleColumn()', () => {
         const modelWithout = AssayDefinitionModel.create(assayDefNoSampleIdJSON);
         const nonSampleColumn = modelWithout.getSampleColumn();
-        expect(nonSampleColumn).toBe(null);
+        expect(nonSampleColumn).toBeUndefined();
     });
 
     test('getSampleColumn with invalid domainType', () => {
         const modelWithSampleId = AssayDefinitionModel.create(assayDefJSON);
         const sampleColumn = modelWithSampleId.getSampleColumn(AssayDomainTypes.BATCH);
-        expect(sampleColumn).toBe(null);
+        expect(sampleColumn).toBeUndefined();
     });
 
     test('getSampleColumn with domainType', () => {
@@ -46,8 +43,8 @@ describe('AssayDefinitionModel', () => {
     test('getSampleColumnFieldKeys()', () => {
         const modelWithSampleId = AssayDefinitionModel.create(assayDefJSON);
         const fieldKeys = modelWithSampleId.getSampleColumnFieldKeys();
-        expect(fieldKeys.size).toBe(1);
-        expect(fieldKeys.get(0)).toBe('SampleID');
+        expect(fieldKeys.length).toBe(1);
+        expect(fieldKeys[0]).toBe('SampleID');
     });
 
     test('getDomainColumns()', () => {
@@ -65,38 +62,6 @@ describe('AssayDefinitionModel', () => {
         expect(dataColumns.size).toBe(4);
         expect(dataColumns.has('Date')).toBeFalsy();
         expect(dataColumns.has('date')).toBeTruthy();
-    });
-
-    test('createSampleFilter, no columns', () => {
-        const model = new AssayDefinitionModel();
-        const filter = model.createSampleFilter(List.of(), [1, 2], Filter.Types.IN);
-        expect(filter).toBeUndefined();
-    });
-
-    test('createSampleFilter, single column', () => {
-        const model = new AssayDefinitionModel();
-        const filter = model.createSampleFilter(List.of('a'), [1, 2], Filter.Types.IN);
-        expect(filter.getURLParameterName()).toBe('query.a/RowId~in');
-        expect(filter.getURLParameterValue()).toBe('1;2');
-    });
-
-    test('createSampleFilter, multiple columns', () => {
-        const model = new AssayDefinitionModel();
-        const filter = model.createSampleFilter(List.of('a', 'b'), [1, 2], Filter.Types.IN);
-        expect(filter.getURLParameterName()).toBe('query.*~where');
-        expect(filter.getURLParameterValue()).toBe(
-            'RowId IN (SELECT RowId FROM Data WHERE "a"."RowId" IN (1,2) UNION SELECT RowId FROM Data WHERE "b"."RowId" IN (1,2))'
-        );
-    });
-
-    // Issue 48364
-    test('createSampleFilter, multiple columns with space in name', () => {
-        const model = new AssayDefinitionModel();
-        const filter = model.createSampleFilter(List.of('sample result', 'b'), [1, 2], Filter.Types.IN);
-        expect(filter.getURLParameterName()).toBe('query.*~where');
-        expect(filter.getURLParameterValue()).toBe(
-            'RowId IN (SELECT RowId FROM Data WHERE "sample result"."RowId" IN (1,2) UNION SELECT RowId FROM Data WHERE "b"."RowId" IN (1,2))'
-        );
     });
 
     test('getDomainFileColumns', () => {

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -1,8 +1,8 @@
-import { fromJS, List, Map, OrderedMap, Record as ImmutableRecord } from 'immutable';
+import { fromJS, List, Map, Record as ImmutableRecord } from 'immutable';
 import { Filter } from '@labkey/api';
 
+import { ExtendedMap } from '../public/ExtendedMap';
 import { QueryColumn } from '../public/QueryColumn';
-
 import { SchemaQuery } from '../public/SchemaQuery';
 
 import { AssayUploadTabs } from './constants';
@@ -299,25 +299,21 @@ export class AssayDefinitionModel extends ImmutableRecord({
         }
     }
 
-    getDomainColumns(type: AssayDomainTypes): OrderedMap<string, QueryColumn> {
-        const columns = OrderedMap<string, QueryColumn>().asMutable();
+    getDomainColumns(type: AssayDomainTypes): ExtendedMap<string, QueryColumn> {
+        const columns = new ExtendedMap<string, QueryColumn>();
 
         if (this.domains && this.domains.size) {
-            const domainColumns = this.getDomainByType(type);
-
-            if (domainColumns && domainColumns.size) {
-                domainColumns.forEach(dc => {
-                    columns.set(dc.fieldKey.toLowerCase(), dc);
-                });
-            }
+            this.getDomainByType(type)?.forEach(dc => {
+                columns.set(dc.fieldKey.toLowerCase(), dc);
+            });
         }
 
-        return columns.asImmutable();
+        return columns;
     }
 
     getDomainFileColumns(type: AssayDomainTypes): QueryColumn[] {
         return this.getDomainColumns(type)
             .filter(col => col.isFileInput)
-            .toArray();
+            .valueArray;
     }
 }

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -11,6 +11,7 @@ import { AppURL, createProductUrlFromParts } from './url/AppURL';
 
 import { SCHEMAS } from './schemas';
 import { WHERE_FILTER_TYPE } from './url/WhereFilterType';
+import { ASSAYS_KEY } from './app/constants';
 
 export enum AssayDomainTypes {
     BATCH = 'Batch',
@@ -66,6 +67,18 @@ export class AssayDefinitionModel extends ImmutableRecord({
     declare reRunSupport: string;
     declare templateLink: string;
     declare type: string;
+
+    get batchesSchemaQuery(): SchemaQuery {
+        return new SchemaQuery(this.protocolSchemaName, 'Batches');
+    }
+
+    get resultsSchemaQuery(): SchemaQuery {
+        return new SchemaQuery(this.protocolSchemaName, 'Data');
+    }
+
+    get runsSchemaQuery(): SchemaQuery {
+        return new SchemaQuery(this.protocolSchemaName, 'Runs');
+    }
 
     static create(rawModel): AssayDefinitionModel {
         let domains = Map<string, List<QueryColumn>>();
@@ -136,7 +149,7 @@ export class AssayDefinitionModel extends ImmutableRecord({
                 targetProductId,
                 currentProductId,
                 params,
-                'assays',
+                ASSAYS_KEY,
                 this.type,
                 this.name,
                 'upload'
@@ -150,8 +163,12 @@ export class AssayDefinitionModel extends ImmutableRecord({
         return url;
     }
 
-    getRunsUrl() {
-        return AppURL.create('assays', this.type, this.name, 'runs');
+    getAppImportUrl(): AppURL {
+        return AppURL.create(ASSAYS_KEY, this.type, this.name, 'upload');
+    }
+
+    getRunsUrl(): AppURL {
+        return AppURL.create(ASSAYS_KEY, this.type, this.name, 'runs');
     }
 
     hasLookup(targetSQ: SchemaQuery, isPicklist?: boolean): boolean {


### PR DESCRIPTION
#### Rationale
Support re-import of plate-based assay runs.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1617
- https://github.com/LabKey/labkey-ui-premium/pull/572
- https://github.com/LabKey/limsModules/pull/855
- https://github.com/LabKey/platform/pull/5978

#### Changes
- Add `SchemaQuery` properties on `AssayDefinitionModel`.
- Refactor `AssayDefinitionModel` to use `ExtendedMap`.
