### PR TITLE
Add identifying fields to grids when editing via grid for Samples and Sources

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.1-fb-identFieldsSampleSourceEdit.0",
+  "version": "5.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.1-fb-identFieldsSampleSourceEdit.0",
+      "version": "5.21.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.19.0-fb-identFieldsSampleSourceEdit.0",
+  "version": "5.19.0-fb-identFieldsSampleSourceEdit.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.19.0-fb-identFieldsSampleSourceEdit.0",
+      "version": "5.19.0-fb-identFieldsSampleSourceEdit.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.19.0",
+  "version": "5.19.0-fb-identFieldsSampleSourceEdit.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.19.0",
+      "version": "5.19.0-fb-identFieldsSampleSourceEdit.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.1",
+  "version": "5.20.1-fb-identFieldsSampleSourceEdit.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.1",
+      "version": "5.20.1-fb-identFieldsSampleSourceEdit.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.0",
+  "version": "5.20.0-fb-identFieldsSampleSourceEdit.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.0",
+      "version": "5.20.0-fb-identFieldsSampleSourceEdit.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.0",
+  "version": "5.20.0-fb-identFieldsSampleSourceEdit.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.1",
+  "version": "5.20.1-fb-identFieldsSampleSourceEdit.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.19.0-fb-identFieldsSampleSourceEdit.0",
+  "version": "5.19.0-fb-identFieldsSampleSourceEdit.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.1-fb-identFieldsSampleSourceEdit.0",
+  "version": "5.21.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.19.0",
+  "version": "5.19.0-fb-identFieldsSampleSourceEdit.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,6 +3,12 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 5.19.0
 *Released*: 31 October 2024
+- Add identifying fields to grids when editing via grid for Samples and Sources
+  - include identifying fields in getSelectionLineageData()
+  - EditorModel.getUpdatedData() to skip non-userEditable fields when comparing values
+
+### version 5.19.0
+*Released*: 31 October 2024
 - Add identifying fields to grids when insert assay data via EditableGrid
   - migrate some sample identifying fields utils from @labkey/premium
   - factor out updateCellKeySampleIdMap() as utility function

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Add identifying fields to grids when editing via grid for Samples and Sources
+    - include identifying fields in getSelectionLineageData()
+    - EditorModel.getUpdatedData() to skip non-userEditable fields when comparing values
+    - getIdentifyingFieldsEditableGridColumns() to take param for hasProductFolders to determine if Folder should be excluded
+
 ### version 5.20.0
 *Released*: 31 October 2024
 - Bump build
@@ -10,13 +17,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 31 October 2024
 - Issue 51557: fix counts for folder deletion summary
 - Support optional `containerPath` on `api.security.getDeletionSummaries()` endpoint wrapper
-
-### version 5.19.0
-*Released*: 31 October 2024
-- Add identifying fields to grids when editing via grid for Samples and Sources
-  - include identifying fields in getSelectionLineageData()
-  - EditorModel.getUpdatedData() to skip non-userEditable fields when comparing values
-  - getIdentifyingFieldsEditableGridColumns() to take param for hasProductFolders to determine if Folder should be excluded
 
 ### version 5.19.0
 *Released*: 31 October 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 5.21.0
+*Released*: 4 November 2024
 - Add identifying fields to grids when editing via grid for Samples and Sources
     - include identifying fields in getSelectionLineageData()
     - EditorModel.getUpdatedData() to skip non-userEditable fields when comparing values

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Add identifying fields to grids when editing via grid for Samples and Sources
   - include identifying fields in getSelectionLineageData()
   - EditorModel.getUpdatedData() to skip non-userEditable fields when comparing values
+  - getIdentifyingFieldsEditableGridColumns() to take param for hasProductFolders to determine if Folder should be excluded
 
 ### version 5.19.0
 *Released*: 31 October 2024

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -692,6 +692,36 @@ describe('EditorModel', () => {
             const updatedRows = em.getUpdatedData();
             expect(updatedRows).toHaveLength(0);
         });
