### PR TITLE
Remove usages of encodePart when dealing with data rows for update cases

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.4-noEncodePart.0",
+  "version": "6.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.4-noEncodePart.0",
+      "version": "6.23.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0",
+  "version": "6.22.0-noEncodePart.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.0",
+      "version": "6.22.0-noEncodePart.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.5",
+  "version": "6.22.0-noEncodePart.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.0-noEncodePart.5",
+      "version": "6.22.0-noEncodePart.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.3-noEncodePart.0",
+  "version": "6.22.3-noEncodePart.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.3-noEncodePart.0",
+      "version": "6.22.3-noEncodePart.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.3",
+  "version": "6.22.3-noEncodePart.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.3",
+      "version": "6.22.3-noEncodePart.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.3",
+  "version": "6.22.0-noEncodePart.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.0-noEncodePart.3",
+      "version": "6.22.0-noEncodePart.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.0",
+  "version": "6.22.0-noEncodePart.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.0-noEncodePart.0",
+      "version": "6.22.0-noEncodePart.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.2",
+  "version": "6.22.0-noEncodePart.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.0-noEncodePart.2",
+      "version": "6.22.0-noEncodePart.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.4",
+  "version": "6.22.4-noEncodePart.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.4",
+      "version": "6.22.4-noEncodePart.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.1",
+  "version": "6.22.0-noEncodePart.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.0-noEncodePart.1",
+      "version": "6.22.0-noEncodePart.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.4",
+  "version": "6.22.0-noEncodePart.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.0-noEncodePart.4",
+      "version": "6.22.0-noEncodePart.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0",
+  "version": "6.22.0-noEncodePart.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.0",
+  "version": "6.22.0-noEncodePart.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.4",
+  "version": "6.22.0-noEncodePart.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.2",
+  "version": "6.22.0-noEncodePart.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.1",
+  "version": "6.22.0-noEncodePart.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.4",
+  "version": "6.22.4-noEncodePart.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.3-noEncodePart.0",
+  "version": "6.22.3-noEncodePart.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.3",
+  "version": "6.22.3-noEncodePart.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.3",
+  "version": "6.22.0-noEncodePart.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.0-noEncodePart.5",
+  "version": "6.22.0-noEncodePart.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.4-noEncodePart.0",
+  "version": "6.23.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Remove usages of encodePart when dealing with data rows for update cases
   - EditableGridLoaderFromSelection not to encodePart() in the data rows, leave keyed by column name as it comes from server
   - BulkUpdateForm no to encodePart() when comparing with original data, use QueryInfo to lookup column instead
+  - Fix up sample aliquot-only vs sample-only fields to use fieldKey instead of name
 
 ### version 6.22.0
 *Released*: 7 February 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -7,6 +7,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   - EditableGridLoaderFromSelection not to encodePart() in the data rows, leave keyed by column name as it comes from server
   - BulkUpdateForm not to encodePart() when comparing with original data, use QueryInfo to lookup column instead
   - Fix up sample aliquot-only vs sample-only fields to use fieldKey instead of name
+  - getSampleIdentifyingFieldGridData() to use column.index instead of column.name for the key
 
 ### version 6.22.0
 *Released*: 7 February 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD February 2025
+### version 6.23.0
+*Released*: 13 February 2025
 - Remove usages of encodePart when dealing with data rows for update cases
   - EditableGridLoaderFromSelection not to encodePart() in the data rows, leave keyed by column name as it comes from server
   - BulkUpdateForm not to encodePart() when comparing with original data, use QueryInfo to lookup column instead

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,7 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD February 2025
 - Remove usages of encodePart when dealing with data rows for update cases
   - EditableGridLoaderFromSelection not to encodePart() in the data rows, leave keyed by column name as it comes from server
-  - BulkUpdateForm no to encodePart() when comparing with original data, use QueryInfo to lookup column instead
+  - BulkUpdateForm not to encodePart() when comparing with original data, use QueryInfo to lookup column instead
   - Fix up sample aliquot-only vs sample-only fields to use fieldKey instead of name
 
 ### version 6.22.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,7 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD February 2025
 - Remove usages of encodePart when dealing with data rows for update cases
   - EditableGridLoaderFromSelection not to encodePart() in the data rows, leave keyed by column name as it comes from server
-  -
+  - BulkUpdateForm no to encodePart() when comparing with original data, use QueryInfo to lookup column instead
 
 ### version 6.22.0
 *Released*: 7 February 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD February 2025
+- Remove usages of encodePart when dealing with data rows for update cases
+  - EditableGridLoaderFromSelection not to encodePart() in the data rows, leave keyed by column name as it comes from server
+  -
+
 ### version 6.22.0
 *Released*: 7 February 2025
 - Only show 'Discussion Threads' Advanced Setting in Lists if relevant Deprecated Feature is turned on

