### PR TITLE
AppContext cleanup of components that can now be directly imported

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.21.1",
+  "version": "6.21.1-appContextCleanupV1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.21.1",
+      "version": "6.21.1-appContextCleanupV1.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.21.1-appContextCleanupV1.0",
+  "version": "6.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.21.1-appContextCleanupV1.0",
+      "version": "6.21.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.21.1",
+  "version": "6.21.1-appContextCleanupV1.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.21.1-appContextCleanupV1.0",
+  "version": "6.21.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- AppContext cleanup of components that can now be directly imported from ui-premium (previously cross subpackage)
+  - includes AddSamplesToStorageModalComponent, JobsButtonComponent, ReferencingNotebooksComponent, SampleStorageLocationComponent, SampleStorageMenuComponent
+
 ### version 6.21.1
 *Released*: 5 February 2025
 - Issue 52143: Grid paging parameter in URL is not always respected

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.21.2
+*Released*: 6 February 2025
 - AppContext cleanup of components that can now be directly imported from ui-premium (previously cross subpackage)
   - includes AddSamplesToStorageModalComponent, JobsButtonComponent, ReferencingNotebooksComponent, SampleStorageLocationComponent, SampleStorageMenuComponent
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1977,11 +1977,7 @@ export type {
 } from './internal/components/labelPrinting/LabelPrintingContextProvider';
 export type { SamplesEditableGridProps } from './internal/sampleModels';
 export type { MeasurementUnit } from './internal/util/measurement';
-export type {
-    SampleStorageLocationComponentProps,
-    SampleStorageMenuComponentProps,
-    SamplesTabbedGridPanelComponentProps,
-} from './internal/sampleModels';
+export type { SamplesTabbedGridPanelComponentProps } from './internal/sampleModels';
 export type { SearchHit, SearchMetadata, SearchResult, SearchOptions } from './internal/components/search/actions';
 export type { TabbedGridPanelProps } from './public/QueryModel/TabbedGridPanel';
 export type { GroupedSampleDisplayColumns } from './internal/components/samples/actions';

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -25,7 +25,6 @@ import {
     NotebookContainerSettings,
     FolderStorageSelection,
     WorkflowNotificationSettings,
-    ReferencingNotebooks,
 } from './app/models';
 import { User } from './components/base/models/User';
 import { DomainDetails } from './components/domainproperties/models';
@@ -33,17 +32,12 @@ import { EntityDataType } from './components/entities/models';
 import { DetailRenderer } from './components/forms/detail/DetailDisplay';
 import { ALIQUOT_FILTER_MODE } from './components/samples/constants';
 import {
-    AddSamplesToStorageModal,
-    JobsButton,
-    JobsMenuOptions,
     SampleStorageButton,
     WorkflowGrid,
 } from './components/samples/models';
 import {
     SampleGridButton,
     SamplesEditableGridProps,
-    SampleStorageLocation,
-    SampleStorageMenu,
     SamplesTabbedGridPanel,
 } from './sampleModels';
 
