### PR TITLE
withAssayModels: filter by "assayName" prop when provided

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.9",
+  "version": "5.22.10-fb-faster-assay.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.9",
+      "version": "5.22.10-fb-faster-assay.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.10-fb-faster-assay.0",
+  "version": "5.22.10-fb-faster-assay.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.10-fb-faster-assay.0",
+      "version": "5.22.10-fb-faster-assay.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.10-fb-faster-assay.1",
+  "version": "5.22.10-fb-faster-assay.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.10-fb-faster-assay.1",
+      "version": "5.22.10-fb-faster-assay.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.10-fb-faster-assay.2",
+  "version": "5.22.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.22.10-fb-faster-assay.2",
+      "version": "5.22.10",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.10-fb-faster-assay.0",
+  "version": "5.22.10-fb-faster-assay.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.10-fb-faster-assay.2",
+  "version": "5.22.10",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.9",
+  "version": "5.22.10-fb-faster-assay.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.22.10-fb-faster-assay.1",
+  "version": "5.22.10-fb-faster-assay.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.22.10
+*Released*: 15 November 2024
+- withAssayModels: filter by "assayName" prop when provided
+
 ### version 5.22.9
 *Released*: 14 November 2024
 - Editable Grid: apply lookupValueFilters when pasting

--- a/packages/components/src/internal/components/assay/withAssayModels.tsx
+++ b/packages/components/src/internal/components/assay/withAssayModels.tsx
@@ -58,8 +58,6 @@ export function withAssayModels<Props>(
     type WrappedProps = Props & WithAssayModelProps;
 
     class ComponentWithAssays extends PureComponent<WrappedProps, State> {
-        static defaultProps;
-
         state: Readonly<State> = produce<State>({} as State, () => ({
             context: { assayDefinition: undefined, assayProtocol: undefined },
             model: new AssayStateModel(),
@@ -124,10 +122,7 @@ export function withAssayModels<Props>(
                     definitions = definitions.filter(def => excludedAssayDesigns.indexOf(def.id) === -1);
                 }
 
-                await this.updateModel({
-                    definitions,
-                    definitionsLoadingState: LoadingState.LOADED,
-                });
+                await this.updateModel({ definitions, definitionsLoadingState: LoadingState.LOADED });
             } catch (definitionsError) {
                 await this.updateModel({
                     definitions: [],
@@ -248,7 +243,6 @@ export function withAssayModels<Props>(
  * specific assay protocol.
  * @param ComponentToWrap The component definition (e.g. class, function) to wrap.
  * This will have [[InjectedAssayModel]] props injected into it when instantiated.
- * @param defaultProps Provide alternative "defaultProps" for this wrapped component.
  */
 // TODO: this component seems kind of unnecessary, it seems like every consumer should be able to just use the RR6
 //  useParams hook directly, it's not particularly complicated.

--- a/packages/components/src/internal/components/assay/withAssayModels.tsx
+++ b/packages/components/src/internal/components/assay/withAssayModels.tsx
@@ -31,7 +31,7 @@ export interface WithAssayModelProps {
 
 export interface InjectedAssayModel extends AssayContextModel {
     assayModel: AssayStateModel;
-    reloadAssays: () => void;
+    reloadAssays: (clearCaches?: boolean) => Promise<void>;
 }
 
 interface State {
@@ -79,7 +79,8 @@ export function withAssayModels<Props>(
         componentDidUpdate = (prevProps: WrappedProps): void => {
             const { assayContainerPath, assayName } = this.props;
             if (assayName !== prevProps.assayName || assayContainerPath !== prevProps.assayContainerPath) {
-                this.load();
+                // When reloading from prop changes do not clear caches
+                this.reload(false);
             }
         };
 
@@ -182,8 +183,10 @@ export function withAssayModels<Props>(
             }
         };
 
-        reload = async (): Promise<void> => {
-            this.api.assay.clearAssayDefinitionCache();
+        reload = async (clearCaches = true): Promise<void> => {
+            if (clearCaches) {
+                this.api.assay.clearAssayDefinitionCache();
+            }
 
             await this.update({
                 context: { assayDefinition: undefined, assayProtocol: undefined },

--- a/packages/components/src/internal/components/assay/withAssayModels.tsx
+++ b/packages/components/src/internal/components/assay/withAssayModels.tsx
@@ -14,6 +14,7 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 import { ModuleContext } from '../base/ServerContext';
 
 import { AssayStateModel } from './models';
+import { GetAssayDefinitionsOptions } from './actions';
 
 interface AssayContextModel {
     assayDefinition: AssayDefinitionModel;
@@ -99,7 +100,7 @@ export function withAssayModels<Props>(
         };
 
         loadDefinitions = async (): Promise<void> => {
-            const { assayContainerPath, excludedAssayDesigns } = this.props;
+            const { assayContainerPath, assayName, excludedAssayDesigns } = this.props;
             const { model } = this.state;
 
             if (model.definitionsLoadingState === LoadingState.LOADED) {
@@ -109,7 +110,14 @@ export function withAssayModels<Props>(
             await this.updateModel({ definitionsError: undefined, definitionsLoadingState: LoadingState.LOADING });
 
             try {
-                let definitions = await this.api.assay.getAssayDefinitions({ containerPath: assayContainerPath });
+                const params: GetAssayDefinitionsOptions = { containerPath: assayContainerPath };
+
+                // If an "assayName" prop is specified, then filter for only the related assay definition
+                if (assayName) {
+                    params.name = assayName;
+                }
+
+                let definitions = await this.api.assay.getAssayDefinitions(params);
 
                 if (excludedAssayDesigns?.length > 0) {
                     definitions = definitions.filter(def => excludedAssayDesigns.indexOf(def.id) === -1);


### PR DESCRIPTION
#### Rationale
The `withAssayModels` component wrapper accepts an `assayName` prop with which it optionally loads an assay protocol. Each time, however, it loads all of the assay definitions in the requested container which can be overly burdensome, especially, in containers with a large number of assays defined. 

This change is an optimization which changes the wrapper to only request the assay definition associated with the provided `assayName` if/when it is furnished. This can have a significant impact on initial page load times for our `/assay` routes since they only need the assay definition of the protocol being requested. 

For example, locally I have a container with 127 assay definitions which is taking ~8 seconds to fulfill the `assay-assayList.api` request for an assay page. With this change, the time is down to sub 200ms.

That said, there are other usages of `withAssayModels` that do not specify an `assayName` prop which will continue to request all of the definitions in the container. This PR doesn't attempt to optimize those and we'll seek to address them at later date.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1645
- https://github.com/LabKey/labkey-ui-premium/pull/599
- https://github.com/LabKey/platform/pull/6057
- https://github.com/LabKey/limsModules/pull/919
- https://github.com/LabKey/commonAssays/pull/822

#### Changes
- When an `assayName` prop is specified on `withAssayModels`, then only load the associated assay definition rather than all definitions in the container.
