### PR TITLE
Improve and report client-side exceptions

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.5",
+  "version": "8.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "8.3.1-fb-source-maps.5",
+      "version": "8.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.0",
+  "version": "8.3.1-fb-source-maps.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "8.3.0",
+      "version": "8.3.1-fb-source-maps.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.1",
+  "version": "8.3.1-fb-source-maps.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "8.3.1-fb-source-maps.1",
+      "version": "8.3.1-fb-source-maps.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.0",
+  "version": "8.3.1-fb-source-maps.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "8.3.1-fb-source-maps.0",
+      "version": "8.3.1-fb-source-maps.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.3",
+  "version": "8.3.1-fb-source-maps.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "8.3.1-fb-source-maps.3",
+      "version": "8.3.1-fb-source-maps.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.4",
+  "version": "8.3.1-fb-source-maps.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "8.3.1-fb-source-maps.4",
+      "version": "8.3.1-fb-source-maps.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.2",
+  "version": "8.3.1-fb-source-maps.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/build",
-      "version": "8.3.1-fb-source-maps.2",
+      "version": "8.3.1-fb-source-maps.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -31,6 +31,7 @@
         "rimraf": "~6.0.1",
         "sass": "~1.77.8",
         "sass-loader": "~14.2.1",
+        "source-map-loader": "~5.0.0",
         "style-loader": "~4.0.0",
         "typescript": "~5.6.3",
         "webpack": "~5.96.1",
@@ -6053,6 +6054,36 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
+      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
+      }
+    },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.1",
+  "version": "8.3.1-fb-source-maps.2",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.2",
+  "version": "8.3.1-fb-source-maps.3",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -34,6 +34,7 @@
     "rimraf": "~6.0.1",
     "sass": "~1.77.8",
     "sass-loader": "~14.2.1",
+    "source-map-loader": "~5.0.0",
     "style-loader": "~4.0.0",
     "typescript": "~5.6.3",
     "webpack": "~5.96.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.4",
+  "version": "8.3.1-fb-source-maps.5",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.0",
+  "version": "8.3.1-fb-source-maps.1",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.3",
+  "version": "8.3.1-fb-source-maps.4",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.0",
+  "version": "8.3.1-fb-source-maps.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/build",
-  "version": "8.3.1-fb-source-maps.5",
+  "version": "8.4.0",
   "description": "LabKey client-side build assets",
   "files": [
     "webpack/"

--- a/packages/build/releaseNotes/build.md
+++ b/packages/build/releaseNotes/build.md
@@ -1,5 +1,10 @@
 # @labkey/build
 
+### version 8.4.0
+*Released*: 17 February 2025
+- Add `source-map-loader` as a dependency
+- Add webpack rule for processing source maps using `source-map-loader`. This is set up to specifically target `@labkey` packages.
+
 ### version 8.3.0
 *Released*: 5 November 2024
 - Package updates

--- a/packages/build/webpack/constants.js
+++ b/packages/build/webpack/constants.js
@@ -241,6 +241,20 @@ module.exports = {
                 type: 'asset',
             }
         ],
