### PR TITLE
Issue 51877: Allow calculated fields for list title column

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0",
+  "version": "6.25.0-listTitleCol51877.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.25.0",
+      "version": "6.25.0-listTitleCol51877.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0-listTitleCol51877.0",
+  "version": "6.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.25.0-listTitleCol51877.0",
+      "version": "6.26.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0-listTitleCol51877.0",
+  "version": "6.26.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0",
+  "version": "6.25.0-listTitleCol51877.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51877: Allow calculated fields for list title column
+
 ### version 6.25.0
 *Released*: 19 February 2025
 - Add new `InternalSpacesWarning` component to warn when values contain multiple spaces between words

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.26.0
+*Released*: 21 February 2025
 - Issue 51877: Allow calculated fields for list title column
 
 ### version 6.25.0

--- a/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListDesignerPanels.tsx
@@ -78,7 +78,7 @@ export class ListDesignerPanelsImpl extends React.PureComponent<
 
         // Issue 40262: If we have a titleColumn selected and the name changes (not the row index), update the titleColumn
         let titleColumn = model.titleColumn;
-        if (titleColumn && !rowIndexChanges) {
+        if (domain && titleColumn && !rowIndexChanges) {
             const index = model.domain.findFieldIndexByName(titleColumn);
             titleColumn = index > -1 ? domain.fields.get(index).name : undefined;
         }

--- a/packages/components/src/internal/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/list/ListPropertiesAdvancedSettings.tsx
@@ -44,7 +44,7 @@ interface DisplayTitleProps {
 }
 
 export const DisplayTitle: FC<DisplayTitleProps> = memo(({ model, onSelectChange, titleColumn }) => {
-    const fields = model.domain.fields.filter(field => !field.isCalculatedField());
+    const fields = model.domain.fields; // Issue 51877: include all fields, including calculated fields for titleColumn options
     const disabled = fields.size === 0;
     const placeholder = disabled ? 'No fields have been defined yet' : 'Auto';
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51877
We were previously filtering out the calculated fields from the options for the title column property of a list. It was still possible to set a calculated field as the title column via the XML metadata and it worked as expected, so this PR makes that possible in the list designer UI as well.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1723
- https://github.com/LabKey/platform/pull/6352
- https://github.com/LabKey/premiumModules/pull/174

#### Changes
- remove filter for calculated fields from DisplayTitle component options
