### PR TITLE
Issue 51557: fix counts for folder deletion summary

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.19.0",
+  "version": "5.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.19.0",
+      "version": "5.19.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.19.0",
+  "version": "5.19.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,10 +1,15 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.19.1
+*Released*: 31 October 2024
+- Issue 51557: fix counts for folder deletion summary
+- Support optional `containerPath` on `api.security.getDeletionSummaries()` endpoint wrapper
+
 ### version 5.19.0
 *Released*: 31 October 2024
 - Add identifying fields to grids when insert assay data via EditableGrid
-  - migrate some sample identifying fields utils from @labkey/premium
+  - migrate some sample identifying fields utils from `@labkey/premium`
   - factor out updateCellKeySampleIdMap() as utility function
   - add QueryColumn.isSingleSampleTypeLookup()
   - EditorModel.getValuesForColumn() to get cellValues for a single column

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -12,7 +12,6 @@ import {
 import { Principal, SecurityPolicy, SecurityRole } from '../permissions/models';
 import { selectRows } from '../../query/selectRows';
 import { SCHEMAS } from '../../schemas';
-import { buildURL } from '../../url/AppURL';
 import { naturalSortByProperty } from '../../../public/sort';
 import { caseInsensitive, handleRequestFailure } from '../../util/utils';
 import { getUserProperties } from '../user/actions';
@@ -67,7 +66,7 @@ export interface SecurityAPIWrapper {
     ) => Promise<SecurityPolicy>;
     fetchRoles: () => Promise<List<SecurityRole>>;
     getAuditLogDate: (filterCol: string, filterVal: string | number) => Promise<string>;
-    getDeletionSummaries: () => Promise<Summary[]>;
+    getDeletionSummaries: (containerPath?: string) => Promise<Summary[]>;
     getGroupMemberships: () => Promise<GroupMembership[]>;
     getInheritedContainers: (container: Container) => Promise<string[]>;
     getUserLimitSettings: (containerPath?: string) => Promise<UserLimitSettings>;
@@ -113,7 +112,7 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
     createApiKey = (type = 'apikey', description?: string): Promise<string> => {
         return new Promise((resolve, reject) => {
             Ajax.request({
-                url: buildURL('security', 'createApiKey.api'),
+                url: ActionURL.buildURL('security', 'createApiKey.api'),
                 method: 'POST',
                 jsonData: { type, description },
                 success: Utils.getCallbackWrapper(response => {
@@ -235,10 +234,10 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         return dateRow.formattedValue ?? dateRow.value;
     };
 
-    getDeletionSummaries = (): Promise<Summary[]> => {
+    getDeletionSummaries = (containerPath?: string): Promise<Summary[]> => {
         return new Promise((resolve, reject) => {
             Ajax.request({
-                url: buildURL('core', 'getModuleSummary.api'),
+                url: ActionURL.buildURL('core', 'getModuleSummary.api', containerPath),
                 success: Utils.getCallbackWrapper(response => {
                     const { moduleSummary } = response;
                     moduleSummary.sort(naturalSortByProperty('noun'));
@@ -339,7 +338,7 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
     updateUserDetails = (data: FormData): Promise<any> => {
         return new Promise((resolve, reject) => {
             Ajax.request({
-                url: buildURL('user', 'updateUserDetails.api'),
+                url: ActionURL.buildURL('user', 'updateUserDetails.api'),
                 method: 'POST',
                 form: data,
                 success: Utils.getCallbackWrapper((response, request) => {

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -52,8 +52,8 @@ export interface RemoveGroupMembersResponse {
 export interface SecurityAPIWrapper {
     addGroupMembers: (groupId: number, principalIds: number[], projectPath: string) => Promise<AddGroupMembersResponse>;
     createApiKey: (type?: string, description?: string) => Promise<string>;
-    deleteApiKeys: (selections: Set<string>) => Promise<QueryCommandResponse>;
     createGroup: (groupName: string, projectPath: string) => Promise<Security.CreateGroupResponse>;
+    deleteApiKeys: (selections: Set<string>) => Promise<QueryCommandResponse>;
     deleteContainer: (options: DeleteContainerOptions) => Promise<Record<string, unknown>>;
     deleteGroup: (id: number, projectPath: string) => Promise<DeleteGroupResponse>;
     deletePolicy: (resourceId: string, containerPath?: string) => Promise<any>;

--- a/packages/components/src/test/jest.setup.ts
+++ b/packages/components/src/test/jest.setup.ts
@@ -5,3 +5,6 @@ import { enableMapSet, enablePatches } from 'immer';
 // See Immer docs for why we do this: https://immerjs.github.io/immer/docs/installation#pick-your-immer-version
 enableMapSet();
 enablePatches();
+
+// JSDom does not provide an implementation for scrollIntoView(). See https://github.com/jsdom/jsdom/issues/1695
+Element.prototype.scrollIntoView = jest.fn();


### PR DESCRIPTION
#### Rationale
See related PRs for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1625
- https://github.com/LabKey/labkey-ui-premium/pull/578
- https://github.com/LabKey/limsModules/pull/867
- https://github.com/LabKey/platform/pull/6005

#### Changes
- Support optional `containerPath` on `api.security.getDeletionSummaries()` endpoint wrapper.
- Specify prototype implementation for `scrollIntoView` for elements in JSDom.