### PR TITLE
App grid MultiValueRenderer update for newline

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.8.0",
+  "version": "6.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.8.0",
+      "version": "6.8.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.7.0",
+  "version": "6.7.0-fb-multiValueNewLine.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.7.0",
+      "version": "6.7.0-fb-multiValueNewLine.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.7.0",
+  "version": "6.7.0-fb-multiValueNewLine.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.8.0",
+  "version": "6.8.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- MultiValueRenderer update for string values wit \n characters, replace them with <br/> elements
+
 ### version 6.7.0
 *Released*: 18 December 2024
 - Parent type selector updates for adding and removing from EditableGrid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 6.8.1
 *Released*: 23 December 2024
-- MultiValueRenderer update for string values wit \n characters, replace them with <br/> elements
+- MultiValueRenderer update for string values wit \n characters, to use white-space CSS to preserver them
 
 ### version 6.8.0
 *Released*: 19 December 2024

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.8.1
+*Released*: 23 December 2024
 - MultiValueRenderer update for string values wit \n characters, replace them with <br/> elements
 
 ### version 6.8.0

--- a/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
@@ -38,8 +38,7 @@ describe('MultiValueRenderer', () => {
     test('data with new line', () => {
         const data = fromJS({ 24: { value: 'first\nsecond\nthird' } });
         render(<MultiValueRenderer data={data} />);
-        expect(document.body.textContent).toBe('firstsecondthird');
-        expect(document.querySelectorAll('br')).toHaveLength(3);
+        expect(document.body.textContent).toBe('first\nsecond\nthird');
     });
 
     test('multiple values', () => {

--- a/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
@@ -35,6 +35,13 @@ describe('MultiValueRenderer', () => {
         expect(document.body.textContent).toBe('Ken Griffey Jr.');
     });
 
+    test('data with new line', () => {
+        const data = fromJS({ 24: { value: 'first\nsecond\nthird' } });
+        render(<MultiValueRenderer data={data} />);
+        expect(document.body.textContent).toBe('firstsecondthird');
+        expect(document.querySelectorAll('br')).toHaveLength(3);
+    });
+
     test('multiple values', () => {
         const data = fromJS({
             11: { displayValue: 'Edgar', value: 11 },

--- a/packages/components/src/internal/renderers/MultiValueRenderer.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.tsx
@@ -50,18 +50,9 @@ export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data }) =
 
                     if (text === undefined || text === null || text === '') return null;
 
-                    // If the string has \n characters, replace them with <br/> elements
+                    // If the string has \n characters, use whiteSpace style to preserve them
                     if (typeof text === 'string' && text.indexOf('\n') > -1) {
-                        text = (
-                            <>
-                                {text.split('\n').map((t, index) => (
-                                    <Fragment key={index}>
-                                        {t}
-                                        <br />
-                                    </Fragment>
-                                ))}
-                            </>
-                        );
+                        text = <span style={{ whiteSpace: 'pre-line' }}>{text}</span>;
                     }
 
                     return (

--- a/packages/components/src/internal/renderers/MultiValueRenderer.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, {FC, Fragment, memo, ReactNode} from 'react';
+import React, { FC, Fragment, memo, ReactNode } from 'react';
 import { Map } from 'immutable';
 
 export interface MultiValueRendererProps {
@@ -28,42 +28,53 @@ export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data }) =
     let i = -1;
     return (
         <div>
-            {data.map((item, key) => {
-                let text: ReactNode;
-                let url: string;
+            {data
+                .map((item, key) => {
+                    let text: ReactNode;
+                    let url: string;
 
-                if (Map.isMap(item)) {
-                    if (item.has('formattedValue')) {
-                        text = item.get('formattedValue');
+                    if (Map.isMap(item)) {
+                        if (item.has('formattedValue')) {
+                            text = item.get('formattedValue');
+                        } else {
+                            const o = item.has('displayValue') ? item.get('displayValue') : item.get('value');
+                            text = o !== null && o !== undefined ? o.toString() : null;
+                        }
+
+                        url = item.get('url');
+                    } else if (item !== undefined && item !== null) {
+                        text = item.toString();
                     } else {
-                        const o = item.has('displayValue') ? item.get('displayValue') : item.get('value');
-                        text = o !== null && o !== undefined ? o.toString() : null;
+                        return null;
                     }
 
-                    url = item.get('url');
-                } else if (item !== undefined && item !== null) {
-                    text = item.toString();
-                } else {
-                    return null;
-                }
+                    if (text === undefined || text === null || text === '') return null;
 
-                if (text === undefined || text === null || text === '') return null;
+                    // If the string has \n characters, replace them with <br/> elements
+                    if (typeof text === 'string' && text.indexOf('\n') > -1) {
+                        text = (
+                            <>
+                                {text.split('\n').map((t, index) => (
+                                    <Fragment key={index}>
+                                        {t}
+                                        <br />
+                                    </Fragment>
+                                ))}
+                            </>
+                        );
+                    }
 
-                // If the string has \n characters, replace them with <br/> elements
-                if (typeof text === 'string' && text.indexOf('\n') > -1) {
-                    text = <>{text.split('\n').map((t, index) => (<Fragment key={index}>{t}<br/></Fragment>))}</>;
-                }
-
-                return (
-                    // IntelliJ mistakenly presumes that key is an index.
-                    // In fact, it is the key of the map which is unique.
-                    // eslint-disable-next-line react/no-array-index-key
-                    <span key={key}>
-                        {++i > 0 ? ', ' : ''}
-                        {url ? <a href={url}>{text}</a> : text}
-                    </span>
-                );
-            }).toArray()}
+                    return (
+                        // IntelliJ mistakenly presumes that key is an index.
+                        // In fact, it is the key of the map which is unique.
+                        // eslint-disable-next-line react/no-array-index-key
+                        <span key={key}>
+                            {++i > 0 ? ', ' : ''}
+                            {url ? <a href={url}>{text}</a> : text}
+                        </span>
+                    );
+                })
+                .toArray()}
         </div>
     );
 });

--- a/packages/components/src/internal/renderers/MultiValueRenderer.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, memo, ReactNode } from 'react';
+import React, {FC, Fragment, memo, ReactNode} from 'react';
 import { Map } from 'immutable';
 
 export interface MultiValueRendererProps {
@@ -48,6 +48,11 @@ export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data }) =
                 }
 
                 if (text === undefined || text === null || text === '') return null;
+
+                // If the string has \n characters, replace them with <br/> elements
+                if (typeof text === 'string' && text.indexOf('\n') > -1) {
+                    text = <>{text.split('\n').map((t, index) => (<Fragment key={index}>{t}<br/></Fragment>))}</>;
+                }
 
                 return (
                     // IntelliJ mistakenly presumes that key is an index.


### PR DESCRIPTION
#### Rationale
When multiline text is passed down to the server in the app grid with `\n` characters, we are basically ignoring them on render. This PR updates that so that we replace those new line characters with `<br/>` on render.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1016

#### Changes
- MultiValueRenderer update for string values wit `\n` characters, replace them with `<br/>` elements