+        test('non-userEditable column should be excluded', () => {
+            const lookupCol = new QueryColumn({
+                name: 'lookup',
+                caption: 'lookup',
+                fieldKey: 'lookup',
+                fieldKeyArray: ['lookup'],
+                shownInInsertView: true,
+                userEditable: false,
+                lookup: { queryName: 'lookupQuery', schemaName: 'lookupSchema' },
+            });
+            const em = modifyEm({
+                columnMap: basicEditorModel.columnMap.set(lookupCol.fieldKey, lookupCol),
+                orderedColumns: basicEditorModel.orderedColumns.push(lookupCol.fieldKey),
+                originalData: basicEditorModel.originalData.setIn(
+                    [0, lookupCol.fieldKey],
+                    List([{ value: 456, displayValue: 'Value 456' }])
+                ),
+                cellValues: basicEditorModel.cellValues.set(
+                    genCellKey('lookup', 0),
+                    List([
+                        {
+                            raw: 123,
+                            display: 'Value 123',
+                        },
+                    ])
+                ),
+            });
+            const updatedRows = em.getUpdatedData();
+            expect(updatedRows).toHaveLength(0);
+        });
         test('expInput value updated', () => {
             const materialInputs = QueryColumn.MATERIAL_INPUTS.toLowerCase();
             const expInputCol = new QueryColumn({

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -763,8 +763,8 @@ export class EditorModel
                     // For lineage grids the parent columns aren't on the queryInfo
                     const col = queryInfo.getColumn(key) ?? this.columnMap.get(key.toLowerCase());
 
-                    // we can skip any readOnly columns
-                    if (col?.readOnly) return row;
+                    // we can skip any readOnly columns or non-userEditable columns
+                    if (col?.readOnly || !col?.userEditable) return row;
 
                     // Convert empty cell to null
                     if (value === '') value = null;

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -241,7 +241,7 @@ export function getSelectionLineageData(
     schema: string,
     query: string,
     viewName: string,
-    columns?: string[]
+    extraColumns: string[] = []
 ): Promise<ISelectRowsResult> {
     if (selections?.size === 0) return Promise.reject('No data is selected.');
     const rowIds = Array.from(selections).map(s => parseInt(s, 10));
@@ -250,7 +250,7 @@ export function getSelectionLineageData(
         schemaName: schema,
         queryName: query,
         viewName,
-        columns: columns ?? List.of('RowId', 'Name', 'LSID', 'Folder').concat(ParentEntityLineageColumns).toArray(),
+        columns: List.of('RowId', 'Name', 'LSID', 'Folder').concat(ParentEntityLineageColumns).toArray().concat(extraColumns),
         filterArray: [Filter.create('RowId', rowIds, Filter.Types.IN)],
     });
 }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -250,7 +250,10 @@ export function getSelectionLineageData(
         schemaName: schema,
         queryName: query,
         viewName,
-        columns: List.of('RowId', 'Name', 'LSID', 'Folder').concat(ParentEntityLineageColumns).toArray().concat(extraColumns),
+        columns: List.of('RowId', 'Name', 'LSID', 'Folder')
+            .concat(ParentEntityLineageColumns)
+            .toArray()
+            .concat(extraColumns),
         filterArray: [Filter.create('RowId', rowIds, Filter.Types.IN)],
     });
 }

--- a/packages/components/src/public/QueryInfo.test.ts
+++ b/packages/components/src/public/QueryInfo.test.ts
@@ -427,7 +427,7 @@ describe('QueryInfo', () => {
     describe('getIdentifyingFieldsEditableGridColumns', () => {
         const columns = [
             { fieldKey: 'name', name: 'name', jsonType: 'string' },
-            { fieldKey: 'intCol', name: 'intCol', jsonType: 'int' },
+            { fieldKey: 'folder', name: 'Folder', jsonType: 'string' },
             { fieldKey: 'doubleCol', name: 'doubleCol', jsonType: 'double' },
             { fieldKey: 'textCol', name: 'textCol', jsonType: 'string' },
         ];
@@ -460,9 +460,9 @@ describe('QueryInfo', () => {
             expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns()).toStrictEqual([]);
             expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true)).toStrictEqual([]);
             expect(
-                QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(false, 'samplePrefixFk')
+                QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(false, false, 'samplePrefixFk')
             ).toStrictEqual([]);
-            expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true, 'samplePrefixFk')).toStrictEqual(
+            expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true, false, 'samplePrefixFk')).toStrictEqual(
                 []
             );
         });
