### PR TITLE
Issue 52228: App using an Identifying field that's required errors during sample import

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.4",
+  "version": "6.22.4-cory253Fixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.4",
+      "version": "6.22.4-cory253Fixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.23.0",
+  "version": "6.23.0-cory253Fixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.23.0",
+      "version": "6.23.0-cory253Fixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.23.0-cory253Fixes.0",
+  "version": "6.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.23.0-cory253Fixes.0",
+      "version": "6.23.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.23.0-cory253Fixes.0",
+  "version": "6.23.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.23.0",
+  "version": "6.23.0-cory253Fixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.4",
+  "version": "6.22.4-cory253Fixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD February 2025
+- Misc 25.3 fixes
+  - Issue 52228: App using an Identifying field that's required errors during sample import
+  - Issue 52230: App broken link under Calculated Columns data field hover tooltip
+
 ### version 6.22.4
 *Released*: 12 February 2025
 - Issue 51973: LIMS: Only one person's updates to templates are saved if two admins are working concurrently

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD February 2025
+### version 6.23.1
+*Released*: 14 February 2025
 - Misc 25.3 fixes
   - Issue 52228: App using an Identifying field that's required errors during sample import
   - Issue 52230: App broken link under Calculated Columns data field hover tooltip

--- a/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/CalculatedFieldOptions.tsx
@@ -68,7 +68,11 @@ const HELP_TIP_BODY = (
         <p>Define the SQL expression to use for this calculated field.</p>
         <p>
             The expression must be valid LabKey SQL and can use the default system fields, custom fields, constants, and
-            operators. Learn more about using <HelpLink topic={LABKEY_SQL_TOPIC}>LabKey SQL</HelpLink>.
+            operators. Learn more about using{' '}
+            <HelpLink topic={LABKEY_SQL_TOPIC} useDefaultUrl>
+                LabKey SQL
+            </HelpLink>
+            .
         </p>
     </div>
 );

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -311,6 +311,7 @@ export class QueryInfo {
                 if (ancestorOnly && !col.name.startsWith('Ancestors/')) return;
                 const qCol = new QueryColumn(col);
                 qCol.readOnly = true;
+                qCol.required = false; // Issue 52228
                 if (prefixFieldKey) {
                     qCol.name = prefixFieldKey + '/' + qCol.name;
                     qCol.fieldKey = prefixFieldKey + '/' + qCol.fieldKey;


### PR DESCRIPTION
#### Rationale
Issue [52228](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52228): LKSM: Using an Identifying field that's required errors during sample import
- when an identifying field is included as read-only in the sample creation editable grid, set it as non-required since this is just reference info and not data entered by the user about the given sample

Issue [52230](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52230): LKSM: Broken Link Under Calculated Columns Data Field
- update tooltip URL generation to use default LKS doc URL

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1718
- https://github.com/LabKey/labkey-ui-premium/pull/682
- https://github.com/LabKey/limsModules/pull/1164

#### Changes
- identifying fields in sample editable grid to be set as non-required in QueryColumn metadata
- Calc columns update tooltip URL generation to use default LKS doc URL
