### PR TITLE
Issue 51879: App grid column header click area above column title should open the menu

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.10.0-appGridHeader51879.0",
+  "version": "6.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.10.0-appGridHeader51879.0",
+      "version": "6.11.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.10.0",
+  "version": "6.10.0-appGridHeader51879.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.10.0",
+      "version": "6.10.0-appGridHeader51879.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.10.0",
+  "version": "6.10.0-appGridHeader51879.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.10.0-appGridHeader51879.0",
+  "version": "6.11.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51879: App grid column header click area above column title should open the menu
+
 ### version 6.10.0
 *Released*: 30 December 2024
 - Customizable File Templates for Sources, Sample Types & Assay Designs

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.11.0
+*Released*: 3 January 2025
 - Issue 51879: App grid column header click area above column title should open the menu
 
 ### version 6.10.0

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -141,7 +141,8 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
         // Issue 48610: app grid column header <th> element to trigger click on child <div>
         const childEl = e.target.getElementsByClassName(GRID_HEADER_CELL_BODY);
         if (childEl?.length === 1) {
-            e.target.getElementsByClassName(GRID_HEADER_CELL_BODY)[0].click();
+            childEl[0].click();
+            e.stopPropagation(); // Issue 51879
         }
     };
 

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -158,63 +158,65 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
         return (
             <thead>
                 <tr>
-                    {columns.map((column, i) => {
-                        const { headerCls, index, fixedWidth, raw, title, width, hideTooltip } = column;
-                        const draggable = onColumnDrop !== undefined;
+                    {columns
+                        .map((column, i) => {
+                            const { headerCls, index, fixedWidth, raw, title, width, hideTooltip } = column;
+                            const draggable = onColumnDrop !== undefined;
 
-                        let style: CSSProperties;
-                        if (fixedWidth) {
-                            style = {
-                                width: `${fixedWidth}px`,
-                            };
-                        }
+                            let style: CSSProperties;
+                            if (fixedWidth) {
+                                style = {
+                                    width: `${fixedWidth}px`,
+                                };
+                            }
 
-                        let colMinWidth = width;
-                        if (colMinWidth === undefined) {
-                            // the additional 45px is to account for the grid column header icons for sort/filter and the dropdown toggle
-                            colMinWidth = calcWidths && title ? Math.max(45 + title.length * 8, 150) : undefined;
-                        }
-                        if (!fixedWidth && colMinWidth !== undefined) {
-                            if (!style) style = {};
-                            style.minWidth = `${colMinWidth}px`;
-                        }
+                            let colMinWidth = width;
+                            if (colMinWidth === undefined) {
+                                // the additional 45px is to account for the grid column header icons for sort/filter and the dropdown toggle
+                                colMinWidth = calcWidths && title ? Math.max(45 + title.length * 8, 150) : undefined;
+                            }
+                            if (!fixedWidth && colMinWidth !== undefined) {
+                                if (!style) style = {};
+                                style.minWidth = `${colMinWidth}px`;
+                            }
 
-                        if (column.showHeader) {
-                            const className = classNames(headerCls, {
-                                'grid-header-cell': headerCls === undefined,
-                                'phi-protected': raw?.phiProtected === true,
-                                'grid-header-draggable': draggable && index !== GRID_SELECTION_INDEX,
-                                'grid-header-drag-over': dragTarget === index,
-                            });
-                            const description = getColumnHoverText(raw);
+                            if (column.showHeader) {
+                                const className = classNames(headerCls, {
+                                    'grid-header-cell': headerCls === undefined,
+                                    'phi-protected': raw?.phiProtected === true,
+                                    'grid-header-draggable': draggable && index !== GRID_SELECTION_INDEX,
+                                    'grid-header-drag-over': dragTarget === index,
+                                });
+                                const description = getColumnHoverText(raw);
 
-                            return (
-                                <th
-                                    id={index}
-                                    key={index}
-                                    className={className}
-                                    style={style}
-                                    title={hideTooltip ? undefined : description}
-                                    draggable={draggable}
-                                    onDragStart={this.handleDragStart}
-                                    onDragOver={this.handleDragOver}
-                                    onDrop={this.handleDrop}
-                                    onDragEnter={this.handleDragEnter}
-                                    onDragEnd={this.handleDragEnd}
-                                    onClick={this.handleHeaderClick}
-                                >
-                                    {headerCell ? headerCell(column, i, columns.size) : title}
-                                    {/* headerCell will render the helpTip, so only render here if not using headerCell() */}
-                                    {!headerCell && column.helpTipRenderer && (
-                                        <LabelHelpTip title={title} popoverClassName="label-help-arrow-top">
-                                            <HelpTipRenderer type={column.helpTipRenderer} />
-                                        </LabelHelpTip>
-                                    )}
-                                </th>
-                            );
-                        }
-                        return <th key={index} style={{ minWidth: style?.minWidth }} />;
-                    }, this).toArray()}
+                                return (
+                                    <th
+                                        id={index}
+                                        key={index}
+                                        className={className}
+                                        style={style}
+                                        title={hideTooltip ? undefined : description}
+                                        draggable={draggable}
+                                        onDragStart={this.handleDragStart}
+                                        onDragOver={this.handleDragOver}
+                                        onDrop={this.handleDrop}
+                                        onDragEnter={this.handleDragEnter}
+                                        onDragEnd={this.handleDragEnd}
+                                        onClick={this.handleHeaderClick}
+                                    >
+                                        {headerCell ? headerCell(column, i, columns.size) : title}
+                                        {/* headerCell will render the helpTip, so only render here if not using headerCell() */}
+                                        {!headerCell && column.helpTipRenderer && (
+                                            <LabelHelpTip title={title} popoverClassName="label-help-arrow-top">
+                                                <HelpTipRenderer type={column.helpTipRenderer} />
+                                            </LabelHelpTip>
+                                        )}
+                                    </th>
+                                );
+                            }
+                            return <th key={index} style={{ minWidth: style?.minWidth }} />;
+                        }, this)
+                        .toArray()}
                 </tr>
             </thead>
         );