--- a/packages/components/src/internal/components/editable/EditableGridLoaderFromSelection.tsx
+++ b/packages/components/src/internal/components/editable/EditableGridLoaderFromSelection.tsx
@@ -29,21 +29,19 @@ export class EditableGridLoaderFromSelection implements EditableGridLoader {
     id: string;
     idsNotPermitted: number[];
     idsNotToUpdate: number[];
-    fieldsNotToUpdate: string[];
+    fieldsNotToUpdate: string[]; // keys here are column fieldKey
     mode: EditorMode;
     model: QueryModel;
     omittedColumns: string[];
     queryModel: QueryModel;
     queryInfo: QueryInfo;
     requiredColumns: string[];
-    updateData: any;
+    updateData: Map<string, any>; // keys here are column fieldKey
 
     constructor(
         id: string,
         queryModel: QueryModel,
-        // FIXME: the types I'm seeing passed as updateData imply Map<string, any> is the correct type, however assuming
-        //  that makes the code fall over
-        updateData: any,
+        updateData: Map<string, any>,
         requiredColumns?: string[],
         omittedColumns?: string[],
         columns?: QueryColumn[],
@@ -58,7 +56,7 @@ export class EditableGridLoaderFromSelection implements EditableGridLoader {
         this.mode = EditorMode.Update;
         this.queryModel = queryModel;
         this.queryInfo = queryModel.queryInfo;
-        this.updateData = updateData || {};
+        this.updateData = updateData || Map<string, any>();
         this.requiredColumns = requiredColumns || [];
         this.omittedColumns = omittedColumns || [];
         this.idsNotToUpdate = idsNotToUpdate || [];
@@ -85,9 +83,8 @@ export class EditableGridLoaderFromSelection implements EditableGridLoader {
         return {
             data: EditorModel.convertQueryDataToEditorData(
                 data,
-                // Coerce to Map<string, any> because despite types seeming to align they're getting clobbered somewhere
-                // and we're not actually passing Map<string, any>.
-                Map<string, any>(this.updateData),
+                this.queryInfo,
+                this.updateData,
                 this.idsNotToUpdate,
                 this.fieldsNotToUpdate
             ),

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -11,6 +11,7 @@ import {
     addColumns,
     changeColumn,
     fillColumnCells,
+    loadEditorModelData,
     parseIntIfNumber,
     parsePastedLookup,
     removeColumn,
@@ -789,7 +790,10 @@ describe('parsePastedLookup', () => {
             valueDescriptors: List([{ display: 'abc', raw: 'abc' }]),
         });
         expect(parsePastedLookup(stringLookupCol, stringLookupValues, 'abc, valueD')).toStrictEqual({
-            message: { message: 'Could not find "abc", "valueD". Please make sure values that contain commas are properly quoted.' },
+            message: {
+                message:
+                    'Could not find "abc", "valueD". Please make sure values that contain commas are properly quoted.',
+            },
             valueDescriptors: List([
                 { display: 'abc', raw: 'abc' },
                 { display: 'valueD', raw: 'valueD' },
@@ -820,7 +824,10 @@ describe('parsePastedLookup', () => {
             valueDescriptors: List([{ display: 'abc', raw: 'abc' }]),
         });
         expect(parsePastedLookup(intLookupCol, intLookupValues, 'abc, valueD')).toStrictEqual({
-            message: { message: 'Could not find "abc", "valueD". Please make sure values that contain commas are properly quoted.' },
+            message: {
+                message:
+                    'Could not find "abc", "valueD". Please make sure values that contain commas are properly quoted.',
+            },
             valueDescriptors: List([
                 { display: 'abc', raw: 'abc' },
                 { display: 'valueD', raw: 'valueD' },
@@ -980,5 +987,164 @@ describe('insertPastedData', () => {
         expect(cellValues.get(genCellKey(fkOne, 1))).toEqual(List([{ display: 'one', raw: 'one' }]));
         expect(cellValues.get(genCellKey(fkOne, 2))).toEqual(List([{ display: 'two', raw: 'two' }]));
         expect(changes.selectionCells).toEqual([genCellKey(fkOne, 1), genCellKey(fkOne, 2)]);
+    });
+});
+
+describe('loadEditorModelData', () => {
+    const orderedRows = ['2811466', '2805931'];
+    const rows = {
+        '2805931': {
+            'TimeField./,$&': '16:10',
+            'IntField./,$&': 333,
+            LSID: 'urn:lsid:labkey.com:Sample.Folder-519.24:26',
+            'tcField./,$&': '2',
+            'DtField./,$&': [{ displayValue: '07Feb2025', value: '2025-02-07 00:00:00.000' }],
+            'txtField./,$&': '777',
+            MaterialExpDate: [{ displayValue: '07Feb25 00:00:00.000', value: '2025-02-07 00:00:00.000' }],
+            SampleState: [{ displayValue: 'Available', value: 70 }],
+            'ontField./,$&': '666',
+            Name: 'S-26',
+            'MultiField./,$&': '444',
+            Folder: [{ displayValue: 'Biologics Example', value: '01b94403-4179-1039-a799-ea54f212702c' }],
+            'idField./,$&': '000631254',
+            Units: 'mL',
+            Alias: [],
+            'DtTimeField./,$&': [{ displayValue: '2025-02-07 16:30', value: '2025-02-07 16:30:00.000' }],
+            'lkField./,$&': [{ displayValue: 'Assay Required File', value: 37721 }],
+            RowId: 2805931,
+            'DecField./,$&': 222,
+            'aliqAndParent$,./': '888',
+            StoredAmount: 99,
+            Description: '111',
+            'sampleField./,$&': [{ displayValue: '10-1-1', value: 117334 }],
+            'BoolField./,$&': false,
+            'userField./,$&': [{ displayValue: 'assaytypedesigner', value: 14688 }],
+            'flagField./,$&': '555',
+        },
+        '2811466': {
+            'TimeField./,$&': '16:20',
+            'IntField./,$&': 3,
+            LSID: 'urn:lsid:labkey.com:Sample.Folder-519.24:27',
+            'tcField./,$&': '3',
+            'DtField./,$&': [{ displayValue: '04Feb2025', value: '2025-02-04 00:00:00.000' }],
+            'txtField./,$&': '7',
+            MaterialExpDate: [{ displayValue: '10Feb25 00:00:00.000', value: '2025-02-10 00:00:00.000' }],
+            SampleState: [{ displayValue: 'Available', value: 70 }],
+            'ontField./,$&': '666',
+            Name: 'S-20-3',
+            'MultiField./,$&': '444',
+            Folder: [{ displayValue: 'Biologics Example', value: '01b94403-4179-1039-a799-ea54f212702c' }],
+            'idField./,$&': '000631255',
+            'fileField./,$&': [
+                {
+                    displayValue: 'sampletype/before.png',
+                    value: '/Users/corynathe/LabKey/trunk/build/deploy/files/Biologics Example/@files/sampletype/before.png',
+                },
+            ],
+            Units: 'mL',
+            Alias: [],
+            'aliqField$,./': '123',
+            'DtTimeField./,$&': [{ displayValue: '2025-01-29 24:00', value: '2025-01-29 00:00:00.000' }],
+            'lkField./,$&': [{ displayValue: 'DAS Testing', value: 42876 }],
+            RowId: 2811466,
+            'DecField./,$&': 22,
+            'aliqAndParent$,./': '456',
+            StoredAmount: 3,
+            Description: 'desc',
+            'sampleField./,$&': [{ displayValue: '00401', value: 2675720 }],
+            'BoolField./,$&': true,
+            'userField./,$&': [{ displayValue: 'editorwithoutdelete', value: 5027 }],
+            'flagField./,$&': '555',
+        },
+    };
+
+    test('get column by index', async () => {
+        const columns = [
+            new QueryColumn({
+                fieldKey: 'Name',
+                fieldKeyArray: ['Name'],
+                fieldKeyPath: 'Name',
+                derivationDataScope: null,
+                name: 'Name',
+            }),
+            new QueryColumn({
+                fieldKey: 'DtField$P$S$C$D$A',
+                fieldKeyArray: ['DtField./,$&'],
+                fieldKeyPath: 'DtField$P$S$C$D$A',
+                derivationDataScope: 'ParentOnly',
+                name: 'DtField./,$&',
+            }),
+            new QueryColumn({
+                fieldKey: 'IntField$P$S$C$D$A',
+                fieldKeyArray: ['IntField./,$&'],
+                fieldKeyPath: 'IntField$P$S$C$D$A',
+                derivationDataScope: 'ParentOnly',
+                name: 'IntField./,$&',
+            }),
+            new QueryColumn({
+                fieldKey: 'lkField$P$S$C$D$A',
+                fieldKeyArray: ['lkField./,$&'],
+                fieldKeyPath: 'lkField$P$S$C$D$A',
+                name: 'lkField./,$&',
+                derivationDataScope: 'ParentOnly',
+                lookup: {
+                    displayColumn: 'Name',
+                    isPublic: true,
+                    keyColumn: 'RowId',
+                    public: true,
+                    queryName: 'AssayList',
+                    schema: 'assay',
+                    schemaName: 'assay',
+                },
+            }),
+            new QueryColumn({
+                fieldKey: 'sampleField$P$S$C$D$A',
+                fieldKeyArray: ['sampleField./,$&'],
+                fieldKeyPath: 'sampleField$P$S$C$D$A',
+                name: 'sampleField./,$&',
+                derivationDataScope: 'ParentOnly',
+                lookup: {
+                    displayColumn: 'Name',
+                    isPublic: true,
+                    keyColumn: 'RowId',
+                    public: true,
+                    queryName: 'Materials',
+                    schema: 'exp',
+                    schemaName: 'exp',
+                },
+            }),
+            new QueryColumn({
+                fieldKey: 'aliqField$D$C$P$S',
+                fieldKeyArray: ['aliqField$,./'],
+                fieldKeyPath: 'aliqField$D$C$P$S',
+                name: 'aliqField$,./',
+                derivationDataScope: 'ChildOnly',
+            }),
+            new QueryColumn({
+                fieldKey: 'aliqAndParent$D$C$P$S',
+                fieldKeyArray: ['aliqAndParent$,./'],
+                fieldKeyPath: 'aliqAndParent$D$C$P$S',
+                name: 'aliqAndParent$,./',
+                derivationDataScope: 'All',
+            }),
+        ];
+
+        const result = await loadEditorModelData(orderedRows, rows, columns, false);
+        expect(result.toJS()).toStrictEqual({
+            'name&&0': [{ display: 'S-20-3', raw: 'S-20-3' }],
+            'name&&1': [{ display: 'S-26', raw: 'S-26' }],
+            'aliqandparent$d$c$p$s&&0': [{ display: '456', raw: '456' }],
+            'samplefield$p$s$c$d$a&&0': [{ display: '00401', raw: 2675720 }],
+            'aliqandparent$d$c$p$s&&1': [{ display: '888', raw: '888' }],
+            'samplefield$p$s$c$d$a&&1': [{ display: '10-1-1', raw: 117334 }],
+            'intfield$p$s$c$d$a&&0': [{ display: 3, raw: 3 }],
+            'dtfield$p$s$c$d$a&&0': [{ display: '04Feb2025', raw: '2025-02-04 00:00:00.000' }],
+            'intfield$p$s$c$d$a&&1': [{ display: 333, raw: 333 }],
+            'aliqfield$d$c$p$s&&0': [{ display: '123', raw: '123' }],
+            'dtfield$p$s$c$d$a&&1': [{ display: '07Feb2025', raw: '2025-02-07 00:00:00.000' }],
+            'aliqfield$d$c$p$s&&1': [{ display: undefined, raw: undefined }],
+            'lkfield$p$s$c$d$a&&0': [{ display: 'DAS Testing', raw: 42876 }],
+            'lkfield$p$s$c$d$a&&1': [{ display: 'Assay Required File', raw: 37721 }],
+        });
     });
 });

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -14,8 +14,6 @@ import { selectRows } from '../../query/selectRows';
 
 import { getContainerFilterForLookups } from '../../query/api';
 
-import { encodePart } from '../../../public/SchemaQuery';
-
 import {
     CellMessage,
     CellMessages,
@@ -48,9 +46,10 @@ const loadEditorModelData = async (
         orderedRows.forEach((id, rn) => {
             const row = rows[id];
             const cellKey = genCellKey(col.fieldKey, rn);
-            // Our loaders (e.g. EditableGridLoaderFromSelection) use EditorModel.convertQueryDataToEditorData which
-            // uses encodePart, so we check for the encoded fieldKey.
-            const value = row[col.fieldKey] ?? row[encodePart(col.fieldKey)];
+
+            // Our loaders (e.g. EditableGridLoaderFromSelection) use data objects from selectRows which has
+            // rows objects keyed by column name
+            const value = row[col.name];
 
             if (Array.isArray(value)) {
                 // assume to be list of {displayValue, value} objects

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -30,9 +30,10 @@ import {
 import { decimalDifference, genCellKey, getLookupFilters, getValidatedEditableGridValue, parseCellKey } from './utils';
 
 /**
- * Do not use this method directly, use initEditorModel instead
+ * Do not use this method directly, use initEditorModel instead.
+ * Exported for jest testing.
  */
-const loadEditorModelData = async (
+export const loadEditorModelData = async (
     orderedRows: string[],
     rows: Record<string, any>,
     columns: QueryColumn[],

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -48,8 +48,9 @@ const loadEditorModelData = async (
             const cellKey = genCellKey(col.fieldKey, rn);
 
             // Our loaders (e.g. EditableGridLoaderFromSelection) use data objects from selectRows which has
-            // rows objects keyed by column name
-            const value = row[col.name];
+            // rows objects keyed by column name for base table columns and by fieldKey for lookup columns
+            // (see comments in QueryColumn index()).
+            const value = row[col.index];
 
             if (Array.isArray(value)) {
                 // assume to be list of {displayValue, value} objects

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -23,6 +23,8 @@ import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 
 import { STORAGE_UNIQUE_ID_CONCEPT_URI } from '../domainproperties/constants';
 
+import { ExtendedMap } from '../../../public/ExtendedMap';
+
 import { EditorModel, ValueDescriptor } from './models';
 import { genCellKey } from './utils';
 
@@ -368,17 +370,64 @@ describe('EditorModel', () => {
                 withValue: 'purple',
                 withDisplay$SValue: 'teal',
             });
-            const result = EditorModel.convertQueryDataToEditorData(queryData, updates);
+            const queryInfo2 = new QueryInfo({
+                columns: new ExtendedMap({
+                    novalue: new QueryColumn({
+                        name: 'noValue',
+                        fieldKey: 'noValue',
+                    }),
+                    withvalue: new QueryColumn({
+                        name: 'withValue',
+                        fieldKey: 'withValue',
+                    }),
+                    withdisplay$svalue: new QueryColumn({
+                        name: 'withDisplay/Value',
+                        fieldKey: 'withDisplay$SValue',
+                    }),
+                    donotchangeme: new QueryColumn({
+                        name: 'doNotChangeMe',
+                        fieldKey: 'doNotChangeMe',
+                    }),
+                }),
+            });
+            const result = EditorModel.convertQueryDataToEditorData(queryData, queryInfo2, updates);
             expect(result).toStrictEqual(
                 Map<string, any>({
                     1: Map<string, any>({
                         withValue: 'purple',
-                        withDisplay$SValue: 'teal',
+                        'withDisplay/Value': 'teal',
                         doNotChangeMe: 'fred',
                     }),
                     2: Map<string, any>({
                         withValue: 'purple',
-                        withDisplay$SValue: 'teal',
+                        'withDisplay/Value': 'teal',
+                        doNotChangeMe: 'maroon',
+                    }),
+                })
+            );
+
+            const result2 = EditorModel.convertQueryDataToEditorData(
+                queryData,
+                queryInfo2,
+                updates,
+                [1],
+                ['withvalue', 'withdisplay$svalue']
+            );
+            expect(result2).toStrictEqual(
+                Map<string, any>({
+                    1: Map<string, any>({
+                        withValue: 'orange',
+                        'withDisplay/Value': List([
+                            {
+                                value: 'b',
+                                displayValue: 'blue',
+                            },
+                        ]),
+                        doNotChangeMe: 'fred',
+                    }),
+                    2: Map<string, any>({
+                        withValue: 'purple',
+                        'withDisplay/Value': 'teal',
                         doNotChangeMe: 'maroon',
                     }),
                 })

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -946,8 +946,10 @@ describe('EditorModel', () => {
 
             expect(editorModel.getRowValue(1).get(identFieldCol.fieldKey)).toEqual(undefined);
             expect(editorModel.getRowValue(1).get(identFieldCol.name)).toEqual(colValue);
+            expect(editorModel.getRowValue(1).get(identFieldCol.index)).toEqual(undefined);
             expect(updatedRow[identFieldCol.fieldKey]).toEqual(undefined);
             expect(updatedRow[identFieldCol.name]).toEqual(colValue);
+            expect(updatedRow[identFieldCol.index]).toEqual(undefined);
         });
         test('column with special chars in name', () => {
             const specCharCol = new QueryColumn({

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -411,7 +411,7 @@ describe('EditorModel', () => {
                 queryInfo2,
                 updates,
                 [1],
-                ['withvalue', 'withdisplay$svalue']
+                ['WithValue', 'WithDisplay$SValue']
             );
             expect(result2).toStrictEqual(
                 Map<string, any>({

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -445,7 +445,7 @@ describe('EditorModel', () => {
                         value: 'orange',
                         ignoreMe: 'nothing to see',
                     },
-                    withDisplayValue: {
+                    'with,.$Display/Value': {
                         value: 'b',
                         displayValue: 'blue',
                         otherField: 'irrelevant',
@@ -463,7 +463,7 @@ describe('EditorModel', () => {
                         value: 'orangish',
                         ignoreMe: 'nothing to see',
                     },
-                    withDisplayValue: {
+                    'with,.$Display/Value': {
                         value: 'b',
                         displayValue: 'black',
                         otherField: 'irrelevant',
@@ -477,7 +477,7 @@ describe('EditorModel', () => {
                 Map<string, any>({
                     1: Map<string, any>({
                         withValue: 'orange',
-                        withDisplayValue: List.of({
+                        'with,.$Display/Value': List.of({
                             value: 'b',
                             displayValue: 'blue',
                         }),
@@ -485,7 +485,7 @@ describe('EditorModel', () => {
                     }),
                     2: Map<string, any>({
                         withValue: 'orangish',
-                        withDisplayValue: List.of({
+                        'with,.$Display/Value': List.of({
                             displayValue: 'black',
                             value: 'b',
                         }),
@@ -948,6 +948,49 @@ describe('EditorModel', () => {
             expect(editorModel.getRowValue(1).get(identFieldCol.name)).toEqual(colValue);
             expect(updatedRow[identFieldCol.fieldKey]).toEqual(undefined);
             expect(updatedRow[identFieldCol.name]).toEqual(colValue);
+        });
+        test('column with special chars in name', () => {
+            const specCharCol = new QueryColumn({
+                caption: 'Test"$/&}~,.\'',
+                fieldKey: 'test"$D$S$A$B$T$C$P\'',
+                fieldKeyArray: ['test"$/&}~,.\''],
+                jsonType: 'string',
+                name: 'test"$/&}~,.\'',
+                shownInInsertView: true,
+                shownInUpdateView: true,
+                required: false,
+                userEditable: true,
+            });
+            const colFk = specCharCol.fieldKey.toLowerCase();
+            const colValue = 'testing';
+
+            const cellValues = fromJS({
+                [genCellKey(colFk, 0)]: List<ValueDescriptor>([{ display: undefined, raw: undefined }]),
+                [genCellKey(colFk, 1)]: List<ValueDescriptor>([
+                    {
+                        display: colValue,
+                        raw: colValue,
+                    },
+                ]),
+            });
+
+            const editorModel = modifyEm({
+                cellValues: basicEditorModel.cellValues.merge(cellValues),
+                columnMap: basicEditorModel.columnMap.set(colFk, specCharCol),
+                orderedColumns: basicEditorModel.orderedColumns.push(colFk),
+                rowCount: 2,
+            });
+
+            const updatedRows = editorModel.getUpdatedData();
+            expect(updatedRows).toHaveLength(1);
+            const [updatedRow] = updatedRows;
+
+            expect(editorModel.getRowValue(1).get(specCharCol.fieldKey)).toEqual(undefined);
+            expect(editorModel.getRowValue(1).get(specCharCol.name)).toEqual(colValue);
+            expect(editorModel.getRowValue(1).get(specCharCol.index)).toEqual(colValue);
+            expect(updatedRow[specCharCol.fieldKey]).toEqual(undefined);
+            expect(updatedRow[specCharCol.name]).toEqual(colValue);
+            expect(updatedRow[specCharCol.index]).toEqual(colValue);
         });
         test('include sample lookup display value', () => {
             const sampleColumn = new QueryColumn({

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -17,8 +17,6 @@ import { Filter, Query, Utils } from '@labkey/api';
 import { fromJS, Iterable, List, Map, Record as ImmutableRecord, Set as ImmutableSet } from 'immutable';
 import { ReactNode } from 'react';
 
-import { encodePart } from '../../../public/SchemaQuery';
-
 import { QueryInfo } from '../../../public/QueryInfo';
 
 import { QueryColumn } from '../../../public/QueryColumn';
@@ -690,38 +688,35 @@ export class EditorModel
     }
 
     static convertQueryDataToEditorData(
-        data: Map<string, any>,
-        updates?: Map<any, any>,
+        data: Map<string, any>, // this map is keyed by column name
+        queryInfo?: QueryInfo,
+        updates?: Map<string, any>, // this map is keyed by column fieldKey
         idsNotToUpdate?: number[],
-        fieldsNotToUpdate?: string[],
-        encode = true
-    ): Map<any, Map<string, any>> {
+        fieldsNotToUpdate?: string[] // keys here are column fieldKey
+    ): Map<string, Map<string, any>> {
         return data
             .map((valueMap, id) => {
-                const returnMap = valueMap.reduce((m, valueMap_, key) => {
+                const returnMap = valueMap.reduce((m, valueMap_, colName) => {
                     const editorData = EditorModel.getEditorDataFromQueryValueMap(valueMap_);
                     if (editorData === undefined) {
                         return m;
                     }
 
-                    // data maps have keys that are display names/captions. We need to convert to the
-                    // encoded keys used in our filters to match up with values from the forms.
-                    const key_ = encode ? encodePart(key) : key;
-                    return m.set(key_, editorData);
-                }, Map<any, any>());
+                    return m.set(colName, editorData);
+                }, Map<string, any>());
 
-                if (!updates) {
+                if (!queryInfo || !updates) {
                     return returnMap;
                 }
 
-                if (!idsNotToUpdate || idsNotToUpdate.indexOf(parseInt(id, 10)) < 0 || !fieldsNotToUpdate) {
-                    return returnMap.merge(updates);
-                }
-
-                let trimmedUpdates = Map<any, any>();
+                let trimmedUpdates = Map<string, any>();
+                const isNotUpdateId = idsNotToUpdate && idsNotToUpdate.indexOf(parseInt(id, 10)) > -1;
                 updates.forEach((value, fieldKey) => {
-                    if (fieldsNotToUpdate.indexOf(fieldKey.toLowerCase()) < 0) {
-                        trimmedUpdates = trimmedUpdates.set(fieldKey, value);
+                    const col = queryInfo.getColumn(fieldKey);
+                    const isFieldNotToUpdate =
+                        fieldsNotToUpdate && fieldsNotToUpdate.indexOf(fieldKey.toLowerCase()) > -1;
+                    if (!isFieldNotToUpdate || !isNotUpdateId) {
+                        trimmedUpdates = trimmedUpdates.set(col.name, value);
                     }
                 });
                 return returnMap.merge(trimmedUpdates);
@@ -739,7 +734,7 @@ export class EditorModel
         });
 
         return {
-            data: EditorModel.convertQueryDataToEditorData(fromJS(data), undefined, undefined, undefined, false),
+            data: EditorModel.convertQueryDataToEditorData(fromJS(data)),
             dataIds: fromJS(dataIds),
         };
     }
@@ -808,7 +803,7 @@ export class EditorModel
                         throw new Error(`Unable to find column for key ${key}.`);
                     }
 
-                    let originalValue = originalRow.get(col.fieldKey, undefined);
+                    let originalValue = originalRow.get(col.name, undefined);
 
                     // we can skip any readOnly columns or non-userEditable columns
                     if (col.readOnly || !col.userEditable) return row;

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -696,13 +696,13 @@ export class EditorModel
     ): Map<string, Map<string, any>> {
         return data
             .map((valueMap, id) => {
-                const returnMap = valueMap.reduce((m, valueMap_, colName) => {
+                const returnMap = valueMap.reduce((m, valueMap_, key) => {
                     const editorData = EditorModel.getEditorDataFromQueryValueMap(valueMap_);
                     if (editorData === undefined) {
                         return m;
                     }
 
-                    return m.set(colName, editorData);
+                    return m.set(key, editorData);
                 }, Map<string, any>());
 
                 if (!queryInfo || !updates) {
@@ -790,7 +790,7 @@ export class EditorModel
                 // the fieldKey (that is, the parts of that lineage lookup have been encoded for Query names (e.g., / becomes $S)
                 // The Lineage field key parts need to be sent encoded so parsing of the field key parts (that is, splitting on the
                 // '/' character) can be done without a problem on the server side. Ideally, we would be able to send field keys in
-                // all cases, but that is for a later day.
+                // all cases, but that is for a later day. See QueryColumn index() comments.
                 const row = editedRow.reduce((row, value, key) => {
                     // We can skip the idField for the diff check, that will be added to the updated rows later
                     if (key === pkFieldKey) return row;
@@ -803,7 +803,7 @@ export class EditorModel
                         throw new Error(`Unable to find column for key ${key}.`);
                     }
 
-                    let originalValue = originalRow.get(col.name, undefined);
+                    let originalValue = originalRow.get(col.index, undefined);
 
                     // we can skip any readOnly columns or non-userEditable columns
                     if (col.readOnly || !col.userEditable) return row;

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -694,6 +694,8 @@ export class EditorModel
         idsNotToUpdate?: number[],
         fieldsNotToUpdate?: string[] // keys here are column fieldKey
     ): Map<string, Map<string, any>> {
+        const fieldsNotToUpdateLower = fieldsNotToUpdate?.map(f => f.toLowerCase()) ?? [];
+
         return data
             .map((valueMap, id) => {
                 const returnMap = valueMap.reduce((m, valueMap_, key) => {
@@ -713,8 +715,7 @@ export class EditorModel
                 const isNotUpdateId = idsNotToUpdate && idsNotToUpdate.indexOf(parseInt(id, 10)) > -1;
                 updates.forEach((value, fieldKey) => {
                     const col = queryInfo.getColumn(fieldKey);
-                    const isFieldNotToUpdate =
-                        fieldsNotToUpdate && fieldsNotToUpdate.indexOf(fieldKey.toLowerCase()) > -1;
+                    const isFieldNotToUpdate = fieldsNotToUpdateLower.indexOf(fieldKey.toLowerCase()) > -1;
                     if (!isFieldNotToUpdate || !isNotUpdateId) {
                         trimmedUpdates = trimmedUpdates.set(col.name, value);
                     }

--- a/packages/components/src/internal/components/entities/actions-getSampleIdentifyingFieldGridData.test.ts
+++ b/packages/components/src/internal/components/entities/actions-getSampleIdentifyingFieldGridData.test.ts
@@ -35,9 +35,9 @@ jest.mock('../../query/selectRows', () => ({
 }));
 
 const columns = [
-    { fieldKey: 'intCol', jsonType: 'int', name: 'intCol' },
-    { fieldKey: 'doubleCol$S', jsonType: 'double', name: 'doubleCol/' },
-    { fieldKey: 'textCol', jsonType: 'string', name: 'textCol' },
+    { fieldKey: 'intCol', jsonType: 'int', name: 'intCol', fieldKeyArray: ['intCol'] },
+    { fieldKey: 'doubleCol$S', jsonType: 'double', name: 'doubleCol/', fieldKeyArray: ['doubleCol/'] },
+    { fieldKey: 'textCol', jsonType: 'string', name: 'textCol', fieldKeyArray: ['textCol'] },
 ];
 const QUERY_INFO_NO_ID_VIEW = QueryInfo.fromJsonForTests(
     {
@@ -77,14 +77,14 @@ describe('getSampleIdentifyingFieldGridData', () => {
     test('with identifying fields, with rows in response', async () => {
         expect(await getSampleIdentifyingFieldGridData([1, 2], QUERY_INFO_WITH_ID_VIEW)).toStrictEqual({
             '1': {
-                doubleCol$S: 1.1,
+                'doubleCol/': 1.1,
                 intCol: 1,
                 rowId: 1,
                 sampleId: 'S1',
                 textCol: 'TEST 1',
             },
             '2': {
-                doubleCol$S: '2.200',
+                'doubleCol/': '2.200',
                 intCol: 2,
                 rowId: 2,
                 sampleId: 'S2',
@@ -96,12 +96,12 @@ describe('getSampleIdentifyingFieldGridData', () => {
     test('includeDefaultColumns false', async () => {
         expect(await getSampleIdentifyingFieldGridData([1, 2], QUERY_INFO_WITH_ID_VIEW, false)).toStrictEqual({
             '1': {
-                doubleCol$S: 1.1,
+                'doubleCol/': 1.1,
                 intCol: 1,
                 textCol: 'TEST 1',
             },
             '2': {
-                doubleCol$S: '2.200',
+                'doubleCol/': '2.200',
                 intCol: 2,
                 textCol: 'test2',
             },

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1482,7 +1482,7 @@ export function updateCellValuesForSampleIds(
                 let updates = Map<string, List<any>>();
                 dataRemovedIndexes.forEach(rowInd => {
                     identifyingColumns
-                        .filter(col => DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.fieldKey.toLowerCase()) === -1)
+                        .filter(col => DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.index.toLowerCase()) === -1)
                         .forEach(col => {
                             updates = updates.set(
                                 // Issue 52038: cell keys are based on fieldKey currently
@@ -1516,10 +1516,11 @@ export function updateCellValuesForSampleIds(
                                 identifyingColumns
                                     .filter(
                                         col =>
-                                            DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.fieldKey.toLowerCase()) === -1
+                                            DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.index.toLowerCase()) === -1
                                     )
                                     .forEach(col => {
                                         updates = updates.set(
+                                            // this one does need to use col.fieldKey since this is a multi part key (we want the encoded fieldKey)
                                             sampleGenCellKey(sampleFieldKeyPrefix_, col.fieldKey, rowInd),
                                             // Issue 52038: getSampleIdentifyingFieldGridData returns data keyed by QueryColumn index
                                             List<any>([

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1412,10 +1412,10 @@ export function getSampleIdentifyingFieldGridData(
                       }
                     : {};
                 sampleIdentifyingColumns.forEach(c => {
-                    // Issue 52038: the Row has data keyed by name, but we want editable grid data to be keyed by fieldKey
+                    // Issue 52038: the Row has data keyed by name so make sure we do the same here (see QueryColumn index() comments)
                     const colData = caseInsensitive(row, c.name);
                     if (colData?.value) {
-                        d[c.fieldKey] = colData?.formattedValue ?? colData?.displayValue ?? colData?.value;
+                        d[c.index] = colData?.formattedValue ?? colData?.displayValue ?? colData?.value;
                     }
                 });
                 samplesData[rowId] = d;
@@ -1482,7 +1482,7 @@ export function updateCellValuesForSampleIds(
                 let updates = Map<string, List<any>>();
                 dataRemovedIndexes.forEach(rowInd => {
                     identifyingColumns
-                        .filter(col => DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.name.toLowerCase()) === -1)
+                        .filter(col => DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.fieldKey.toLowerCase()) === -1)
                         .forEach(col => {
                             updates = updates.set(
                                 // Issue 52038: cell keys are based on fieldKey currently
@@ -1516,16 +1516,16 @@ export function updateCellValuesForSampleIds(
                                 identifyingColumns
                                     .filter(
                                         col =>
-                                            DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.name.toLowerCase()) === -1
+                                            DEFAULT_SAMPLE_EDITABLE_GRID_COLUMNS.indexOf(col.fieldKey.toLowerCase()) === -1
                                     )
                                     .forEach(col => {
                                         updates = updates.set(
                                             sampleGenCellKey(sampleFieldKeyPrefix_, col.fieldKey, rowInd),
-                                            // Issue 52038: getSampleIdentifyingFieldGridData returns data keyed by fieldKey
+                                            // Issue 52038: getSampleIdentifyingFieldGridData returns data keyed by QueryColumn index
                                             List<any>([
                                                 {
-                                                    display: data[col.fieldKey],
-                                                    raw: data[col.fieldKey],
+                                                    display: data[col.index],
+                                                    raw: data[col.index],
                                                 },
                                             ])
                                         );

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -502,6 +502,7 @@ export interface EntityDataType {
     nounAsParentPlural: string;
     nounAsParentSingular: string;
     nounPlural: string;
+    nounSingular: string;
     operationConfirmationActionName: string;
     operationConfirmationControllerName: string;
     sampleFinderCardType?: SampleFinderCardType;
@@ -512,7 +513,6 @@ export interface EntityDataType {
     typeNounAsParentSingular: string;
     typeNounSingular: string;
     uniqueFieldKey: string;
-    nounSingular: string;
 }
 
 interface OperationContainerInfo {

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -284,7 +284,7 @@ export class EntityIdCreationModel extends Record({
     getIdentifyingFields(): ExtendedMap<string, QueryColumn> {
         let columns = new ExtendedMap<string, QueryColumn>();
         this.identifyingFields.forEach(col => {
-            columns = columns.set(col.name.toLowerCase(), col);
+            columns = columns.set(col.fieldKey.toLowerCase(), col);
         });
         return columns;
     }

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -203,7 +203,7 @@ export class BulkUpdateForm extends PureComponent<Props, State> {
         }
 
         const rows = !Utils.isEmptyObj(data)
-            ? getUpdatedData(this.state.originalDataForSelection, updateData, queryInfo.pkCols, queryInfo.altUpdateKeys)
+            ? getUpdatedData(this.state.originalDataForSelection, updateData, queryInfo, queryInfo.altUpdateKeys)
             : [];
 
         return updateRows(queryInfo.schemaQuery, rows, comment);

--- a/packages/components/src/internal/components/samples/actions.test.ts
+++ b/packages/components/src/internal/components/samples/actions.test.ts
@@ -1,0 +1,96 @@
+import { fromJS } from 'immutable';
+
+import { QueryInfo } from '../../../public/QueryInfo';
+import { DomainDesign, DomainDetails } from '../domainproperties/models';
+import { CALCULATED_CONCEPT_URI } from '../domainproperties/constants';
+
+import { ExtendedMap } from '../../../public/ExtendedMap';
+import { QueryColumn } from '../../../public/QueryColumn';
+
+import { _getGroupedSampleDomainFields } from './actions';
+
+describe('getGroupedSampleDomainFields', () => {
+    const sampleTypeDomain = new DomainDetails({
+        options: fromJS({}),
+        domainDesign: DomainDesign.create({
+            fields: [
+                {
+                    name: 'Name',
+                    fieldKey: 'Name',
+                    derivationDataScope: null,
+                    conceptURI: undefined,
+                },
+                {
+                    name: 'Spec Char,./',
+                    fieldKey: 'Spec Char$C$D$S',
+                    derivationDataScope: null,
+                    conceptURI: undefined,
+                },
+                {
+                    name: 'Calc,./',
+                    fieldKey: 'Calc$C$D$S',
+                    derivationDataScope: null,
+                    conceptURI: CALCULATED_CONCEPT_URI,
+                },
+                {
+                    name: 'Aliq,./',
+                    fieldKey: 'Aliq$C$D$S',
+                    derivationDataScope: 'ChildOnly',
+                    conceptURI: undefined,
+                },
+                {
+                    name: 'Parent,./',
+                    fieldKey: 'Parent$C$D$S',
+                    derivationDataScope: 'ParentOnly',
+                    conceptURI: undefined,
+                },
+                {
+                    name: 'All,./',
+                    fieldKey: 'All$C$D$S',
+                    derivationDataScope: 'All',
+                    conceptURI: undefined,
+                },
+            ],
+        }),
+    });
+    const queryInfo = new QueryInfo({
+        columns: new ExtendedMap({
+            Name: new QueryColumn({
+                name: 'Name',
+                fieldKey: 'Name',
+            }),
+            'Spec Char$C$D$S': new QueryColumn({
+                name: 'Spec Char,./',
+                fieldKey: 'Spec Char$C$D$S',
+            }),
+            Calc$C$D$S: new QueryColumn({
+                name: 'Calc,./',
+                fieldKey: 'Calc$C$D$S',
+            }),
+            Aliq$C$D$S: new QueryColumn({
+                name: 'Aliq,./',
+                fieldKey: 'Aliq$C$D$S',
+            }),
+            Parent$C$D$S: new QueryColumn({
+                name: 'Parent,./',
+                fieldKey: 'Parent$C$D$S',
+            }),
+            All$C$D$S: new QueryColumn({
+                name: 'All,./',
+                fieldKey: 'All$C$D$S',
+            }),
+        }),
+    });
+
+    test('field split by derivationDataScope', () => {
+        const result = _getGroupedSampleDomainFields(sampleTypeDomain, queryInfo);
+        expect(result.aliquotFields.length).toBe(1);
+        expect(result.aliquotFields[0]).toBe('aliq$c$d$s');
+        expect(result.independentFields.length).toBe(1);
+        expect(result.independentFields[0]).toBe('all$c$d$s');
+        expect(result.metaFields.length).toBe(3);
+        expect(result.metaFields[0]).toBe('name');
+        expect(result.metaFields[1]).toBe('spec char$c$d$s');
+        expect(result.metaFields[2]).toBe('parent$c$d$s');
+    });
+});

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -51,6 +51,8 @@ import { buildURL } from '../../url/AppURL';
 
 import { selectRows } from '../../query/selectRows';
 
+import { QueryInfo } from '../../../public/QueryInfo';
+
 import {
     AMOUNT_AND_UNITS_COLUMNS_LC,
     SAMPLE_STORAGE_COLUMNS_LC,
@@ -197,13 +199,21 @@ export async function getSelectedSampleIdsFromSelectionKey(searchParams: URLSear
 }
 
 export async function getGroupedSampleDomainFields(sampleType: string): Promise<GroupedSampleFields> {
-    const metaFields = [];
-    const independentFields = [];
-    const aliquotFields = [];
-
     // use domain fields as we only want to include fields defined by the user, but use queryInfo to map to fieldKey
     const sampleTypeDomain = await getSampleTypeDetails(new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType));
     const queryInfo = await getQueryDetails(new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType));
+
+    return _getGroupedSampleDomainFields(sampleTypeDomain, queryInfo);
+}
+
+// exported for jest testing
+export function _getGroupedSampleDomainFields(
+    sampleTypeDomain: DomainDetails,
+    queryInfo: QueryInfo
+): GroupedSampleFields {
+    const metaFields = [];
+    const independentFields = [];
+    const aliquotFields = [];
 
     sampleTypeDomain.domainDesign.fields.forEach(field => {
         const col = queryInfo.getColumnFromName(field.name);
@@ -537,7 +547,12 @@ export async function getLookupRowIdsFromSelection(
 
     if (fieldKey) {
         const rowIdFieldKey = `${fieldKey}/RowId`; // Pull the rowId of the lookup
-        const { data, dataIds } = await getSelectedDataDeprecated(schemaName, queryName, selected, 'RowId,' + rowIdFieldKey); // Include the RowId column to prevent warnings
+        const { data, dataIds } = await getSelectedDataDeprecated(
+            schemaName,
+            queryName,
+            selected,
+            'RowId,' + rowIdFieldKey
+        ); // Include the RowId column to prevent warnings
         if (data) {
             const rows = data.toJS();
             dataIds.forEach(rowId => {

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -34,6 +34,7 @@ import { SCHEMAS } from '../../schemas';
 
 import {
     getContainerFilter,
+    getQueryDetails,
     invalidateFullQueryDetailsCache,
     ISelectRowsResult,
     selectDistinctRows,
@@ -200,15 +201,18 @@ export async function getGroupedSampleDomainFields(sampleType: string): Promise<
     const independentFields = [];
     const aliquotFields = [];
 
+    // use domain fields as we only want to include fields defined by the user, but use queryInfo to map to fieldKey
     const sampleTypeDomain = await getSampleTypeDetails(new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType));
+    const queryInfo = await getQueryDetails(new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleType));
 
     sampleTypeDomain.domainDesign.fields.forEach(field => {
+        const col = queryInfo.getColumnFromName(field.name);
         if (field.derivationDataScope === DERIVATION_DATA_SCOPES.CHILD_ONLY) {
-            aliquotFields.push(field.name.toLowerCase());
+            aliquotFields.push(col.fieldKey.toLowerCase());
         } else if (field.derivationDataScope === DERIVATION_DATA_SCOPES.ALL) {
-            independentFields.push(field.name.toLowerCase());
-        } else {
-            metaFields.push(field.name.toLowerCase());
+            independentFields.push(col.fieldKey.toLowerCase());
+        } else if (!field.isCalculatedField()) {
+            metaFields.push(col.fieldKey.toLowerCase());
         }
     });
 
@@ -285,11 +289,11 @@ export function getGroupedSampleDisplayColumns(
     const aliquotHeaderDisplayColumns = [];
 
     allDisplayColumns.forEach(col => {
-        const colName = col.name.toLowerCase();
-        if (SAMPLE_STORAGE_COLUMNS_LC.indexOf(colName) > -1) {
+        const lcFieldKey = col.fieldKey.toLowerCase();
+        if (SAMPLE_STORAGE_COLUMNS_LC.indexOf(lcFieldKey) > -1) {
             return;
         }
-        if (AMOUNT_AND_UNITS_COLUMNS_LC.indexOf(colName) > -1 && canBeInStorage) {
+        if (AMOUNT_AND_UNITS_COLUMNS_LC.indexOf(lcFieldKey) > -1 && canBeInStorage) {
             return;
         }
         if (isAliquot) {
@@ -299,38 +303,38 @@ export function getGroupedSampleDisplayColumns(
             }
             // display parent meta for aliquot
             else if (
-                sampleTypeDomainFields.aliquotFields.indexOf(colName) > -1 ||
-                sampleTypeDomainFields.independentFields.indexOf(colName) > -1
+                sampleTypeDomainFields.aliquotFields.indexOf(lcFieldKey) > -1 ||
+                sampleTypeDomainFields.independentFields.indexOf(lcFieldKey) > -1
             ) {
                 aliquotHeaderDisplayColumns.push(col);
             }
         } else {
-            if (sampleTypeDomainFields.aliquotFields.indexOf(colName) === -1) {
+            if (sampleTypeDomainFields.aliquotFields.indexOf(lcFieldKey) === -1) {
                 displayColumns.push(col);
             }
         }
     });
 
     allUpdateColumns.forEach(col => {
-        const colName = col.name.toLowerCase();
-        if (SAMPLE_STORAGE_COLUMNS_LC.indexOf(colName) > -1) {
+        const lcFieldKey = col.fieldKey.toLowerCase();
+        if (SAMPLE_STORAGE_COLUMNS_LC.indexOf(lcFieldKey) > -1) {
             return;
         }
-        if (AMOUNT_AND_UNITS_COLUMNS_LC.indexOf(colName) > -1 && canBeInStorage) {
+        if (AMOUNT_AND_UNITS_COLUMNS_LC.indexOf(lcFieldKey) > -1 && canBeInStorage) {
             return;
         }
-        if (sampleTypeDomainFields.independentFields.indexOf(colName) > -1) {
+        if (sampleTypeDomainFields.independentFields.indexOf(lcFieldKey) > -1) {
             editColumns.push(col);
             return;
         }
         if (isAliquot) {
-            if (sampleTypeDomainFields.aliquotFields.indexOf(colName) > -1) {
+            if (sampleTypeDomainFields.aliquotFields.indexOf(lcFieldKey) > -1) {
                 editColumns.push(col);
-            } else if (isAliquotEditableField(colName)) {
+            } else if (isAliquotEditableField(lcFieldKey)) {
                 editColumns.push(col);
             }
         } else {
-            if (sampleTypeDomainFields.aliquotFields.indexOf(colName) === -1) {
+            if (sampleTypeDomainFields.aliquotFields.indexOf(lcFieldKey) === -1) {
                 editColumns.push(col);
             }
         }

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -134,7 +134,7 @@ export async function fetchSamples(
 
     orderedModels[key].forEach(id => {
         data.setIn(
-            [id, sampleColumn.fieldKey],
+            [id, sampleColumn.index],
             List([
                 {
                     displayValue: caseInsensitive(rows[id], displayValueKey)?.value,

--- a/packages/components/src/internal/components/samples/models.ts
+++ b/packages/components/src/internal/components/samples/models.ts
@@ -67,12 +67,9 @@ export const ALIQUOT_CREATION: EntityCreationTypeModel = {
 };
 
 export interface GroupedSampleFields {
-    // aliquot-specific
-    aliquotFields: string[];
-    // aliquot & parent rename to sharedFields
-    independentFields: string[];
-    // parent only
-    metaFields: string[];
+    aliquotFields: string[]; // aliquot-specific (lowercase column fieldKey)
+    independentFields: string[]; // aliquot & parent rename to sharedFields (lowercase column fieldKey)
+    metaFields: string[]; // parent only (lowercase column fieldKey)
     metricUnit: string;
 }
 

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -15,6 +15,10 @@
  */
 import { fromJS, List, Map } from 'immutable';
 
+import { QueryInfo } from '../../public/QueryInfo';
+import { ExtendedMap } from '../../public/ExtendedMap';
+import { QueryColumn } from '../../public/QueryColumn';
+
 import {
     arrayEquals,
     camelCaseToTitleCase,
@@ -446,8 +450,46 @@ describe('getUpdatedData', () => {
         },
     });
 
+    const queryInfo = new QueryInfo({
+        pkCols: ['RowId'],
+        columns: new ExtendedMap({
+            rowid: new QueryColumn({
+                name: 'RowId',
+                fieldKey: 'RowId',
+            }),
+            name: new QueryColumn({
+                name: 'Name',
+                fieldKey: 'Name',
+            }),
+            alias: new QueryColumn({
+                name: 'Alias',
+                fieldKey: 'Alias',
+            }),
+            data: new QueryColumn({
+                name: 'Data',
+                fieldKey: 'Data',
+            }),
+            and$sagain: new QueryColumn({
+                name: 'And/Again',
+                fieldKey: 'And$SAgain',
+            }),
+            value: new QueryColumn({
+                name: 'Value',
+                fieldKey: 'Value',
+            }),
+            other: new QueryColumn({
+                name: 'Other',
+                fieldKey: 'Other',
+            }),
+            intvalue: new QueryColumn({
+                name: 'IntValue',
+                fieldKey: 'IntValue',
+            }),
+        }),
+    });
+
     test('empty updates', () => {
-        const updatedData = getUpdatedData(originalData, {}, ['RowId']);
+        const updatedData = getUpdatedData(originalData, {}, queryInfo);
         expect(updatedData).toHaveLength(0);
     });
 
@@ -458,7 +500,7 @@ describe('getUpdatedData', () => {
                 Data: 'data1',
                 And$SAgain: 'again',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(0);
     });
@@ -472,7 +514,7 @@ describe('getUpdatedData', () => {
                 And$SAgain: 'again',
                 Other: 'other3',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(3);
         expect(updatedData[0]).toStrictEqual({
@@ -500,7 +542,7 @@ describe('getUpdatedData', () => {
                 And$SAgain: 'again2',
                 Other: 'not another',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(4);
         expect(updatedData[0]).toStrictEqual({
@@ -541,7 +583,7 @@ describe('getUpdatedData', () => {
                 And$SAgain: undefined,
                 Other: 'not another',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(4);
         expect(updatedData[0]).toStrictEqual({
@@ -585,7 +627,7 @@ describe('getUpdatedData', () => {
             {
                 IntValue: '123',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(0);
     });
@@ -607,7 +649,7 @@ describe('getUpdatedData', () => {
             {
                 IntValue: '234',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(1);
         expect(updatedData[0]).toStrictEqual({
@@ -635,7 +677,7 @@ describe('getUpdatedData', () => {
             {
                 Alias: ['alias3'],
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(1);
         expect(updatedData[0]).toStrictEqual({
@@ -663,7 +705,7 @@ describe('getUpdatedData', () => {
             {
                 Alias: [2],
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(1);
         expect(updatedData[0]).toStrictEqual({
@@ -691,7 +733,7 @@ describe('getUpdatedData', () => {
             {
                 Alias: [],
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData).toHaveLength(1);
         expect(updatedData[0]).toStrictEqual({
@@ -708,7 +750,7 @@ describe('getUpdatedData', () => {
                 And$SAgain: 'again',
                 Other: 'other3',
             },
-            ['RowId'],
+            queryInfo,
             new Set(['Data'])
         );
         expect(updatedData).toHaveLength(3);
@@ -768,7 +810,7 @@ describe('getUpdatedData', () => {
                 And$SAgain: 'again',
                 Other: 'other3',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData[0]).toStrictEqual({
             RowId: 448,
@@ -815,7 +857,7 @@ describe('getUpdatedData', () => {
                 And$SAgain: 'again',
                 Other: 'other3',
             },
-            ['RowId']
+            queryInfo
         );
         expect(updatedData[0]).toStrictEqual({
             RowId: 448,
@@ -1385,7 +1427,7 @@ describe('getDataStylingString', () => {
         expect(
             getDataStyling({
                 value: 1,
-                style: ';font-style: italic;color: #7b64ff;background-color: #fe9200 !important;'
+                style: ';font-style: italic;color: #7b64ff;background-color: #fe9200 !important;',
             })
         ).toStrictEqual({
             fontStyle: 'italic',
@@ -1436,25 +1478,17 @@ describe('styleStringToObj', () => {
             color: '#7b64ff',
             backgroundColor: '#fe9200',
         });
-        expect(
-            styleStringToObj('font-style: italic')
-        ).toStrictEqual({
+        expect(styleStringToObj('font-style: italic')).toStrictEqual({
             fontStyle: 'italic',
         });
-        expect(
-            styleStringToObj('font-style: italic; color: blue')
-        ).toStrictEqual({
+        expect(styleStringToObj('font-style: italic; color: blue')).toStrictEqual({
             fontStyle: 'italic',
             color: 'blue',
         });
-        expect(
-            styleStringToObj('; color: blue')
-        ).toStrictEqual({
+        expect(styleStringToObj('; color: blue')).toStrictEqual({
             color: 'blue',
         });
-        expect(
-            styleStringToObj(' background-color: blue;  ')
-        ).toStrictEqual({
+        expect(styleStringToObj(' background-color: blue;  ')).toStrictEqual({
             backgroundColor: 'blue',
         });
     });

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -371,7 +371,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            'And/Again': {
+            'And,./Again': {
                 value: 'again',
             },
             Name: {
@@ -393,7 +393,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            'And/Again': {
+            'And,./Again': {
                 value: 'again',
             },
             Name: {
@@ -415,7 +415,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            'And/Again': {
+            'And,./Again': {
                 value: 'again',
             },
             Name: {
@@ -437,7 +437,7 @@ describe('getUpdatedData', () => {
             Data: {
                 value: 'data1',
             },
-            'And/Again': {
+            'And,./Again': {
                 value: 'again',
             },
             Name: {
@@ -469,9 +469,9 @@ describe('getUpdatedData', () => {
                 name: 'Data',
                 fieldKey: 'Data',
             }),
-            and$sagain: new QueryColumn({
-                name: 'And/Again',
-                fieldKey: 'And$SAgain',
+            and$c$d$sagain: new QueryColumn({
+                name: 'And,./Again',
+                fieldKey: 'And$C$D$SAgain',
             }),
             value: new QueryColumn({
                 name: 'Value',
@@ -498,7 +498,7 @@ describe('getUpdatedData', () => {
             originalData,
             {
                 Data: 'data1',
-                And$SAgain: 'again',
+                And$C$D$SAgain: 'again',
             },
             queryInfo
         );
@@ -511,7 +511,7 @@ describe('getUpdatedData', () => {
             {
                 Value: 'val',
                 Data: 'data1',
-                And$SAgain: 'again',
+                And$C$D$SAgain: 'again',
                 Other: 'other3',
             },
             queryInfo
@@ -539,7 +539,7 @@ describe('getUpdatedData', () => {
             {
                 Value: 'val2',
                 Data: 'data2',
-                And$SAgain: 'again2',
+                And$C$D$SAgain: 'again2',
                 Other: 'not another',
             },
             queryInfo
@@ -549,28 +549,28 @@ describe('getUpdatedData', () => {
             RowId: 445,
             Value: 'val2',
             Data: 'data2',
-            'And/Again': 'again2',
+            'And,./Again': 'again2',
             Other: 'not another',
         });
         expect(updatedData[1]).toStrictEqual({
             RowId: 446,
             Value: 'val2',
             Data: 'data2',
-            'And/Again': 'again2',
+            'And,./Again': 'again2',
             Other: 'not another',
         });
         expect(updatedData[2]).toStrictEqual({
             RowId: 447,
             Value: 'val2',
             Data: 'data2',
-            'And/Again': 'again2',
+            'And,./Again': 'again2',
             Other: 'not another',
         });
         expect(updatedData[3]).toStrictEqual({
             RowId: 448,
             Value: 'val2',
             Data: 'data2',
-            'And/Again': 'again2',
+            'And,./Again': 'again2',
             Other: 'not another',
         });
     });
@@ -580,7 +580,7 @@ describe('getUpdatedData', () => {
             originalData,
             {
                 Value: null,
-                And$SAgain: undefined,
+                And$C$D$SAgain: undefined,
                 Other: 'not another',
             },
             queryInfo
@@ -589,23 +589,23 @@ describe('getUpdatedData', () => {
         expect(updatedData[0]).toStrictEqual({
             RowId: 445,
             Value: null,
-            'And/Again': null,
+            'And,./Again': null,
             Other: 'not another',
         });
         expect(updatedData[1]).toStrictEqual({
             RowId: 446,
             Value: null,
-            'And/Again': null,
+            'And,./Again': null,
             Other: 'not another',
         });
         expect(updatedData[2]).toStrictEqual({
             RowId: 447,
-            'And/Again': null,
+            'And,./Again': null,
             Other: 'not another',
         });
         expect(updatedData[3]).toStrictEqual({
             RowId: 448,
-            'And/Again': null,
+            'And,./Again': null,
             Other: 'not another',
         });
     });
@@ -747,7 +747,7 @@ describe('getUpdatedData', () => {
             originalData,
             {
                 Value: 'val',
-                And$SAgain: 'again',
+                And$C$D$SAgain: 'again',
                 Other: 'other3',
             },
             queryInfo,
@@ -786,7 +786,7 @@ describe('getUpdatedData', () => {
                 Data: {
                     value: 'data1',
                 },
-                'And/Again': {
+                'And,./Again': {
                     value: 'again',
                 },
                 Name: {
@@ -807,7 +807,7 @@ describe('getUpdatedData', () => {
             originalData_,
             {
                 Value: 'val',
-                And$SAgain: 'again',
+                And$C$D$SAgain: 'again',
                 Other: 'other3',
             },
             queryInfo
@@ -833,7 +833,7 @@ describe('getUpdatedData', () => {
                 Data: {
                     value: 'data1',
                 },
-                'And/Again': {
+                'And,./Again': {
                     value: 'again',
                 },
                 Name: {
@@ -854,7 +854,7 @@ describe('getUpdatedData', () => {
             originalData_,
             {
                 Value: 'val',
-                And$SAgain: 'again',
+                And$C$D$SAgain: 'again changed',
                 Other: 'other3',
             },
             queryInfo
@@ -862,6 +862,7 @@ describe('getUpdatedData', () => {
         expect(updatedData[0]).toStrictEqual({
             RowId: 448,
             Value: 'val',
+            'And,./Again': 'again changed',
             Other: 'other3',
             Container: 'ENTITYID-A',
         });

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -18,8 +18,7 @@ import { getServerContext, Utils } from '@labkey/api';
 import { ChangeEvent, CSSProperties } from 'react';
 
 import { hasParameter, toggleParameter } from '../url/ActionURL';
-import { encodePart } from '../../public/SchemaQuery';
-import { GridColumn } from '../components/base/models/GridColumn';
+import { QueryInfo } from '../../public/QueryInfo';
 
 // Case-insensitive Object reference. Returns undefined if either object or prop does not resolve.
 // If both casings exist (e.g. 'x' and 'X' are props) then either value may be returned.
@@ -275,18 +274,18 @@ function isSameWithStringCompare(value1: any, value2: any): boolean {
  *
  * @param originalData a map from an id field to a Map from fieldKeys to an object with a 'value' field
  * @param updatedValues an object mapping fieldKeys to values that are being updated
- * @param primaryKeys the list of primary fieldKey names
+ * @param queryInfo the queryInfo to get column information from
  * @param additionalCols additional array of fieldKeys to include
  */
 export function getUpdatedData(
-    originalData: Map<string, any>,
-    updatedValues: any,
-    primaryKeys: string[],
+    originalData: Map<string, any>, // the rows in the original data have column names as keys
+    updatedValues: any, // the keys here are column fieldKeys
+    queryInfo: QueryInfo,
     additionalCols?: Set<string>
 ): any[] {
     const updateValuesMap = Map<any, any>(updatedValues);
     const pkColsLc = new Set<string>();
-    primaryKeys.forEach(key => pkColsLc.add(key.toLowerCase()));
+    queryInfo.pkCols.forEach(key => pkColsLc.add(key.toLowerCase()));
     additionalCols?.forEach(col => pkColsLc.add(col.toLowerCase()));
 
     // if the originalData has the container/folder values, keep those as well (i.e. treat it as a primary key)
@@ -298,19 +297,28 @@ export function getUpdatedData(
 
     const updatedData = originalData.map(originalRowMap => {
         return originalRowMap.reduce((m, fieldValueMap, key) => {
-            // Issue 42672: The original data has keys that are names or captions for the columns.  We need to use
-            // the encoded key that will match what's expected for filtering on the server side (e.g., "U g$Sl" instead of "U g/l")
-            const encodedKey = encodePart(key);
+            // Issue 42672: The original data has keys that are column names. Need to get the QueryColumn object from that
+            // name so that we can get the fieldKey for the column to get the updated value from the updateValuesMap.
+            // (e.g., "U g$Sl" instead of "U g/l")
+            const col = queryInfo.getColumnFromName(key);
+            if (!col) {
+                if (fieldValueMap) {
+                    throw new Error(`Unable to find column for key ${key}.`);
+                } else {
+                    return m;
+                }
+            }
+
             if (fieldValueMap?.has('value')) {
                 if (pkColsLc.has(key.toLowerCase())) {
                     return m.set(key, fieldValueMap.get('value'));
                 } else if (
-                    updateValuesMap.has(encodedKey) &&
-                    !isSameWithStringCompare(updateValuesMap.get(encodedKey), fieldValueMap.get('value'))
+                    updateValuesMap.has(col.fieldKey) &&
+                    !isSameWithStringCompare(updateValuesMap.get(col.fieldKey), fieldValueMap.get('value'))
                 ) {
                     return m.set(
                         key,
-                        updateValuesMap.get(encodedKey) == undefined ? null : updateValuesMap.get(encodedKey)
+                        updateValuesMap.get(col.fieldKey) == undefined ? null : updateValuesMap.get(col.fieldKey)
                     );
                 } else {
                     return m;
@@ -318,7 +326,7 @@ export function getUpdatedData(
             }
             // Handle multi-value select
             else if (List.isList(fieldValueMap)) {
-                let updatedVal = updateValuesMap.get(encodedKey);
+                let updatedVal = updateValuesMap.get(col.fieldKey);
                 if (Array.isArray(updatedVal)) {
                     updatedVal = updatedVal.map(val => {
                         const match = fieldValueMap.find(original => original.get('value') === val);
@@ -329,11 +337,11 @@ export function getUpdatedData(
                     });
 
                     return m.set(key, updatedVal);
-                } else if (updateValuesMap.has(encodedKey) && updatedVal === undefined) {
+                } else if (updateValuesMap.has(col.fieldKey) && updatedVal === undefined) {
                     return m.set(key, []);
                 } else return m;
             } else return m;
-        }, Map<any, any>());
+        }, Map<string, any>());
     });
     // we want the rows that contain more than just the primaryKeys
     return updatedData

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -297,11 +297,13 @@ export function getUpdatedData(
 
     const updatedData = originalData.map(originalRowMap => {
         return originalRowMap.reduce((m, fieldValueMap, key) => {
+            const isPKCol = pkColsLc.has(key.toLowerCase());
+
             // Issue 42672: The original data has keys that are column names. Need to get the QueryColumn object from that
             // name so that we can get the fieldKey for the column to get the updated value from the updateValuesMap.
             // (e.g., "U g$Sl" instead of "U g/l")
             const col = queryInfo.getColumnFromName(key);
-            if (!col) {
+            if (!col && !isPKCol) {
                 if (fieldValueMap) {
                     throw new Error(`Unable to find column for key ${key}.`);
                 } else {
@@ -310,7 +312,7 @@ export function getUpdatedData(
             }
 
             if (fieldValueMap?.has('value')) {
-                if (pkColsLc.has(key.toLowerCase())) {
+                if (isPKCol) {
                     return m.set(key, fieldValueMap.get('value'));
                 } else if (
                     updateValuesMap.has(col.fieldKey) &&

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -279,7 +279,7 @@ function isSameWithStringCompare(value1: any, value2: any): boolean {
  */
 export function getUpdatedData(
     originalData: Map<string, any>, // the rows in the original data have column names as keys
-    updatedValues: any, // the keys here are column fieldKeys
+    updatedValues: Record<string, any>, // the keys here are column fieldKeys
     queryInfo: QueryInfo,
     additionalCols?: Set<string>
 ): any[] {

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -189,6 +189,7 @@ export class QueryInfo {
         return undefined;
     }
 
+    // TODO rename to getColumnFromFieldKey
     getColumn(fieldKey: string): QueryColumn {
         if (fieldKey) {
             return this.columns.get(fieldKey.toLowerCase());


### PR DESCRIPTION
#### Rationale
Part of the issues we have been fixing recently is because the data rows response from selectRows is keyed by column names and several other places in the client side code we use column fieldKeys (which are encoded when when the column name has certain special characters in it. Previously we were using `encodePart()` on the client side to transform the selectRows data row keys to be fieldKey-like. This works for the single part key cases but can cause double encoding for multi part keys (like lookup columns). 

This PR removes those usages of `encodePart()` on the client side data objects (for EditorModel and details form data cases) so that the client code is just dealing with the response from the server and using `QueryColumn.index` (which is a helper to account for single part vs multi part keys) to do the data diff / retrieval from the various data objects.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1715
- https://github.com/LabKey/labkey-ui-premium/pull/675
- https://github.com/LabKey/limsModules/pull/1153
- https://github.com/LabKey/testAutomation/pull/2271

#### Changes
- EditableGridLoaderFromSelection not to encodePart() in the data rows, leave keyed by column name as it comes from server
- BulkUpdateForm not to encodePart() when comparing with original data, use QueryInfo to lookup column instead
- Fix up sample aliquot-only vs sample-only fields to use fieldKey instead of name
- getSampleIdentifyingFieldGridData() to use column.index instead of column.name for the key
