### PR TITLE
Issue 52304: Sample Manager: Edit Lineage in grid not saving updates if names contains comma

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.2-fb-issue52304.1",
+  "version": "6.26.2-fb-issue52304.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.2-fb-issue52304.1",
+      "version": "6.26.2-fb-issue52304.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.2-fb-issue52304.2",
+  "version": "6.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.2-fb-issue52304.2",
+      "version": "6.26.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.1",
+  "version": "6.26.2-fb-issue52304.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.1",
+      "version": "6.26.2-fb-issue52304.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0",
+  "version": "6.25.1-fb-issue52304.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.25.0",
+      "version": "6.25.1-fb-issue52304.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.0",
+  "version": "6.26.1-fb-issue52304.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.0",
+      "version": "6.26.1-fb-issue52304.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0",
+  "version": "6.25.1-fb-issue52304.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.2-fb-issue52304.2",
+  "version": "6.26.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.2-fb-issue52304.1",
+  "version": "6.26.2-fb-issue52304.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.24.X
+*Released*: X February 2025
+- Issue 52304: Sample Manager: Edit Lineage in grid not saving updates if names contains comma
+
 ### version 6.25.0
 *Released*: 19 February 2025
 - Add new `InternalSpacesWarning` component to warn when values contain multiple spaces between words

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.26.X
-*Released*: X February 2025
+### version 6.26.2
+*Released*: 25 February 2025
 - Issue 52304: Sample Manager: Edit Lineage in grid not saving updates if names contains comma
 
 ### version 6.26.1

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -771,7 +771,7 @@ describe('EditorModel', () => {
             const updatedRows = em.getUpdatedData();
             expect(updatedRows).toHaveLength(0);
         });
