### PR TITLE
Issue 51967: Submit formatted date value from editable grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.5-fb-date-tz-51967.0",
+  "version": "5.20.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.5-fb-date-tz-51967.0",
+      "version": "5.20.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.4",
+  "version": "5.20.5-fb-date-tz-51967.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.4",
+      "version": "5.20.5-fb-date-tz-51967.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.5-fb-date-tz-51967.0",
+  "version": "5.20.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.4",
+  "version": "5.20.5-fb-date-tz-51967.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.20.5
+*Released*: 13 January 2025
+- Issue 51967: Submit formatted date value from editable grid
+
 ### version 5.20.4
 *Released*: 9 November 2024
 - Use userId instead of email for password related APIs


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51967](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51967) by ensuring we call into `getValidatedEditableGridValue()` when processing data to be submitted to the server. For dates, this will strip the timezone context from the submitted string to prevent date shifting in the database persisted value.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1068

#### Changes
- In `getRowValue()` pass the raw `Date` value rather than `toString()` so that the validated grid value is parsed appropriately
- In `getUpdatedData()`, after value comparison for change, resolve the formatted value for the submission data.
- Add regression coverage
