### PR TITLE
Use userId instead of email for password related APIs

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.3",
+  "version": "5.20.4-fb-userIdPw.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.3",
+      "version": "5.20.4-fb-userIdPw.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.4-fb-userIdPw.1",
+  "version": "5.20.4-fb-userIdPw.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.4-fb-userIdPw.1",
+      "version": "5.20.4-fb-userIdPw.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.4-fb-userIdPw.2",
+  "version": "5.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.4-fb-userIdPw.2",
+      "version": "5.20.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.3",
+  "version": "5.20.4-fb-userIdPw.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.4-fb-userIdPw.2",
+  "version": "5.20.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.4-fb-userIdPw.1",
+  "version": "5.20.4-fb-userIdPw.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages
 
 ### version 5.20.4
-*Released*: X November 2024
+*Released*: 9 November 2024
 - Use userId instead of email for password related APIs
 
 ### version 5.20.3

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.20.4
+*Released*: X November 2024
+- User userId instead of email for password related APIs
+
 ### version 5.20.3
 *Released*: 7 November 2024
 - Replace some curly quotes with normal quotes

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 5.20.4
 *Released*: X November 2024
-- User userId instead of email for password related APIs
+- Use userId instead of email for password related APIs
 
 ### version 5.20.3
 *Released*: 7 November 2024