@@ -470,8 +470,8 @@ describe('QueryInfo', () => {
         test('with identifying view', () => {
             let cols = QUERY_INFO_WITH_ID_VIEW.getIdentifyingFieldsEditableGridColumns();
             expect(cols).toHaveLength(3);
-            expect(cols[0].fieldKey).toBe('intCol');
-            expect(cols[0].name).toBe('intCol');
+            expect(cols[0].fieldKey).toBe('folder');
+            expect(cols[0].name).toBe('Folder');
             expect(cols[0].readOnly).toBe(true);
             expect(cols[1].fieldKey).toBe('doubleCol');
             expect(cols[1].name).toBe('doubleCol');
@@ -480,20 +480,17 @@ describe('QueryInfo', () => {
             expect(cols[2].name).toBe('textCol');
             expect(cols[2].readOnly).toBe(true);
 
-            cols = QUERY_INFO_WITH_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true, 'samplePrefixFk');
-            expect(cols).toHaveLength(4);
+            cols = QUERY_INFO_WITH_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true, true, 'samplePrefixFk');
+            expect(cols).toHaveLength(3);
             expect(cols[0].fieldKey).toBe('samplePrefixFk/name');
             expect(cols[0].name).toBe('samplePrefixFk/name');
             expect(cols[0].readOnly).toBe(true);
-            expect(cols[1].fieldKey).toBe('samplePrefixFk/intCol');
-            expect(cols[1].name).toBe('samplePrefixFk/intCol');
+            expect(cols[1].fieldKey).toBe('samplePrefixFk/doubleCol');
+            expect(cols[1].name).toBe('samplePrefixFk/doubleCol');
             expect(cols[1].readOnly).toBe(true);
-            expect(cols[2].fieldKey).toBe('samplePrefixFk/doubleCol');
-            expect(cols[2].name).toBe('samplePrefixFk/doubleCol');
+            expect(cols[2].fieldKey).toBe('samplePrefixFk/textCol');
+            expect(cols[2].name).toBe('samplePrefixFk/textCol');
             expect(cols[2].readOnly).toBe(true);
-            expect(cols[3].fieldKey).toBe('samplePrefixFk/textCol');
-            expect(cols[3].name).toBe('samplePrefixFk/textCol');
-            expect(cols[3].readOnly).toBe(true);
         });
     });
 });

--- a/packages/components/src/public/QueryInfo.test.ts
+++ b/packages/components/src/public/QueryInfo.test.ts
@@ -462,9 +462,9 @@ describe('QueryInfo', () => {
             expect(
                 QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(false, false, 'samplePrefixFk')
             ).toStrictEqual([]);
-            expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true, false, 'samplePrefixFk')).toStrictEqual(
-                []
-            );
+            expect(
+                QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true, false, 'samplePrefixFk')
+            ).toStrictEqual([]);
         });
 
         test('with identifying view', () => {

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -261,19 +261,26 @@ export class QueryInfo {
         return extraDisplayColumn;
     }
 
-    getIdentifyingFieldsEditableGridColumns(includeNameField = false, prefixFieldKey?: string): QueryColumn[] {
+    getIdentifyingFieldsEditableGridColumns(
+        includeNameField = false,
+        hasProductFolders = false,
+        prefixFieldKey?: string
+    ): QueryColumn[] {
         const cols: QueryColumn[] = [];
         if (this.views.has(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME)) {
-            this.getDisplayColumns(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME).forEach(col => {
+            const identifyingCols = this.getDisplayColumns(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME)
+                .filter(col => includeNameField || col.fieldKey.toLowerCase() !== 'name')
+                // if app hasProductFolders and Folder is set as an identifying field, we don't want to include it since it will already be in the editable grid
+                .filter(col => !hasProductFolders || col.fieldKey.toLowerCase() !== 'folder');
+
+            identifyingCols.forEach(col => {
                 const qCol = new QueryColumn(col);
-                if (includeNameField || col.fieldKey.toLowerCase() !== 'name') {
-                    qCol.readOnly = true;
-                    if (prefixFieldKey) {
-                        qCol.name = prefixFieldKey + '/' + qCol.name;
-                        qCol.fieldKey = prefixFieldKey + '/' + qCol.fieldKey;
-                    }
-                    cols.push(qCol);
+                qCol.readOnly = true;
+                if (prefixFieldKey) {
+                    qCol.name = prefixFieldKey + '/' + qCol.name;
+                    qCol.fieldKey = prefixFieldKey + '/' + qCol.fieldKey;
                 }
+                cols.push(qCol);
             });
         }
         return cols;


### PR DESCRIPTION
#### Rationale
Next up for identifying fields support in editable grid cases are the Sample Type and Source Type grids. This set of PRs supports including relevant identifying fields in the Edit in Grid and Edit Lineage cases for sample types, sources, LKB registry and LKB ingredients grids. Note that for "Edit in Grid" we only include the Ancestors based identifying fields and for "Edit Lineage" we only include the non-Ancestors based identifying fields. This is because of the other editable columns in those grids and not wanting to show redundant information.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1627
- https://github.com/LabKey/labkey-ui-premium/pull/583
- https://github.com/LabKey/limsModules/pull/876

#### Changes
- include identifying fields in getSelectionLineageData()
- EditorModel.getUpdatedData() to skip non-userEditable fields when comparing values
