### PR TITLE
Issue 51816: Trim string values before attempting to validate them

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.8.1-trimForValidation.0",
+  "version": "6.8.2-trimForValidation.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.8.1-trimForValidation.0",
+      "version": "6.8.2-trimForValidation.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.8.0",
+  "version": "6.8.1-trimForValidation.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.8.0",
+      "version": "6.8.1-trimForValidation.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.8.2-trimForValidation.0",
+  "version": "6.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.8.2-trimForValidation.0",
+      "version": "6.8.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.8.0",
+  "version": "6.8.1-trimForValidation.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.8.2-trimForValidation.0",
+  "version": "6.8.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51816: pasted values from spreadsheet retain new lines and look invalid
+
 ### version 6.8.0
 *Released*: 19 December 2024
 - Add FilterCriteriaRenderer

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.8.2
+*Released*: 27 December 2024
 - Issue 51816: pasted values from spreadsheet retain new lines and look invalid
 
 ### version 6.8.1

--- a/packages/components/src/internal/components/editable/utils.test.ts
+++ b/packages/components/src/internal/components/editable/utils.test.ts
@@ -201,8 +201,8 @@ describe('getValidatedEditableGridValue', () => {
     test('time column', () => {
         const timeCol = new QueryColumn({ jsonType: 'time' });
 
-        let validValues: any[] = [null, undefined, ''];
-        let results = [null, undefined, ''];
+        let validValues: any[] = [null, undefined, '', ' '];
+        let results = [null, undefined, '', ''];
         validValues.forEach((value, ind) => {
             expect(getValidatedEditableGridValue(value, timeCol)).toStrictEqual({
                 message: undefined,
@@ -218,7 +218,7 @@ describe('getValidatedEditableGridValue', () => {
             expect(result.value).toContain(results[ind]);
         });
 
-        const invalidValues = [' ', 'Bogus', true, NaN];
+        const invalidValues = ['Bogus', true, NaN];
         invalidValues.forEach(value => {
             expect(getValidatedEditableGridValue(value, timeCol)).toStrictEqual({
                 message: {
@@ -254,12 +254,12 @@ describe('getValidatedEditableGridValue', () => {
     test('float column', () => {
         const floatCol = new QueryColumn({ jsonType: 'float' });
 
-        const validValues = [null, undefined, '', 0, -1, 100, 1.1e3, '100', '0.0', 1.11, '1.11', 123.456e2];
+        const validValues = [null, undefined, '', ' ', 0, -1, 100, 1.1e3, '100', '0.0', 1.11, '1.11', 123.456e2];
         validValues.forEach(value => {
-            expect(getValidatedEditableGridValue(value, floatCol)).toStrictEqual({ message: undefined, value });
+            expect(getValidatedEditableGridValue(value, floatCol)).toStrictEqual({ message: undefined, value: Utils.isString(value) ? value.trim() : value });
         });
 
-        const invalidValues = [' ', 'Bogus', true, NaN];
+        const invalidValues = [ 'Bogus', true, NaN];
         invalidValues.forEach(value => {
             expect(getValidatedEditableGridValue(value, floatCol)).toStrictEqual({
                 message: {
@@ -296,7 +296,8 @@ describe('getValidatedEditableGridValue', () => {
         validValues.forEach(value => {
             expect(getValidatedEditableGridValue(value, boolCol)).toStrictEqual({
                 message: undefined,
-                value: Utils.isString(value) ? value.trim() : value, });
+                value: Utils.isString(value) ? value.trim() : value,
+            });
         });
 
         const invalidValues = ['tr', 'correct', 'wrong', '-1', '0.0', 'fail', 'bogus'];
@@ -315,7 +316,10 @@ describe('getValidatedEditableGridValue', () => {
 
         const validValues = [null, undefined, '', ' ', 'a', 'ab', 'ab cd ef', 'ab cd efgh'];
         validValues.forEach(value => {
-            expect(getValidatedEditableGridValue(value, textCol)).toStrictEqual({ message: undefined, value });
+            expect(getValidatedEditableGridValue(value, textCol)).toStrictEqual({
+                message: undefined,
+                value: value == undefined ? value : value.trim(),
+            });
         });
 
         const invalidValues = ['ab cd efghi', 'ab cd efghi jkl'];
@@ -328,18 +332,21 @@ describe('getValidatedEditableGridValue', () => {
     test('textchoice column', () => {
         const textChoiceCol = new QueryColumn({ jsonType: 'string', validValues: ['a', 'B'] });
 
-        const validValues = [null, undefined, '', 'a', 'B'];
+        const validValues = [null, undefined, '', ' ', 'a', 'B'];
         validValues.forEach(value => {
-            expect(getValidatedEditableGridValue(value, textChoiceCol)).toStrictEqual({ message: undefined, value });
+            expect(getValidatedEditableGridValue(value, textChoiceCol)).toStrictEqual({
+                message: undefined,
+                value: value == undefined ? value : value.trim(),
+            });
         });
 
-        const invalidValues = [' ', 'A', 'b', 'aB', 'ab', ' ab  '];
+        const invalidValues = ['A', 'b', 'aB', 'ab', ' ab  '];
         invalidValues.forEach(value => {
             expect(getValidatedEditableGridValue(value, textChoiceCol)).toStrictEqual({
                 message: {
                     message: `'${value.trim()}' is not a valid choice`,
                 },
-                value,
+                value: value.trim(),
             });
         });
     });
@@ -358,7 +365,7 @@ describe('getValidatedEditableGridValue', () => {
                 message: {
                     message: 'ReqCol is required.',
                 },
-                value,
+                value: value == undefined ? value : value.trim(),
             });
         });
     });

--- a/packages/components/src/internal/components/editable/utils.test.ts
+++ b/packages/components/src/internal/components/editable/utils.test.ts
@@ -17,6 +17,7 @@ import {
     sortCellKeys,
 } from './utils';
 import { initEditorModel } from './actions';
+import { Utils } from '@labkey/api';
 
 class MockEditableGridLoader implements EditableGridLoader {
     columns: QueryColumn[];
@@ -231,12 +232,15 @@ describe('getValidatedEditableGridValue', () => {
     test('int column', () => {
         const intCol = new QueryColumn({ jsonType: 'int' });
 
-        const validValues = [null, undefined, '', 0, -1, 100, 1.1e3, '100', '0.0'];
+        const validValues = [null, undefined, '', ' ', 0, -1, 100, 1.1e3, '100', '100 ', '0.0'];
         validValues.forEach(value => {
-            expect(getValidatedEditableGridValue(value, intCol)).toStrictEqual({ message: undefined, value });
+            expect(getValidatedEditableGridValue(value, intCol)).toStrictEqual({
+                message: undefined,
+                value: Utils.isString(value) ? value.trim() : value,
+            });
         });
 
-        const invalidValues = [1.11, ' ', 'Bogus', true, NaN];
+        const invalidValues = [1.11, 'Bogus', true, NaN];
         invalidValues.forEach(value => {
             expect(getValidatedEditableGridValue(value, intCol)).toStrictEqual({
                 message: {
@@ -274,12 +278,15 @@ describe('getValidatedEditableGridValue', () => {
             undefined,
             '',
             'true',
+            'true\r',
             't',
             'yes',
             'y',
             'on',
             '1',
             'false',
+            ' false',
+            ' false ',
             'f',
             'no',
             'n',
@@ -287,7 +294,9 @@ describe('getValidatedEditableGridValue', () => {
             '0',
         ];
         validValues.forEach(value => {
-            expect(getValidatedEditableGridValue(value, boolCol)).toStrictEqual({ message: undefined, value });
+            expect(getValidatedEditableGridValue(value, boolCol)).toStrictEqual({
+                message: undefined,
+                value: Utils.isString(value) ? value.trim() : value, });
         });
 
         const invalidValues = ['tr', 'correct', 'wrong', '-1', '0.0', 'fail', 'bogus'];
@@ -296,7 +305,7 @@ describe('getValidatedEditableGridValue', () => {
                 message: {
                     message: 'Invalid boolean',
                 },
-                value,
+                value
             });
         });
     });

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@labkey/api';
+import { Filter, Utils } from '@labkey/api';
 
 import { Operation, QueryColumn } from '../../../public/QueryColumn';
 
@@ -33,6 +33,10 @@ export const getValidatedEditableGridValue = (origValue: any, col: QueryColumn):
     const isDateType = isDateTimeType && isDateOnlyColumn;
     let message;
     let value = origValue;
+    // Issue 51816: pasted values from spreadsheet retain new lines and look invalid
+    if (Utils.isString(value)) {
+        value = value.trim();
+    }
 
     // Issue 44398: match JSON dateTime format provided by LK server when submitting date values back for insert/update
     // Issue 45140: use QueryColumn date format for parseDate()


### PR DESCRIPTION
#### Rationale
Issue [51816](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51816) - Values copied from spreadsheets and pasted into the grid will retain the newline characters from the spreadsheet, which results in non-string values looking like invalid values.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/630
- https://github.com/LabKey/limsModules/pull/1029

#### Changes
- Update `getValidatedEditableGridValue` to trim string values before validating.
