### PR TITLE
Issue 51491: DateTime field should tolerate Date and DateTime pseudo format patterns

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.18.0",
+  "version": "5.18.1-fb-issue51491.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.18.0",
+      "version": "5.18.1-fb-issue51491.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.19.1",
+  "version": "5.19.2-fb-issue51491.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.19.1",
+      "version": "5.19.2-fb-issue51491.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.0",
+  "version": "5.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.0",
+      "version": "5.20.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.18.0",
+  "version": "5.18.1-fb-issue51491.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.0",
+  "version": "5.20.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.X
+*Released*: X October 2024
+- Issue 51491: DateTime field should tolerate Date and DateTime pseudo format patterns
+
 ### version 5.18.0
 *Released*: 29 October 2024
 - Folders: Archive V1 (Hide from view/show hidden)

--- a/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.test.tsx
@@ -6,10 +6,11 @@ import { userEvent } from '@testing-library/user-event';
 
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 
+import { isValidAltDateTimeFormatOptions } from '../../util/Date';
+
 import { createFormInputId } from './utils';
 import { DOMAIN_FIELD_FORMAT, DOMAIN_FIELD_NOT_LOCKED } from './constants';
 import { DateTimeFieldOptions } from './DateTimeFieldOptions';
-import { isValidAltDateTimeFormatOptions } from '../../util/Date';
 
 const DEFAULT_PROP = {
     index: 1,
@@ -66,7 +67,9 @@ function verifyInputs(
     if (type === 'dateTime') {
         expect(selectInputs[1].hasAttribute('aria-disabled')).toEqual(inherit);
         expect(selectInputs[0].textContent.startsWith(date + (skipDatePreview ? '' : ' ('))).toBeTruthy();
-        expect(selectInputs[1].textContent.startsWith(time ? time + (skipTimePreview ? '' : ' (') : '<none>')).toBeTruthy();
+        expect(
+            selectInputs[1].textContent.startsWith(time ? time + (skipTimePreview ? '' : ' (') : '<none>')
+        ).toBeTruthy();
     } else if (type === 'date') {
         expect(selectInputs[0].textContent.startsWith(date + (skipDatePreview ? '' : ' ('))).toBeTruthy();
     } else {

--- a/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.tsx
@@ -125,10 +125,13 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                         updates.timeFormat = parts[1];
                     }
                 }
-                updates.invalidWarning = getDateTimeSettingWarning({
-                    ...prevSetting,
-                    ...updates,
-                } as DateTimeSettingProp, true);
+                updates.invalidWarning = getDateTimeSettingWarning(
+                    {
+                        ...prevSetting,
+                        ...updates,
+                    } as DateTimeSettingProp,
+                    true
+                );
                 const updatedSetting = {
                     ...prevSetting,
                     ...updates,
@@ -148,10 +151,13 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                 const updates: Partial<DateTimeSettingProp> = {
                     [isTime ? 'timeFormat' : 'dateFormat']: newFormat == null ? '' : newFormat,
                 };
-                updates.invalidWarning = getDateTimeSettingWarning({
-                    ...prevSetting,
-                    ...updates,
-                } as DateTimeSettingProp, true);
+                updates.invalidWarning = getDateTimeSettingWarning(
+                    {
+                        ...prevSetting,
+                        ...updates,
+                    } as DateTimeSettingProp,
+                    true
+                );
 
                 const updatedSetting = {
                     ...prevSetting,

--- a/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.tsx
@@ -12,6 +12,7 @@ import {
     getNonStandardFormatWarning,
     getDateTimeSettingWarning,
     splitDateTimeFormat,
+    isValidAltDateTimeFormatOptions,
 } from '../../util/Date';
 
 import { useServerContext } from '../base/ServerContext';
@@ -65,7 +66,7 @@ export const getInitDateTimeSetting = (
             currentFormat = inherited ? parentFormat : fieldFormat;
             timeFormat = currentFormat;
     }
-    const invalidWarning = getNonStandardFormatWarning(formatType, currentFormat);
+    const invalidWarning = getNonStandardFormatWarning(formatType, currentFormat, true);
     if (invalidWarning && formatType === DateFormatType.DateTime) {
         dateFormat = currentFormat;
         timeFormat = '';
@@ -127,7 +128,7 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                 updates.invalidWarning = getDateTimeSettingWarning({
                     ...prevSetting,
                     ...updates,
-                } as DateTimeSettingProp);
+                } as DateTimeSettingProp, true);
                 const updatedSetting = {
                     ...prevSetting,
                     ...updates,
@@ -150,7 +151,7 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                 updates.invalidWarning = getDateTimeSettingWarning({
                     ...prevSetting,
                     ...updates,
-                } as DateTimeSettingProp);
+                } as DateTimeSettingProp, true);
 
                 const updatedSetting = {
                     ...prevSetting,
@@ -169,6 +170,10 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
         },
         [onFormatChange]
     );
