### PR TITLE
Issue 51645: Escape advanced search characters

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.23.0",
+      "version": "5.24.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.24.0
+*Released*: 19 November 2024
+- Issue 51645: Escape advanced search characters
+- Migrate `sanitizeSearchQuery()` implementation to this package and rename to `escapeSearchQuery()`.
+- Add `escapeQuery = false` and `escapeQuotes = false` as optional properties on the search API wrapper.
+
 ### version 5.23.0
 *Released*: 18 November 2024
 - Include identifying fields in editable entity grids - sample create/derive/aliquot

--- a/packages/components/src/internal/components/search/SearchPanel.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.tsx
@@ -189,6 +189,7 @@ export const SearchPanel: FC<SearchPanelProps> = memo(props => {
                 const entities = await searchUsingIndex(
                     {
                         category,
+                        escapeQuery: true,
                         q: searchTerm,
                         limit: pageSize,
                         offset,

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -1416,7 +1416,7 @@ describe('getSearchResultCardData', () => {
 });
 
 describe('decodeErrorMessage', () => {
-    test('emtpy string', () => {
+    test('empty string', () => {
         expect(decodeErrorMessage('')).toBe('');
     });
     test('undefined', () => {

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -18,9 +18,10 @@ import { isOntologyEnabled } from '../../app/utils';
 
 import { REGISTRY_KEY } from '../../app/constants';
 
+import { makeCommaSeparatedString } from '../../util/utils';
+
 import { SearchCategory, SearchScope } from './constants';
 import { FieldFilter, FieldFilterOption, FilterSelection, SearchResultCardData } from './models';
-import { makeCommaSeparatedString } from '../../util/utils';
 
 export const SAMPLE_FILTER_METRIC_AREA = 'sampleFinder';
 
@@ -45,11 +46,11 @@ export function getFilterOptionsForType(field: QueryColumn, isAncestor: boolean)
 
     const useConceptFilters = field.isConceptCodeColumn && isOntologyEnabled();
 
-    let filterList = (
-        useConceptFilters ? CONCEPT_COLUMN_FILTER_TYPES : Filter.getFilterTypesForType(jsonType)
-    ).filter(function (result) {
-        return Filter.Types.HAS_ANY_VALUE.getURLSuffix() !== result.getURLSuffix();
-    });
+    let filterList = (useConceptFilters ? CONCEPT_COLUMN_FILTER_TYPES : Filter.getFilterTypesForType(jsonType)).filter(
+        function (result) {
+            return Filter.Types.HAS_ANY_VALUE.getURLSuffix() !== result.getURLSuffix();
+        }
+    );
 
     if (jsonType === 'date') {
         filterList.push(Filter.Types.BETWEEN);
@@ -62,11 +63,11 @@ export function getFilterOptionsForType(field: QueryColumn, isAncestor: boolean)
             filterList = [
                 ...filterList.slice(0, equalsOneOfInd),
                 ANCESTOR_MATCHES_ALL_OF_FILTER_TYPE,
-                ...filterList.slice(equalsOneOfInd)
+                ...filterList.slice(equalsOneOfInd),
             ];
-        }
-        else
+        } else {
             filterList.push(ANCESTOR_MATCHES_ALL_OF_FILTER_TYPE);
+        }
     }
 
     return filterList.map(filter => {
@@ -95,10 +96,7 @@ const MAX_MULTI_VALUE_FILTER_VALUES = 200;
 
 export function getFilterTypePlaceHolder(suffix: string): string {
     if (suffix === 'in' || suffix === 'notin' || suffix === 'containsoneof' || suffix === 'containsnoneof') {
-        return (
-            'Use new line or semicolon to separate entries. ' +
-            ' Max of ' + MAX_MULTI_VALUE_FILTER_VALUES + ' values.'
-        );
+        return `Use new line or semicolon to separate entries.  Max of ${MAX_MULTI_VALUE_FILTER_VALUES} values.`;
     }
 
     return null;
@@ -200,8 +198,9 @@ export function getFieldFiltersValidationResult(
     }
 
     let msg = '';
-    if (maxMatchAllErrorField)
-        msg += "At most 10 values can be selected for 'Equals All Of' filter type for '" + maxMatchAllErrorField + "'. ";
+    if (maxMatchAllErrorField) {
+        msg += `At most 10 values can be selected for 'Equals All Of' filter type for "${maxMatchAllErrorField}". `;
+    }
 
     if (multiValueErrorFields.size > 0) {
         msg +=

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -199,7 +199,7 @@ export function getFieldFiltersValidationResult(
 
     let msg = '';
     if (maxMatchAllErrorField) {
-        msg += `At most 10 values can be selected for 'Equals All Of' filter type for "${maxMatchAllErrorField}". `;
+        msg += `At most 10 values can be selected for 'Equals All Of' filter type for '${maxMatchAllErrorField}'. `;
     }
 
     if (multiValueErrorFields.size > 0) {


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51645](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51645) by defaulting our application search pages to escape Lucene search characters. Quotes are the only characters not escaped.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1646
- https://github.com/LabKey/labkey-ui-premium/pull/601
- https://github.com/LabKey/limsModules/pull/933

#### Changes
- Migrate `sanitizeSearchQuery()` implementation to this package and rename to `escapeSearchQuery()`.
- Add `escapeQuery = false` and `escapeQuotes = false` as optional properties on the search API wrapper.
