### PR TITLE
Issue 52103: Add component for warning about multiple spaces between words

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.5-trimDomainNames.1",
+  "version": "6.23.1-trimDomainNames.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.5-trimDomainNames.1",
+      "version": "6.23.1-trimDomainNames.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.24.1-trimDomainNames.1",
+  "version": "6.24.3-trimDomainNames.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.24.1-trimDomainNames.1",
+      "version": "6.24.3-trimDomainNames.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.3",
+  "version": "6.22.4-trimDomainNames.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.3",
+      "version": "6.22.4-trimDomainNames.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.24.3-trimDomainNames.1",
+  "version": "6.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.24.3-trimDomainNames.1",
+      "version": "6.25.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.4-trimDomainNames.0",
+  "version": "6.22.5-trimDomainNames.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.22.4-trimDomainNames.0",
+      "version": "6.22.5-trimDomainNames.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.5-trimDomainNames.0",
+  "version": "6.22.5-trimDomainNames.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.24.3-trimDomainNames.1",
+  "version": "6.25.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.22.3",
+  "version": "6.22.4-trimDomainNames.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.25.0
+*Released*: 19 February 2025
 - Add new `InternalSpacesWarning` component to warn when values contain multiple spaces between words
 - Use component in `EntityDetailsForm`, `QueryFormInputs`, `AssayPropertiesInput`, and `TextInput`
 - Do some more error message resolution

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - Add new `InternalSpacesWarning` component to warn when values contain multiple spaces between words
+- Use component in `EntityDetailsForm`, `QueryFormInputs`, `AssayPropertiesInput`, and `TextInput`
+- Do some more error message resolution
 
 ### version 6.22.4
 *Released*: 12 February 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Add new `InternalSpacesWarning` component to warn when values contain multiple spaces between words
+
 ### version 6.22.3
 *Released*: 12 February 2025
 - Merge from release25.2-SNAPSHOT to develop
@@ -13,7 +17,7 @@ Components, models, actions, and utility functions for LabKey applications and p
   - add StoragePositionNumber field to SampleFinder filter cards
 
 ### version 6.22.1
-*Release*: 11 February 2025
+*Released*: 11 February 2025
 - Issue 52193: Update `QueryColumn.isImportColumn` to match on caption fully stripped of spaces
 
 ### version 6.22.0

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -94,6 +94,7 @@ import {
     resolveErrorMessage,
 } from './internal/util/messaging';
 import { WHERE_FILTER_TYPE } from './internal/url/WhereFilterType';
+import { InternalSpacesWarning } from './internal/components/forms/InternalSpacesWarning';
 import { AddEntityButton, AddEntityElement } from './internal/components/buttons/AddEntityButton';
 import { RemoveEntityButton } from './internal/components/buttons/RemoveEntityButton';
 import { Alert } from './internal/components/base/Alert';
