### PR TITLE
Issue 52038: Fix problems for fields whose names and fieldKeys are different

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.2",
+  "version": "5.20.6-fieldKeyConfusion.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.2",
+      "version": "5.20.6-fieldKeyConfusion.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.3",
+  "version": "5.20.6-fieldKeyConfusion.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.3",
+      "version": "5.20.6-fieldKeyConfusion.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.0",
+  "version": "5.20.6-fieldKeyConfusion.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.0",
+      "version": "5.20.6-fieldKeyConfusion.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.4",
+  "version": "5.20.6-fieldKeyConfusion.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.4",
+      "version": "5.20.6-fieldKeyConfusion.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.1",
+  "version": "5.20.6-fieldKeyConfusion.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.1",
+      "version": "5.20.6-fieldKeyConfusion.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.5",
+  "version": "5.20.6-fieldKeyConfusion.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.5",
+      "version": "5.20.6-fieldKeyConfusion.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.7",
+  "version": "5.20.6-fieldKeyConfusion.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.7",
+      "version": "5.20.6-fieldKeyConfusion.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.5",
+  "version": "5.20.6-fieldKeyConfusion.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.5",
+      "version": "5.20.6-fieldKeyConfusion.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.6",
+  "version": "5.20.6-fieldKeyConfusion.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.6",
+      "version": "5.20.6-fieldKeyConfusion.7",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.8",
+  "version": "5.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "5.20.6-fieldKeyConfusion.8",
+      "version": "5.20.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.4",
+  "version": "5.20.6-fieldKeyConfusion.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.5",
+  "version": "5.20.6-fieldKeyConfusion.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.2",
+  "version": "5.20.6-fieldKeyConfusion.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.3",
+  "version": "5.20.6-fieldKeyConfusion.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.0",
+  "version": "5.20.6-fieldKeyConfusion.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.1",
+  "version": "5.20.6-fieldKeyConfusion.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.8",
+  "version": "5.20.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.6",
+  "version": "5.20.6-fieldKeyConfusion.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.5",
+  "version": "5.20.6-fieldKeyConfusion.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "5.20.6-fieldKeyConfusion.7",
+  "version": "5.20.6-fieldKeyConfusion.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,8 +3,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 5.20.6
 *Released*: TBD
-- Issue 52038: Fix problem with editable grid not saving changes for fields whose names and fieldKeys are different
-
+- Issue 52038: Fix problems fields whose names and fieldKeys are different
+ - Editable grid needs to find columns using names not field key
+ - detail editing needs to use name instead of fieldKey for changed values
 
 ### version 5.20.5
 *Released*: 13 January 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Issue 52038: Fix problems fields whose names and fieldKeys are different
  - Editable grid needs to find columns using names not field key
  - detail editing needs to use name instead of fieldKey for changed values
+ - Fixes for identifying field retrieval and population in the grid
 
 ### version 5.20.5
 *Released*: 13 January 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.20.6
+*Released*: TBD
+- Issue 52038: Fix problem with editable grid not saving changes for fields whose names and fieldKeys are different
+
+
 ### version 5.20.5
 *Released*: 13 January 2025
 - Issue 51967: Submit formatted date value from editable grid

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
  - Editable grid needs to find columns using names not field key
  - detail editing needs to use name instead of fieldKey for changed values
  - Fixes for identifying field retrieval and population in the grid
+ - Update CheckboxInput.tsx and DatePickerInput.tsx to use column.fieldKey for input name prop (to match other input types)
 
 ### version 5.20.5
 *Released*: 13 January 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages
 
 ### version 5.20.6
-*Released*: TBD
+*Released*: 27 January 2025
 - Issue 52038: Fix problems fields whose names and fieldKeys are different
  - Editable grid needs to find columns using names not field key
  - detail editing needs to use name instead of fieldKey for changed values

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1283,7 +1283,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const insertData = OrderedMap<string, any>().asMutable();
         this.props.editorModel.queryInfo
             .getInsertColumns(this.props.bulkAddProps.isIncludedColumn)
