### PR TITLE
Fix parseVerificationToken() helper to reflect verification URL change

### DIFF
--- a/packages/test/package-lock.json
+++ b/packages/test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/test",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/test",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "properties-reader": "2.3.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.6.3-fb_fix_authUtil.1",
+  "version": "1.6.3-fb-fix-authUtil.1",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.6.3-fb-fix-authUtil.1",
+  "version": "1.6.3",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/test",
-  "version": "1.6.2",
+  "version": "1.6.3-fb_fix_authUtil.1",
   "description": "Configurations and utilities for JavaScript-based testing",
   "main": "dist/test.js",
   "module": "dist/test.js",

--- a/packages/test/releaseNotes/test.md
+++ b/packages/test/releaseNotes/test.md
@@ -2,7 +2,7 @@
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
 ### version 1.6.3
-*Released* TBD
+*Released* 11 November 2024
 * Fix parseVerificationToken() helper to reflect verification URL change
 
 ### version 1.6.2

--- a/packages/test/releaseNotes/test.md
+++ b/packages/test/releaseNotes/test.md
@@ -1,6 +1,10 @@
 # @labkey/test
 Utilities and configurations for running JavaScript tests with LabKey Server.
 
+### version 1.6.3
+*Released* TBD
+* Fix parseVerificationToken() helper to reflect verification URL change
+
 ### version 1.6.2
 *Released* 30 September 2024
 * Add helper util for random/shuffle and ExperimentCRUDUtils

--- a/packages/test/src/integrationUtils.ts
+++ b/packages/test/src/integrationUtils.ts
@@ -361,18 +361,21 @@ const parseSessionId = (response: Response): string => {
 /**
  * Parses the verification token from the message supplied via the createNewUser.api upon creating a new user.
  * e.g. Expected to contain a link like:
- * http://localhost:8080/labkey/login-setPassword.view?verification=p9PVITQgdpiny1tI0kCPvVp8fu72Miab&amp;email=newuser@test.com
+ * http://localhost:8080/labkey/login-setPassword.view?verification=p9PVITQgdpiny1tI0kCPvVp8fu72Miab
  */
 const parseVerificationToken = (user: CreateNewUser): string => {
     const { email, message } = user;
     const tokenPrefix = 'setPassword.view?verification=';
-    const tokenSuffix = '&amp;email=';
+    const idx = message.indexOf(tokenPrefix);
 
-    if (message.indexOf(tokenPrefix) === -1 || message.indexOf(tokenSuffix) === -1) {
+    if (idx === -1) {
         throw new Error(`Failed to parse verification token. Unexpected response message for account "${email}".`);
     }
 
-    return message.split(tokenPrefix)[1].split(tokenSuffix)[0];
+    const start = idx + tokenPrefix.length;
+    const end = start + 32; // Verification token is 32 characters long
+
+    return message.substring(start, end);
 }
 
 const postRequest = (


### PR DESCRIPTION
#### Rationale
Verification URL format changed. Update test helper to match.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6021
- https://github.com/LabKey/limsModules/pull/905