### PR TITLE
Remove combineParentTypes

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.0",
+      "version": "5.22.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.??.??
+*Released*: ?? November 2024
+- Remove combineParentTypes
+
 ### version 5.22.0
 *Released*: 5 November 2024
 - Package updates

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 5.??.??
-*Released*: ?? November 2024
+### version 5.22.1
+*Released*: 5 November 2024
 - Remove combineParentTypes
 
 ### version 5.22.0

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -68,7 +68,6 @@ export interface SampleTypeAppContext {
     SamplesTabbedGridPanelComponent: SamplesTabbedGridPanel;
     WorkflowGridComponent: WorkflowGrid;
     assayProviderType?: string;
-    combineParentTypes?: boolean;
     controllerName: string;
     dataClassAliasCaption?: string;
     dataClassParentageLabel?: string;

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -68,8 +68,7 @@ export interface EntityAPIWrapper {
         parentSchemaQueries: Map<string, EntityDataType>,
         targetQueryName: string,
         allowParents: boolean,
-        isItemSamples: boolean,
-        combineParentTypes: boolean
+        isItemSamples: boolean
     ) => Promise<Partial<EntityIdCreationModel>>;
     getMoveConfirmationData: (
         dataType: EntityDataType,

--- a/packages/components/src/internal/components/entities/actions.test.ts
+++ b/packages/components/src/internal/components/entities/actions.test.ts
@@ -12,21 +12,12 @@ describe('extractEntityTypeOptionFromRow', () => {
         LSID: { value: 'ABC123' },
     };
 
-    test('lowerCaseValue = true', () => {
+    test('return value as expected', () => {
         const options = extractEntityTypeOptionFromRow(ROW);
         expect(options.label).toBe(NAME);
         expect(options.lsid).toBe('ABC123');
         expect(options.rowId).toBe(1);
         expect(options.value).toBe(NAME.toLowerCase());
-        expect(options.query).toBe(NAME);
-    });
-
-    test('lowerCaseValue = false', () => {
-        const options = extractEntityTypeOptionFromRow(ROW, false);
-        expect(options.label).toBe(NAME);
-        expect(options.lsid).toBe('ABC123');
-        expect(options.rowId).toBe(1);
-        expect(options.value).toBe(NAME);
         expect(options.query).toBe(NAME);
     });
 });

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -461,8 +461,7 @@ export async function getChosenParentData(
     parentEntityDataTypes: Map<string, EntityDataType>,
     allowParents: boolean,
     isItemSamples?: boolean,
-    targetQueryName?: string,
-    combineParentTypes?: boolean
+    targetQueryName?: string
 ): Promise<Partial<EntityIdCreationModel>> {
     const entityParents = EntityIdCreationModel.getEmptyEntityParents(
         parentEntityDataTypes.reduce(
@@ -492,13 +491,7 @@ export async function getChosenParentData(
             if (chosenParent.value !== undefined && parentSchemaNames.contains(chosenParent.schema)) {
                 totalParentValueCount += chosenParent.value.size;
                 isParentTypeOnly = chosenParent.isParentTypeOnly;
-
-                // If combining parent types, use the first parent type for the queryName
-                parentEntityDataType = (
-                    combineParentTypes
-                        ? parentEntityDataTypes.valueSeq().first()
-                        : parentEntityDataTypes.get(chosenParent.schema)
-                ).typeListingSchemaQuery.queryName;
+                parentEntityDataType = parentEntityDataTypes.get(chosenParent.schema).typeListingSchemaQuery.queryName;
             }
         });
 
@@ -609,7 +602,6 @@ export async function getFolderConfigurableEntityTypeOptions(
  * @param targetQueryName the name of the listing schema query that represents the initial target for creation.
  * @param allowParents are parents of this entity type allowed or not
  * @param isItemSamples use the selectionKey from inventory.items table to query sample parents
- * @param combineParentTypes
  */
 export function getEntityTypeData(
     model: EntityIdCreationModel,
@@ -617,21 +609,13 @@ export function getEntityTypeData(
     parentSchemaQueries: Map<string, EntityDataType>,
     targetQueryName: string,
     allowParents: boolean,
-    isItemSamples: boolean,
-    combineParentTypes: boolean
+    isItemSamples: boolean
 ): Promise<Partial<EntityIdCreationModel>> {
     return new Promise((resolve, reject) => {
         const promises: Array<Promise<any>> = [
             getEntityTypeOptions(entityDataType),
             // get all the parent schemaQuery data
-            getChosenParentData(
-                model,
-                parentSchemaQueries,
-                allowParents,
-                isItemSamples,
-                targetQueryName,
-                combineParentTypes
-            ),
+            getChosenParentData(model, parentSchemaQueries, allowParents, isItemSamples, targetQueryName),
             ...parentSchemaQueries.map(edt => getEntityTypeOptions(edt)).toArray(),
         ];
 

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -434,7 +434,6 @@ function resolveEntityParentTypeFromIds(
 // export for jest
 export function extractEntityTypeOptionFromRow(
     row: Row,
-    lowerCaseValue = true,
     entityDataType?: EntityDataType,
     requiredParentTypes?: string[]
 ): IEntityTypeOption {
@@ -447,7 +446,7 @@ export function extractEntityTypeOptionFromRow(
         label: name,
         lsid: caseInsensitive(row, 'LSID').value,
         rowId: caseInsensitive(row, 'RowId').value,
-        value: lowerCaseValue ? name.toLowerCase() : name, // we match values on lower case because (at least) when parsed from an id they are lower case
+        value: name.toLowerCase(), // we match values on lower case because (at least) when parsed from an id they are lower case
         query: name,
         entityDataType,
         isFromSharedContainer: caseInsensitive(row, 'Folder/Path')?.value === SHARED_CONTAINER_PATH,
@@ -551,7 +550,7 @@ export async function getEntityTypeOptions(
 
     const options: IEntityTypeOption[] = result.rows
         .map(row => ({
-            ...extractEntityTypeOptionFromRow(row, true, entityDataType, requiredParentTypes),
+            ...extractEntityTypeOptionFromRow(row, entityDataType, requiredParentTypes),
             schema: instanceSchemaName, // e.g. "samples" or "dataclasses"
         }))
         .sort(naturalSortByProperty('label'));

--- a/packages/components/src/internal/sampleModels.ts
+++ b/packages/components/src/internal/sampleModels.ts
@@ -70,7 +70,6 @@ export type SampleGridButton = ComponentType<SampleGridButtonProps & RequiresMod
 
 // This interface stores app-wide settings passed to the LineageEditableGrid
 export interface LineageEditableGridProps {
-    combineParentTypes?: boolean;
     parentDataTypes: EntityDataType[];
 }
 


### PR DESCRIPTION
#### Rationale
We have a combineParentTypes flag used by Biologics combine samples and sources as parent types when creating entities and editing their lineage. We want to remove this flag so SM and Biologics have the same behavior. See [Issue 51486](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51486)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1628
- https://github.com/LabKey/labkey-ui-premium/pull/584
- https://github.com/LabKey/limsModules/pull/877
- https://github.com/LabKey/testAutomation/pull/2124

#### Changes
- Remove combineParentTypes flag
