### PR TITLE
Issue 51680: Use proper container path for importing assay data for jobs

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.0.1",
+  "version": "6.0.2-workflowAssayFixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.0.1",
+      "version": "6.0.2-workflowAssayFixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.0.2-workflowAssayFixes.0",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.0.2-workflowAssayFixes.0",
+      "version": "6.0.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.0.1",
+  "version": "6.0.2-workflowAssayFixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.0.2-workflowAssayFixes.0",
+  "version": "6.0.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51680: Use proper container path for importing assay data for jobs
+
 ### version 6.0.1
 *Released*: 27 November 2024
 - Incorporate Recent Storage Dashboard Widget

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.0.2
+*Released*: 29 November 2024
 - Issue 51680: Use proper container path for importing assay data for jobs
 
 ### version 6.0.1

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -9,7 +9,7 @@ import { QueryInfo } from '../public/QueryInfo';
 
 import { AssayUploadTabs } from './constants';
 
-import { AppURL, createProductUrlFromParts } from './url/AppURL';
+import { AppURL, createProductUrlFromPartsWithContainer } from './url/AppURL';
 
 import { SCHEMAS } from './schemas';
 import { ASSAYS_KEY } from './app/constants';
@@ -128,7 +128,8 @@ export class AssayDefinitionModel extends ImmutableRecord({
         isPicklist?: boolean,
         currentProductId?: string,
         targetProductId?: string,
-        ignoreFilter?: boolean
+        ignoreFilter?: boolean,
+        containerPath?: string
     ): string {
         let url: AppURL | string;
         // Note, will need to handle the re-import run case separately. Possibly introduce another URL via links
@@ -147,9 +148,10 @@ export class AssayDefinitionModel extends ImmutableRecord({
             }
             if (selectionKey) params.selectionKey = selectionKey;
             if (isPicklist) params.isPicklist = true;
-            url = createProductUrlFromParts(
+            url = createProductUrlFromPartsWithContainer(
                 targetProductId,
                 currentProductId,
+                containerPath,
                 params,
                 ASSAYS_KEY,
                 this.type,


### PR DESCRIPTION
#### Rationale
Issue 51680: [LKSM: Can import assay data with samples in the wrong context via workflow](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51680)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/607
- https://github.com/LabKey/limsModules/pull/951

#### Changes
- Add container path when constructing import URL
