### PR TITLE
Issue 52167: Update isCalculatedFieldsEnabled() check for LKS distributions

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.24.0",
+  "version": "6.24.0-calcFieldProductConfig.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.24.0",
+      "version": "6.24.0-calcFieldProductConfig.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.24.1",
+      "version": "6.24.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.24.0",
+  "version": "6.24.0-calcFieldProductConfig.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 52167: Update isCalculatedFieldsEnabled() check for LKS distributions
+
 ### version 6.24.0
 *Released*: 17 February 2025
 - Bump `@labkey/api` and `@labkey/build`.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.24.2
+*Released*: 18 February 2025
 - Issue 52167: Update isCalculatedFieldsEnabled() check for LKS distributions
 
 ### version 6.24.1

--- a/packages/components/src/internal/app/utils.test.ts
+++ b/packages/components/src/internal/app/utils.test.ts
@@ -830,48 +830,70 @@ describe('utils', () => {
     test('isCommunityDistribution', () => {
         expect(isCommunityDistribution({ api: { moduleNames: ['api'] } })).toBeTruthy(); // LKS Community
         expect(isCommunityDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
-        expect(isCommunityDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
-        expect(isCommunityDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
+        expect(isCommunityDistribution({ api: { moduleNames: ['premium', 'samplemanagement'] } })).toBeFalsy(); // LKS Starter
         expect(
-            isCommunityDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+            isCommunityDistribution({ api: { moduleNames: ['premium', 'professional', 'samplemanagement'] } })
+        ).toBeFalsy(); // LKS Professional
+        expect(
+            isCommunityDistribution({
+                api: { moduleNames: ['premium', 'professional', 'compliance', 'samplemanagement'] },
+            })
         ).toBeFalsy(); // LKS Enterprise
     });
 
     test('isSampleManagerDistribution', () => {
         expect(isSampleManagerDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
         expect(isSampleManagerDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeTruthy(); // LKSM-only
-        expect(isSampleManagerDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
-        expect(isSampleManagerDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
+        expect(isSampleManagerDistribution({ api: { moduleNames: ['premium', 'samplemanagement'] } })).toBeFalsy(); // LKS Starter
         expect(
-            isSampleManagerDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+            isSampleManagerDistribution({ api: { moduleNames: ['premium', 'professional', 'samplemanagement'] } })
+        ).toBeFalsy(); // LKS Professional
+        expect(
+            isSampleManagerDistribution({
+                api: { moduleNames: ['premium', 'professional', 'compliance', 'samplemanagement'] },
+            })
         ).toBeFalsy(); // LKS Enterprise
     });
 
     test('isStarterDistribution', () => {
         expect(isStarterDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
         expect(isStarterDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
-        expect(isStarterDistribution({ api: { moduleNames: ['premium'] } })).toBeTruthy(); // LKS Starter
-        expect(isStarterDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
-        expect(isStarterDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })).toBeFalsy(); // LKS Enterprise
+        expect(isStarterDistribution({ api: { moduleNames: ['premium', 'samplemanagement'] } })).toBeTruthy(); // LKS Starter
+        expect(
+            isStarterDistribution({ api: { moduleNames: ['premium', 'professional', 'samplemanagement'] } })
+        ).toBeFalsy(); // LKS Professional
+        expect(
+            isStarterDistribution({
+                api: { moduleNames: ['premium', 'professional', 'compliance', 'samplemanagement'] },
+            })
+        ).toBeFalsy(); // LKS Enterprise
     });
 
     test('isProfessionalDistribution', () => {
         expect(isProfessionalDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
         expect(isProfessionalDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
-        expect(isProfessionalDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
-        expect(isProfessionalDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeTruthy(); // LKS Professional
+        expect(isProfessionalDistribution({ api: { moduleNames: ['premium', 'samplemanagement'] } })).toBeFalsy(); // LKS Starter
         expect(
-            isProfessionalDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+            isProfessionalDistribution({ api: { moduleNames: ['premium', 'professional', 'samplemanagement'] } })
+        ).toBeTruthy(); // LKS Professional
+        expect(
+            isProfessionalDistribution({
+                api: { moduleNames: ['premium', 'professional', 'compliance', 'samplemanagement'] },
+            })
         ).toBeFalsy(); // LKS Enterprise
     });
 
     test('isEnterpriseDistribution', () => {
         expect(isEnterpriseDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
         expect(isEnterpriseDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
-        expect(isEnterpriseDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
-        expect(isEnterpriseDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
+        expect(isEnterpriseDistribution({ api: { moduleNames: ['premium', 'samplemanagement'] } })).toBeFalsy(); // LKS Starter
         expect(
-            isEnterpriseDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+            isEnterpriseDistribution({ api: { moduleNames: ['premium', 'professional', 'samplemanagement'] } })
+        ).toBeFalsy(); // LKS Professional
+        expect(
+            isEnterpriseDistribution({
+                api: { moduleNames: ['premium', 'professional', 'compliance', 'samplemanagement'] },
+            })
         ).toBeTruthy(); // LKS Enterprise
     });
 
@@ -1014,11 +1036,15 @@ describe('utils', () => {
     test('isCalculatedFieldsEnabled', () => {
         expect(isCalculatedFieldsEnabled()).toBeFalsy();
         expect(isCalculatedFieldsEnabled()).toBeFalsy();
-        expect(isCalculatedFieldsEnabled({ api: { moduleNames: [] } })).toBeFalsy(); // LKS Community
-        expect(isCalculatedFieldsEnabled({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
-        expect(isCalculatedFieldsEnabled({ api: { moduleNames: ['premium', 'professional'] } })).toBeTruthy(); // LKS Professional
+        expect(isCalculatedFieldsEnabled({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
+        expect(isCalculatedFieldsEnabled({ api: { moduleNames: ['premium', 'samplemanagement'] } })).toBeFalsy(); // LKS Starter
         expect(
-            isCalculatedFieldsEnabled({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+            isCalculatedFieldsEnabled({ api: { moduleNames: ['premium', 'professional', 'samplemanagement'] } })
+        ).toBeTruthy(); // LKS Professional
+        expect(
+            isCalculatedFieldsEnabled({
+                api: { moduleNames: ['premium', 'professional', 'compliance', 'samplemanagement'] },
+            })
         ).toBeTruthy(); // LKS Enterprise
 
         window.history.pushState({}, 'Test Title', '/samplemanager-app.view#'); // isApp()
@@ -1030,12 +1056,16 @@ describe('utils', () => {
     });
 
     test('isConditionalFormattingEnabled', () => {
-        expect(isConditionalFormattingEnabled({ api: { moduleNames: [] } })).toBeTruthy(); // LKS Community
+        expect(isConditionalFormattingEnabled({ api: { moduleNames: ['api'] } })).toBeTruthy(); // LKS Community
         expect(isConditionalFormattingEnabled({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
-        expect(isConditionalFormattingEnabled({ api: { moduleNames: ['premium'] } })).toBeTruthy(); // LKS Starter
-        expect(isConditionalFormattingEnabled({ api: { moduleNames: ['premium', 'professional'] } })).toBeTruthy(); // LKS Professional
+        expect(isConditionalFormattingEnabled({ api: { moduleNames: ['premium', 'samplemanagement'] } })).toBeTruthy(); // LKS Starter
         expect(
-            isConditionalFormattingEnabled({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+            isConditionalFormattingEnabled({ api: { moduleNames: ['premium', 'professional', 'samplemanagement'] } })
+        ).toBeTruthy(); // LKS Professional
+        expect(
+            isConditionalFormattingEnabled({
+                api: { moduleNames: ['premium', 'professional', 'compliance', 'samplemanagement'] },
+            })
         ).toBeTruthy(); // LKS Enterprise
 
         window.history.pushState({}, 'Test Title', '/samplemanager-app.view#'); // isApp()

--- a/packages/components/src/internal/app/utils.test.ts
+++ b/packages/components/src/internal/app/utils.test.ts
@@ -64,6 +64,11 @@ import {
     userCanReadGroupDetails,
     userCanReadUserDetails,
     isQueryMetadataEditor,
+    isConditionalFormattingEnabled,
+    isSampleManagerDistribution,
+    isStarterDistribution,
+    isProfessionalDistribution,
+    isEnterpriseDistribution,
 } from './utils';
 import {
     ASSAYS_KEY,
@@ -823,10 +828,51 @@ describe('utils', () => {
     });
 
     test('isCommunityDistribution', () => {
-        expect(isCommunityDistribution({})).toBeTruthy();
-        expect(isCommunityDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy();
-        expect(isCommunityDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy();
-        expect(isCommunityDistribution({ api: { moduleNames: ['api'] } })).toBeTruthy();
+        expect(isCommunityDistribution({ api: { moduleNames: ['api'] } })).toBeTruthy(); // LKS Community
+        expect(isCommunityDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
+        expect(isCommunityDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
+        expect(isCommunityDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
+        expect(
+            isCommunityDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+        ).toBeFalsy(); // LKS Enterprise
+    });
+
+    test('isSampleManagerDistribution', () => {
+        expect(isSampleManagerDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
+        expect(isSampleManagerDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeTruthy(); // LKSM-only
+        expect(isSampleManagerDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
+        expect(isSampleManagerDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
+        expect(
+            isSampleManagerDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+        ).toBeFalsy(); // LKS Enterprise
+    });
+
+    test('isStarterDistribution', () => {
+        expect(isStarterDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
+        expect(isStarterDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
+        expect(isStarterDistribution({ api: { moduleNames: ['premium'] } })).toBeTruthy(); // LKS Starter
+        expect(isStarterDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
+        expect(isStarterDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })).toBeFalsy(); // LKS Enterprise
+    });
+
+    test('isProfessionalDistribution', () => {
+        expect(isProfessionalDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
+        expect(isProfessionalDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
+        expect(isProfessionalDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
+        expect(isProfessionalDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeTruthy(); // LKS Professional
+        expect(
+            isProfessionalDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+        ).toBeFalsy(); // LKS Enterprise
+    });
+
+    test('isEnterpriseDistribution', () => {
+        expect(isEnterpriseDistribution({ api: { moduleNames: ['api'] } })).toBeFalsy(); // LKS Community
+        expect(isEnterpriseDistribution({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
+        expect(isEnterpriseDistribution({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
+        expect(isEnterpriseDistribution({ api: { moduleNames: ['premium', 'professional'] } })).toBeFalsy(); // LKS Professional
+        expect(
+            isEnterpriseDistribution({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+        ).toBeTruthy(); // LKS Enterprise
     });
 
     test('isProjectContainer', () => {
@@ -968,14 +1014,42 @@ describe('utils', () => {
     test('isCalculatedFieldsEnabled', () => {
         expect(isCalculatedFieldsEnabled()).toBeFalsy();
         expect(isCalculatedFieldsEnabled()).toBeFalsy();
-        expect(isCalculatedFieldsEnabled({ api: { moduleNames: [] } })).toBeFalsy(); // community
-        expect(isCalculatedFieldsEnabled({ api: { moduleNames: ['premium'] } })).toBeTruthy(); // LKS Prof
+        expect(isCalculatedFieldsEnabled({ api: { moduleNames: [] } })).toBeFalsy(); // LKS Community
+        expect(isCalculatedFieldsEnabled({ api: { moduleNames: ['premium'] } })).toBeFalsy(); // LKS Starter
+        expect(isCalculatedFieldsEnabled({ api: { moduleNames: ['premium', 'professional'] } })).toBeTruthy(); // LKS Professional
+        expect(
+            isCalculatedFieldsEnabled({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+        ).toBeTruthy(); // LKS Enterprise
 
         window.history.pushState({}, 'Test Title', '/samplemanager-app.view#'); // isApp()
         expect(isCalculatedFieldsEnabled()).toBeFalsy();
         expect(isCalculatedFieldsEnabled({ core: { productFeatures: [] } })).toBeFalsy();
         expect(
             isCalculatedFieldsEnabled({ core: { productFeatures: [ProductFeature.CalculatedFields] } })
+        ).toBeTruthy();
+    });
+
+    test('isConditionalFormattingEnabled', () => {
+        expect(isConditionalFormattingEnabled({ api: { moduleNames: [] } })).toBeTruthy(); // LKS Community
+        expect(isConditionalFormattingEnabled({ api: { moduleNames: ['samplemanagement'] } })).toBeFalsy(); // LKSM-only
+        expect(isConditionalFormattingEnabled({ api: { moduleNames: ['premium'] } })).toBeTruthy(); // LKS Starter
+        expect(isConditionalFormattingEnabled({ api: { moduleNames: ['premium', 'professional'] } })).toBeTruthy(); // LKS Professional
+        expect(
+            isConditionalFormattingEnabled({ api: { moduleNames: ['premium', 'professional', 'compliance'] } })
+        ).toBeTruthy(); // LKS Enterprise
+
+        window.history.pushState({}, 'Test Title', '/samplemanager-app.view#'); // isApp()
+        expect(
+            isConditionalFormattingEnabled({
+                api: { moduleNames: ['samplemanagement'] },
+                core: { productFeatures: [] },
+            })
+        ).toBeFalsy();
+        expect(
+            isConditionalFormattingEnabled({
+                api: { moduleNames: ['samplemanagement'] },
+                core: { productFeatures: [ProductFeature.ConditionalFormatting] },
+            })
         ).toBeTruthy();
     });
 

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -448,7 +448,7 @@ export function isDataChangeCommentRequirementFeatureEnabled(moduleContext?: Mod
     return isFeatureEnabled(ProductFeature.DataChangeCommentRequirement, moduleContext);
 }
 
-// should be enabled for LKSM Professional, LIMS, LKB (via ProductFeature) AND for LKS Professional, LKS Enterprise
+// should be enabled via ProductFeature for LKSM Professional, LIMS, LKB AND via distribution for LKS Professional, LKS Enterprise
 export function isCalculatedFieldsEnabled(moduleContext?: ModuleContext): boolean {
     return isApp()
         ? isFeatureEnabled(ProductFeature.CalculatedFields, moduleContext)

--- a/packages/components/src/internal/app/utils.ts
+++ b/packages/components/src/internal/app/utils.ts
@@ -234,7 +234,7 @@ export function freezerManagerIsCurrentApp(): boolean {
 }
 
 export function isSampleStatusEnabled(moduleContext?: ModuleContext): boolean {
-    return hasModule('SampleManagement', moduleContext);
+    return hasSampleManagementModule(moduleContext);
 }
 
 export function isQueryMetadataEditor(): boolean {
@@ -410,7 +410,7 @@ export function isELNEnabled(moduleContext?: ModuleContext): boolean {
 }
 
 export function isProtectedDataEnabled(moduleContext?: ModuleContext): boolean {
-    return hasModule('compliance', moduleContext) && hasModule('complianceActivities', moduleContext);
+    return hasComplianceModule(moduleContext) && hasModule('complianceActivities', moduleContext);
 }
 
 export function isNamingPrefixEnabled(moduleContext?: ModuleContext): boolean {
@@ -448,10 +448,11 @@ export function isDataChangeCommentRequirementFeatureEnabled(moduleContext?: Mod
     return isFeatureEnabled(ProductFeature.DataChangeCommentRequirement, moduleContext);
 }
 
+// should be enabled for LKSM Professional, LIMS, LKB (via ProductFeature) AND for LKS Professional, LKS Enterprise
 export function isCalculatedFieldsEnabled(moduleContext?: ModuleContext): boolean {
     return isApp()
         ? isFeatureEnabled(ProductFeature.CalculatedFields, moduleContext)
-        : !isCommunityDistribution(moduleContext);
+        : isProfessionalDistribution(moduleContext) || isEnterpriseDistribution(moduleContext);
 }
 
 export function isCustomImportTemplatesEnabled(moduleContext?: ModuleContext): boolean {
@@ -461,7 +462,10 @@ export function isCustomImportTemplatesEnabled(moduleContext?: ModuleContext): b
 // This is enabled for all distributions except sample manager-only distributions. LKS distributions don't
 // currently supply feature flags, so a pure flag check is not sufficient.
 export function isConditionalFormattingEnabled(moduleContext?: ModuleContext): boolean {
-    return isFeatureEnabled(ProductFeature.ConditionalFormatting) || !isSampleManagerDistribution(moduleContext);
+    return (
+        isFeatureEnabled(ProductFeature.ConditionalFormatting, moduleContext) ||
+        !isSampleManagerDistribution(moduleContext)
+    );
 }
 
 export function isFeatureEnabled(flag: ProductFeature, moduleContext?: ModuleContext): boolean {
@@ -484,12 +488,42 @@ export function hasPremiumModule(moduleContext?: ModuleContext): boolean {
     return hasModule('Premium', moduleContext);
 }
 
-export function isCommunityDistribution(moduleContext?: ModuleContext): boolean {
-    return !hasModule('SampleManagement', moduleContext) && !hasPremiumModule(moduleContext);
+export function hasProfessionalModule(moduleContext?: ModuleContext): boolean {
+    return hasModule('Professional', moduleContext);
+}
+
+export function hasComplianceModule(moduleContext?: ModuleContext): boolean {
+    return hasModule('Compliance', moduleContext);
+}
+
+export function hasSampleManagementModule(moduleContext?: ModuleContext): boolean {
+    return hasModule('SampleManagement', moduleContext);
+}
+
+export function isEnterpriseDistribution(moduleContext?: ModuleContext): boolean {
+    return (
+        hasPremiumModule(moduleContext) && hasProfessionalModule(moduleContext) && hasComplianceModule(moduleContext)
+    );
+}
+
+export function isProfessionalDistribution(moduleContext?: ModuleContext): boolean {
+    return (
+        hasPremiumModule(moduleContext) && hasProfessionalModule(moduleContext) && !hasComplianceModule(moduleContext)
+    );
+}
+
+export function isStarterDistribution(moduleContext?: ModuleContext): boolean {
+    return (
+        hasPremiumModule(moduleContext) && !hasProfessionalModule(moduleContext) && !hasComplianceModule(moduleContext)
+    );
 }
 
 export function isSampleManagerDistribution(moduleContext?: ModuleContext): boolean {
-    return hasModule('SampleManagement', moduleContext) && !hasPremiumModule(moduleContext);
+    return hasSampleManagementModule(moduleContext) && !hasPremiumModule(moduleContext);
+}
+
+export function isCommunityDistribution(moduleContext?: ModuleContext): boolean {
+    return !hasSampleManagementModule(moduleContext) && !hasPremiumModule(moduleContext);
 }
 
 export function isRestrictedIssueListSupported(moduleContext?: ModuleContext): boolean {

--- a/packages/components/src/internal/components/domainproperties/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.test.ts
@@ -372,7 +372,7 @@ describe('domain properties actions', () => {
         expect(available.contains(TEXT_CHOICE_TYPE)).toBeTruthy();
         expect(available.contains(SAMPLE_TYPE)).toBeTruthy();
         expect(available.contains(PARTICIPANT_TYPE)).toBeTruthy();
-        expect(available.contains(CALCULATED_TYPE)).toBeTruthy();
+        expect(available.contains(CALCULATED_TYPE)).toBeFalsy();
     });
 
     test('getAvailableTypes, no optional allowed', () => {
@@ -462,6 +462,17 @@ describe('domain properties actions', () => {
 
     test('getAvailableTypes, sampleType Premium', () => {
         LABKEY.moduleContext.api = { moduleNames: ['premium'] };
+        const domain = DomainDesign.create({
+            domainKindName: Domain.KINDS.SAMPLE_TYPE,
+            allowCalculatedFields: true,
+        });
+        const available = getAvailableTypes(domain);
+        expect(available.contains(UNIQUE_ID_TYPE)).toBeTruthy();
+        expect(available.contains(CALCULATED_TYPE)).toBeFalsy();
+    });
+
+    test('getAvailableTypes, sampleType Professional', () => {
+        LABKEY.moduleContext.api = { moduleNames: ['premium', 'professional'] };
         const domain = DomainDesign.create({
             domainKindName: Domain.KINDS.SAMPLE_TYPE,
             allowCalculatedFields: true,


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52167
The calculated field UI should be enabled for the following distributions: LKSM Professional, LIMS, LKB, LKS Professional, and LKS Enterprise

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1721
- https://github.com/LabKey/platform/pull/6335
- https://github.com/LabKey/limsModules/pull/1173

#### Changes
- update isCalculatedFieldsEnabled()
- add isStarterDistribution(), isProfessionalDistribution(), and isEnterpriseDistribution()
