### PR TITLE
Issue 52197: Groups without workflow editor permission in folder should not be able to be assigned work

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-workflowFixes.0",
+  "version": "6.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.20.3-workflowFixes.0",
+      "version": "6.20.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.2",
+  "version": "6.20.3-workflowFixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.20.2",
+      "version": "6.20.3-workflowFixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.3-workflowFixes.0",
+  "version": "6.20.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.20.2",
+  "version": "6.20.3-workflowFixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 52197: use current container when querying for groups with permissions for job and task assignments
+
 ### version 6.20.2
 *Released*: 31 January 2025
 - Merge from release24.11-SNAPSHOT to develop

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.20.3
+*Released*: 11 February 2025
 - Issue 52197: use current container when querying for groups with permissions for job and task assignments
 
 ### version 6.20.2

--- a/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/UserSelectInput.tsx
@@ -118,7 +118,7 @@ export const UserSelectInput: FC<UserSelectInputProps> = memo(props => {
                 const users = await api.security.getUsersWithPermissions(permissions, containerPath, includeInactive);
                 let groups: FetchedGroup[];
                 if (includeGroups)
-                    groups = await api.security.fetchGroups(getProjectPath(containerPath), permissions, true);
+                    groups = await api.security.fetchGroups(containerPath, permissions, true);
 
                 return getUserGroupOptions(users, groups, input, notifyList, useEmail);
             } catch (e) {


### PR DESCRIPTION
#### Rationale
Issue [52197](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52197)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1152
- https://github.com/LabKey/labkey-ui-premium/pull/674

#### Changes
- Get groups from current container, not always the project folder in `UserSelectInput`