--- a/packages/components/src/internal/components/user/ChangePasswordModal.tsx
+++ b/packages/components/src/internal/components/user/ChangePasswordModal.tsx
@@ -66,7 +66,7 @@ export class ChangePasswordModal extends React.Component<Props, State> {
 
         this.state = {
             model: new ChangePasswordModel({
-                email: props.user.email,
+                userId: props.user.id,
             }),
             passwordRule: undefined,
             submitting: false,

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -337,6 +337,7 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
                     {allowResetPassword && showDialog === 'reset' && (
                         <UserResetPasswordConfirmModal
                             email={caseInsensitive(userProperties, 'email')}
+                            userId={caseInsensitive(userProperties, 'userId')}
                             hasLogin={Utils.isString(caseInsensitive(userProperties, 'lastLogin'))}
                             onComplete={response => this.onUsersStateChangeComplete(response, false)}
                             onCancel={() => this.toggleDialog(undefined)}

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.test.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.test.tsx
@@ -21,12 +21,14 @@ import { UserResetPasswordConfirmModal, UserResetPasswordConfirmModalProps } fro
 
 describe('UserResetPasswordConfirmModal', () => {
     const email = 'jest@localhost.test';
+    const userId = 5002;
     const DEFAULT_PROPS: UserResetPasswordConfirmModalProps = {
         email,
         hasLogin: true,
         onCancel: jest.fn(),
         onComplete: jest.fn(),
-        resetPasswordApi: jest.fn().mockResolvedValue({ email, resetPassword: true }),
+        resetPasswordApi: jest.fn().mockResolvedValue({ userId, resetPassword: true }),
+        userId,
     };
 
     test('with login', () => {
@@ -59,7 +61,7 @@ describe('UserResetPasswordConfirmModal', () => {
 
         await userEvent.click(document.querySelector('.btn-success'));
 
-        expect(resetPasswordApi).toHaveBeenCalledWith(DEFAULT_PROPS.email);
+        expect(resetPasswordApi).toHaveBeenCalledWith(DEFAULT_PROPS.userId);
         expect(screen.getByText(errorMsg)).toBeInTheDocument();
     });
 });

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
@@ -25,7 +25,7 @@ export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProp
 
         try {
             const response = await resetPasswordApi(userId);
-            onComplete(response);
+            onComplete({email, ...response});
         } catch (e) {
             setError(resolveErrorMessage(e, 'user', 'users', 'update') ?? 'Failed to reset password');
         } finally {

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
@@ -8,11 +8,11 @@ import { resetPassword, ResetPasswordResponse } from './actions';
 
 export interface UserResetPasswordConfirmModalProps {
     email: string;
-    userId: number;
     hasLogin: boolean;
     onCancel: () => void;
     onComplete: (response: ResetPasswordResponse) => void;
     resetPasswordApi?: (userId: number) => Promise<ResetPasswordResponse>;
+    userId: number;
 }
 
 export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProps> = memo(props => {

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
@@ -8,14 +8,15 @@ import { resetPassword, ResetPasswordResponse } from './actions';
 
 export interface UserResetPasswordConfirmModalProps {
     email: string;
+    userId: number;
     hasLogin: boolean;
     onCancel: () => void;
     onComplete: (response: ResetPasswordResponse) => void;
-    resetPasswordApi?: (email: string) => Promise<ResetPasswordResponse>;
+    resetPasswordApi?: (userId: number) => Promise<ResetPasswordResponse>;
 }
 
 export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProps> = memo(props => {
-    const { email, hasLogin, onCancel, onComplete, resetPasswordApi = resetPassword } = props;
+    const { email, userId, hasLogin, onCancel, onComplete, resetPasswordApi = resetPassword } = props;
     const [error, setError] = useState<string>();
     const [submitting, setSubmitting] = useState<boolean>(false);
 
@@ -23,14 +24,14 @@ export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProp
         setSubmitting(true);
 
         try {
-            const response = await resetPasswordApi(email);
+            const response = await resetPasswordApi(userId);
             onComplete(response);
         } catch (e) {
             setError(resolveErrorMessage(e, 'user', 'users', 'update') ?? 'Failed to reset password');
         } finally {
             setSubmitting(false);
         }
-    }, [email, onComplete, resetPasswordApi]);
+    }, [userId, onComplete, resetPasswordApi]);
 
     return (
         <Modal

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -197,6 +197,7 @@ function updateUsersState(userIds: number[], isDelete: boolean, isActivate: bool
 export type ResetPasswordResponse = {
     resetPassword: boolean;
     userId: number;
+    email?: string;
 };
 
 export function resetPassword(userId: number): Promise<ResetPasswordResponse> {

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -195,18 +195,18 @@ function updateUsersState(userIds: number[], isDelete: boolean, isActivate: bool
 }
 
 export type ResetPasswordResponse = {
-    email: string;
+    userId: number;
     resetPassword: boolean;
 };
 
-export function resetPassword(email: string): Promise<ResetPasswordResponse> {
+export function resetPassword(userId: number): Promise<ResetPasswordResponse> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: buildURL('security', 'adminResetPassword.api'),
             method: 'POST',
-            params: { email },
+            params: { userId },
             success: Utils.getCallbackWrapper(() => {
-                resolve({ email, resetPassword: true });
+                resolve({ userId, resetPassword: true });
             }),
             failure: Utils.getCallbackWrapper(error => {
                 console.error('Failed to reset password.', error);

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -195,8 +195,8 @@ function updateUsersState(userIds: number[], isDelete: boolean, isActivate: bool
 }
 
 export type ResetPasswordResponse = {
-    userId: number;
     resetPassword: boolean;
+    userId: number;
 };
 
 export function resetPassword(userId: number): Promise<ResetPasswordResponse> {

--- a/packages/components/src/internal/components/user/models.ts
+++ b/packages/components/src/internal/components/user/models.ts
@@ -1,12 +1,12 @@
 import { Record } from 'immutable';
 
 export class ChangePasswordModel extends Record({
-    email: undefined,
+    userId: undefined,
     oldPassword: '',
     password: '',
     password2: '',
 }) {
-    declare email: string;
+    declare userId: number;
     declare oldPassword: string;
     declare password: string;
     declare password2: string;


### PR DESCRIPTION
#### Rationale
security-adminResetPassword.api and login-changePasswordApi.api have been updated to accept userId instead of email as param. This PR updates the app side usage of those apis. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6021
- https://github.com/LabKey/labkey-ui-components/pull/1637
- https://github.com/LabKey/limsModules/pull/900

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