+
+    const isValidNewOption = useCallback((inputValue: string) => {
+        return isValidAltDateTimeFormatOptions(inputValue);
+    }, []);
 
     const onTimeFormatChange = useCallback(
         (name: string, selectedValue: string, selectedOption: SelectInputOption): void => {
@@ -214,6 +219,8 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                 {setting.isDate && (
                     <div className="col-xs-3">
                         <SelectInput
+                            allowCreate
+                            isValidNewOption={isValidNewOption}
                             containerClass=""
                             inputClass="form-group"
                             id={createFormInputId(DOMAIN_FIELD_FORMAT + '_date' + type, domainIndex, index)}
@@ -231,6 +238,8 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                 {setting.isTime && (
                     <div className="col-xs-3">
                         <SelectInput
+                            allowCreate={setting.isTimeRequired}
+                            isValidNewOption={setting.isTimeRequired ? isValidNewOption : undefined}
                             containerClass=""
                             inputClass="form-group"
                             id={createFormInputId(DOMAIN_FIELD_FORMAT + '_time' + type, domainIndex, index)}

--- a/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.tsx
@@ -177,10 +177,6 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
         [onFormatChange]
     );
 
-    const isValidNewOption = useCallback((inputValue: string) => {
-        return isValidAltDateTimeFormatOptions(inputValue);
-    }, []);
-
     const onTimeFormatChange = useCallback(
         (name: string, selectedValue: string, selectedOption: SelectInputOption): void => {
             onFormatChange(selectedOption?.value, true);
@@ -226,7 +222,7 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                     <div className="col-xs-3">
                         <SelectInput
                             allowCreate
-                            isValidNewOption={isValidNewOption}
+                            isValidNewOption={isValidAltDateTimeFormatOptions}
                             containerClass=""
                             inputClass="form-group"
                             id={createFormInputId(DOMAIN_FIELD_FORMAT + '_date' + type, domainIndex, index)}
@@ -245,7 +241,7 @@ export const DateTimeFieldOptions: FC<DateTimeFieldProps> = memo(props => {
                     <div className="col-xs-3">
                         <SelectInput
                             allowCreate={setting.isTimeRequired}
-                            isValidNewOption={setting.isTimeRequired ? isValidNewOption : undefined}
+                            isValidNewOption={setting.isTimeRequired ? isValidAltDateTimeFormatOptions : undefined}
                             containerClass=""
                             inputClass="form-group"
                             id={createFormInputId(DOMAIN_FIELD_FORMAT + '_time' + type, domainIndex, index)}

--- a/packages/components/src/internal/util/Date.test.ts
+++ b/packages/components/src/internal/util/Date.test.ts
@@ -108,6 +108,34 @@ describe('Date Utilities', () => {
             'Non-standard date-time format.'
         );
         expect(getNonStandardFormatWarning(DateFormatType.Time, 'hh:mm aa')).toBe('Non-standard time format.');
+
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'DaTe')).toBe('Non-standard date format.');
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'DaTeTime')).toBe('Non-standard date format.');
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'time')).toBe('Non-standard date format.');
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'time')).toBe('Non-standard date-time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'datetime')).toBe('Non-standard date-time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'DATE')).toBe('Non-standard date-time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.Time, 'DateTime')).toBe('Non-standard time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.Time, 'Date')).toBe('Non-standard time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.Time, 'TIME')).toBe('Non-standard time format.');
+
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'DaTe', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'DaTeTime', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'time', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'time', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'datetime', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'DATE', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.Time, 'DateTime', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.Time, 'Date', true)).toBeNull();
+        expect(getNonStandardFormatWarning(DateFormatType.Time, 'TIME', true)).toBeNull();
+
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'Date Time', true)).toBe('Non-standard date format.');
+        expect(getNonStandardFormatWarning(DateFormatType.Date, 'timestamp', true)).toBe('Non-standard date format.');
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'time ', true)).toBe('Non-standard date-time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'date and time', true)).toBe('Non-standard date-time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'DATEONLY', true)).toBe('Non-standard date-time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.Time, 'Time only', true)).toBe('Non-standard time format.');
+
     });
 
     test('getDateTimeInputOptions', () => {

--- a/packages/components/src/internal/util/Date.test.ts
+++ b/packages/components/src/internal/util/Date.test.ts
@@ -87,9 +87,7 @@ describe('Date Utilities', () => {
     test('getNonStandardFormatWarning', () => {
         expect(getNonStandardFormatWarning(DateFormatType.Date, null)).toBe('Non-standard date format.');
         expect(getNonStandardFormatWarning(DateFormatType.Time, '')).toBe('Non-standard time format.');
-        expect(getNonStandardFormatWarning(DateFormatType.DateTime, undefined)).toBe(
-            'Non-standard date-time format.'
-        );
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, undefined)).toBe('Non-standard date-time format.');
 
         expect(getNonStandardFormatWarning(DateFormatType.Date, 'yyyy-MM-dd')).toBeNull();
         expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'yyyy-MM-dd')).toBeNull();
@@ -131,11 +129,16 @@ describe('Date Utilities', () => {
 
         expect(getNonStandardFormatWarning(DateFormatType.Date, 'Date Time', true)).toBe('Non-standard date format.');
         expect(getNonStandardFormatWarning(DateFormatType.Date, 'timestamp', true)).toBe('Non-standard date format.');
-        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'time ', true)).toBe('Non-standard date-time format.');
-        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'date and time', true)).toBe('Non-standard date-time format.');
-        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'DATEONLY', true)).toBe('Non-standard date-time format.');
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'time ', true)).toBe(
+            'Non-standard date-time format.'
+        );
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'date and time', true)).toBe(
+            'Non-standard date-time format.'
+        );
+        expect(getNonStandardFormatWarning(DateFormatType.DateTime, 'DATEONLY', true)).toBe(
+            'Non-standard date-time format.'
+        );
         expect(getNonStandardFormatWarning(DateFormatType.Time, 'Time only', true)).toBe('Non-standard time format.');
