### PR TITLE
Issue51518: Upgrade ModuleEditor to React 18

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.1.0",
+  "version": "6.1.0-fb-moduleeditorreact18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.1.0",
+      "version": "6.1.0-fb-moduleeditorreact18.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.2.1",
+  "version": "6.2.1-fb-moduleeditorreact18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.2.1",
+      "version": "6.2.1-fb-moduleeditorreact18.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.2.1",
+  "version": "6.2.1-fb-moduleeditorreact18.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.1.0",
+  "version": "6.1.0-fb-moduleeditorreact18.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.3.1
+*Released*: 4 December 2024
+- Reinstate prior removed fn
+
 ### version 6.3.0
 *Released*: 4 December 2024
 - Chart builder support for Trendline option in line chart

--- a/packages/components/src/public/files/FileAttachmentForm.tsx
+++ b/packages/components/src/public/files/FileAttachmentForm.tsx
@@ -201,6 +201,11 @@ export class FileAttachmentForm extends PureComponent<FileAttachmentFormProps, S
         );
     };
 
+    // Used in module editor—see DirectoryOperations.tsx
+    manuallyClearFiles = (attachmentName: string): void => {
+        this.fileAttachmentContainerRef.current.handleRemove(attachmentName);
+    };
+
     handleSubmit = (): void => {
         this.props.onSubmit?.(this.state.attachedFiles);
 


### PR DESCRIPTION
#### Rationale
See issue [here](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51518).

#### Related Pull Requests
* Prior React 18 Work: https://github.com/LabKey/labkey-ui-components/pull/1554
* https://github.com/LabKey/premiumModules/pull/125
* https://github.com/LabKey/labkey-ui-components/pull/1657

#### Changes
- Re-add prior removed fn
