### PR TITLE
Issue 52151: resolve assay batch/run from search results

### DIFF
--- a/packages/components/__mocks__/react-router-dom.ts
+++ b/packages/components/__mocks__/react-router-dom.ts
@@ -30,3 +30,7 @@ export const useSearchParams = () => {
 let params = {};
 export const __setParams = (mockParams: Record<string, string>) => params = mockParams;
 export const useParams = () => params;
+
+let pathMatch = {};
+export const __setMatch = (mockPathMatch: Record<string, string>) => pathMatch = mockPathMatch;
+export const useMatch = () => pathMatch;

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-fb-assay-search.1",
+  "version": "6.20.3-fb-assay-search.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.20.3-fb-assay-search.1",
+      "version": "6.20.3-fb-assay-search.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.2",
+  "version": "6.20.3-fb-assay-search.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.20.2",
+      "version": "6.20.3-fb-assay-search.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-fb-assay-search.0",
+  "version": "6.20.3-fb-assay-search.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.20.3-fb-assay-search.0",
+      "version": "6.20.3-fb-assay-search.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-fb-assay-search.2",
+  "version": "6.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.20.3-fb-assay-search.2",
+      "version": "6.21.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-fb-assay-search.1",
+  "version": "6.20.3-fb-assay-search.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-fb-assay-search.2",
+  "version": "6.21.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.2",
+  "version": "6.20.3-fb-assay-search.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-fb-assay-search.0",
+  "version": "6.20.3-fb-assay-search.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.21.0
+*Released*: 4 February 2025
+- Issue 52151: resolve assay batches/runs from search results
+- Resolve an icon for assay batch and assay run search results
+
 ### version 6.20.2
 *Released*: 31 January 2025
 - Merge from release24.11-SNAPSHOT to develop

--- a/packages/components/src/internal/components/navigation/model.ts
+++ b/packages/components/src/internal/components/navigation/model.ts
@@ -17,7 +17,6 @@ import { List, Record } from 'immutable';
 import { Ajax, Utils, QueryKey } from '@labkey/api';
 
 import { buildURL, createProductUrl, AppURL, createProductUrlFromPartsWithContainer } from '../../url/AppURL';
-import { ASSAYS_KEY } from '../../app/constants';
 
 export class MenuSectionModel extends Record({
     label: undefined,
@@ -99,9 +98,6 @@ export class MenuItemModel extends Record({
                     .split('/')
                     .filter(val => val !== '')
                     .map(QueryKey.decodePart);
-                if (sectionKey === ASSAYS_KEY && subParts.length > 0) { // Issue 50640. We want to link to 'runs' since we'll get better subnav highlighting
-                    subParts.push('runs');
-                }
 
                 const decoded = subParts.join('/');
                 const decodedKey = rawData.key.replace(rawData.key, () => decoded); // use the functional version to skip any additional pattern substitutions https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -1237,16 +1237,13 @@ describe('getSearchResultCardData', () => {
 
     test('data.dataClass', () => {
         expect(
-            getSearchResultCardData(
-                {
-                    name: 'Test',
-                    dataClass: {
-                        name: 'Test Class',
-                        category: 'sources',
-                    },
+            getSearchResultCardData({
+                name: 'Test',
+                dataClass: {
+                    name: 'Test Class',
+                    category: 'sources',
                 },
-                undefined
-            )
+            })
         ).toStrictEqual({
             iconSrc: 'sources',
             category: 'Sources',
@@ -1256,13 +1253,10 @@ describe('getSearchResultCardData', () => {
 
     test('data.type is sampleSet, no metadata', () => {
         expect(
-            getSearchResultCardData(
-                {
-                    name: 'Test',
-                    type: 'sampleSet',
-                },
-                undefined
-            )
+            getSearchResultCardData({
+                name: 'Test',
+                type: 'sampleSet',
+            })
         ).toStrictEqual({
             iconSrc: 'sample_set',
             category: 'Sample Type',
@@ -1349,13 +1343,10 @@ describe('getSearchResultCardData', () => {
 
     test('data.type is generic dataClass', () => {
         expect(
-            getSearchResultCardData(
-                {
-                    name: 'Test Source',
-                    type: 'dataClass',
-                },
-                undefined
-            )
+            getSearchResultCardData({
+                name: 'Test Source',
+                type: 'dataClass',
+            })
         ).toStrictEqual({
             iconSrc: 'source_type',
             category: 'Source Type',
@@ -1366,13 +1357,10 @@ describe('getSearchResultCardData', () => {
 
     test('data.type is source dataClass', () => {
         expect(
-            getSearchResultCardData(
-                {
-                    name: 'Test Source',
-                    type: 'dataClass:sources',
-                },
-                undefined
-            )
+            getSearchResultCardData({
+                name: 'Test Source',
+                type: 'dataClass:sources',
+            })
         ).toStrictEqual({
             iconSrc: 'source_type',
             category: 'Source Type',
@@ -1383,13 +1371,10 @@ describe('getSearchResultCardData', () => {
 
     test('data.type is registry dataClass', () => {
         expect(
-            getSearchResultCardData(
-                {
-                    name: 'TestRegistrySource',
-                    type: 'dataClass:registry',
-                },
-                undefined
-            )
+            getSearchResultCardData({
+                name: 'TestRegistrySource',
+                type: 'dataClass:registry',
+            })
         ).toStrictEqual({
             iconSrc: 'testregistrysource',
             category: 'Source Type',
@@ -1397,17 +1382,18 @@ describe('getSearchResultCardData', () => {
         });
     });
 
-    test('data.type is assay', () => {
-        expect(
-            getSearchResultCardData(
-                {
-                    name: 'Test Assay',
-                    type: 'assay',
-                },
-                undefined
-            )
-        ).toStrictEqual({
+    test('data.name with assay categories', () => {
+        expect(getSearchResultCardData({ name: 'Test Assay' }, SearchCategory.Assay)).toStrictEqual({
             category: 'Assay',
+            iconSrc: 'assay',
+        });
+        expect(getSearchResultCardData({ name: 'Test Assay Run' }, SearchCategory.AssayRun)).toStrictEqual({
+            category: 'Assay Run',
+            iconSrc: 'assay',
+        });
+        expect(getSearchResultCardData({ name: 'Test Assay Batch' }, SearchCategory.AssayBatch)).toStrictEqual({
+            category: 'Assay Batch',
+            iconSrc: 'assay',
         });
     });
 

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -622,12 +622,6 @@ export function getSearchResultCardData(
                         category: 'Source Type',
                     };
                 }
-                return {
-                    altText: 'source_type-icon',
-                    iconSrc: 'source_type',
-                    category: 'Source Type',
-                    title: dataName,
-                };
             }
         } else if (data.sampleSet?.name) {
             const sampleSetName = data.sampleSet.name.toLowerCase();

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -628,8 +628,6 @@ export function getSearchResultCardData(
                     category: 'Source Type',
                     title: dataName,
                 };
-            } else if (type === 'assay') {
-                return { category: 'Assay' };
             }
         } else if (data.sampleSet?.name) {
             const sampleSetName = data.sampleSet.name.toLowerCase();
@@ -651,7 +649,11 @@ export function getSearchResultCardData(
 
     switch (category) {
         case SearchCategory.Assay:
-            return { category: 'Assay' };
+            return { category: 'Assay', iconSrc: 'assay' };
+        case SearchCategory.AssayBatch:
+            return { category: 'Assay Batch', iconSrc: 'assay' };
+        case SearchCategory.AssayRun:
+            return { category: 'Assay Run', iconSrc: 'assay' };
         case SearchCategory.Plate:
             return { iconSrc: 'plates' };
         case SearchCategory.WorkflowJob:

--- a/packages/components/src/internal/schemas.ts
+++ b/packages/components/src/internal/schemas.ts
@@ -40,6 +40,7 @@ export const EXP_TABLES = {
     DATA_CLASS_CATEGORY_TYPE: new SchemaQuery(EXP_SCHEMA, 'DataClassCategoryType'),
     MATERIALS: new SchemaQuery(EXP_SCHEMA, 'Materials'),
     PROTOCOLS: new SchemaQuery(EXP_SCHEMA, 'Protocols'),
+    RUN_GROUPS: new SchemaQuery(EXP_SCHEMA, 'RunGroups'),
     SCHEMA: EXP_SCHEMA,
     SAMPLE_SETS: new SchemaQuery(EXP_SCHEMA, 'SampleSets'),
     SAMPLE_SETS_DETAILS: new SchemaQuery(EXP_SCHEMA, 'SampleSets', ViewInfo.DETAIL_NAME),

--- a/packages/components/src/internal/url/URLResolver.test.ts
+++ b/packages/components/src/internal/url/URLResolver.test.ts
@@ -51,7 +51,27 @@ describe('URLResolver', () => {
             expect(resolved).toHaveProperty(['hits', 0, 'data', 'name'], 'Molecule'); // not sure if this is best place to check this...
         });
 
-        test('assay runs', () => {
+        test('assay batch', () => {
+            // Arrange
+            const assayBatchRowId = 3927119;
+            const assayRunSearchHit: SearchHit = {
+                category: SearchCategory.AssayBatch,
+                container: TEST_PROJECT_CONTAINER.id,
+                data: { id: assayBatchRowId },
+                id: [SearchCategory.AssayBatch, assayBatchRowId].join(':'),
+                title: 'Assay Batch - NY_Marathon_2023-06-09_15-03-39',
+                url: `/labkey/testContainer/experiment-details.view?rowId=${assayBatchRowId}&_docid=assayRun%3A${assayBatchRowId}`,
+            };
+
+            // Act
+            const searchResult = resolver.resolveSearchUsingIndex(createSearchResult(assayRunSearchHit));
+
+            // Assert
+            const [searchHit] = searchResult.hits;
+            expect(searchHit.url).toEqual(`#/rd/assaybatch/${assayBatchRowId}`);
+        });
+
+        test('assay run', () => {
             // Arrange
             const assayRunRowId = 711392;
             const assayRunSearchHit: SearchHit = {

--- a/packages/components/src/internal/url/URLResolver.test.ts
+++ b/packages/components/src/internal/url/URLResolver.test.ts
@@ -8,8 +8,12 @@ import { registerDefaultURLMappers } from '../test/testHelpers';
 
 import { QueryColumn, QueryLookup } from '../../public/QueryColumn';
 
-import { LookupMapper, URLResolver } from './URLResolver';
+import { SearchCategory } from '../components/search/constants';
+import { SearchHit, SearchResult } from '../components/search/actions';
+import { TEST_PROJECT_CONTAINER } from '../containerFixtures';
+
 import { AppURL } from './AppURL';
+import { LookupMapper, URLResolver } from './URLResolver';
 
 beforeAll(() => {
     LABKEY.container = {
@@ -21,139 +25,177 @@ beforeAll(() => {
     registerDefaultURLMappers();
 });
 
-describe('resolveSearchUsingIndex', () => {
-    test('resolve Sample Set url', () => {
-        const resolved = new URLResolver().resolveSearchUsingIndex(entitiesJSON);
-        expect(resolved).toHaveProperty(['hits']);
-        expect(resolved).toHaveProperty(['hits', 0]);
-        expect(resolved).toHaveProperty(['hits', 0, 'url'], '#/samples/Molecule');
-        expect(resolved).toHaveProperty(['hits', 0, 'data', 'name'], 'Molecule'); // not sure if this is best place to check this...
-    });
-});
+describe('URLResolver', () => {
+    describe('resolveSearchUsingIndex', () => {
+        const resolver = new URLResolver();
 
-describe('LookupMapper', () => {
-    test('resolve without lookup container', () => {
-        const mapper = new LookupMapper('test', undefined);
-        const resolved = mapper.resolve(
-            '#/list/a',
-            fromJS({ value: 1 }),
-            new QueryColumn({ lookup: new QueryLookup({ schemaName: 'list', queryName: 'testing' }) }),
-            undefined,
-            undefined
-        );
-        expect(resolved).toStrictEqual(AppURL.create('test', 'list', 'testing', 1));
+        function createSearchResult(searchHit: SearchHit): SearchResult {
+            return {
+                hits: [searchHit],
+                metaData: {
+                    idProperty: 'id',
+                    root: 'hits',
+                    successProperty: 'success',
+                },
+                q: 'searchQuery',
+                success: true,
+                totalHits: 1,
+            };
+        }
+
+        test('resolve Sample Set url', () => {
+            const resolved = resolver.resolveSearchUsingIndex(entitiesJSON);
+            expect(resolved).toHaveProperty(['hits']);
+            expect(resolved).toHaveProperty(['hits', 0]);
+            expect(resolved).toHaveProperty(['hits', 0, 'url'], '#/samples/Molecule');
+            expect(resolved).toHaveProperty(['hits', 0, 'data', 'name'], 'Molecule'); // not sure if this is best place to check this...
+        });
+
+        test('assay runs', () => {
+            // Arrange
+            const assayRunRowId = 711392;
+            const assayRunSearchHit: SearchHit = {
+                category: SearchCategory.AssayRun,
+                container: TEST_PROJECT_CONTAINER.id,
+                data: { id: assayRunRowId },
+                id: [SearchCategory.AssayRun, assayRunRowId].join(':'),
+                title: 'Assay Run - NY_Marathon_2023-06-09_15-03-39',
+                url: `/labkey/testContainer/experiment-showRunGraph.view?rowId=${assayRunRowId}&_docid=assayRun%3A${assayRunRowId}`,
+            };
+
+            // Act
+            const searchResult = resolver.resolveSearchUsingIndex(createSearchResult(assayRunSearchHit));
+
+            // Assert
+            const [searchHit] = searchResult.hits;
+            expect(searchHit.url).toEqual(`#/rd/assayrun/${assayRunRowId}`);
+        });
     });
 
-    test('resolve with lookup container same as current', () => {
-        const mapper = new LookupMapper('test', undefined);
-        const resolved = mapper.resolve(
-            '#/list/a',
-            fromJS({ value: 1 }),
-            new QueryColumn({
-                lookup: new QueryLookup({
-                    schemaName: 'list',
-                    queryName: 'testing',
-                    containerPath: LABKEY.container.path,
+    describe('LookupMapper', () => {
+        test('resolve without lookup container', () => {
+            const mapper = new LookupMapper('test', undefined);
+            const resolved = mapper.resolve(
+                '#/list/a',
+                fromJS({ value: 1 }),
+                new QueryColumn({ lookup: new QueryLookup({ schemaName: 'list', queryName: 'testing' }) }),
+                undefined,
+                undefined
+            );
+            expect(resolved).toStrictEqual(AppURL.create('test', 'list', 'testing', 1));
+        });
+
+        test('resolve with lookup container same as current', () => {
+            const mapper = new LookupMapper('test', undefined);
+            const resolved = mapper.resolve(
+                '#/list/a',
+                fromJS({ value: 1 }),
+                new QueryColumn({
+                    lookup: new QueryLookup({
+                        schemaName: 'list',
+                        queryName: 'testing',
+                        containerPath: LABKEY.container.path,
+                    }),
                 }),
-            }),
-            undefined,
-            undefined
-        );
-        expect(resolved).toStrictEqual(AppURL.create('test', 'list', 'testing', 1));
-    });
-
-    test('resolve with different lookup container', () => {
-        const mapper = new LookupMapper('test', undefined);
-        const resolved = mapper.resolve(
-            '#/list/a',
-            fromJS({ value: 1 }),
-            new QueryColumn({
-                lookup: new QueryLookup({ schemaName: 'list', queryName: 'testing', containerPath: '/other/path' }),
-            }),
-            undefined,
-            undefined
-        );
-        expect(resolved).toBeUndefined();
-    });
-});
-
-describe('resolveLineage', () => {
-    const resolver = new URLResolver();
-
-    const node = {
-        lsid: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
-        children: [
-            {
-                lsid: 'urn:lsid:labkey.com:Run.Folder-252:a6e5fa05-28cd-1038-ad87-68bd1b9ac33e',
-                role: 'no role',
-            },
-        ],
-        name: 'D-32',
-        cpasType: 'urn:lsid:labkey.com:DataClass.Folder-252:Source+1',
-        queryName: 'Source 1',
-        type: 'Data',
-        schemaName: 'exp.data',
-        url: '/labkey/testContainer/experiment-showData.view?rowId=6648',
-        parents: [],
-        rowId: 6648,
-    };
-
-    test('name with spaces', () => {
-        const lineageResult = LineageResult.create({
-            seed: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
-            nodes: {
-                'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4': node,
-            },
+                undefined,
+                undefined
+            );
+            expect(resolved).toStrictEqual(AppURL.create('test', 'list', 'testing', 1));
         });
-        const resolvedLinks = resolver.resolveLineageItem(
-            lineageResult.nodes.get('urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4')
-        );
 
-        expect(resolvedLinks.list).toEqual('#/rd/dataclass/Source%201');
-        expect(resolvedLinks.overview).toEqual('#/rd/expdata/6648');
-    });
-
-    test('url to different container', () => {
-        const url = '/labkey/otherContainer/experiment-showData.view?rowId=6648';
-        node['url'] = url;
-        const lineageResult = LineageResult.create({
-            seed: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
-            nodes: {
-                'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4': node,
-            },
+        test('resolve with different lookup container', () => {
+            const mapper = new LookupMapper('test', undefined);
+            const resolved = mapper.resolve(
+                '#/list/a',
+                fromJS({ value: 1 }),
+                new QueryColumn({
+                    lookup: new QueryLookup({ schemaName: 'list', queryName: 'testing', containerPath: '/other/path' }),
+                }),
+                undefined,
+                undefined
+            );
+            expect(resolved).toBeUndefined();
         });
-        const resolvedLinks = resolver.resolveLineageItem(
-            lineageResult.nodes.get('urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4')
-        );
-
-        expect(resolvedLinks.list).toEqual('#/rd/dataclass/Source%201');
-        expect(resolvedLinks.overview).toEqual(url);
     });
 
-    test('accepted types', () => {
-        const lineageResult = LineageResult.create(lineageJSON);
-        let resolvedLinks = resolver.resolveLineageItem(
-            lineageResult.nodes.get('urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3')
-        );
+    describe('resolveLineage', () => {
+        const resolver = new URLResolver();
 
-        // test a sample type
-        expect(resolvedLinks.list).toEqual('#/samples/Hemoglobin');
-        expect(resolvedLinks.overview).toEqual('#/rd/samples/6814');
+        const node = {
+            lsid: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
+            children: [
+                {
+                    lsid: 'urn:lsid:labkey.com:Run.Folder-252:a6e5fa05-28cd-1038-ad87-68bd1b9ac33e',
+                    role: 'no role',
+                },
+            ],
+            name: 'D-32',
+            cpasType: 'urn:lsid:labkey.com:DataClass.Folder-252:Source+1',
+            queryName: 'Source 1',
+            type: 'Data',
+            schemaName: 'exp.data',
+            url: '/labkey/testContainer/experiment-showData.view?rowId=6648',
+            parents: [],
+            rowId: 6648,
+        };
 
-        // TODO test that the run node doesn't show up
-        resolvedLinks = resolver.resolveLineageItem(
-            lineageResult.nodes.get('urn:lsid:labkey.com:Run.Folder-61:dbcee598-54f9-1038-9426-08c060dcd006')
-        );
+        test('name with spaces', () => {
+            const lineageResult = LineageResult.create({
+                seed: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
+                nodes: {
+                    'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4': node,
+                },
+            });
+            const resolvedLinks = resolver.resolveLineageItem(
+                lineageResult.nodes.get('urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4')
+            );
 
-        expect(resolvedLinks.list).toEqual(undefined);
-        expect(resolvedLinks.overview).toEqual('/labkey/testContainer/experiment-showRunGraph.view?rowId=794');
+            expect(resolvedLinks.list).toEqual('#/rd/dataclass/Source%201');
+            expect(resolvedLinks.overview).toEqual('#/rd/expdata/6648');
+        });
 
-        // Issue 48836: resolve list URL via queryName if available
-        // Note that the node "urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone" uses
-        // the new "cpasType" which does not include the name of the sample type.
-        resolvedLinks = resolver.resolveLineageItem(
-            lineageResult.nodes.get('urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone')
-        );
-        expect(resolvedLinks.list).toEqual('#/samples/shemoglobin');
+        test('url to different container', () => {
+            const url = '/labkey/otherContainer/experiment-showData.view?rowId=6648';
+            node['url'] = url;
+            const lineageResult = LineageResult.create({
+                seed: 'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4',
+                nodes: {
+                    'urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4': node,
+                },
+            });
+            const resolvedLinks = resolver.resolveLineageItem(
+                lineageResult.nodes.get('urn:lsid:labkey.com:Data.Folder-252:f34174d2-2678-1038-9c2a-d1b4d4df18c4')
+            );
+
+            expect(resolvedLinks.list).toEqual('#/rd/dataclass/Source%201');
+            expect(resolvedLinks.overview).toEqual(url);
+        });
+
+        test('accepted types', () => {
+            const lineageResult = LineageResult.create(lineageJSON);
+            let resolvedLinks = resolver.resolveLineageItem(
+                lineageResult.nodes.get('urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3')
+            );
+
+            // test a sample type
+            expect(resolvedLinks.list).toEqual('#/samples/Hemoglobin');
+            expect(resolvedLinks.overview).toEqual('#/rd/samples/6814');
+
+            // TODO test that the run node doesn't show up
+            resolvedLinks = resolver.resolveLineageItem(
+                lineageResult.nodes.get('urn:lsid:labkey.com:Run.Folder-61:dbcee598-54f9-1038-9426-08c060dcd006')
+            );
+
+            expect(resolvedLinks.list).toEqual(undefined);
+            expect(resolvedLinks.overview).toEqual('/labkey/testContainer/experiment-showRunGraph.view?rowId=794');
+
+            // Issue 48836: resolve list URL via queryName if available
+            // Note that the node "urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone" uses
+            // the new "cpasType" which does not include the name of the sample type.
+            resolvedLinks = resolver.resolveLineageItem(
+                lineageResult.nodes.get('urn:lsid:labkey.com:Sample.61.Hemoglobin:Hgb3.3-clone')
+            );
+            expect(resolvedLinks.list).toEqual('#/samples/shemoglobin');
+        });
     });
 });

--- a/packages/components/src/internal/url/URLResolver.test.ts
+++ b/packages/components/src/internal/url/URLResolver.test.ts
@@ -43,7 +43,7 @@ describe('URLResolver', () => {
             };
         }
 
-        test('resolve Sample Set url', () => {
+        test('resolve sample type url', () => {
             const resolved = resolver.resolveSearchUsingIndex(entitiesJSON);
             expect(resolved).toHaveProperty(['hits']);
             expect(resolved).toHaveProperty(['hits', 0]);

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -26,7 +26,7 @@ import { QueryInfo } from '../../public/QueryInfo';
 
 import { QueryColumn } from '../../public/QueryColumn';
 
-import { SearchResult } from '../components/search/actions';
+import { SearchHit, SearchResult } from '../components/search/actions';
 
 import { SearchCategory } from '../components/search/constants';
 
@@ -250,12 +250,25 @@ const ASSAY_MAPPERS = [
     new ActionMapper('experiment', 'showRunGraph', row => {
         const url = row.get('url');
         if (url) {
-            // Note: This intentionally only matches when the "row" supplied is a search result.
-            const category = row.get('category');
-            if (SearchCategory.AssayRun === category) {
-                const runId = parseInt(row.getIn(['data', 'id']), 10);
+            const hit: SearchHit = row.toJS();
+            if (hit.category === SearchCategory.AssayRun) {
+                const runId = parseInt(hit.data?.id, 10);
                 if (!isNaN(runId)) {
                     return AppURL.create('rd', 'assayrun', runId);
+                }
+            }
+        }
+    }),
+
+    // Issue 52151: resolve assay batches from search results
+    new ActionMapper('experiment', 'details', row => {
+        const url = row.get('url');
+        if (url) {
+            const hit: SearchHit = row.toJS();
+            if (hit.category === SearchCategory.AssayBatch) {
+                const batchRowId = parseInt(hit.data?.id, 10);
+                if (!isNaN(batchRowId)) {
+                    return AppURL.create('rd', 'assaybatch', batchRowId);
                 }
             }
         }
@@ -731,7 +744,6 @@ export class URLResolver {
         return resolved.toJS();
     }
 
-    // ToDo: this is rather fragile and data specific. this should be reworked with the mappers and rest of the resolvers to provide for more thorough coverage of our incoming URLs
     resolveSearchUsingIndex(result: SearchResult): SearchResult {
         let resolved = fromJS(JSON.parse(JSON.stringify(result)));
 
@@ -742,7 +754,7 @@ export class URLResolver {
                     let url = row.get('url');
                     let query;
 
-                    // TODO: add reroute for assays/runs when pages and URLs are decided
+                    // TODO: This should be refactored to be based off hit.category (SearchCategory) matching
                     if (row.has('data') && row.hasIn(['data', 'dataClass'])) {
                         query = row.getIn(['data', 'dataClass', 'name']);
                         url = url.substring(0, url.indexOf('&')); // URL includes documentID value, this will split off at the start of the docID

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -28,6 +28,8 @@ import { QueryColumn } from '../../public/QueryColumn';
 
 import { SearchResult } from '../components/search/actions';
 
+import { SearchCategory } from '../components/search/constants';
+
 import { AppURL, createProductUrl, createProductUrlFromParts } from './AppURL';
 import { AppRouteResolver } from './models';
 import { encodeListResolverPath } from './utils';
@@ -240,6 +242,21 @@ const ASSAY_MAPPERS = [
 
                 delete params.rowId; // strip the rowId and pass through the remaining params
                 return AppURL.create('assays', rowId, 'data').addParams(params);
+            }
+        }
+    }),
+
+    // Issue 52151: resolve assay runs from search results
+    new ActionMapper('experiment', 'showRunGraph', row => {
+        const url = row.get('url');
+        if (url) {
+            // Note: This intentionally only matches when the "row" supplied is a search result.
+            const category = row.get('category');
+            if (SearchCategory.AssayRun === category) {
+                const runId = parseInt(row.getIn(['data', 'id']), 10);
+                if (!isNaN(runId)) {
+                    return AppURL.create('rd', 'assayrun', runId);
+                }
             }
         }
     }),


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52151](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52151) by introducing URL mappers and a new URL resolver for assay batches and runs.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1707
- https://github.com/LabKey/labkey-ui-premium/pull/665
- https://github.com/LabKey/limsModules/pull/1129

#### Changes
- Resolve `experiment-showRunGraph.view` to `/rd/assayrun/<runId>` for assay run search results
- Resolve `experiment-details.view` to `/rd/assaybatch/<batchId>` for assay batch search results
- Resolve an icon for assay batch and assay run search results
- Add unit test coverage for the new assay batch URL resolver