### PR TITLE
Issue 51853: display configured date/time format in DateInput

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.4-fb-dating.0",
+  "version": "6.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.5.4-fb-dating.0",
+      "version": "6.5.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.3",
+  "version": "6.5.4-fb-dating.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.5.3",
+      "version": "6.5.4-fb-dating.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.4-fb-dating.0",
+  "version": "6.5.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.5.3",
+  "version": "6.5.4-fb-dating.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.5.4
+*Released*: 17 December 2024
+- Update `DateInput` to determine the default date/time from container configuration
+- Lineage: be defensive against seed not being set when focusing graph
+- Refactor `ColorPickerInput` to a functional component
+
 ### version 6.5.3
 *Released*: 16 December 2024
 - Add restrictions on names of domains

--- a/packages/components/src/internal/components/DateInput.tsx
+++ b/packages/components/src/internal/components/DateInput.tsx
@@ -1,9 +1,24 @@
-import React, { FC, memo, useCallback, useRef } from 'react';
+import React, { FC, memo, useCallback, useMemo, useRef } from 'react';
 import DatePicker, { DatePickerProps } from 'react-datepicker';
 
-export const DateInput: FC<DatePickerProps> = memo(props => {
-    const { onSelect } = props;
+import { getDateFNSDateFormat, parseDateFNSTimeFormat } from '../util/Date';
+
+import { Container } from './base/models/Container';
+
+export interface DateInputProps {
+    container?: Container;
+}
+
+export const DateInput: FC<DateInputProps & DatePickerProps> = memo(props => {
+    const { container, dateFormat, onSelect, timeFormat, ...pickerProps } = props;
     const input = useRef<DatePicker>(undefined);
+    const formats = useMemo(() => {
+        const dateFormat_ = dateFormat ?? getDateFNSDateFormat(container);
+        return {
+            dateFormat: dateFormat_,
+            timeFormat: timeFormat ?? parseDateFNSTimeFormat(dateFormat_ as string),
+        };
+    }, [container, dateFormat, timeFormat]);
 
     const onIconClick = useCallback(() => {
         input.current?.setFocus();
@@ -23,10 +38,11 @@ export const DateInput: FC<DatePickerProps> = memo(props => {
             <DatePicker
                 autoComplete="off"
                 className="form-control"
-                dateFormat="MM/dd/yyyy"
                 wrapperClassName="form-control"
                 showTimeSelect={false}
-                {...props}
+                {...pickerProps}
+                dateFormat={formats.dateFormat}
+                timeFormat={formats.timeFormat}
                 ref={input}
                 onSelect={onSelect_}
             />

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -6,7 +6,6 @@ import {
     getColDateFormat,
     getDateFNSDateFormat,
     getJsonDateTimeFormatString,
-    parseDateFNSTimeFormat,
     getJsonDateFormatString,
 } from '../util/Date';
 import { Key, useEnterEscape } from '../../public/useEnterEscape';
@@ -191,8 +190,8 @@ export const EditInlineField: FC<Props> = memo(props => {
     }, []);
 
     const dateInputDateFormat = useMemo<string>(
-        () => (isDate ? getColDateFormat(column, column ? undefined : getDateFNSDateFormat()) : undefined),
-        [column, isDate]
+        () => (isDate ? getColDateFormat(column, column ? undefined : getDateFNSDateFormat(container)) : undefined),
+        [column, container, isDate]
     );
 
     return (
@@ -216,6 +215,7 @@ export const EditInlineField: FC<Props> = memo(props => {
             {state.editing && isDateOrTime && !column && (
                 <DateInput
                     autoFocus
+                    container={container}
                     name={name}
                     onBlur={onBlur}
                     onKeyDown={onKeyDown}
@@ -225,7 +225,6 @@ export const EditInlineField: FC<Props> = memo(props => {
                     selected={dateValue}
                     showTimeSelect={!!column}
                     dateFormat={dateInputDateFormat}
-                    timeFormat={parseDateFNSTimeFormat(dateInputDateFormat)}
                 />
             )}
             {state.editing && isTextArea && (

--- a/packages/components/src/internal/components/forms/input/ColorPickerInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/ColorPickerInput.test.tsx
@@ -6,39 +6,33 @@ import { ColorPickerInput } from './ColorPickerInput';
 
 describe('ColorPickerInput', () => {
     test('default props', () => {
-        const component = <ColorPickerInput value="#000000" onChange={jest.fn} />;
-        const { container } = render(component);
+        const { container } = render(<ColorPickerInput value="#000000" onChange={jest.fn} />);
         expect(container).toMatchSnapshot();
     });
 
     test('without value', () => {
-        const component = <ColorPickerInput value={undefined} onChange={jest.fn} />;
-        const { container } = render(component);
+        const { container } = render(<ColorPickerInput value={undefined} onChange={jest.fn} />);
         expect(container).toMatchSnapshot();
     });
 
     test('with button text', () => {
-        const component = <ColorPickerInput value="#000000" text="Select color..." onChange={jest.fn} />;
-        const { container } = render(component);
+        const { container } = render(<ColorPickerInput value="#000000" text="Select color..." onChange={jest.fn} />);
         expect(container).toMatchSnapshot();
     });
 
     test('showPicker', async () => {
-        const component = <ColorPickerInput value="#000000" onChange={jest.fn} />;
-        const { container } = render(component);
+        const { container } = render(<ColorPickerInput value="#000000" onChange={jest.fn} />);
         await userEvent.click(document.querySelector('.color-picker__button'));
         expect(container).toMatchSnapshot();
     });
 
     test('allowRemove', () => {
-        const component = <ColorPickerInput value="#000000" onChange={jest.fn} allowRemove={true} />;
-        const { container } = render(component);
+        const { container } = render(<ColorPickerInput value="#000000" onChange={jest.fn} allowRemove />);
         expect(container).toMatchSnapshot();
     });
 
     test('disabled', () => {
-        const component = <ColorPickerInput value="#000000" onChange={jest.fn} disabled={true} />;
-        const { container } = render(component);
+        const { container } = render(<ColorPickerInput value="#000000" onChange={jest.fn} disabled />);
         expect(container).toMatchSnapshot();
     });
 });

--- a/packages/components/src/internal/components/forms/input/ColorPickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/ColorPickerInput.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, ReactNode } from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 import { ColorResult, CompactPicker } from 'react-color';
 import classNames from 'classnames';
 
@@ -15,62 +15,50 @@ interface Props {
     value: string;
 }
 
-interface State {
-    showPicker: boolean;
-}
+export const ColorPickerInput: FC<Props> = memo(props => {
+    const { allowRemove, colors, disabled, name, onChange, text, value } = props;
+    const [showPicker, setShowPicker] = useState<boolean>(false);
+    const onChangeComplete = useCallback(
+        (color?: ColorResult) => {
+            onChange(name, color?.hex);
+        },
+        [name, onChange]
+    );
+    const onRemove = useCallback(() => {
+        onChangeComplete();
+    }, [onChangeComplete]);
+    const togglePicker = useCallback(() => {
+        setShowPicker(s => !s);
+    }, []);
 
-export class ColorPickerInput extends PureComponent<Props, State> {
-    state: Readonly<State> = {
-        showPicker: false,
-    };
+    return (
+        <div className="color-picker">
+            <button
+                type="button"
+                className="color-picker__button btn btn-default"
+                onClick={togglePicker}
+                disabled={disabled}
+            >
+                {text ? text : value ? <ColorIcon cls="color-picker__chip-small" asSquare value={value} /> : 'None'}
+                <i className={classNames('fa', { 'fa-caret-up': showPicker, 'fa-caret-down': !showPicker })} />
+            </button>
 
-    onChange = (color?: ColorResult): void => {
-        this.props.onChange(this.props.name, color?.hex);
-    };
+            {text !== undefined && <ColorIcon cls="color-picker__chip" asSquare value={value} />}
 
-    togglePicker = (): void => {
-        this.setState(state => ({ showPicker: !state.showPicker }));
-    };
+            {allowRemove && value && !disabled && (
+                <RemoveEntityButton onClick={onRemove} labelClass="color-picker__remove" />
+            )}
 
-    render(): ReactNode {
-        const { colors, disabled, text, value, allowRemove } = this.props;
-        const { showPicker } = this.state;
-        const iconClassName = classNames('fa', { 'fa-caret-up': showPicker, 'fa-caret-down': !showPicker });
-        const showChip = text !== undefined;
-
-        return (
-            <div className="color-picker">
-                <button
-                    type="button"
-                    className="color-picker__button btn btn-default"
-                    onClick={this.togglePicker}
-                    disabled={disabled}
-                >
-                    {text ? (
-                        text
-                    ) : value ? (
-                        <ColorIcon cls="color-picker__chip-small" asSquare={true} value={value} />
-                    ) : (
-                        'None'
-                    )}
-                    <i className={iconClassName} />
-                </button>
-
-                {showChip && <ColorIcon cls="color-picker__chip" asSquare={true} value={value} />}
-
-                {allowRemove && value && !disabled && (
-                    <RemoveEntityButton onClick={() => this.onChange()} labelClass="color-picker__remove" />
+            <div className="color-picker__picker">
+                {showPicker && (
+                    <>
+                        <div className="color-picker__mask" onClick={togglePicker} />
+                        <CompactPicker onChangeComplete={onChangeComplete} color={value} colors={colors} />
+                    </>
                 )}
-
-                <div className="color-picker__picker">
-                    {showPicker && (
-                        <>
-                            <div className="color-picker__mask" onClick={this.togglePicker} />
-                            <CompactPicker onChangeComplete={this.onChange} color={value} colors={colors} />
-                        </>
-                    )}
-                </div>
             </div>
-        );
-    }
-}
+        </div>
+    );
+});
+
+ColorPickerInput.displayName = 'ColorPickerInput';

--- a/packages/components/src/internal/components/lineage/vis/VisGraph.tsx
+++ b/packages/components/src/internal/components/lineage/vis/VisGraph.tsx
@@ -157,7 +157,7 @@ export class VisGraph extends Component<VisGraphProps, VisGraphState> {
         }
     };
 
-    // move the node to the end of the list so it is drawn on top of any of it's neighbors
+    // move the node to the end of the list so it is drawn on top of it's neighbors
     private moveNodeToTop = (id: IdType): void => {
         const { nodeIndices } = this.network.body;
         const idx = nodeIndices.indexOf(id);
@@ -176,23 +176,21 @@ export class VisGraph extends Component<VisGraphProps, VisGraphState> {
     };
 
     fitGraph = (): void => {
-        // NK: This is a arbitrarily set heuristic for deciding when to focus vs when to fit to
+        const { seed } = this.props;
+
+        // NK: This is an arbitrarily set heuristic for deciding when to focus vs when to fit to
         // the entire graph. I'm trying to delineate "small" graphs from "large" graphs.
-        if (this.network.body.nodeIndices.length > 50) {
-            this.focusSeed();
+        if (this.network.body.nodeIndices.length > 50 && seed) {
+            // Focus on the seed (if set)
+            this.network.fit({ animation: false, nodes: [seed] });
+
+            // Zoom out a bit from the default fitted zoom level
+            const scale = this.network.getScale() - 0.25;
+            if (scale > 0) {
+                this.network.moveTo({ scale });
+            }
         } else {
             this.network.fit();
-        }
-    };
-
-    focusSeed = (): void => {
-        // Focus on the seed
-        this.network.fit({ animation: false, nodes: [this.props.seed] });
-
-        // Zoom out a bit from the default fitted zoom level
-        const scale = this.network.getScale() - 0.25;
-        if (scale > 0) {
-            this.network.moveTo({ scale });
         }
     };
 

--- a/packages/components/src/internal/components/user/ChangePasswordModal.test.tsx
+++ b/packages/components/src/internal/components/user/ChangePasswordModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import { TEST_USER_READER } from '../../userFixtures';
 
@@ -10,13 +10,16 @@ jest.mock('./actions', () => ({
     ...jest.requireActual('./actions'),
     getPasswordRuleInfo: jest
         .fn()
-        .mockResolvedValue({ summary: 'Testing password rule description', shouldShowPasswordGuidance: true }),
+        // Setting shouldShowPasswordGuidance = false to prevent invocation of PasswordGauge.createComponent()
+        .mockResolvedValue({ summary: 'Testing password rule description', shouldShowPasswordGuidance: false }),
 }));
 
 describe('ChangePasswordModal', () => {
-    test('default props', () => {
+    test('default props', async () => {
         render(<ChangePasswordModal user={TEST_USER_READER} onSuccess={jest.fn()} onHide={jest.fn()} />);
-
+        await waitFor(() => {
+            expect(document.querySelector('.modal-dialog')).toBeVisible();
+        });
         const modal = document.querySelector('.modal-dialog');
         expect(modal.querySelectorAll('.alert')).toHaveLength(0);
         expect(modal.querySelectorAll('input')).toHaveLength(3);


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51853](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51853) by updating the `DateInput` to determine the default date/time formats if not supplied. Previously, it had been hardcoded to a specific format which does not necessarily align with the configured format(s).

This also addresses an issue reported by a user where when the lineage graph attempts to focus on the seed node it can cause the app to crash. I wasn't able to reproduce the scenario but am proactively adding defensiveness so that we prevent calling into the focusing if a seed value is not provided.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/993

#### Changes
- Update `DateInput` to determine the default date/time from container configuration
- [Ticket 51826](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51826): Lineage: be defensive against seed not being set when focusing graph
- Refactor `ColorPickerInput` to a functional component
