### PR TITLE
Issue 51293: remove useExperimentalCoreUI flag

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.6",
+  "version": "5.17.7-fb-ui-flag.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.6",
+      "version": "5.17.7-fb-ui-flag.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.3",
+        "@labkey/api": "1.35.4-fb-ui-flag.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",
@@ -3527,9 +3527,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.3.tgz",
-      "integrity": "sha512-ma6CTKkdPuGobJekbnI6VBoGSRJV9rzPo+wF0VuJ0+vTvinAWDBlrI4zm3Fam/FizyD8pOkZiBFjRprCXb4SfA=="
+      "version": "1.35.4-fb-ui-flag.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.4-fb-ui-flag.0.tgz",
+      "integrity": "sha512-sIQovKnROdigh0M+2RYEThPbLeBGZ/QeR7OVZkOuKSIVr3CEZ/uW+ZfHp/bxbVIIZKznpy+il0FZ7qIstUptIg=="
     },
     "node_modules/@labkey/build": {
       "version": "7.7.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.4-fb-ui-flag.0",
+        "@labkey/api": "1.35.4",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",
@@ -3527,9 +3527,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.4-fb-ui-flag.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.4-fb-ui-flag.0.tgz",
-      "integrity": "sha512-sIQovKnROdigh0M+2RYEThPbLeBGZ/QeR7OVZkOuKSIVr3CEZ/uW+ZfHp/bxbVIIZKznpy+il0FZ7qIstUptIg=="
+      "version": "1.35.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.4.tgz",
+      "integrity": "sha512-7wJ6HKcCQiG/w6lQ4dY/BeTTrEUBdBBGkOGQjdqdbMfMAl0VqydojdGWHSw0qcg6H442VaYrq24hMUUkY2visQ=="
     },
     "node_modules/@labkey/build": {
       "version": "7.7.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.7-fb-ui-flag.0",
+  "version": "5.17.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.7-fb-ui-flag.0",
+      "version": "5.17.7",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.6",
+  "version": "5.17.7-fb-ui-flag.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "16.6.0",
-    "@labkey/api": "1.35.4-fb-ui-flag.0",
+    "@labkey/api": "1.35.4",
     "@testing-library/jest-dom": "~6.5.0",
     "@testing-library/react": "~16.0.1",
     "@testing-library/dom": "~10.4.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "16.6.0",
-    "@labkey/api": "1.35.3",
+    "@labkey/api": "1.35.4-fb-ui-flag.0",
     "@testing-library/jest-dom": "~6.5.0",
     "@testing-library/react": "~16.0.1",
     "@testing-library/dom": "~10.4.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.7-fb-ui-flag.0",
+  "version": "5.17.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.17.7
+*Released*: 28 October 2024
+- Bump `@labkey/api` package dependency
+
 ### version 5.17.6
 *Released*: 28 October 2024
 - Update to `vis-network@9.1.9`


### PR DESCRIPTION
#### Rationale
Removes reference to a long since incorporated experimental flag. Addresses [Issue 51293](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51293).

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/186
- https://github.com/LabKey/labkey-ui-components/pull/1622
- https://github.com/LabKey/platform/pull/5996
- https://github.com/LabKey/nlp/pull/253

#### Changes
- Bump `@labkey/api`