+        SOURCE_MAP: [
+            {
+                // Matches against package source files (e.g. premium.js, components.js, etc.)
+                test: /\.js$/,
+                enforce: 'pre',
+                use: [{
+                    loader: 'source-map-loader',
+                    options: {
+                        // Match only against source maps provided by @labkey packages
+                        filterSourceMappingUrl: (url, resourcePath) => /\/@labkey\//.test(resourcePath),
+                    }
+                }],
+            }
+        ],
         STYLE: [
             {
                 test: /\.css$/,

--- a/packages/build/webpack/dev.config.js
+++ b/packages/build/webpack/dev.config.js
@@ -17,7 +17,7 @@ module.exports = {
         filename: '[name].[contenthash].js'
     },
     module: {
-        rules: constants.loaders.TYPESCRIPT.concat(constants.loaders.STYLE).concat(constants.loaders.FILES),
+        rules: constants.loaders.TYPESCRIPT.concat(constants.loaders.STYLE, constants.loaders.FILES),
     },
     resolve: {
         alias: constants.aliases.LABKEY_PACKAGES,

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -4,7 +4,6 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 const path = require('path');
-const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const constants = require('./constants');
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
@@ -40,9 +39,6 @@ const plugins = [
         exclude: /node_modules/,
         include: /src/,
         failOnError: true,
-    }),
-    new webpack.SourceMapDevToolPlugin({
-        filename: '[file].map'
     }),
 ];
 if (process.env.ANALYZE) {

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -47,6 +47,7 @@ if (process.env.ANALYZE) {
 
 module.exports = {
     entry: './src/index.ts',
+    devtool: 'source-map',
     target: 'web',
     mode: 'production',
     module: {

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -4,6 +4,7 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 const path = require('path');
+const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const constants = require('./constants');
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -41,29 +41,17 @@ const plugins = [
         include: /src/,
         failOnError: true,
     }),
+    new webpack.SourceMapDevToolPlugin({
+        filename: '[file].map'
+    }),
 ];
-// HACK
-if (constants.lkModule === 'components' || constants.lkModule === 'premium') {
-    let repositoryUrl;
-    if (constants.lkModule === 'components') {
-        repositoryUrl = 'https://github.com/LabKey/labkey-ui-components/tree/develop/packages/components/';
-    } else {
-        repositoryUrl = 'https://github.com/LabKey/labkey-ui-premium/tree/develop/';
-    }
-    plugins.push(
-        new webpack.SourceMapDevToolPlugin({
-            moduleFilenameTemplate: repositoryUrl + '[resource-path]?[loaders]',
-            filename: '[file].map',
-        }),
-    );
-}
 if (process.env.ANALYZE) {
     plugins.push(new BundleAnalyzerPlugin());
 }
 
 module.exports = {
     entry: './src/index.ts',
-    devtool: false,
+    devtool: 'source-map',
     target: 'web',
     mode: 'production',
     module: {

--- a/packages/build/webpack/package.config.js
+++ b/packages/build/webpack/package.config.js
@@ -41,13 +41,28 @@ const plugins = [
         failOnError: true,
     }),
 ];
+// HACK
+if (constants.lkModule === 'components' || constants.lkModule === 'premium') {
+    let repositoryUrl;
+    if (constants.lkModule === 'components') {
+        repositoryUrl = 'https://github.com/LabKey/labkey-ui-components/tree/develop/packages/components/';
+    } else {
+        repositoryUrl = 'https://github.com/LabKey/labkey-ui-premium/tree/develop/';
+    }
+    plugins.push(
+        new webpack.SourceMapDevToolPlugin({
+            moduleFilenameTemplate: repositoryUrl + '[resource-path]?[loaders]',
+            filename: '[file].map',
+        }),
+    );
+}
 if (process.env.ANALYZE) {
     plugins.push(new BundleAnalyzerPlugin());
 }
 
 module.exports = {
     entry: './src/index.ts',
-    devtool: 'source-map',
+    devtool: false,
     target: 'web',
     mode: 'production',
     module: {

--- a/packages/build/webpack/prod.config.js
+++ b/packages/build/webpack/prod.config.js
@@ -18,7 +18,11 @@ module.exports = {
         filename: '[name].[contenthash].cache.js'
     },
     module: {
-        rules: constants.loaders.TYPESCRIPT.concat(constants.loaders.STYLE).concat(constants.loaders.FILES),
+        rules: constants.loaders.TYPESCRIPT.concat(
+            constants.loaders.STYLE,
+            constants.loaders.FILES,
+            constants.loaders.SOURCE_MAP
+        ),
     },
     resolve: {
         alias: constants.aliases.LABKEY_PACKAGES,

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "8.3.1-fb-source-maps.0",
+        "@labkey/build": "8.3.1-fb-source-maps.2",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.14",
@@ -3053,9 +3053,9 @@
       "integrity": "sha512-PIuzYGEm0O6ydWoXWEqCV+hHGqzDsVZ5Q3JD6i/d/bvp6On0jML9lnmz45hw4ZAXiwLSpd09whaTeSPVxnDxig=="
     },
     "node_modules/@labkey/build": {
-      "version": "8.3.1-fb-source-maps.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.0.tgz",
-      "integrity": "sha512-5e+rlDjTwYMYvpU/U/eJwNP0ZtloMzOfq/rDHlO43a43g+QuYfy4mn4DG9yCvp4UwqOcTWl+i9nossy+j2pcjg==",
+      "version": "8.3.1-fb-source-maps.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.2.tgz",
+      "integrity": "sha512-cVaEB9If9XPZYM4CP3cdryVZn+/wFyRZmc9iQw/pkq/WCKKsAm2fno6RbRwVGKdkjpr35NAGCXSRk46TCNUUXw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
-        "@labkey/api": "1.37.0",
+        "@labkey/api": "1.37.1-fb-source-maps.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.0.1",
@@ -3048,9 +3048,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.37.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.37.0.tgz",
-      "integrity": "sha512-PIuzYGEm0O6ydWoXWEqCV+hHGqzDsVZ5Q3JD6i/d/bvp6On0jML9lnmz45hw4ZAXiwLSpd09whaTeSPVxnDxig=="
+      "version": "1.37.1-fb-source-maps.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.37.1-fb-source-maps.0.tgz",
+      "integrity": "sha512-4n7YvmTynbWl7ppW7VgPDfCA+75c8qoAdoNexnxphz2VhjapVjyLm1Sq5fOg1inAmDJvd5MVw9b/vACtQ2s2pg=="
     },
     "node_modules/@labkey/build": {
       "version": "8.3.1-fb-source-maps.5",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.23.1",
+  "version": "6.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.23.1",
+      "version": "6.24.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
-        "@labkey/api": "1.37.1-fb-source-maps.1",
+        "@labkey/api": "1.38.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.0.1",
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "8.3.1-fb-source-maps.5",
+        "@labkey/build": "8.4.0",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.14",
@@ -3048,14 +3048,14 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.37.1-fb-source-maps.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.37.1-fb-source-maps.1.tgz",
-      "integrity": "sha512-Mcik5XCDR43jw/zgc1z8Pfyjf8xsh2Xpn0cTTMhkwso1u3zb3vYk1iEYYoaPmha5gQggxoOxIAztupk4i9ADBw=="
+      "version": "1.38.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.38.0.tgz",
+      "integrity": "sha512-3hgFMq0PEJo9Bd3AKbIEe0OcxkW/omRccsRFe0fEToMpzI5wDLSiyXOU3AfCshZLS20Tr/73QlkiIUacAwQJhg=="
     },
     "node_modules/@labkey/build": {
-      "version": "8.3.1-fb-source-maps.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.5.tgz",
-      "integrity": "sha512-KVdWRwcpnoi4d2dNv6bBSn5Xvwsu4P3OBScjTghha6f72LLZ5RVFYFUNy9nxE8+ctmqhaXgdlAbcNYcSfJ+mBg==",
+      "version": "8.4.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.4.0.tgz",
+      "integrity": "sha512-iMHkUWuzAvGixek4nsJ5O5o8zmbTf95DeRgkXW76wbm3PhGPPfP/sPxfPZK6+NkKwOBVf52kjGEmq5x75Bl7JQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "8.3.1-fb-source-maps.3",
+        "@labkey/build": "8.3.1-fb-source-maps.4",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.14",
@@ -3053,9 +3053,9 @@
       "integrity": "sha512-PIuzYGEm0O6ydWoXWEqCV+hHGqzDsVZ5Q3JD6i/d/bvp6On0jML9lnmz45hw4ZAXiwLSpd09whaTeSPVxnDxig=="
     },
     "node_modules/@labkey/build": {
-      "version": "8.3.1-fb-source-maps.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.3.tgz",
-      "integrity": "sha512-G6GXG45S5nOOIwXCQxzk2MvJVgnouXa3ALvznJrt8zTzyCxfnGCKQubO9cLrXB4jmvjKwY6XaoIFBbqRzFgQgQ==",
+      "version": "8.3.1-fb-source-maps.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.4.tgz",
+      "integrity": "sha512-JJHm7paKFYIKV2LU52PNmQ5aG/+MkCuUicYYY0RHRteqMjAOnVQKYpWjSzKsR/DeD5Ur4QmGMHmDj24Uc50xOw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "8.3.1-fb-source-maps.4",
+        "@labkey/build": "8.3.1-fb-source-maps.5",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.14",
@@ -3053,9 +3053,9 @@
       "integrity": "sha512-PIuzYGEm0O6ydWoXWEqCV+hHGqzDsVZ5Q3JD6i/d/bvp6On0jML9lnmz45hw4ZAXiwLSpd09whaTeSPVxnDxig=="
     },
     "node_modules/@labkey/build": {
-      "version": "8.3.1-fb-source-maps.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.4.tgz",
-      "integrity": "sha512-JJHm7paKFYIKV2LU52PNmQ5aG/+MkCuUicYYY0RHRteqMjAOnVQKYpWjSzKsR/DeD5Ur4QmGMHmDj24Uc50xOw==",
+      "version": "8.3.1-fb-source-maps.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.5.tgz",
+      "integrity": "sha512-KVdWRwcpnoi4d2dNv6bBSn5Xvwsu4P3OBScjTghha6f72LLZ5RVFYFUNy9nxE8+ctmqhaXgdlAbcNYcSfJ+mBg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
-        "@labkey/api": "1.37.1-fb-source-maps.0",
+        "@labkey/api": "1.37.1-fb-source-maps.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.0.1",
@@ -3048,9 +3048,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.37.1-fb-source-maps.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.37.1-fb-source-maps.0.tgz",
-      "integrity": "sha512-4n7YvmTynbWl7ppW7VgPDfCA+75c8qoAdoNexnxphz2VhjapVjyLm1Sq5fOg1inAmDJvd5MVw9b/vACtQ2s2pg=="
+      "version": "1.37.1-fb-source-maps.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.37.1-fb-source-maps.1.tgz",
+      "integrity": "sha512-Mcik5XCDR43jw/zgc1z8Pfyjf8xsh2Xpn0cTTMhkwso1u3zb3vYk1iEYYoaPmha5gQggxoOxIAztupk4i9ADBw=="
     },
     "node_modules/@labkey/build": {
       "version": "8.3.1-fb-source-maps.5",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "8.3.0",
+        "@labkey/build": "8.3.1-fb-source-maps.0",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.14",
@@ -3053,9 +3053,9 @@
       "integrity": "sha512-PIuzYGEm0O6ydWoXWEqCV+hHGqzDsVZ5Q3JD6i/d/bvp6On0jML9lnmz45hw4ZAXiwLSpd09whaTeSPVxnDxig=="
     },
     "node_modules/@labkey/build": {
-      "version": "8.3.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.0.tgz",
-      "integrity": "sha512-HeD0ukjhcvls4sY7V9bqwVABFMjML6WCDjsaDX6t/pKN9cL+uedNVqYyp/jwSJM8HDRQp36EPsvnD0C1aHFusg==",
+      "version": "8.3.1-fb-source-maps.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.0.tgz",
+      "integrity": "sha512-5e+rlDjTwYMYvpU/U/eJwNP0ZtloMzOfq/rDHlO43a43g+QuYfy4mn4DG9yCvp4UwqOcTWl+i9nossy+j2pcjg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.26.0",
@@ -3080,6 +3080,7 @@
         "rimraf": "~6.0.1",
         "sass": "~1.77.8",
         "sass-loader": "~14.2.1",
+        "source-map-loader": "~5.0.0",
         "style-loader": "~4.0.0",
         "typescript": "~5.6.3",
         "webpack": "~5.96.1",
@@ -13252,6 +13253,38 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
+      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
+      }
+    },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -35,7 +35,7 @@
         "vis-network": "~9.1.9"
       },
       "devDependencies": {
-        "@labkey/build": "8.3.1-fb-source-maps.2",
+        "@labkey/build": "8.3.1-fb-source-maps.3",
         "@labkey/eslint-config-react": "0.0.15",
         "@types/history": "4.7.11",
         "@types/jest": "29.5.14",
@@ -3053,9 +3053,9 @@
       "integrity": "sha512-PIuzYGEm0O6ydWoXWEqCV+hHGqzDsVZ5Q3JD6i/d/bvp6On0jML9lnmz45hw4ZAXiwLSpd09whaTeSPVxnDxig=="
     },
     "node_modules/@labkey/build": {
-      "version": "8.3.1-fb-source-maps.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.2.tgz",
-      "integrity": "sha512-cVaEB9If9XPZYM4CP3cdryVZn+/wFyRZmc9iQw/pkq/WCKKsAm2fno6RbRwVGKdkjpr35NAGCXSRk46TCNUUXw==",
+      "version": "8.3.1-fb-source-maps.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-8.3.1-fb-source-maps.3.tgz",
+      "integrity": "sha512-G6GXG45S5nOOIwXCQxzk2MvJVgnouXa3ALvznJrt8zTzyCxfnGCKQubO9cLrXB4jmvjKwY6XaoIFBbqRzFgQgQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.26.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.23.1",
+  "version": "6.24.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "8.3.1-fb-source-maps.4",
+    "@labkey/build": "8.3.1-fb-source-maps.5",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.14",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "17.0.0",
-    "@labkey/api": "1.37.0",
+    "@labkey/api": "1.37.1-fb-source-maps.0",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "8.3.0",
+    "@labkey/build": "8.3.1-fb-source-maps.0",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.14",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "17.0.0",
-    "@labkey/api": "1.37.1-fb-source-maps.0",
+    "@labkey/api": "1.37.1-fb-source-maps.1",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "8.3.1-fb-source-maps.2",
+    "@labkey/build": "8.3.1-fb-source-maps.3",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.14",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "8.3.1-fb-source-maps.3",
+    "@labkey/build": "8.3.1-fb-source-maps.4",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.14",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "8.3.1-fb-source-maps.0",
+    "@labkey/build": "8.3.1-fb-source-maps.2",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.14",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "17.0.0",
-    "@labkey/api": "1.37.1-fb-source-maps.1",
+    "@labkey/api": "1.38.0",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.0.1",
@@ -74,7 +74,7 @@
     "vis-network": "~9.1.9"
   },
   "devDependencies": {
-    "@labkey/build": "8.3.1-fb-source-maps.5",
+    "@labkey/build": "8.4.0",
     "@labkey/eslint-config-react": "0.0.15",
     "@types/history": "4.7.11",
     "@types/jest": "29.5.14",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.24.0
+*Released*: 17 February 2025
+- Bump `@labkey/api` and `@labkey/build`.
+- Distribution now includes source maps.
+
 ### version 6.23.1
 *Released*: 14 February 2025
 - Misc 25.3 fixes


### PR DESCRIPTION
#### Rationale
This improves client-side exceptions generated from errors in our packages by defaulting our package build to use `devtool: 'source-map'` and then in production builds of applications they will bundle source maps from our packages into their generated source maps. This gives much improved code line/column detail insight into where the error occurred.

**Note:** This is specifically targeting improving stack traces for production builds. I elected to not incur the multiple second build penalty per client-side app in development builds so those stack traces are not as detailed.

**Note:** Adding these source maps to our bundled packages does significantly increase the size of the artifacts:

<img width="576" alt="image" src="https://github.com/user-attachments/assets/77f2c819-6cdf-4232-a8e4-6042a0e3a41b" />

Here is the dist:
<img width="307" alt="image" src="https://github.com/user-attachments/assets/8db8751d-9088-4be9-b3c3-03a1f7e40249" />


#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/190
- https://github.com/LabKey/labkey-ui-components/pull/1717
- https://github.com/LabKey/labkey-ui-premium/pull/680
- https://github.com/LabKey/limsModules/pull/1161
- https://github.com/LabKey/platform/pull/6312

#### Changes
**@labkey/build**
- Add `source-map-loader` as a dependency
- Add webpack rule for processing source maps using `source-map-loader`. This is set up to specifically target `@labkey` packages.

**@labkey/components**
- Bump `@labkey/api` and `@labkey/build`.
