### PR TITLE
Package update: vis-network

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.5",
+  "version": "5.17.6-fb-upgrade-visjs.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.5",
+      "version": "5.17.6-fb-upgrade-visjs.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -31,7 +31,8 @@
         "react-router-dom": "~6.24.1",
         "react-select": "~5.8.0",
         "react-treebeard": "~3.2.4",
-        "vis-network": "~6.5.2"
+        "vis-data": "~7.1.9",
+        "vis-network": "~9.1.9"
       },
       "devDependencies": {
         "@labkey/build": "7.7.1",
@@ -16572,20 +16573,34 @@
         "react-dom": ">=15.0.0"
       }
     },
-    "node_modules/vis-network": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-6.5.2.tgz",
-      "integrity": "sha512-Dj5oEtZMUWuhq7D7dwdmxmtJgrK3kwfV4Ov/ePSrhPZgNdJlXzpeDZU/Eq0pKGyOAPLClemgVImc0bZpZ4Yafw==",
-      "hasInstallScript": true,
+    "node_modules/vis-data": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.9.tgz",
+      "integrity": "sha512-COQsxlVrmcRIbZMMTYwD+C2bxYCFDNQ2EHESklPiInbD/Pk3JZ6qNL84Bp9wWjYjAzXfSlsNaFtRk+hO9yBPWA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/visjs"
       },
       "peerDependencies": {
-        "keycharm": "^0.2.0",
-        "moment": "^2.24.0",
-        "vis-data": "^6.2.1",
-        "vis-util": "^1.1.8"
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "vis-util": "^5.0.1"
+      }
+    },
+    "node_modules/vis-network": {
+      "version": "9.1.9",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.1.9.tgz",
+      "integrity": "sha512-Ft+hLBVyiLstVYSb69Q1OIQeh3FeUxHJn0WdFcq+BFPqs+Vq1ibMi2sb//cxgq1CP7PH4yOXnHxEH/B2VzpZYA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "vis-data": "^6.3.0 || ^7.0.0",
+        "vis-util": "^5.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.6-fb-upgrade-visjs.0",
+  "version": "5.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.6-fb-upgrade-visjs.0",
+      "version": "5.17.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.5",
+  "version": "5.17.6-fb-upgrade-visjs.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.6-fb-upgrade-visjs.0",
+  "version": "5.17.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -70,7 +70,8 @@
     "react-router-dom": "~6.24.1",
     "react-select": "~5.8.0",
     "react-treebeard": "~3.2.4",
-    "vis-network": "~6.5.2"
+    "vis-data": "~7.1.9",
+    "vis-network": "~9.1.9"
   },
   "devDependencies": {
     "@labkey/build": "7.7.1",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.17.6
+*Released*: 28 October 2024
+- Update to `vis-network@9.1.9`
+- Add necessary peer dependency `vis-data@7.1.9` to our dependencies
+- Simplify typings and adjust API usages to match latest version
+
 ### version 5.17.5
 *Released*: 26 October 2024
 - Remove reference to the experimental flag for plates.

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -4,8 +4,10 @@
  */
 import { immerable, produce } from 'immer';
 import { List, Map, Record as ImmutableRecord } from 'immutable';
+import { DataSet } from 'vis-data';
+import { Edge, IdType, Node } from 'vis-network';
+
 import { Experiment, Utils } from '@labkey/api';
-import { DataSet, Edge, IdType, Node } from 'vis-network';
 
 import { QueryInfo } from '../../../public/QueryInfo';
 
@@ -683,7 +685,7 @@ export interface VisGraphCombinedNode extends Node {
 
 // vis.js doesn't expose cluster nodes directly, so this is our shim
 interface VisGraphClusterNode {
-    id: string | number;
+    id: IdType;
     kind: 'cluster';
     nodesInCluster: VisGraphNodeType[];
 }
@@ -702,14 +704,7 @@ export function isClusterNode(item: VisGraphNodeType): item is VisGraphClusterNo
     return item && item.kind === 'cluster';
 }
 
-interface IVisGraphOptions {
-    edges: DataSet<Edge>;
-    initialSelection: string[];
-    nodes: DataSet<VisGraphNode | VisGraphCombinedNode>;
-    options: Record<string, any>;
-}
-
-export class VisGraphOptions implements IVisGraphOptions {
+export class VisGraphOptions {
     [immerable] = true;
 
     readonly edges: DataSet<Edge>;
@@ -717,7 +712,7 @@ export class VisGraphOptions implements IVisGraphOptions {
     readonly nodes: DataSet<VisGraphNode | VisGraphCombinedNode>;
     readonly options: Record<string, any>;
 
-    constructor(config?: Partial<IVisGraphOptions>) {
+    constructor(config?: Partial<VisGraphOptions>) {
         Object.assign(this, config);
     }
 

--- a/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
+++ b/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
@@ -79,7 +79,11 @@ export class VisGraphControls extends PureComponent<GraphControlsProps> {
                     </div>
                 </div>
                 <div className="lineage-visgraph-control-pan">
-                    <button className="lineage-visgraph-control-pan-up btn btn-default" onClick={this.panUp} type="button">
+                    <button
+                        className="lineage-visgraph-control-pan-up btn btn-default"
+                        onClick={this.panUp}
+                        type="button"
+                    >
                         <i className="fa fa-arrow-up" />
                     </button>
                     <div className="btn-group">

--- a/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
+++ b/packages/components/src/internal/components/lineage/vis/VisGraphControls.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent, ReactNode } from 'react';
 import { Network } from 'vis-network';
+
 import { DropdownButton, MenuItem } from '../../../dropdowns';
 
 const PAN_INCREMENT = 20;


### PR DESCRIPTION
#### Rationale
This updates our package dependency vis-network to the latest version. This addresses [Issue 47426](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47426).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1620
- https://github.com/LabKey/limsModules/pull/862
- https://github.com/LabKey/platform/pull/5993

#### Changes
- Update to `vis-network@9.1.9`
- Add necessary peer dependency `vis-data@7.1.9` to our dependencies
- Simplify typings and adjust API usages to match latest version
