### PR TITLE
@labkey/build: support "dependencies" in entry points

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.7.2-fb-build-depends.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.7.2-fb-build-depends.0",
+      "version": "8.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.24.9",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "7.7.1",
+  "version": "7.7.2-fb-build-depends.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "7.7.1",
+      "version": "7.7.2-fb-build-depends.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.24.9",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.7.2-fb-build-depends.0",
+  "version": "8.0.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "7.7.1",
+  "version": "7.7.2-fb-build-depends.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,11 @@
 # @labkey/build
 
+### version 8.0.0
+*Released*: 29 October 2024
+- support "dependencies" on entry points
+- remove "passwordGauge.js", "vis/vis", and "vis/genericChart/genericChartHelper.js" dependencies from default generated view.xml
+- retain "clientapi" dependency in default generated view.xml
+
 ### version 7.7.1
 *Released*: 10 September 2024
 - Add `date-fns/format` and `date-fns-tz` to list of external packages.

--- a/packages/build/webpack/app.view.template.xml
+++ b/packages/build/webpack/app.view.template.xml
@@ -29,16 +29,18 @@
     <% } %>
     <dependencies>
         <dependency path="clientapi"/>
-        <dependency path="passwordGauge.js"/>
-        <dependency path="vis/vis"/>
-        <dependency path="vis/genericChart/genericChartHelper.js"/>
+    <% if (htmlWebpackPlugin.options.dependencies) { %>
+        <% htmlWebpackPlugin.options.dependencies.forEach((dependencyPath) => { %>
+        <dependency path="<%= dependencyPath %>"/>
+        <% }); %>
+    <% } %>
     <% if (options.mode !== 'dev') { %>
         <%
             const publicPath = files.publicPath;
             const resourcesPath = 'gen/';
             [...files.css, ...files.js].forEach((filePath) => {
                 // It would be preferred to map these by entryPoint rather than hard code the file paths.
-                // This could theoretically be done by poking the "compilation" object from webpack but I could not
+                // This could theoretically be done by poking the "compilation" object from webpack, but I could not
                 // find a strategy that works.
                 if (filePath.indexOf('vendors') > -1 || filePath.indexOf(options.name) > -1) {
         %>

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -300,6 +300,7 @@ module.exports = {
                         module: lkModule,
                         name: app.name,
                         title: app.title,
+                        dependencies: app.dependencies,
                         viewTemplate: app.template,
                         filename: '../../web/gen/' + app.name + '.lib.xml',
                         template: 'node_modules/@labkey/build/webpack/lib.template.xml',
@@ -313,6 +314,7 @@ module.exports = {
                         module: lkModule,
                         name: app.name,
                         title: app.title,
+                        dependencies: app.dependencies,
                         permission: app.permission, // deprecated
                         permissionClasses: app.permissionClasses,
                         requiresLogin: app.requiresLogin,
@@ -334,6 +336,7 @@ module.exports = {
                         module: lkModule,
                         name: app.name,
                         title: app.title,
+                        dependencies: app.dependencies,
                         permission: app.permission, // deprecated
                         permissionClasses: app.permissionClasses,
                         requiresLogin: app.requiresLogin,

--- a/packages/build/webpack/lib.template.xml
+++ b/packages/build/webpack/lib.template.xml
@@ -1,11 +1,16 @@
 <libraries xmlns="http://labkey.org/clientLibrary/xml/">
     <dependencies>
+        <% if (htmlWebpackPlugin.options.dependencies) { %>
+            <% htmlWebpackPlugin.options.dependencies.forEach((dependencyPath) => { %>
+        <dependency path="<%= dependencyPath %>"/>
+            <% }); %>
+        <% } %>
         <%
             const { files, options } = htmlWebpackPlugin;
             const publicPath = files.publicPath;
             const resourcesPath = 'gen/';
             // It would be preferred to map these by entryPoint rather than hard code the file paths.
-            // This could theoretically be done by poking the "compilation" object from webpack but I could not
+            // This could theoretically be done by poking the "compilation" object from webpack, but I could not
             // find a strategy that works.
             [...files.css, ...files.js].forEach((filePath) => {
                 if (filePath.indexOf('vendors') > -1 || filePath.indexOf(options.name) > -1) {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.7",
+  "version": "5.17.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.17.7",
+      "version": "5.17.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "7.7.1",
+        "@labkey/build": "7.7.2-fb-build-depends.0",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.12",
@@ -3532,9 +3532,9 @@
       "integrity": "sha512-7wJ6HKcCQiG/w6lQ4dY/BeTTrEUBdBBGkOGQjdqdbMfMAl0VqydojdGWHSw0qcg6H442VaYrq24hMUUkY2visQ=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.7.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.7.1.tgz",
-      "integrity": "sha512-yyhnElpvFXc/OJ/G1kU6HsJczequIkfMhCv2P93VOUXMK5usYZFqi9z8nFXy6yL5b6Z9sFdzWYfLPE9gtSTnHg==",
+      "version": "7.7.2-fb-build-depends.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.7.2-fb-build-depends.0.tgz",
+      "integrity": "sha512-R4MlUYhUxqRnZaOnVV30jZSsmwOJLUCGTEZW8BtVmbenn+qP+ebdAGRlvUC0Djn3cy2CA245vUO8q/T2jidn8w==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.24.9",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "7.7.2-fb-build-depends.0",
+        "@labkey/build": "8.0.0",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.12",
@@ -3532,9 +3532,9 @@
       "integrity": "sha512-7wJ6HKcCQiG/w6lQ4dY/BeTTrEUBdBBGkOGQjdqdbMfMAl0VqydojdGWHSw0qcg6H442VaYrq24hMUUkY2visQ=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.7.2-fb-build-depends.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.7.2-fb-build-depends.0.tgz",
-      "integrity": "sha512-R4MlUYhUxqRnZaOnVV30jZSsmwOJLUCGTEZW8BtVmbenn+qP+ebdAGRlvUC0Djn3cy2CA245vUO8q/T2jidn8w==",
+      "version": "8.0.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.0.0.tgz",
+      "integrity": "sha512-iHt/Q6O6d8tvoLf4FoRn/THwXU3s59qKmUsmwo9T51mH87+KI7Aa/3hUZqvOIc4WkHN3KFVNYAsT4SLFpKMMwQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.24.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "7.7.2-fb-build-depends.0",
+    "@labkey/build": "8.0.0",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.12",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "7.7.1",
+    "@labkey/build": "7.7.2-fb-build-depends.0",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.12",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.17.7",
+  "version": "5.17.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.17.8
+*Released*: 29 October 2024
+- Bump `@labkey/build` package dependency
+
 ### version 5.17.7
 *Released*: 28 October 2024
 - Bump `@labkey/api` package dependency


### PR DESCRIPTION
#### Rationale
This updates `@labkey/build` to allow for entry points to declare dependencies on external scripts that are needed/desired in  the generated view.xml/lib.xml. This allows for us to remove a hardcoded set of scripts from the package itself. Addresses [Issue 51230](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51230).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1623
- https://github.com/LabKey/labkey-ui-premium/pull/576
- https://github.com/LabKey/limsModules/pull/864
- https://github.com/LabKey/platform/pull/5998

#### Changes
- support `"dependencies"` on entry points
- remove hardcoded dependencies from default generated view.xml
- retain "clientapi" dependency in default generated view.xml
- Intended to have this as a major release to prevent any backwards compatibility issues for users who may have depended on the hardcoded dependencies at all.
