### PR TITLE
Issue 51908: increase precision for display and storage of stored amounts to nanoliters and nanograms

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.11.5",
+  "version": "6.11.6-nanoUnits.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.11.5",
+      "version": "6.11.6-nanoUnits.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.11.6-nanoUnits.0",
+  "version": "6.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.11.6-nanoUnits.0",
+      "version": "6.12.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.11.5",
+  "version": "6.11.6-nanoUnits.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.11.7-nanoUnits.0",
+  "version": "6.12.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51908: increase precision for stored amounts to nanoliters and nanograms
+
 ### version 6.11.5
 *Released*: 10 January 2025
 - Issue 51824: TSV/CSV file import ignore lines that start with #

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -4,7 +4,6 @@ import {
     getAltMetricUnitOptions,
     getAltUnitKeys,
     getMetricUnitOptions,
-    getMultiAltUnitKeys,
     getStoredAmountDisplay,
     isValuePrecisionValid,
     UnitModel,
@@ -16,7 +15,9 @@ describe('UnitModel', () => {
         expect(new UnitModel(10, 'mL').toString()).toBe('10 mL');
 
         expect(new UnitModel(99999, 'uL').as('L').toString()).toBe('0.099999 L');
-        expect(new UnitModel(99999.133, 'uL').as('L').toString()).toBe('0.099999 L');
+        expect(new UnitModel(99999.133, 'uL').as('L').toString()).toBe('0.099999133 L');
+        expect(new UnitModel(99999.13345678, 'uL').as('L').toString()).toBe('0.099999133 L');
+        expect(new UnitModel(99999.13345678, 'mg').as('kg').toString()).toBe('0.099999133457 kg');
         expect(new UnitModel(10, 'mL').as('L').toString()).toBe('0.01 L');
         expect(new UnitModel(10, 'mL').add(10, 'uL').toString()).toBe('10.01 mL');
         expect(new UnitModel(undefined, 'mL').as('L').toString()).toBe('0 L');
@@ -153,7 +154,8 @@ describe('MetricUnit utils', () => {
         expect(convertUnitDisplay(10, 'mL', 'bad', true)).toBe('10 mL');
 
         expect(convertUnitDisplay(99999, 'uL', 'L', true)).toBe('0.099999 L');
-        expect(convertUnitDisplay(99999.133, 'uL', 'L', true)).toBe('0.099999 L');
+        expect(convertUnitDisplay(99999.133, 'uL', 'L', true)).toBe('0.099999133 L');
+        expect(convertUnitDisplay(99999.1334544, 'uL', 'L', true)).toBe('0.099999133 L');
         expect(convertUnitDisplay(10, 'mL', 'L', true)).toBe('0.01 L');
         expect(convertUnitDisplay(10, 'L', 'mL', true)).toBe('10,000 mL');
         expect(convertUnitDisplay(10, 'g', 'kg', true)).toBe('0.01 kg');
@@ -166,8 +168,10 @@ describe('MetricUnit utils', () => {
     test('getStoredAmountDisplay', () => {
         expect(getStoredAmountDisplay('99999 uL (L)')).toBe('0.099999');
         expect(getStoredAmountDisplay('99999 uL (L)', true)).toBe('0.099999 L');
-        expect(getStoredAmountDisplay('99999.123 uL (L)')).toBe('0.099999');
-        expect(getStoredAmountDisplay('99999.123 uL (L)', true)).toBe('0.099999 L');
+        expect(getStoredAmountDisplay('99999.123 uL (L)')).toBe('0.099999123');
+        expect(getStoredAmountDisplay('99999.123 uL (L)', true)).toBe('0.099999123 L');
+        expect(getStoredAmountDisplay('99999.12345 uL (L)')).toBe('0.099999123');
+        expect(getStoredAmountDisplay('99999.12345 uL (L)', true)).toBe('0.099999123 L');
         expect(getStoredAmountDisplay('10 mL (L)', true)).toBe('0.01 L');
         expect(getStoredAmountDisplay('10 L (L)', true)).toBe('10 L');
         expect(getStoredAmountDisplay('10 mL')).toBe('10');

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -46,7 +46,7 @@ export class UnitModel {
         }
 
         const newValue = this.value * (this.unit.ratio / newUnit.ratio);
-        return new UnitModel(parseFloat(newValue.toFixed(6)), newUnit.label.toLowerCase());
+        return new UnitModel(parseFloat(newValue.toFixed(newUnit.displayPrecision)), newUnit.label.toLowerCase());
     }
 
     add(deltaValue: number, deltaUnitStr?: string) {
@@ -118,7 +118,7 @@ export const MEASUREMENT_UNITS: { [key: string]: MeasurementUnit } = {
         longLabelPlural: 'grams',
         baseUnit: BASE_UNITS.MASS,
         ratio: 1,
-        displayPrecision: 3, // enable smallest precision of mg
+        displayPrecision: 9, // enable smallest precision of ng
     },
     mg: {
         label: 'mg',
@@ -126,7 +126,7 @@ export const MEASUREMENT_UNITS: { [key: string]: MeasurementUnit } = {
         longLabelPlural: 'milligrams',
         baseUnit: BASE_UNITS.MASS,
         ratio: 0.001,
-        displayPrecision: 0,
+        displayPrecision: 6,
     },
     kg: {
         label: 'kg',
@@ -134,7 +134,7 @@ export const MEASUREMENT_UNITS: { [key: string]: MeasurementUnit } = {
         longLabelPlural: 'kilograms',
         baseUnit: BASE_UNITS.MASS,
         ratio: 1000,
-        displayPrecision: 6, // enable smallest precision of mg
+        displayPrecision: 12, // enable smallest precision of ng
     },
     ml: {
         label: 'mL',
@@ -142,7 +142,7 @@ export const MEASUREMENT_UNITS: { [key: string]: MeasurementUnit } = {
         longLabelPlural: 'milliliters',
         baseUnit: BASE_UNITS.VOLUME,
         ratio: 1,
-        displayPrecision: 3,
+        displayPrecision: 6, // enable smallest precision of nanoliters
     },
     ul: {
         label: 'uL',
@@ -150,7 +150,7 @@ export const MEASUREMENT_UNITS: { [key: string]: MeasurementUnit } = {
         longLabelPlural: 'microliters',
         baseUnit: BASE_UNITS.VOLUME,
         ratio: 0.001,
-        displayPrecision: 0,
+        displayPrecision: 3,
     },
     l: {
         label: 'L',
@@ -158,7 +158,7 @@ export const MEASUREMENT_UNITS: { [key: string]: MeasurementUnit } = {
         longLabelPlural: 'liters',
         baseUnit: BASE_UNITS.VOLUME,
         ratio: 1000,
-        displayPrecision: 6,
+        displayPrecision: 9,
     },
     unit: {
         label: 'unit',
@@ -251,7 +251,7 @@ export function convertUnitsForInput(amount: number, unit: string, displayUnit: 
         return amount;
     }
     // show up to 6 decimal places
-    return parseFloat((amount * (currentUnit.ratio / targetUnit.ratio)).toFixed(6));
+    return parseFloat((amount * (currentUnit.ratio / targetUnit.ratio)).toFixed(targetUnit.displayPrecision));
 }
 
 export function convertUnitDisplay(


### PR DESCRIPTION
#### Rationale
Issue [51908](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51908): The request here is to allow values to be stored with a precision of nanoliter or nanogram, but not to add these as explicit unit types (yet).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/644
- https://github.com/LabKey/platform/pull/6219
- https://github.com/LabKey/limsModules/pull/1076

#### Changes
- Increase display precision for the various units
