### PR TITLE
Add QueryInfo.hasIdentifyingFieldsView()

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.3",
+  "version": "5.22.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.3",
+      "version": "5.22.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.1",
+  "version": "5.22.1-fb-identFieldsLKBMediaFix.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.1",
+      "version": "5.22.1-fb-identFieldsLKBMediaFix.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.1",
+  "version": "5.22.1-fb-identFieldsLKBMediaFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.3",
+  "version": "5.22.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- QueryInfo.hasIdentifyingFieldsView() to check for identifying fields view existence and if it has more than just the default "Name" column
+
 ### version 5.22.1
 *Released*: 5 November 2024
 - Remove combineParentTypes

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 5.22.4
+*Released*: 6 November 2024
 - QueryInfo.hasIdentifyingFieldsView() to check for identifying fields view existence and if it has more than just the default "Name" column
 
 ### version 5.22.3

--- a/packages/components/src/public/QueryInfo.test.ts
+++ b/packages/components/src/public/QueryInfo.test.ts
@@ -23,6 +23,49 @@ import { ExtendedMap } from './ExtendedMap';
 
 import { QueryInfo } from './QueryInfo';
 
+const columns = [
+    { fieldKey: 'name', name: 'name', jsonType: 'string' },
+    { fieldKey: 'folder', name: 'Folder', jsonType: 'string' },
+    { fieldKey: 'doubleCol', name: 'doubleCol', jsonType: 'double' },
+    { fieldKey: 'textCol', name: 'textCol', jsonType: 'string' },
+];
+const QUERY_INFO_NO_ID_VIEW = QueryInfo.fromJsonForTests(
+    {
+        columns,
+        name: 'query',
+        schemaName: 'schema',
+        views: [
+            { columns, name: ViewInfo.DEFAULT_NAME },
+            { columns, name: 'view' },
+        ],
+    },
+    true
+);
+const QUERY_INFO_WITH_ID_VIEW = QueryInfo.fromJsonForTests(
+    {
+        columns,
+        name: 'query',
+        schemaName: 'schema',
+        views: [
+            { columns, name: ViewInfo.DEFAULT_NAME },
+            { columns, name: ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME },
+        ],
+    },
+    true
+);
+const QUERY_INFO_WITH_ID_VIEW_NAME_ONLY = QueryInfo.fromJsonForTests(
+    {
+        columns,
+        name: 'query',
+        schemaName: 'schema',
+        views: [
+            { name: ViewInfo.DEFAULT_NAME, columns },
+            { name: ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME, columns: [{ fieldKey: 'name', name: 'name', jsonType: 'string' }] },
+        ],
+    },
+    true
+);
+
 describe('getColumnFieldKeys', () => {
     test('missing params', () => {
         const queryInfo = new QueryInfo({});
@@ -424,37 +467,18 @@ describe('QueryInfo', () => {
         });
     });
 
+    describe('hasIdentifyingFieldsView', () => {
+        test('without identifying view', () => {
+            expect(QUERY_INFO_NO_ID_VIEW.hasIdentifyingFieldsView()).toBe(false);
+            expect(QUERY_INFO_WITH_ID_VIEW_NAME_ONLY.hasIdentifyingFieldsView()).toBe(false);
+        });
+        test('with identifying view', () => {
+            expect(QUERY_INFO_WITH_ID_VIEW.hasIdentifyingFieldsView()).toBe(true);
+        });
+    });
+
     describe('getIdentifyingFieldsEditableGridColumns', () => {
-        const columns = [
-            { fieldKey: 'name', name: 'name', jsonType: 'string' },
-            { fieldKey: 'folder', name: 'Folder', jsonType: 'string' },
-            { fieldKey: 'doubleCol', name: 'doubleCol', jsonType: 'double' },
-            { fieldKey: 'textCol', name: 'textCol', jsonType: 'string' },
-        ];
-        const QUERY_INFO_NO_ID_VIEW = QueryInfo.fromJsonForTests(
-            {
-                columns,
-                name: 'query',
-                schemaName: 'schema',
-                views: [
-                    { columns, name: ViewInfo.DEFAULT_NAME },
-                    { columns, name: 'view' },
-                ],
-            },
-            true
-        );
-        const QUERY_INFO_WITH_ID_VIEW = QueryInfo.fromJsonForTests(
-            {
-                columns,
-                name: 'query',
-                schemaName: 'schema',
-                views: [
-                    { columns, name: ViewInfo.DEFAULT_NAME },
-                    { columns, name: ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME },
-                ],
-            },
-            true
-        );
+
 
         test('without identifying view', () => {
             expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns()).toStrictEqual([]);

--- a/packages/components/src/public/QueryInfo.test.ts
+++ b/packages/components/src/public/QueryInfo.test.ts
@@ -60,7 +60,10 @@ const QUERY_INFO_WITH_ID_VIEW_NAME_ONLY = QueryInfo.fromJsonForTests(
         schemaName: 'schema',
         views: [
             { name: ViewInfo.DEFAULT_NAME, columns },
-            { name: ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME, columns: [{ fieldKey: 'name', name: 'name', jsonType: 'string' }] },
+            {
+                name: ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME,
+                columns: [{ fieldKey: 'name', name: 'name', jsonType: 'string' }],
+            },
         ],
     },
     true
@@ -478,8 +481,6 @@ describe('QueryInfo', () => {
     });
 
     describe('getIdentifyingFieldsEditableGridColumns', () => {
-
-
         test('without identifying view', () => {
             expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns()).toStrictEqual([]);
             expect(QUERY_INFO_NO_ID_VIEW.getIdentifyingFieldsEditableGridColumns(true)).toStrictEqual([]);

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -261,13 +261,24 @@ export class QueryInfo {
         return extraDisplayColumn;
     }
 
+    hasIdentifyingFieldsView(): boolean {
+        if (this.views.has(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME)) {
+            // if the view is defined but only has the default Name column, consider it not to be defined
+            const cols = this.views
+                .get(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME)
+                .columns.filter(col => col.fieldKey.toLowerCase() !== 'name');
+            return cols.length > 0;
+        }
+        return false;
+    }
+
     getIdentifyingFieldsEditableGridColumns(
         includeNameField = false,
         hasProductFolders = false,
         prefixFieldKey?: string
     ): QueryColumn[] {
         const cols: QueryColumn[] = [];
-        if (this.views.has(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME)) {
+        if (this.hasIdentifyingFieldsView()) {
             const identifyingCols = this.getDisplayColumns(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME)
                 .filter(col => includeNameField || col.fieldKey.toLowerCase() !== 'name')
                 // if app hasProductFolders and Folder is set as an identifying field, we don't want to include it since it will already be in the editable grid
@@ -288,7 +299,7 @@ export class QueryInfo {
 
     getLookupViewColumns(displayColumnFieldKey?: string): QueryColumn[] {
         let cols: QueryColumn[] = [];
-        if (this.views.has(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME)) {
+        if (this.hasIdentifyingFieldsView()) {
             this.views.get(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME).columns.forEach(col => {
                 const qCol = this.getColumn(col.fieldKey);
                 if (qCol) {


### PR DESCRIPTION
#### Rationale
When a sample / source type has an identifying fields view created, it starts with always including the "Name" column as a default view. However, there is no way for a user to remove this view in the UI. All they can do is remove all other identifying fields. This PR adds a helper to check if QueryInfo.hasIdentifyingFieldsView() which will verify not only that the view exists but that it has more than just the Name column defined.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1634
- https://github.com/LabKey/labkey-ui-premium/pull/590

#### Changes
- QueryInfo.hasIdentifyingFieldsView() to check for identifying fields view existence and if it has more than just the default "Name" column
