### PR TITLE
Issue 49044: Add mega-menu back to Admin pages

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.10.0",
+  "version": "6.10.1-miscFixesAndTests252seh.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.10.0",
+      "version": "6.10.1-miscFixesAndTests252seh.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.10.1-miscFixesAndTests252seh.0",
+  "version": "6.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.10.1-miscFixesAndTests252seh.0",
+      "version": "6.11.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.10.0",
+  "version": "6.10.1-miscFixesAndTests252seh.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.11.1-miscFixesAndTests252seh.0",
+  "version": "6.11.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 49044: Add mega-menu back to Admin pages
+
 ### version 6.10.0
 *Released*: 30 December 2024
 - Customizable File Templates for Sources, Sample Types & Assay Designs

--- a/packages/components/src/internal/components/navigation/NavigationBar.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.tsx
@@ -99,7 +99,7 @@ export const NavigationBar: FC<Props> = memo(props => {
                     <div className="row">
                         <div className="navbar-left col-xs-6 col-md-6">
                             <span className="navbar-item navbar-left-icon pull-left">{brand}</span>
-                            {showNavMenu && !isAdminPage && (
+                            {showNavMenu && (
                                 <span className="navbar-item navbar-left-menu">
                                     <ProductMenuButton
                                         key={folderMenuContext.key} // re-render and reload folderItems when folder added
@@ -108,7 +108,6 @@ export const NavigationBar: FC<Props> = memo(props => {
                                     />
                                 </span>
                             )}
-                            {isAdminPage && <div className="navbar-left-sub">Administration</div>}
                         </div>
                         <div className="navbar-right col-xs-6 col-md-6">
                             {!!user && (


### PR DESCRIPTION
#### Rationale
Issue [49044](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49044)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/631
- https://github.com/LabKey/limsModules/pull/1039

#### Changes
- Remove special casing from `NavigationBar` related to admin pages
