### PR TITLE
Plates: remove experimental flag

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.4",
+  "version": "5.17.5-fb-remove-plate-flag.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.4",
+      "version": "5.17.5-fb-remove-plate-flag.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.5-fb-remove-plate-flag.0",
+  "version": "5.17.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.5-fb-remove-plate-flag.0",
+      "version": "5.17.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.4",
+  "version": "5.17.5-fb-remove-plate-flag.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.5-fb-remove-plate-flag.0",
+  "version": "5.17.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.17.5
+*Released*: 26 October 2024
+- Remove reference to the experimental flag for plates.
+
 ### version 5.17.4
 *Released*: 25 October 2024
 - Add `SchemaQuery` properties on `AssayDefinitionModel`.

--- a/packages/components/src/internal/app/constants.ts
+++ b/packages/components/src/internal/app/constants.ts
@@ -108,8 +108,6 @@ export const NOTIFICATION_TIMEOUT = 500;
 
 export const SERVER_NOTIFICATION_MAX_ROWS = 8;
 
-export const EXPERIMENTAL_APP_PLATE_SUPPORT = 'experimental-app-plate-support';
-
 export const EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = 'queryProductAllFolderLookups';
 export const EXPERIMENTAL_PRODUCT_FOLDER_DATA_LISTING_SCOPED = 'queryProductProjectDataListingScoped';
 export const EXPERIMENTAL_REQUESTS_MENU = 'experimental-biologics-requests-menu';

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -22,7 +22,6 @@ import { AppProperties } from './models';
 import {
     ASSAYS_KEY,
     BIOLOGICS_APP_PROPERTIES,
-    EXPERIMENTAL_APP_PLATE_SUPPORT,
     EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS,
     EXPERIMENTAL_PRODUCT_FOLDER_DATA_LISTING_SCOPED,
     EXPERIMENTAL_REQUESTS_MENU,
@@ -354,10 +353,7 @@ export function isNonstandardAssayEnabled(moduleContext?: ModuleContext): boolea
 }
 
 export function isPlatesEnabled(moduleContext?: ModuleContext): boolean {
-    return (
-        biologicsIsPrimaryApp(moduleContext) &&
-        resolveModuleContext(moduleContext)?.biologics?.[EXPERIMENTAL_APP_PLATE_SUPPORT] === true
-    );
+    return biologicsIsPrimaryApp(moduleContext);
 }
 
 export function isChartBuilderEnabled(moduleContext?: ModuleContext): boolean {


### PR DESCRIPTION
#### Rationale
Removes the experimental flag for plate support.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1619
- https://github.com/LabKey/limsModules/pull/860
- https://github.com/LabKey/platform/pull/5988

#### Changes
- Remove reference to the experimental flag for plates on the biologics module context.