-            .forEach(col => insertData.set(col.name, undefined));
+            .forEach(col => insertData.set(col.fieldKey, undefined));
         return insertData.merge(data).asImmutable();
     };
 

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -758,13 +758,19 @@ export class EditorModel
             });
             const originalRow = originalData.get(id.toString());
             if (originalRow) {
+                // N.B. key here is almost always the column name (not the fieldKey) and should remain so since that is
+                // the key we need to send to the server when saving the rows. For lineage columns, key is actually more like
+                // the fieldKey (that is, the parts of that lineage lookup have been encoded for Query names (e.g., / becomes $S)
+                // The Lineage field key parts need to be sent encoded so parsing of the field key parts (that is, splitting on the
+                // '/' character) can be done without a problem on the server side. Ideally, we would be able to send field keys in
+                // all cases, but that is for a later day.
                 const row = editedRow.reduce((row, value, key) => {
                     // We can skip the idField for the diff check, that will be added to the updated rows later
                     if (key === pkFieldKey) return row;
 
-                    let originalValue = originalRow.get(key, undefined);
                     // For lineage grids the parent columns aren't on the queryInfo
-                    const col = queryInfo.getColumn(key) ?? this.columnMap.get(key.toLowerCase());
+                    const col = queryInfo.getColumnFromName(key) ?? this.columnMap.get(key.toLowerCase());
+                    let originalValue = originalRow.get(col.fieldKey, undefined);
 
                     // we can skip any readOnly columns
                     if (col?.readOnly) return row;

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -758,7 +758,7 @@ export class EditorModel
             });
             const originalRow = originalData.get(id.toString());
             if (originalRow) {
-                // N.B. key here is almost always the column name (not the fieldKey) and should remain so since that is
+                // Issue 52038: key here is almost always the column name (not the fieldKey) and should remain so since that is
                 // the key we need to send to the server when saving the rows. For lineage columns, key is actually more like
                 // the fieldKey (that is, the parts of that lineage lookup have been encoded for Query names (e.g., / becomes $S)
                 // The Lineage field key parts need to be sent encoded so parsing of the field key parts (that is, splitting on the

--- a/packages/components/src/internal/components/entities/actions-getSampleIdentifyingFieldGridData.test.ts
+++ b/packages/components/src/internal/components/entities/actions-getSampleIdentifyingFieldGridData.test.ts
@@ -18,14 +18,14 @@ jest.mock('../../query/selectRows', () => ({
                         RowId: { value: 1 },
                         Name: { value: 'S1' },
                         intCol: { value: 1 },
-                        doubleCol: { value: 1.1 },
+                        "doubleCol/": { value: 1.1 },
                         textCol: { value: 'test1', displayValue: 'TEST 1' },
                     },
                     {
                         RowId: { value: 2 },
                         Name: { value: 'S2' },
                         intCol: { value: 2 },
-                        doubleCol: { value: 2.2, formattedValue: '2.200' },
+                        "doubleCol/": { value: 2.2, formattedValue: '2.200' },
                         textCol: { value: 'test2' },
                     },
                 ],
@@ -35,9 +35,9 @@ jest.mock('../../query/selectRows', () => ({
 }));
 
 const columns = [
-    { fieldKey: 'intCol', jsonType: 'int' },
-    { fieldKey: 'doubleCol', jsonType: 'double' },
-    { fieldKey: 'textCol', jsonType: 'string' },
+    { fieldKey: 'intCol', jsonType: 'int', name: 'intCol' },
+    { fieldKey: 'doubleCol$S', jsonType: 'double', name: 'doubleCol/' },
+    { fieldKey: 'textCol', jsonType: 'string', name: 'textCol' },
 ];
 const QUERY_INFO_NO_ID_VIEW = QueryInfo.fromJsonForTests(
     {
@@ -77,14 +77,14 @@ describe('getSampleIdentifyingFieldGridData', () => {
     test('with identifying fields, with rows in response', async () => {
         expect(await getSampleIdentifyingFieldGridData([1, 2], QUERY_INFO_WITH_ID_VIEW)).toStrictEqual({
             '1': {
-                doubleCol: 1.1,
+                doubleCol$S: 1.1,
                 intCol: 1,
                 rowId: 1,
                 sampleId: 'S1',
                 textCol: 'TEST 1',
             },
             '2': {
-                doubleCol: '2.200',
+                doubleCol$S: '2.200',
                 intCol: 2,
                 rowId: 2,
                 sampleId: 'S2',
@@ -96,12 +96,12 @@ describe('getSampleIdentifyingFieldGridData', () => {
     test('includeDefaultColumns false', async () => {
         expect(await getSampleIdentifyingFieldGridData([1, 2], QUERY_INFO_WITH_ID_VIEW, false)).toStrictEqual({
             '1': {
-                doubleCol: 1.1,
+                doubleCol$S: 1.1,
                 intCol: 1,
                 textCol: 'TEST 1',
             },
             '2': {
-                doubleCol: '2.200',
+                doubleCol$S: '2.200',
                 intCol: 2,
                 textCol: 'test2',
             },

--- a/packages/components/src/internal/components/entities/utils.test.ts
+++ b/packages/components/src/internal/components/entities/utils.test.ts
@@ -25,7 +25,7 @@ import {
     getCellKeyColumnMap,
     getEntityDescription,
     getEntityNoun,
-    getIdentifyingFieldKeys,
+    getIdentifyingColumns,
     getInitialParentChoices,
     getJobCreationHref,
     getSampleIdCellKey,
@@ -318,11 +318,11 @@ describe('getJobCreationHref', () => {
     });
 });
 
-describe('getIdentifyingFieldKeys', () => {
+describe('getIdentifyingColumns', () => {
     const columns = [
-        { fieldKey: 'intCol', jsonType: 'int' },
-        { fieldKey: 'doubleCol', jsonType: 'double' },
-        { fieldKey: 'textCol', jsonType: 'string' },
+        { fieldKey: 'intCol', jsonType: 'int', name: 'intCol' },
+        { fieldKey: 'doubleCol$S', jsonType: 'double', name: 'doubleCol/' },
+        { fieldKey: 'textCol', jsonType: 'string', name: 'textCol' },
     ];
     const QUERY_INFO_NO_ID_VIEW = QueryInfo.fromJsonForTests(
         {
@@ -350,16 +350,23 @@ describe('getIdentifyingFieldKeys', () => {
     );
 
     test('no view defined', () => {
-        expect(getIdentifyingFieldKeys(undefined)).toStrictEqual([]);
-        expect(getIdentifyingFieldKeys(QUERY_INFO_NO_ID_VIEW)).toStrictEqual([]);
+        expect(getIdentifyingColumns(undefined)).toStrictEqual([]);
+        expect(getIdentifyingColumns(QUERY_INFO_NO_ID_VIEW)).toStrictEqual([]);
     });
 
     test('view with default labels', () => {
-        expect(getIdentifyingFieldKeys(QUERY_INFO_WITH_ID_VIEW)).toStrictEqual(['intCol', 'doubleCol', 'textCol']);
+        const cols = getIdentifyingColumns(QUERY_INFO_WITH_ID_VIEW);
+        expect(cols).toHaveLength(3);
+        expect(cols[1].name).toBe('doubleCol/');
+        expect(cols[1].fieldKey).toBe('doubleCol$S');
+        expect(cols[0].name).toBe('intCol');
+        expect(cols[0].fieldKey).toBe('intCol');
+        expect(cols[2].name).toBe('textCol');
+        expect(cols[2].fieldKey).toBe('textCol');
     });
 
     test('view with custom labels', () => {
-        const newColumn = { fieldKey: 'intCol', jsonType: 'int', title: 'Counter' };
+        const newColumn = { fieldKey: 'intCol', jsonType: 'int', title: 'Counter', name: 'intCol' };
         const queryInfo = QueryInfo.fromJsonForTests(
             {
                 columns: [newColumn, columns[1], columns[2]],
@@ -372,7 +379,12 @@ describe('getIdentifyingFieldKeys', () => {
             },
             true
         );
-        expect(getIdentifyingFieldKeys(queryInfo)).toStrictEqual(['doubleCol', 'intCol']);
+        const cols = getIdentifyingColumns(queryInfo);
+        expect(cols).toHaveLength(2);
+        expect(cols[0].name).toBe('doubleCol/');
+        expect(cols[0].fieldKey).toBe('doubleCol$S');
+        expect(cols[1].name).toBe('intCol');
+        expect(cols[1].fieldKey).toBe('intCol');
     });
 });
 

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -19,6 +19,7 @@ import { ViewInfo } from '../../ViewInfo';
 import { EntityChoice, EntityDataType, IEntityTypeOption } from './models';
 
 import { ParentIdData } from './actions';
+import { QueryColumn } from '../../../public/QueryColumn';
 
 export function sampleDeleteDependencyText(): string {
     let deleteMsg = '';
@@ -164,12 +165,12 @@ export function getJobCreationHref(
     return actionUrl instanceof AppURL ? actionUrl.toHref() : actionUrl;
 }
 
-export function getIdentifyingFieldKeys(queryInfo: QueryInfo): string[] {
+export function getIdentifyingColumns(queryInfo: QueryInfo): QueryColumn[] {
     const idView = queryInfo?.getView(ViewInfo.IDENTIFYING_FIELDS_VIEW_NAME);
     if (!idView) {
         return [];
     }
-    return queryInfo.getIdentifyingFieldsEditableGridColumns(true).map(col => col.fieldKey);
+    return queryInfo.getIdentifyingFieldsEditableGridColumns(true)
 }
 
 export const SAMPLE_ID_FIELD_KEY = 'sampleid';

--- a/packages/components/src/internal/components/forms/detail/utils.ts
+++ b/packages/components/src/internal/components/forms/detail/utils.ts
@@ -37,7 +37,7 @@ export function extractChanges(
             if (!changedValue && existingValue.size === 0) {
                 return false;
             }
-            // Issue 52038: storage changed values using column name as key not fieldKey since server won't recognize
+            // Issue 52038: store changedValues using column name as key not fieldKey since server won't recognize
                 // the fields if you use fieldKey and thus no changes will be saved.
             // If the submitted value is empty and there is an existing value, should update field
             else if (!changedValue && existingValue.size > 0) {

--- a/packages/components/src/internal/components/forms/detail/utils.ts
+++ b/packages/components/src/internal/components/forms/detail/utils.ts
@@ -27,7 +27,10 @@ export function extractChanges(
     const changedValues = {};
     // Loop through submitted formValues and check against existing currentData from server
     Object.keys(formValues).forEach(field => {
-        const col = queryInfo.getColumn(field);
+        // Issue 52038: we expect the field values here to be fieldKey, but fall back to looking for the column by name
+        let col = queryInfo.getColumn(field);
+        if (!col) col = queryInfo.getColumnFromName(field);
+
         let existingValue = currentData.get(col.name);
         const changedValue = formValues[field];
 

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -30,7 +30,6 @@ interface CheckboxInputProps extends DisableableInputProps {
     formsy?: boolean;
     label?: any;
     labelClassName?: string;
-    name?: string;
     queryColumn: QueryColumn;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
     rowClassName?: any[] | string;
@@ -93,7 +92,6 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputImplProps, Checkbo
             formsy,
             label,
             labelClassName,
-            name,
             queryColumn,
             showLabel,
             renderFieldLabel,
@@ -135,7 +133,7 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputImplProps, Checkbo
                 <div className={wrapperClassName}>
                     <input
                         disabled={isDisabled}
-                        name={name ?? queryColumn.fieldKey}
+                        name={queryColumn.fieldKey}
                         // Issue 43299: Ignore "required" property for boolean columns as this will
                         // cause any false value (i.e. unchecked) to prevent submission.
                         // required={queryColumn.required}
@@ -159,7 +157,7 @@ const CheckboxInputFormsy = withFormsy<CheckboxInputProps, boolean>(CheckboxInpu
 export const CheckboxInput: FC<CheckboxInputProps> = props => {
     const { formsy = true } = props;
     if (formsy) {
-        return <CheckboxInputFormsy name={props.name ?? props.queryColumn.name} {...props} formsy />;
+        return <CheckboxInputFormsy name={props.queryColumn.fieldKey} {...props} formsy />;
     }
     return <CheckboxInputImpl {...(props as CheckboxInputImplProps)} formsy={false} />;
 };

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -328,7 +328,7 @@ const DatePickerInputFormsy = withFormsy<DatePickerInputProps, string>(DatePicke
 export const DatePickerInput: FC<DatePickerInputProps> = props => {
     const { formsy = true } = props;
     if (formsy) {
-        return <DatePickerInputFormsy name={props.name ?? props.queryColumn.name} {...props} formsy />;
+        return <DatePickerInputFormsy name={props.name ?? props.queryColumn.fieldKey} {...props} formsy />;
     }
     return <DatePickerInputImpl {...(props as DatePickerInputImplProps)} formsy={false} />;
 };

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -299,7 +299,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputImplPro
                         label={label}
                         labelOverlayProps={{
                             isFormsy: false,
-                            inputId: queryColumn.fieldKey,
+                            inputId: queryColumn.name,
                             required: queryColumn.required,
                             addLabelAsterisk,
                             labelClass: allowDisable ? undefined : labelClassName,

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -299,7 +299,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputImplPro
                         label={label}
                         labelOverlayProps={{
                             isFormsy: false,
-                            inputId: queryColumn.name,
+                            inputId: queryColumn.fieldKey,
                             required: queryColumn.required,
                             addLabelAsterisk,
                             labelClass: allowDisable ? undefined : labelClassName,

--- a/packages/components/src/public/QueryInfo.test.ts
+++ b/packages/components/src/public/QueryInfo.test.ts
@@ -496,4 +496,22 @@ describe('QueryInfo', () => {
             expect(cols[3].readOnly).toBe(true);
         });
     });
+
+    describe('getColumnFromName', () => {
+        test('no name', () => {
+            expect(queryInfo.getColumnFromName(undefined)).toBeUndefined();
+            expect(queryInfo.getColumnFromName("")).toBeUndefined();
+            expect(queryInfo.getColumnFromName(null)).toBeUndefined();
+        });
+
+        test('invalid name', () => {
+            expect(queryInfo.getColumnFromName("nonesuch")).toBeUndefined();
+            expect(queryInfo.getColumnFromName("NAME")).toBeUndefined();
+        });
+
+        test('valid name', () => {
+            const col = queryInfo.getColumnFromName("Name");
+            expect(col.name).toBe("Name");
+        })
+    })
 });

--- a/packages/components/src/public/QueryInfo.test.ts
+++ b/packages/components/src/public/QueryInfo.test.ts
@@ -506,12 +506,17 @@ describe('QueryInfo', () => {
 
         test('invalid name', () => {
             expect(queryInfo.getColumnFromName("nonesuch")).toBeUndefined();
-            expect(queryInfo.getColumnFromName("NAME")).toBeUndefined();
+            expect(queryInfo.getColumnFromName("NAMEe")).toBeUndefined();
         });
 
         test('valid name', () => {
             const col = queryInfo.getColumnFromName("Name");
             expect(col.name).toBe("Name");
-        })
-    })
+        });
+
+        test('case-insensitive', () => {
+            const col = queryInfo.getColumnFromName("NAME");
+            expect(col.name).toBe("Name");
+        });
+    });
 });

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -171,6 +171,17 @@ export class QueryInfo {
         return this.appEditableTable && this.getPkCols().length > 0;
     }
 
+    getColumnFromName(name: string): QueryColumn {
+        if (name) {
+            const matchingCols = this.columns.filter(col => col.name === name).valueArray;
+            if (matchingCols.length > 1)
+                console.warn("Found " + matchingCols.length + " columns with name " + name + ". Returning first.", matchingCols);
+            if (matchingCols.length > 0)
+                return matchingCols[0];
+        }
+        return undefined;
+    }
+
     getColumn(fieldKey: string): QueryColumn {
         if (fieldKey) {
             return this.columns.get(fieldKey.toLowerCase());

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -173,7 +173,8 @@ export class QueryInfo {
 
     getColumnFromName(name: string): QueryColumn {
         if (name) {
-            const matchingCols = this.columns.filter(col => col.name === name).valueArray;
+            const lcName = name.toLowerCase();
+            const matchingCols = this.columns.filter(col => col.name.toLowerCase() === lcName).valueArray;
             if (matchingCols.length > 1)
                 console.warn("Found " + matchingCols.length + " columns with name " + name + ". Returning first.", matchingCols);
             if (matchingCols.length > 0)

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -466,7 +466,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
 
         const _sorts = view ? sorts.concat(view.sorts) : sorts;
         _sorts.forEach((sort): void => {
-            const column = model.getColumn(sort.fieldKey);
+            const column = model.getColumnByFieldKey(sort.fieldKey);
             if (column) {
                 actionValues.push(this.gridActions.sort.actionValueFromSort(sort, column?.shortCaption));
             }
@@ -475,7 +475,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         // handle the view's saved filters (which will be shown as read only)
         if (view && view.filters.length) {
             view.filters.forEach((filter): void => {
-                const column = model.getColumn(filter.getColumnName());
+                const column = model.getColumnByFieldKey(filter.getColumnName());
                 if (column) {
                     actionValues.push(
                         this.gridActions.filter.actionValueFromFilter(filter, column, 'Locked (saved with view)')
@@ -494,11 +494,11 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                 const searchAction = this.gridActions.search.actionValueFromFilter(filter);
                 searchActionValues.push(searchAction);
             } else {
-                const column = model.getColumn(filter.getColumnName());
+                const column = model.getColumnByFieldKey(filter.getColumnName());
                 if (column) {
                     actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
                 } else if (filter.getColumnName().indexOf('/') > -1) {
-                    const lookupCol = model.getColumn(filter.getColumnName().split('/')[0]);
+                    const lookupCol = model.getColumnByFieldKey(filter.getColumnName().split('/')[0]);
                     if (lookupCol) actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
                 }
             }

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -499,7 +499,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                     actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
                 } else if (filter.getColumnName().indexOf('/') > -1) {
                     const lookupCol = model.getColumnByFieldKey(filter.getColumnName().split('/')[0]);
-                    if (lookupCol) actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, column));
+                    if (lookupCol) actionValues.push(this.gridActions.filter.actionValueFromFilter(filter, lookupCol));
                 }
             }
         });

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -830,7 +830,7 @@ export class QueryModel {
         const locFieldKey = fieldKey.toLowerCase();
         let col = this.allColumns?.find(c => c.fieldKey?.toLowerCase() === locFieldKey);
         if (!col) {
-            col = this.allColumns.filter(queryColumn => {
+            col = this.allColumns?.filter(queryColumn => {
                 if (queryColumn.isLookup()) {
                     return (
                         queryColumn.displayField?.toLowerCase() === locFieldKey

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -828,7 +828,17 @@ export class QueryModel {
      */
     getColumnByFieldKey(fieldKey: string): QueryColumn {
         const locFieldKey = fieldKey.toLowerCase();
-        return this.allColumns?.find(c => c.fieldKey?.toLowerCase() === locFieldKey);
+        let col = this.allColumns?.find(c => c.fieldKey?.toLowerCase() === locFieldKey);
+        if (!col) {
+            col = this.allColumns.filter(queryColumn => {
+                if (queryColumn.isLookup()) {
+                    return (
+                        queryColumn.displayField?.toLowerCase() === locFieldKey
+                    );
+                }
+            })?.[0];
+        }
+        return col;
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Issue [52038](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52038) 

Server-side code expects column names to be sent when inserting or updating data, not field keys. 

For the editable grid, we therefore use the column name (mostly) as the key to the map containing the edited values. The original data, however, is stored using the field key instead of the name. Usually the field key and the name are the same, but when a field name contain any of the characters in `QUERY_KEY_CHAR_DECODED`, these two values are different. Original values for the editable grid are stored in a map that uses the FieldKey as the key, so we need to make sure to use the proper key for the proper map when comparing the original and edited values to determine if there are any changes.  It would be nice to be able to use the same key type in all the maps, but that seems a larger change that I would like for a patch. However, if it seem less risky overall I can look into it.

For detail editing, we have been sending the updated values in a map that is keyed from the fieldKey, but it needs to be keyed from the name instead.

#### Related Pull Requests

- https://github.com/LabKey/labkey-ui-premium/pull/652
- https://github.com/LabKey/limsModules/pull/1093

#### Changes
- Editable grid needs to find columns using names not field key
- detail editing needs to use name instead of fieldKey for changed values