@@ -1246,6 +1247,7 @@ export {
     formsyRules,
     withFormsy,
     // form related items
+    InternalSpacesWarning,
     BulkUpdateForm,
     QueryFormInputs,
     LookupSelectInput,

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -31,6 +31,7 @@ import { AssayProtocolModel, ProtocolTransformScript } from './models';
 import { FORM_IDS, SCRIPTS_DIR } from './constants';
 import { getScriptEngineForExtension, getValidPublishTargets } from './actions';
 import { useFilterCriteriaContext } from './FilterCriteriaContext';
+import { InternalSpacesWarning } from '../../forms/InternalSpacesWarning';
 
 interface AssayPropertiesInputProps extends DomainFieldLabelProps, PropsWithChildren {
     colSize?: number;
@@ -83,6 +84,7 @@ export const NameInput: FC<InputProps> = memo(props => (
             onChange={props.onChange}
             disabled={!props.model.isNew() && !props.canRename}
         />
+        <InternalSpacesWarning value={props.model.name || ''} fieldName="name" />
     </AssayPropertiesInput>
 ));
 NameInput.displayName = 'NameInput';

--- a/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayPropertiesInput.tsx
@@ -84,7 +84,7 @@ export const NameInput: FC<InputProps> = memo(props => (
             onChange={props.onChange}
             disabled={!props.model.isNew() && !props.canRename}
         />
-        <InternalSpacesWarning value={props.model.name || ''} fieldName="name" />
+        <InternalSpacesWarning value={props.model.name} fieldName="name" />
     </AssayPropertiesInput>
 ));
 NameInput.displayName = 'NameInput';

--- a/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/DataClassDesigner.tsx
@@ -264,7 +264,7 @@ export class DataClassDesignerImpl extends PureComponent<DataClassDesignerProps,
             });
 
             setSubmitting(false, () => {
-                this.saveModel({ domain: savedDomain, exception: undefined }, () => {
+                this.saveModel({ name: savedDomain.name, domain: savedDomain, exception: undefined }, () => {
                     onComplete(this.state.model);
                 });
             });

--- a/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/entities/EntityDetailsForm.tsx
@@ -13,6 +13,8 @@ import { IEntityDetails } from './models';
 import { getEntityDescriptionValue, getEntityNameExpressionValue, getEntityNameValue, } from './actions';
 import { ENTITY_FORM_IDS } from './constants';
 
+import { InternalSpacesWarning } from '../../forms/InternalSpacesWarning';
+
 export interface EntityDetailsProps {
     data?: Map<string, any>;
     formValues?: IEntityDetails;
@@ -29,7 +31,7 @@ export interface EntityDetailsProps {
     warning?: string;
 }
 
-export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, any> {
+export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps> {
     render() {
         const {
             nameExpressionInfoUrl,
@@ -72,6 +74,12 @@ export class EntityDetailsForm extends React.PureComponent<EntityDetailsProps, a
                             value={getEntityNameValue(formValues, data)}
                             disabled={nameReadOnly}
                         />
+                    </div>
+                    <div>
+                        <div className="col-xs-2"></div>
+                        <div className="col-xs-10">
+                            <InternalSpacesWarning value={getEntityNameValue(formValues, data)} />
+                        </div>
                     </div>
                 </div>
                 <div className="row margin-bottom">

--- a/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/entities/__snapshots__/EntityDetailsForm.test.tsx.snap
@@ -27,6 +27,14 @@ exports[`<EntityDetailsForm/> default properties 1`] = `
           value=""
         />
       </div>
+      <div>
+        <div
+          class="col-xs-2"
+        />
+        <div
+          class="col-xs-10"
+        />
+      </div>
     </div>
     <div
       class="row margin-bottom"
@@ -128,6 +136,14 @@ exports[`<EntityDetailsForm/> initial data 1`] = `
           placeholder="Enter a name for this entity"
           type="text"
           value="Test Entity Name"
+        />
+      </div>
+      <div>
+        <div
+          class="col-xs-2"
+        />
+        <div
+          class="col-xs-10"
         />
       </div>
     </div>
@@ -235,6 +251,14 @@ exports[`<EntityDetailsForm/> nameExpression properties 1`] = `
           value=""
         />
       </div>
+      <div>
+        <div
+          class="col-xs-2"
+        />
+        <div
+          class="col-xs-10"
+        />
+      </div>
     </div>
     <div
       class="row margin-bottom"
@@ -337,6 +361,14 @@ exports[`<EntityDetailsForm/> with formValues 1`] = `
           placeholder="Enter a name for this entity"
           type="text"
           value="Test Entity Name"
+        />
+      </div>
+      <div>
+        <div
+          class="col-xs-2"
+        />
+        <div
+          class="col-xs-10"
         />
       </div>
     </div>
@@ -442,6 +474,14 @@ exports[`<EntityDetailsForm/> with previewName 1`] = `
           placeholder="Enter a name for this entity"
           type="text"
           value="Test Entity Name"
+        />
+      </div>
+      <div>
+        <div
+          class="col-xs-2"
+        />
+        <div
+          class="col-xs-10"
         />
       </div>
     </div>

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -412,7 +412,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
             if (!hasConfirmedNameExpression && this.props.validateProperties) {
                 const response = await this.props.validateProperties(details);
                 if (response.error) {
-                    const updatedModel = model.set('exception', response.error) as SampleTypeModel;
+                    const updatedModel = model.set('exception', resolveErrorMessage(response.error)) as SampleTypeModel;
                     setSubmitting(false, () => {
                         this.setState(
                             () => ({ model: updatedModel, showUniqueIdConfirmation: false }),

--- a/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.test.tsx.snap
+++ b/packages/components/src/internal/components/domainproperties/samples/__snapshots__/SampleTypePropertiesPanel.test.tsx.snap
@@ -75,6 +75,14 @@ exports[`SampleTypePropertiesPanel appPropertiesOnly 1`] = `
                   value=""
                 />
               </div>
+              <div>
+                <div
+                  class="col-xs-2"
+                />
+                <div
+                  class="col-xs-10"
+                />
+              </div>
             </div>
             <div
               class="row margin-bottom"
@@ -330,6 +338,14 @@ exports[`SampleTypePropertiesPanel appPropertiesOnly 1`] = `
                 placeholder="Enter a name for this sample type"
                 type="text"
                 value=""
+              />
+            </div>
+            <div>
+              <div
+                class="col-xs-2"
+              />
+              <div
+                class="col-xs-10"
               />
             </div>
           </div>
@@ -626,6 +642,14 @@ exports[`SampleTypePropertiesPanel default props 1`] = `
                   value=""
                 />
               </div>
+              <div>
+                <div
+                  class="col-xs-2"
+                />
+                <div
+                  class="col-xs-10"
+                />
+              </div>
             </div>
             <div
               class="row margin-bottom"
@@ -821,6 +845,14 @@ exports[`SampleTypePropertiesPanel default props 1`] = `
                 placeholder="Enter a name for this sample type"
                 type="text"
                 value=""
+              />
+            </div>
+            <div>
+              <div
+                class="col-xs-2"
+              />
+              <div
+                class="col-xs-10"
               />
             </div>
           </div>
@@ -1067,6 +1099,14 @@ exports[`SampleTypePropertiesPanel include dataclass and use custom labels 1`] =
                   value=""
                 />
               </div>
+              <div>
+                <div
+                  class="col-xs-2"
+                />
+                <div
+                  class="col-xs-10"
+                />
+              </div>
             </div>
             <div
               class="row margin-bottom"
@@ -1290,6 +1330,14 @@ exports[`SampleTypePropertiesPanel include dataclass and use custom labels 1`] =
                 placeholder="Enter a name for this sample type"
                 type="text"
                 value=""
+              />
+            </div>
+            <div>
+              <div
+                class="col-xs-2"
+              />
+              <div
+                class="col-xs-10"
               />
             </div>
           </div>

--- a/packages/components/src/internal/components/forms/InternalSpacesWarning.test.tsx
+++ b/packages/components/src/internal/components/forms/InternalSpacesWarning.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { InternalSpacesWarning } from './InternalSpacesWarning';
+import { render } from '@testing-library/react';
+
+describe('InternalSpacesWarning', () => {
+    test('undefined value', () => {
+        const { container } = render(<InternalSpacesWarning value={undefined} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('null value', () => {
+        const { container } = render(<InternalSpacesWarning value={null} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('empty value', () => {
+        const { container } = render(<InternalSpacesWarning value="" />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('only spaces value', () => {
+        const { container } = render(<InternalSpacesWarning value={'    '} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('leading spaces value', () => {
+        const { container } = render(<InternalSpacesWarning value="  leading spaces" />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('trailing spaces value', () => {
+        const { container } = render(<InternalSpacesWarning value="trailingSpaces  " />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('single spaced value', () => {
+        const { container } = render(<InternalSpacesWarning value="single spaces between   " />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('multiple spaces value', () => {
+        const { container } = render(<InternalSpacesWarning value="multiple spaces   between   " />);
+        expect(container).toHaveTextContent("This name contains multiple spaces between words. The extra spaces won't be visible to users.");
+    });
+
+    test('multiple spaces value, custom name', () => {
+        const { container } = render(<InternalSpacesWarning value="  multiple  spaces" fieldName="sample" />);
+        expect(container).toHaveTextContent("This sample contains multiple spaces between words. The extra spaces won't be visible to users.");
+    });
+});

--- a/packages/components/src/internal/components/forms/InternalSpacesWarning.tsx
+++ b/packages/components/src/internal/components/forms/InternalSpacesWarning.tsx
@@ -18,3 +18,5 @@ export const InternalSpacesWarning: FC<Props> = ({ value, fieldName = 'name' }) 
     }
     return null;
 };
+
+InternalSpacesWarning.displayName = 'InternalSpacesWarning';

--- a/packages/components/src/internal/components/forms/InternalSpacesWarning.tsx
+++ b/packages/components/src/internal/components/forms/InternalSpacesWarning.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+
+interface Props {
+    fieldName?: string;
+    value: string;
+}
+
+const INTERNAL_SPACES_PATTERN = /\S\s\s+\S/;
+
+export const InternalSpacesWarning: FC<Props> = ({ value, fieldName = 'name' }) => {
+    if (INTERNAL_SPACES_PATTERN.test(value)) {
+        return (
+            <span className="text-danger">
+                <span className="fa fa-exclamation-circle" /> This {fieldName} contains multiple spaces between words.
+                The extra spaces won't be visible to users.
+            </span>
+        );
+    }
+    return null;
+};

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -403,7 +403,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                                 />
                                             </div>
                                         </div>
-
                                     )}
                                 </>
                             );

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -41,6 +41,7 @@ import { DatePickerInput } from './input/DatePickerInput';
 import { TextChoiceInput } from './input/TextChoiceInput';
 
 import { getQueryFormLabelFieldName, isQueryFormLabelField } from './utils';
+import { InternalSpacesWarning } from './InternalSpacesWarning';
 
 export interface QueryFormInputsProps {
     allowFieldDisable?: boolean;
@@ -56,6 +57,7 @@ export interface QueryFormInputsProps {
     fireQSChangeOnInit?: boolean;
     includeLabelField?: boolean;
     initiallyDisableFields?: boolean;
+    internalSpacesWarningFieldKeys?: string[];
     // isIncludedColumn can be used when you want to keep certain columns always filtered out (e.g., aliquot- or
     // sample-only columns). Note: This props is never used by QueryFormInputs, but is needed because this interface is
     // shared with other components. We should probably move this particular prop to a more appropriate place.
@@ -164,6 +166,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
             columnFilter,
             containerFilter,
             containerPath,
+            internalSpacesWarningFieldKeys,
             preventCrossFolderEnable,
             pluralNoun = 'rows',
             fieldValues,
@@ -379,16 +382,30 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                             );
                         default:
                             return (
-                                <TextInput
-                                    key={i}
-                                    queryColumn={col}
-                                    value={value ? String(value) : value}
-                                    allowDisable={allowFieldDisable}
-                                    initiallyDisabled={shouldDisableField}
-                                    onToggleDisable={this.onToggleDisable}
-                                    addLabelAsterisk={showAsteriskSymbol}
-                                    renderFieldLabel={renderFieldLabel}
-                                />
+                                <>
+                                    <TextInput
+                                        key={i}
+                                        queryColumn={col}
+                                        value={value ? String(value) : value}
+                                        allowDisable={allowFieldDisable}
+                                        initiallyDisabled={shouldDisableField}
+                                        onToggleDisable={this.onToggleDisable}
+                                        addLabelAsterisk={showAsteriskSymbol}
+                                        renderFieldLabel={renderFieldLabel}
+                                    />
+                                    {internalSpacesWarningFieldKeys?.indexOf(col.fieldKey.toLowerCase()) > -1 && (
+                                        <div className="row shift-margin-to-bottom">
+                                            <div className="col-sm-3 col-xs-12" />
+                                            <div className="col-sm-9 col-xs-12 text-danger">
+                                                <InternalSpacesWarning
+                                                    value={value}
+                                                    fieldName={col.caption?.toLowerCase() ?? col.name.toLowerCase()}
+                                                />
+                                            </div>
+                                        </div>
+
+                                    )}
+                                </>
                             );
                     }
                 });

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -50,6 +50,7 @@ export interface RenderOptions {
     /** A container path that will be applied to all query-based inputs on this form */
     containerPath?: string;
     hideLabel?: boolean;
+    includeSpacesWarning?: boolean;
 }
 
 export interface EditRendererOptions extends RenderOptions {
@@ -94,11 +95,14 @@ function processFields(
     titleRenderer?: TitleRenderer,
     options?: RenderOptions,
     fileInputRenderer?: (col: QueryColumn, data: any) => ReactNode,
-    onAdditionalFormDataChange?: (name: string, value: any) => any
+    onAdditionalFormDataChange?: (name: string, value: any) => any,
+    internalSpacesWarningFieldKeys?: string[]
 ): OrderedMap<string, DetailField> {
     return queryColumns.reduce((fields, c) => {
         const fieldKey = c.fieldKey.toLowerCase();
-
+        if (internalSpacesWarningFieldKeys?.indexOf(fieldKey) > -1) {
+            options.includeSpacesWarning = true;
+        }
         return fields.set(
             fieldKey,
             new DetailField({
@@ -144,6 +148,7 @@ export interface DetailDisplaySharedProps extends RenderOptions {
     editingMode?: boolean;
     fieldHelpTexts?: Record<string, string>;
     fileInputRenderer?: (col: QueryColumn, data: any) => ReactNode;
+    internalSpacesWarningFieldKeys?: string[];
     onAdditionalFormDataChange?: (name: string, value: any) => any;
     tableCls?: string;
     titleRenderer?: TitleRenderer;
@@ -166,6 +171,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
         fieldHelpTexts,
         onAdditionalFormDataChange,
         tableCls,
+        internalSpacesWarningFieldKeys,
     } = props;
 
     const detailRenderer = useMemo(() => {
@@ -193,7 +199,8 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
             titleRenderer,
             options,
             fileInputRenderer,
-            onAdditionalFormDataChange
+            onAdditionalFormDataChange,
+            internalSpacesWarningFieldKeys
         );
 
         body = (
@@ -427,6 +434,7 @@ export function resolveDetailEditRenderer(
                         // required if the nameExpression is not defined to force the form to require a value.
                         required={col.required || col.nameExpression !== undefined}
                         showLabel={showLabel}
+                        includeSpacesWarning={options.includeSpacesWarning}
                         validatePristine
                         validationError={validationError}
                         value={value}

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -23,6 +23,7 @@ import { INPUT_LABEL_CLASS_NAME, INPUT_WRAPPER_CLASS_NAME } from '../constants';
 
 import { FormsyInput, FormsyInputProps } from './FormsyReactComponents';
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
+import { InternalSpacesWarning } from '../InternalSpacesWarning';
 
 export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputProps, 'onChange'> {
     addLabelAsterisk?: boolean;
@@ -31,6 +32,7 @@ export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputP
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
     showLabel?: boolean;
     startFocused?: boolean;
+    includeSpacesWarning?: boolean;
 }
 
 interface TextInputState extends DisableableInputState {
@@ -58,6 +60,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
         this.state = {
             didFocus: false,
             isDisabled: props.initiallyDisabled,
+            inputValue: props.value,
         };
 
         this.textInput = React.createRef();
@@ -101,10 +104,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
     }
 
     onChange = (name: string, value: any): void => {
-        if (this.props.allowDisable) {
-            this.setState({ inputValue: value });
-        }
-
+        this.setState({ inputValue: value });
         this.props.onChange?.(value);
     };
 
@@ -120,6 +120,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
             queryColumn,
             showLabel,
             startFocused,
+            includeSpacesWarning,
             ...inputProps
         } = rest;
         let { validations } = inputProps;
@@ -145,23 +146,26 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
         }
 
         return (
-            <FormsyInput
-                id={queryColumn.fieldKey}
-                name={queryColumn.fieldKey}
-                placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
-                required={queryColumn.required}
-                {...inputProps}
-                componentRef={this.textInput}
-                disabled={this.state.isDisabled}
-                help={help}
-                label={this.renderLabel()}
-                labelClassName={showLabel ? labelClassName : 'hide-label'}
-                onChange={this.onChange}
-                step={step}
-                type={type}
-                validations={validations}
-                value={this.getInputValue()}
-            />
+            <>
+                <FormsyInput
+                    id={queryColumn.fieldKey}
+                    name={queryColumn.fieldKey}
+                    placeholder={`Enter ${queryColumn.caption.toLowerCase()}`}
+                    required={queryColumn.required}
+                    {...inputProps}
+                    componentRef={this.textInput}
+                    disabled={this.state.isDisabled}
+                    help={help}
+                    label={this.renderLabel()}
+                    labelClassName={showLabel ? labelClassName : 'hide-label'}
+                    onChange={this.onChange}
+                    step={step}
+                    type={type}
+                    validations={validations}
+                    value={this.getInputValue()}
+                />
+                {includeSpacesWarning && <InternalSpacesWarning value={this.state.inputValue} />}
+            </>
         );
     }
 }

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -178,14 +178,14 @@ export function resolveErrorMessage(
             const fieldname =
                 startIndex > -1 ? 'for field ' + lcMessage.substring(startIndex + 13, lcMessage.indexOf(')=(')) : '';
             return `Unable to create a unique constraint ${fieldname} because duplicate values already exists in the data.`;
-        } else if (errorMsg.indexOf('Invalid SampleSet name "') >= 0) {
+        } else if (errorMsg.indexOf("Invalid SampleSet name '") >= 0) {
             return errorMsg
                 .replace('. SampleSet', '. Sample type')
-                .replace('Invalid SampleSet name "', 'Invalid sample type name "');
-        } else if (errorMsg.indexOf('Invalid DataClass name "') >= 0) {
+                .replace("Invalid SampleSet name '", "Invalid sample type name '");
+        } else if (errorMsg.indexOf("Invalid DataClass name '") >= 0) {
             return errorMsg
                 .replace('. DataClass', '. Source type')
-                .replace('Invalid DataClass name "', 'Invalid source type name "');
+                .replace("Invalid DataClass name '", "Invalid source type name '");
         } else if (errorMsg.indexOf('ERROR: invalid byte sequence for encoding') > -1) {
             if (errorMsg.indexOf('0x00') > 0)
                 return verbPresent === 'import'

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -33,6 +33,7 @@ export interface EditableDetailPanelProps {
     detailRenderer?: DetailRenderer;
     disabled?: boolean;
     editColumns?: QueryColumn[];
+    internalSpacesWarningFieldKeys?: string[];
     model: QueryModel;
     onAdditionalFormDataChange?: (name: string, value: any) => any;
     onBeforeUpdate?: (row: Record<string, any>) => void;
@@ -58,6 +59,7 @@ export const EditableDetailPanel: FC<EditableDetailPanelProps> = props => {
         detailEditRenderer,
         detailHeader,
         detailRenderer,
+        internalSpacesWarningFieldKeys,
         asSubPanel,
         canUpdate,
         editColumns,
@@ -194,6 +196,7 @@ export const EditableDetailPanel: FC<EditableDetailPanelProps> = props => {
                             editColumns={editColumns}
                             editingMode
                             fileInputRenderer={fileInputRenderer}
+                            internalSpacesWarningFieldKeys={internalSpacesWarningFieldKeys}
                             onAdditionalFormDataChange={onAdditionalFormDataChange}
                             queryConfig={{
                                 ...model.queryConfig,

--- a/packages/components/src/theme/utils.scss
+++ b/packages/components/src/theme/utils.scss
@@ -82,6 +82,11 @@
     margin-left: 15px;
 }
 
+.shift-margin-to-bottom {
+    margin-top: -15px;
+    margin-bottom: 15px;
+}
+
 /** Padding **/
 
 .no-padding {


### PR DESCRIPTION
#### Rationale
Issue [52103](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52103) - when someone has put multiple spaces between words in the name of something, this is likely not to be intentional and can cause confusion and consternation since the extra spaces are not evident in HTML.  This PR adds a component to display a warning about multiple spaces between words and uses that component in various places.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1165
- https://github.com/LabKey/platform/pull/6319
- https://github.com/LabKey/labkey-ui-premium/pull/683

#### Changes
- Add new `InternalSpacesWarning` component to warn when values contain multiple spaces between words.
- Add component to `EntityDetailsForm`, `QueryFormInputs`, and `AssayPropertiesInput`
- Do some more error message resolution