-        test('expInput value updated', () => {
+        describe('expInput value updated', () => {
             const materialInputs = QueryColumn.MATERIAL_INPUTS.toLowerCase();
             const expInputCol = new QueryColumn({
                 name: `${materialInputs}/input`,
@@ -782,9 +782,12 @@ describe('EditorModel', () => {
                 userEditable: true,
                 lookup: { queryName: 'lookupQuery', schemaName: 'lookupSchema' },
             });
-            const em = modifyEm({
+            const editorModel = modifyEm({
                 columnMap: basicEditorModel.columnMap.set(expInputCol.fieldKey.toLowerCase(), expInputCol),
-                orderedColumns: basicEditorModel.orderedColumns.push(expInputCol.fieldKey.toLowerCase()),
+                orderedColumns: basicEditorModel.orderedColumns.push(expInputCol.fieldKey.toLowerCase())
+            });
+
+            const emMultipleInputs = modifyEm({
                 cellValues: basicEditorModel.cellValues.set(
                     genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
                     List([
@@ -798,10 +801,128 @@ describe('EditorModel', () => {
                         },
                     ])
                 ),
+            }, editorModel);
+
+            const emSingleInputs = modifyEm({
+                cellValues: basicEditorModel.cellValues.set(
+                    genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
+                    List([
+                        {
+                            raw: 155,
+                            display: 'Value 123, Value 321',
+                        }
+                    ])
+                ),
+            }, editorModel);
+
+            const originalSingleValueWithComma = fromJS({
+                0: {
+                    [expInputCol.fieldKey]: {
+                        value: 155,
+                        displayValue: 'Value 123, Value 321'
+                    }
+                },
+                1: {
+                    [expInputCol.fieldKey]: null
+                }
             });
-            const updatedRows = em.getUpdatedData();
-            // ExpInput columns should be converted to comma separated string values
-            expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+
+            const originalMultiValues = fromJS({
+                0: {
+                    [expInputCol.fieldKey]: [{
+                        value: 123,
+                        displayValue: 'Value 123'
+                    }, {
+                        value: 321,
+                        displayValue: 'Value 321'
+                    }]
+                },
+                1: {
+                    [expInputCol.fieldKey]: null
+                }
+            });
+            test('no original value', () => {
+                let updatedRows = emSingleInputs.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
+
+                updatedRows = emMultipleInputs.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+
+            });
+
+            test("with original single value, new single value", () => {
+                let updatedRows = emSingleInputs.getUpdatedData(originalSingleValueWithComma);
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
+
+                const edWithOriginal = modifyEm({
+                    originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma)
+                }, emSingleInputs);
+                updatedRows = edWithOriginal.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
+
+                updatedRows = emSingleInputs.getUpdatedData(fromJS({
+                    0: {
+                        [expInputCol.fieldKey]: {
+                            value: 155,
+                            displayValue: 'Not Comma'
+                        }
+                    },
+                    1: {
+                        [expInputCol.fieldKey]: null
+                    }
+                }));
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
+            });
+
+            test("with original single value, multiple new values", () => {
+                let updatedRows = emMultipleInputs.getUpdatedData(originalSingleValueWithComma);
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+
+                const edWithOriginal = modifyEm({
+                    originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma)
+                }, emMultipleInputs);
+                updatedRows = edWithOriginal.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+            });
+
+            test("with original multi values, single new value", () => {
+                let updatedRows = emSingleInputs.getUpdatedData(originalMultiValues);
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
+
+                const edWithOriginal = modifyEm({
+                    originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues)
+                }, emSingleInputs);
+                updatedRows = edWithOriginal.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
+            });
+
+            test("with original multi values, multiple new value", () => {
+                let updatedRows = emMultipleInputs.getUpdatedData(originalMultiValues);
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
+
+                const edWithOriginal = modifyEm({
+                    originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues)
+                }, emMultipleInputs);
+                updatedRows = edWithOriginal.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
+
+                updatedRows = emMultipleInputs.getUpdatedData(fromJS({
+                    0: {
+                        [expInputCol.fieldKey]: [{
+                            value: 345,
+                            displayValue: 'Value 345'
+                        }, {
+                            value: 678,
+                            displayValue: 'Value 678'
+                        }]
+                    },
+                    1: {
+                        [expInputCol.fieldKey]: null
+                    }
+                }));
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+            });
+
         });
         test('altUpdateKeys', () => {
             const queryInfo = basicEditorModel.queryInfo.mutate({ altUpdateKeys: new Set([colTwoFk]) });

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -784,62 +784,71 @@ describe('EditorModel', () => {
             });
             const editorModel = modifyEm({
                 columnMap: basicEditorModel.columnMap.set(expInputCol.fieldKey.toLowerCase(), expInputCol),
-                orderedColumns: basicEditorModel.orderedColumns.push(expInputCol.fieldKey.toLowerCase())
+                orderedColumns: basicEditorModel.orderedColumns.push(expInputCol.fieldKey.toLowerCase()),
             });
 
-            const emMultipleInputs = modifyEm({
-                cellValues: basicEditorModel.cellValues.set(
-                    genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
-                    List([
-                        {
-                            raw: 123,
-                            display: 'Value 123',
-                        },
-                        {
-                            raw: 321,
-                            display: 'Value 321',
-                        },
-                    ])
-                ),
-            }, editorModel);
+            const emMultipleInputs = modifyEm(
+                {
+                    cellValues: basicEditorModel.cellValues.set(
+                        genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
+                        List([
+                            {
+                                raw: 123,
+                                display: 'Value 123',
+                            },
+                            {
+                                raw: 321,
+                                display: 'Value 321',
+                            },
+                        ])
+                    ),
+                },
+                editorModel
+            );
 
-            const emSingleInputs = modifyEm({
-                cellValues: basicEditorModel.cellValues.set(
-                    genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
-                    List([
-                        {
-                            raw: 155,
-                            display: 'Value 123, Value 321',
-                        }
-                    ])
-                ),
-            }, editorModel);
+            const emSingleInputs = modifyEm(
+                {
+                    cellValues: basicEditorModel.cellValues.set(
+                        genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
+                        List([
+                            {
+                                raw: 155,
+                                display: 'Value 123, Value 321',
+                            },
+                        ])
+                    ),
+                },
+                editorModel
+            );
 
             const originalSingleValueWithComma = fromJS({
                 0: {
                     [expInputCol.fieldKey]: {
                         value: 155,
-                        displayValue: 'Value 123, Value 321'
-                    }
+                        displayValue: 'Value 123, Value 321',
+                    },
                 },
                 1: {
-                    [expInputCol.fieldKey]: null
-                }
+                    [expInputCol.fieldKey]: null,
+                },
             });
 
             const originalMultiValues = fromJS({
                 0: {
-                    [expInputCol.fieldKey]: [{
-                        value: 123,
-                        displayValue: 'Value 123'
-                    }, {
-                        value: 321,
-                        displayValue: 'Value 321'
-                    }]
+                    [expInputCol.fieldKey]: [
+                        {
+                            value: 123,
+                            displayValue: 'Value 123',
+                        },
+                        {
+                            value: 321,
+                            displayValue: 'Value 321',
+                        },
+                    ],
                 },
                 1: {
-                    [expInputCol.fieldKey]: null
-                }
+                    [expInputCol.fieldKey]: null,
+                },
             });
             test('no original value', () => {
                 let updatedRows = emSingleInputs.getUpdatedData();
@@ -847,82 +856,99 @@ describe('EditorModel', () => {
 
                 updatedRows = emMultipleInputs.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
-
             });
 
-            test("with original single value, new single value", () => {
+            test('with original single value, new single value', () => {
                 let updatedRows = emSingleInputs.getUpdatedData(originalSingleValueWithComma);
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
 
-                const edWithOriginal = modifyEm({
-                    originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma)
-                }, emSingleInputs);
+                const edWithOriginal = modifyEm(
+                    {
+                        originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma),
+                    },
+                    emSingleInputs
+                );
                 updatedRows = edWithOriginal.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
 
-                updatedRows = emSingleInputs.getUpdatedData(fromJS({
-                    0: {
-                        [expInputCol.fieldKey]: {
-                            value: 155,
-                            displayValue: 'Not Comma'
-                        }
-                    },
-                    1: {
-                        [expInputCol.fieldKey]: null
-                    }
-                }));
+                updatedRows = emSingleInputs.getUpdatedData(
+                    fromJS({
+                        0: {
+                            [expInputCol.fieldKey]: {
+                                value: 155,
+                                displayValue: 'Not Comma',
+                            },
+                        },
+                        1: {
+                            [expInputCol.fieldKey]: null,
+                        },
+                    })
+                );
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
             });
 
-            test("with original single value, multiple new values", () => {
+            test('with original single value, multiple new values', () => {
                 let updatedRows = emMultipleInputs.getUpdatedData(originalSingleValueWithComma);
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
 
-                const edWithOriginal = modifyEm({
-                    originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma)
-                }, emMultipleInputs);
+                const edWithOriginal = modifyEm(
+                    {
+                        originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma),
+                    },
+                    emMultipleInputs
+                );
                 updatedRows = edWithOriginal.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
             });
 
-            test("with original multi values, single new value", () => {
+            test('with original multi values, single new value', () => {
                 let updatedRows = emSingleInputs.getUpdatedData(originalMultiValues);
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
 
-                const edWithOriginal = modifyEm({
-                    originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues)
-                }, emSingleInputs);
+                const edWithOriginal = modifyEm(
+                    {
+                        originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues),
+                    },
+                    emSingleInputs
+                );
                 updatedRows = edWithOriginal.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
             });
 
-            test("with original multi values, multiple new value", () => {
+            test('with original multi values, multiple new value', () => {
                 let updatedRows = emMultipleInputs.getUpdatedData(originalMultiValues);
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
 
-                const edWithOriginal = modifyEm({
-                    originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues)
-                }, emMultipleInputs);
+                const edWithOriginal = modifyEm(
+                    {
+                        originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues),
+                    },
+                    emMultipleInputs
+                );
                 updatedRows = edWithOriginal.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
 
-                updatedRows = emMultipleInputs.getUpdatedData(fromJS({
-                    0: {
-                        [expInputCol.fieldKey]: [{
-                            value: 345,
-                            displayValue: 'Value 345'
-                        }, {
-                            value: 678,
-                            displayValue: 'Value 678'
-                        }]
-                    },
-                    1: {
-                        [expInputCol.fieldKey]: null
-                    }
-                }));
+                updatedRows = emMultipleInputs.getUpdatedData(
+                    fromJS({
+                        0: {
+                            [expInputCol.fieldKey]: [
+                                {
+                                    value: 345,
+                                    displayValue: 'Value 345',
+                                },
+                                {
+                                    value: 678,
+                                    displayValue: 'Value 678',
+                                },
+                            ],
+                        },
+                        1: {
+                            [expInputCol.fieldKey]: null,
+                        },
+                    })
+                );
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
             });
-
         });
         test('altUpdateKeys', () => {
             const queryInfo = basicEditorModel.queryInfo.mutate({ altUpdateKeys: new Set([colTwoFk]) });

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -1034,6 +1034,29 @@ describe('EditorModel', () => {
                 );
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, "Value 123, Value 321"');
             });
+
+            test('with original multi values, multiple same values, but ordering is changed', () => {
+                let updatedRows = emMultipleComplexInputs.getUpdatedData(
+                    fromJS({
+                        0: {
+                            [expInputCol.fieldKey]: [
+                                {
+                                    value: 155,
+                                    displayValue: 'Value 123, Value 321',
+                                },
+                                {
+                                    value: 123,
+                                    displayValue: 'Value 123',
+                                }
+                            ],
+                        },
+                        1: {
+                            [expInputCol.fieldKey]: null,
+                        },
+                    })
+                );
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
+            });
         });
         test('altUpdateKeys', () => {
             const queryInfo = basicEditorModel.queryInfo.mutate({ altUpdateKeys: new Set([colTwoFk]) });

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -787,7 +787,7 @@ describe('EditorModel', () => {
                 orderedColumns: basicEditorModel.orderedColumns.push(expInputCol.fieldKey.toLowerCase()),
             });
 
-            const emMultipleInputs = modifyEm(
+            const emMultipleSimpleInputs = modifyEm(
                 {
                     cellValues: basicEditorModel.cellValues.set(
                         genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
@@ -799,6 +799,25 @@ describe('EditorModel', () => {
                             {
                                 raw: 321,
                                 display: 'Value 321',
+                            },
+                        ])
+                    ),
+                },
+                editorModel
+            );
+
+            const emMultipleComplexInputs = modifyEm(
+                {
+                    cellValues: basicEditorModel.cellValues.set(
+                        genCellKey(expInputCol.fieldKey.toLowerCase(), 0),
+                        List([
+                            {
+                                raw: 123,
+                                display: 'Value 123',
+                            },
+                            {
+                                raw: 155,
+                                display: 'Value 123, Value 321',
                             },
                         ])
                     ),
@@ -833,7 +852,25 @@ describe('EditorModel', () => {
                 },
             });
 
-            const originalMultiValues = fromJS({
+            const originalMultiComplexValues = fromJS({
+                0: {
+                    [expInputCol.fieldKey]: [
+                        {
+                            value: 123,
+                            displayValue: 'Value 123',
+                        },
+                        {
+                            value: 155,
+                            displayValue: 'Value 123, Value 321',
+                        },
+                    ],
+                },
+                1: {
+                    [expInputCol.fieldKey]: null,
+                },
+            });
+
+            const originalMultiSimpleValues = fromJS({
                 0: {
                     [expInputCol.fieldKey]: [
                         {
@@ -854,8 +891,11 @@ describe('EditorModel', () => {
                 let updatedRows = emSingleInputs.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
 
-                updatedRows = emMultipleInputs.getUpdatedData();
+                updatedRows = emMultipleSimpleInputs.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+
+                updatedRows = emMultipleComplexInputs.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, "Value 123, Value 321"');
             });
 
             test('with original single value, new single value', () => {
@@ -888,26 +928,38 @@ describe('EditorModel', () => {
             });
 
             test('with original single value, multiple new values', () => {
-                let updatedRows = emMultipleInputs.getUpdatedData(originalSingleValueWithComma);
+                let updatedRows = emMultipleSimpleInputs.getUpdatedData(originalSingleValueWithComma);
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
 
-                const edWithOriginal = modifyEm(
+                let edWithOriginal = modifyEm(
                     {
                         originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma),
                     },
-                    emMultipleInputs
+                    emMultipleSimpleInputs
                 );
                 updatedRows = edWithOriginal.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+
+                updatedRows = emMultipleComplexInputs.getUpdatedData(originalSingleValueWithComma);
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, "Value 123, Value 321"');
+
+                edWithOriginal = modifyEm(
+                    {
+                        originalData: EditorModel.convertQueryDataToEditorData(originalSingleValueWithComma),
+                    },
+                    emMultipleComplexInputs
+                );
+                updatedRows = edWithOriginal.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, "Value 123, Value 321"');
             });
 
             test('with original multi values, single new value', () => {
-                let updatedRows = emSingleInputs.getUpdatedData(originalMultiValues);
+                let updatedRows = emSingleInputs.getUpdatedData(originalMultiSimpleValues);
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('"Value 123, Value 321"');
 
                 const edWithOriginal = modifyEm(
                     {
-                        originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues),
+                        originalData: EditorModel.convertQueryDataToEditorData(originalMultiSimpleValues),
                     },
                     emSingleInputs
                 );
@@ -916,19 +968,31 @@ describe('EditorModel', () => {
             });
 
             test('with original multi values, multiple new value', () => {
-                let updatedRows = emMultipleInputs.getUpdatedData(originalMultiValues);
+                let updatedRows = emMultipleSimpleInputs.getUpdatedData(originalMultiSimpleValues);
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
 
-                const edWithOriginal = modifyEm(
+                let edWithOriginal = modifyEm(
                     {
-                        originalData: EditorModel.convertQueryDataToEditorData(originalMultiValues),
+                        originalData: EditorModel.convertQueryDataToEditorData(originalMultiSimpleValues),
                     },
-                    emMultipleInputs
+                    emMultipleSimpleInputs
                 );
                 updatedRows = edWithOriginal.getUpdatedData();
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
 
-                updatedRows = emMultipleInputs.getUpdatedData(
+                updatedRows = emMultipleComplexInputs.getUpdatedData(originalMultiComplexValues);
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
+
+                edWithOriginal = modifyEm(
+                    {
+                        originalData: EditorModel.convertQueryDataToEditorData(originalMultiComplexValues),
+                    },
+                    emMultipleComplexInputs
+                );
+                updatedRows = edWithOriginal.getUpdatedData();
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toBeUndefined();
+
+                updatedRows = emMultipleSimpleInputs.getUpdatedData(
                     fromJS({
                         0: {
                             [expInputCol.fieldKey]: [
@@ -948,6 +1012,27 @@ describe('EditorModel', () => {
                     })
                 );
                 expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, Value 321');
+
+                updatedRows = emMultipleComplexInputs.getUpdatedData(
+                    fromJS({
+                        0: {
+                            [expInputCol.fieldKey]: [
+                                {
+                                    value: 123,
+                                    displayValue: 'Value 123',
+                                },
+                                {
+                                    value: 321,
+                                    displayValue: 'Value 321',
+                                },
+                            ],
+                        },
+                        1: {
+                            [expInputCol.fieldKey]: null,
+                        },
+                    })
+                );
+                expect(updatedRows[0][expInputCol.fieldKey.toLowerCase()]).toEqual('Value 123, "Value 123, Value 321"');
             });
         });
         test('altUpdateKeys', () => {

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -826,6 +826,7 @@ export class EditorModel
                             // We have to compare displayValues for ExpInput columns for name expressions to work
                             // row values were processed with quoteValueWithDelimiters, originalValue should be compared using the same process
                             originalValue = originalValue
+                                .sortBy((v) => v.displayValue)
                                 .map(v =>
                                     isQuotedWithDelimiters(v.displayValue, ',')
                                         ? v.displayValue

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -825,7 +825,13 @@ export class EditorModel
                         if (col.isExpInput()) {
                             // We have to compare displayValues for ExpInput columns for name expressions to work
                             // row values were processed with quoteValueWithDelimiters, originalValue should be compared using the same process
-                            originalValue = originalValue.map(v => isQuotedWithDelimiters(v.displayValue, ',') ? v.displayValue : quoteValueWithDelimiters(v.displayValue, ',')).join(', ');
+                            originalValue = originalValue
+                                .map(v =>
+                                    isQuotedWithDelimiters(v.displayValue, ',')
+                                        ? v.displayValue
+                                        : quoteValueWithDelimiters(v.displayValue, ',')
+                                )
+                                .join(', ');
                         } else {
                             const valueObj = originalValue.get(0);
                             originalValue = Map.isMap(valueObj) ? valueObj.get('value') : valueObj.value;

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -824,7 +824,8 @@ export class EditorModel
                     if (List.isList(originalValue) && !Array.isArray(value)) {
                         if (col.isExpInput()) {
                             // We have to compare displayValues for ExpInput columns for name expressions to work
-                            originalValue = originalValue.map(v => v.displayValue).join(', ');
+                            // row values were processed with quoteValueWithDelimiters, originalValue should be compared using the same process
+                            originalValue = originalValue.map(v => isQuotedWithDelimiters(v.displayValue, ',') ? v.displayValue : quoteValueWithDelimiters(v.displayValue, ',')).join(', ');
                         } else {
                             const valueObj = originalValue.get(0);
                             originalValue = Map.isMap(valueObj) ? valueObj.get('value') : valueObj.value;


### PR DESCRIPTION
#### Rationale
Issue 52304: Sample Manager: Edit Lineage in grid not saving updates if names contains comma

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1722
- https://github.com/LabKey/labkey-ui-premium/pull/688
- https://github.com/LabKey/platform/pull/6351
- https://github.com/LabKey/limsModules/pull/1184

#### Changes
- use `quoteValueWithDelimiters` when comparing new vs existing parent inputs for editable grid update
