### PR TITLE
RadioGroupInput fix for formsy input usage 

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.0",
+  "version": "6.5.0-fb-radioGroupInputFix.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.5.0",
+      "version": "6.5.0-fb-radioGroupInputFix.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.0-fb-radioGroupInputFix.0",
+  "version": "6.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.5.0-fb-radioGroupInputFix.0",
+      "version": "6.5.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.0",
+  "version": "6.5.0-fb-radioGroupInputFix.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.0-fb-radioGroupInputFix.0",
+  "version": "6.5.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: 11 December 2024
+- RadioGroupInput fix for formsy input usage
+  - need to call setValue on each change of radio selection
+
 ### version 6.5.0
 *Released*: 10 December 2024
 - Chart builder support for axis layout options

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
+### version 6.5.1
 *Released*: 11 December 2024
 - RadioGroupInput fix for formsy input usage
   - need to call setValue on each change of radio selection

--- a/packages/components/src/internal/components/forms/input/RadioGroupInput.tsx
+++ b/packages/components/src/internal/components/forms/input/RadioGroupInput.tsx
@@ -74,16 +74,11 @@ const RadioGroupInputImpl: FC<RadioGroupInputProps> = memo(props => {
     const selected = useMemo(() => options?.find(option => option.selected), [options]);
     const [selectedValue, setSelectedValue] = useState<string>(selected?.value);
 
-    useEffect(
-        () => {
-            if (selected?.value && formsy) {
-                setValue?.(selected.value);
-            }
-        },
-        [
-            /* constructor */
-        ]
-    );
+    useEffect(() => {
+        if (selectedValue && formsy) {
+            setValue?.(selectedValue);
+        }
+    }, [formsy, selectedValue, setValue]);
 
     const onSetValue = useCallback(
         (value: string): void => {


### PR DESCRIPTION
#### Rationale
The related PR converted the RadioGroupInput component to FC and introduced a regeression for the formsy input case that caused a selenium test failure. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1659
- https://github.com/LabKey/limsModules/pull/989

#### Changes
- need to call setValue on each change of radio selection