@@ -58,13 +52,8 @@ export interface AdminAppContext {
 }
 
 export interface SampleTypeAppContext {
-    AddSamplesToStorageModalComponent: AddSamplesToStorageModal;
-    JobsButtonComponent: JobsButton;
-    ReferencingNotebooksComponent: ReferencingNotebooks;
     SampleGridButtonComponent: SampleGridButton;
     SampleStorageButtonComponent: SampleStorageButton;
-    SampleStorageLocationComponent: SampleStorageLocation;
-    SampleStorageMenuComponent: SampleStorageMenu;
     SamplesTabbedGridPanelComponent: SamplesTabbedGridPanel;
     WorkflowGridComponent: WorkflowGrid;
     assayProviderType?: string;
@@ -104,8 +93,6 @@ export interface SampleTypeAppContext {
 }
 
 export interface AssayAppContext {
-    JobsMenuOptionsComponent: JobsMenuOptions;
-    ReferencingNotebooksComponent: ReferencingNotebooks;
     assayProviderType?: string;
     assayTypes?: string[];
     detailRenderer?: DetailRenderer;

--- a/packages/components/src/internal/AppContext.tsx
+++ b/packages/components/src/internal/AppContext.tsx
@@ -31,15 +31,8 @@ import { DomainDetails } from './components/domainproperties/models';
 import { EntityDataType } from './components/entities/models';
 import { DetailRenderer } from './components/forms/detail/DetailDisplay';
 import { ALIQUOT_FILTER_MODE } from './components/samples/constants';
-import {
-    SampleStorageButton,
-    WorkflowGrid,
-} from './components/samples/models';
-import {
-    SampleGridButton,
-    SamplesEditableGridProps,
-    SamplesTabbedGridPanel,
-} from './sampleModels';
+import { SampleStorageButton, WorkflowGrid } from './components/samples/models';
+import { SampleGridButton, SamplesEditableGridProps, SamplesTabbedGridPanel } from './sampleModels';
 
 export interface AdminAppContext {
     FolderStorageSelectionComponent?: FolderStorageSelection;

--- a/packages/components/src/internal/app/models.ts
+++ b/packages/components/src/internal/app/models.ts
@@ -52,17 +52,6 @@ export interface AppProperties {
     searchPlaceholder?: string;
 }
 
-// Note: this should stay in sync with the eln/src/ReferencingNotebooks.tsx props
-interface ReferencingNotebooksComponentProps {
-    label: string;
-    noun: string;
-    queryName: string;
-    schemaName: string;
-    value: number;
-}
-
-export type ReferencingNotebooks = ComponentType<ReferencingNotebooksComponentProps>;
-
 interface NotebookContainerSettingsProps {
     containerPath?: string;
     labelsAPI: LabelsAPIWrapper;

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -105,17 +105,6 @@ export interface StorageActionStatusCounts {
     total: number;
 }
 
-// Note: this should stay in sync with the freezermanager/src/components/AddSamplesToStorageModal.tsx props
-interface AddSamplesToStorageModalComponentProps {
-    actionStatusCounts?: StorageActionStatusCounts;
-    onCancel: () => void;
-    onSuccess?: () => void;
-    samplesSelectionKey?: string;
-    user: User;
-}
-
-export type AddSamplesToStorageModal = ComponentType<AddSamplesToStorageModalComponentProps>;
-
 // Note: this should stay in sync with the freezermanager/src/components/StorageButton.tsx props
 interface SampleStorageButtonComponentProps {
     afterStorageUpdate?: () => void;
@@ -127,19 +116,6 @@ interface SampleStorageButtonComponentProps {
 }
 
 export type SampleStorageButton = ComponentType<SampleStorageButtonComponentProps>;
-
-// Note: this should stay in sync with the workflow/src/Components/JobsButton.tsx props
-interface JobsButtonsComponentProps {
-    isAssay?: boolean;
-    metricFeatureArea?: string;
-    model: QueryModel;
-    user: User;
-}
-
-export type JobsButton = ComponentType<JobsButtonsComponentProps>;
-
-// Note: this is meant to correspond to the JobsMenuOptions component in workflow/src/Components/JobsButton.tsx
-export type JobsMenuOptions = ComponentType<JobsButtonsComponentProps>;
 
 // Note: this should stay in sync with the workflow/src/Components/WorkflowGrid.tsx props
 interface WorkflowGridComponentProps {

--- a/packages/components/src/internal/sampleModels.ts
+++ b/packages/components/src/internal/sampleModels.ts
@@ -46,26 +46,6 @@ export interface SamplesTabbedGridPanelComponentProps {
 
 export type SamplesTabbedGridPanel = ComponentType<SamplesTabbedGridPanelComponentProps & InjectedQueryModels>;
 
-export interface SampleStorageLocationComponentProps {
-    actionChangeCount?: number;
-    currentProductId?: string;
-    onUpdate?: () => void;
-    sampleId: string | number;
-    sampleQueryModel: QueryModel;
-    updateAllowed: boolean;
-    user: User;
-}
-
-export type SampleStorageLocation = ComponentType<SampleStorageLocationComponentProps>;
-
-export interface SampleStorageMenuComponentProps {
-    onUpdate?: (skipChangeCount?: boolean) => void;
-    sampleModel: QueryModel;
-    sampleUser: User;
-}
-
-export type SampleStorageMenu = ComponentType<SampleStorageMenuComponentProps>;
-
 export type SampleGridButton = ComponentType<SampleGridButtonProps & RequiresModelAndActions>;
 
 // This interface stores app-wide settings passed to the LineageEditableGrid


### PR DESCRIPTION
#### Rationale
Now that we have removed the subpackages in ui-premium, several of the components that previously had to go through the AppContext to prevent cross subpackage imports can now be directly imported. This PR is a start to cleaning up the AppContext (note that there are likely more that can be removed from the context).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1711
- https://github.com/LabKey/labkey-ui-premium/pull/670
- https://github.com/LabKey/limsModules/pull/1143

#### Changes
- AppContext cleanup of AddSamplesToStorageModalComponent, JobsButtonComponent, ReferencingNotebooksComponent, SampleStorageLocationComponent, SampleStorageMenuComponent