-
     });
 
     test('getDateTimeInputOptions', () => {

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -32,6 +32,8 @@ const STANDARD_DATE_DISPLAY_FORMATS = ['yyyy-MM-dd', 'yyyy-MMM-dd', 'dd-MMM-yyyy
 
 const STANDARD_TIME_DISPLAY_FORMATS = ['HH:mm:ss', 'HH:mm', 'HH:mm:ss.SSS', 'hh:mm a'];
 
+const FIELD_ALT_DATETIME_FORMATS = ['date', 'datetime', 'time'];
+
 const MISSING_FORMAT_DISPLAY = '<none>';
 
 // Intended to match against ISO_DATE_FORMAT_STRING
@@ -443,7 +445,14 @@ export function getNonStandardDateTimeFormatWarning(dateTimeFormat: string): str
     return warning;
 }
 
-export function getNonStandardFormatWarning(formatType: DateFormatType, formatPattern: string): string {
+export function isValidAltDateTimeFormatOptions(format: string): boolean {
+    return FIELD_ALT_DATETIME_FORMATS.indexOf(format?.toLowerCase()) > -1;
+}
+
+export function getNonStandardFormatWarning(formatType: DateFormatType, formatPattern: string, allowAltFormat?: boolean): string {
+    if (allowAltFormat && isValidAltDateTimeFormatOptions(formatPattern))
+        return null;
+
     switch (formatType) {
         case DateFormatType.Date:
             return isStandardDateDisplayFormat(formatPattern) ? null : 'Non-standard date format.';
@@ -523,9 +532,9 @@ export const getDateTimeSettingFormat = (setting: DateTimeSettingProp, checkInhe
           : timeFormat;
 };
 
-export const getDateTimeSettingWarning = (setting: DateTimeSettingProp): string => {
+export const getDateTimeSettingWarning = (setting: DateTimeSettingProp, allowAltFormat?: boolean): string => {
     const { formatType } = setting;
-    return getNonStandardFormatWarning(formatType, getDateTimeSettingFormat(setting, true));
+    return getNonStandardFormatWarning(formatType, getDateTimeSettingFormat(setting, true), allowAltFormat);
 };
 
 function _formatDate(date: Date | string | number, dateFormat: string, timezone?: string): string {

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -449,9 +449,12 @@ export function isValidAltDateTimeFormatOptions(format: string): boolean {
     return FIELD_ALT_DATETIME_FORMATS.indexOf(format?.toLowerCase()) > -1;
 }
 
-export function getNonStandardFormatWarning(formatType: DateFormatType, formatPattern: string, allowAltFormat?: boolean): string {
-    if (allowAltFormat && isValidAltDateTimeFormatOptions(formatPattern))
-        return null;
+export function getNonStandardFormatWarning(
+    formatType: DateFormatType,
+    formatPattern: string,
+    allowAltFormat?: boolean
+): string {
+    if (allowAltFormat && isValidAltDateTimeFormatOptions(formatPattern)) return null;
 
     switch (formatType) {
         case DateFormatType.Date:


### PR DESCRIPTION
#### Rationale
Issue 51491: DateTime field should tolerate Date and DateTime pseudo format patterns

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1626
- https://github.com/LabKey/labkey-ui-premium/pull/582
- https://github.com/LabKey/limsModules/pull/875

#### Changes
- allow user to type in pseudo formats for date/time fields
- don't show warning for pseudo formats set at field level
