### PR TITLE
Editable Grid: apply lookupValueFilters when pasting

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.8",
+  "version": "5.22.9-fb-plate-well-cf.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.8",
+      "version": "5.22.9-fb-plate-well-cf.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.9-fb-plate-well-cf.0",
+  "version": "5.22.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.9-fb-plate-well-cf.0",
+      "version": "5.22.9",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.8",
+  "version": "5.22.9-fb-plate-well-cf.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.9-fb-plate-well-cf.0",
+  "version": "5.22.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.22.9
+*Released*: 14 November 2024
+- Editable Grid: apply lookupValueFilters when pasting
+
 ### version 5.22.8
 *Released*: 13 November 2024
 - Merge from release24.11-SNAPSHOT to develop

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -916,7 +916,15 @@ async function getParsedLookup(
     const cacheKey = `${column.fieldKey}||${containerPath}`;
     let descriptors = lookupColumnContainerCache[cacheKey];
     if (!descriptors) {
-        const response = await findLookupValues(column, undefined, display, undefined, forUpdate, containerPath);
+        const columnMetadata = editorModel.getColumnMetadata(column.fieldKey);
+        const response = await findLookupValues(
+            column,
+            undefined,
+            display,
+            columnMetadata?.lookupValueFilters,
+            forUpdate,
+            containerPath
+        );
         descriptors = response.descriptors;
         lookupColumnContainerCache[cacheKey] = descriptors;
     }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51652](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51652) by respecting the `columnMetadata.lookupValueFilters` on requests that are attempting to resolve pasted values for a lookup cell.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1643
- https://github.com/LabKey/limsModules/pull/911
- https://github.com/LabKey/platform/pull/6049

#### Changes
- Furnish `lookupValueFilters` to `findLookupValues()` from the editor model column metadata when pasting.
- Improve the lookup value caching to immediately populate a promise into the cache.