### PR TITLE
Issue 52066: LKSM: Editing aliquots in UI is treated as parent samples if the default grid view as a saved filter on IsAliquot field

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.0",
+  "version": "6.17.1-fb-issue52066.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.17.0",
+      "version": "6.17.1-fb-issue52066.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.1-fb-issue52066.1",
+  "version": "6.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.17.1-fb-issue52066.1",
+      "version": "6.17.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.0",
+  "version": "6.17.1-fb-issue52066.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.1-fb-issue52066.1",
+  "version": "6.17.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X January 2025
+- Issue 52066: LKSM: Editing aliquots in UI is treated as parent samples if the default grid view as a saved filter on IsAliquot field
+
 ### version 6.17.0
 *Released*: 23 January 2025
 - Add support for conditional formatting in LIMS and SDMS products

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X January 2025
+### version 6.17.1
+*Released*: 26 January 2025
 - Issue 52066: LKSM: Editing aliquots in UI is treated as parent samples if the default grid view as a saved filter on IsAliquot field
 
 ### version 6.17.0

--- a/packages/components/src/internal/query/selectRows.ts
+++ b/packages/components/src/internal/query/selectRows.ts
@@ -37,7 +37,8 @@ export async function selectRows(options: SelectRowsOptions): Promise<SelectRows
         schemaQuery,
         ...selectRowsOptions
     } = options;
-    const { queryName, schemaName, viewName } = schemaQuery;
+    const { queryName, schemaName } = schemaQuery;
+    const viewName = options.viewName ?? schemaQuery.viewName; // favor explicit viewName param over schemaQuery.viewName
 
     const [queryInfo, response] = await Promise.all([
         getQueryDetails({ containerPath: options.containerPath, schemaQuery }),


### PR DESCRIPTION
#### Rationale
There are many usages where an explicit `viewName` is passed to `selectRows` call to work around issues when the default view is customized. The `viewName` is currently ignored and the `viewName` from the `schemaQuery` is used instead. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1698
- https://github.com/LabKey/labkey-ui-premium/pull/655
- https://github.com/LabKey/limsModules/pull/1095

#### Changes
- use `viewName` param that's passed in to `selectRows`
