### PR TITLE
Issue 52082: Escape quotes in application search terms

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.2",
+  "version": "6.17.3-fb-search-52082.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.17.2",
+      "version": "6.17.3-fb-search-52082.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.3-fb-search-52082.0",
+  "version": "6.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.17.3-fb-search-52082.0",
+      "version": "6.17.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.3-fb-search-52082.0",
+  "version": "6.17.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.17.2",
+  "version": "6.17.3-fb-search-52082.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.17.3
+*Released*: 28 January 2025
+- Issue 52082: default `SearchPanel` to `encodeQuotes: true`
+
 ### version 6.17.2
 *Released*: 27 January 2025
 - Ability to Edit Sample IDs in the Grid

--- a/packages/components/src/internal/components/search/SearchPanel.tsx
+++ b/packages/components/src/internal/components/search/SearchPanel.tsx
@@ -137,6 +137,7 @@ export const SearchPanelImpl: FC<SearchPanelImplProps> = memo(props => {
         </Section>
     );
 });
+SearchPanelImpl.displayName = 'SearchPanelImpl';
 
 // FIXME: This component should be moved into premium, the props should be refactored:
 //      - search prop should be removed, and it should be handled internally via react router hooks (setting search
@@ -191,6 +192,7 @@ export const SearchPanel: FC<SearchPanelProps> = memo(props => {
                     {
                         category,
                         escapeQuery: true,
+                        escapeQuotes: true,
                         q: searchTerm,
                         limit: pageSize,
                         offset,
@@ -226,3 +228,4 @@ export const SearchPanel: FC<SearchPanelProps> = memo(props => {
 
     return <SearchPanelImpl {...props} search={search} model={model} onPageChange={onPage} offset={offset} />;
 });
+SearchPanel.displayName = 'SearchPanel';


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52082](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52082) by switching search terms on the search page(s) to escape quotes. Formerly, we escaped all other Lucene syntax leaving quotes as the remaining tool for users to use as an advanced search technique. Given that we accept quotes in naming of entities in our system, we've elected to escape quotes in search terms as well.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1106

#### Changes
- Set `escapeQuotes: true` in `SearchPanel` in the search request configuration.