@@ -227,14 +229,16 @@ interface GridMessagesProps {
 
 const GridMessages: FC<GridMessagesProps> = memo(({ messages }) => (
     <div className="grid-messages">
-        {messages.map((message: Map<string, string>, i) => {
-            return (
-                // eslint-disable-next-line react/no-array-index-key
-                <div className={classNames('grid-message', message.get('type'))} key={i}>
-                    {message.get('content')}
-                </div>
-            );
-        }).toArray()}
+        {messages
+            .map((message: Map<string, string>, i) => {
+                return (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <div className={classNames('grid-message', message.get('type'))} key={i}>
+                        {message.get('content')}
+                    </div>
+                );
+            })
+            .toArray()}
     </div>
 ));
 
@@ -256,15 +260,19 @@ const GridRow: FC<GridRowProps> = memo(({ columns, highlight, row, rowIdx }) => 
                 'grid-row': rowIdx % 2 === 1,
             })}
         >
-            {columns.map((column: GridColumn, c: number) =>
-                column.tableCell ? (
-                    <Fragment key={column.index}>{column.cell(row.get(column.index), row, column, rowIdx, c)}</Fragment>
-                ) : (
-                    <td key={column.index} style={{ textAlign: column.align || 'left' } as any}>
-                        {column.cell(row.get(column.index), row, column, rowIdx, c)}
-                    </td>
+            {columns
+                .map((column: GridColumn, c: number) =>
+                    column.tableCell ? (
+                        <Fragment key={column.index}>
+                            {column.cell(row.get(column.index), row, column, rowIdx, c)}
+                        </Fragment>
+                    ) : (
+                        <td key={column.index} style={{ textAlign: column.align || 'left' } as any}>
+                            {column.cell(row.get(column.index), row, column, rowIdx, c)}
+                        </td>
+                    )
                 )
-            ).toArray()}
+                .toArray()}
         </tr>
     );
 });
@@ -299,11 +307,13 @@ const GridBody: FC<GridBodyProps> = memo(props => {
 
     return (
         <tbody>
-            {data.map((row, ind) => {
-                const highlight = highlightRowIndexes && highlightRowIndexes.contains(ind);
-                const key = rowKey ? row.get(rowKey) : ind;
-                return <GridRow columns={columns} highlight={highlight} key={key} row={row} rowIdx={ind} />;
-            }).toArray()}
+            {data
+                .map((row, ind) => {
+                    const highlight = highlightRowIndexes && highlightRowIndexes.contains(ind);
+                    const key = rowKey ? row.get(rowKey) : ind;
+                    return <GridRow columns={columns} highlight={highlight} key={key} row={row} rowIdx={ind} />;
+                })
+                .toArray()}
 
             {data.isEmpty() && (
                 <EmptyGridRow


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51879
On app grid header `<th>` click  setOpen was getting set to true but then the original click event was setting it back to false. We need to call stopPropagation() on the original click event in this case to prevent that.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1037

#### Changes
- call stopPropagation() on the original click event for app grid th
