### PR TITLE
Issue 52337: ensure that items being excluded from view customization are fields

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0",
+  "version": "6.25.1-customizeAncestors.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.25.0",
+      "version": "6.25.1-customizeAncestors.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.1-customizeAncestors.0",
+  "version": "6.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.25.1-customizeAncestors.0",
+      "version": "6.26.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.25.0",
+  "version": "6.25.1-customizeAncestors.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.1-customizeAncestors.0",
+  "version": "6.26.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 52337: ensure that items being excluded from view customization are fields, not ancestor nodes
+
 ### version 6.25.0
 *Released*: 19 February 2025
 - Add new `InternalSpacesWarning` component to warn when values contain multiple spaces between words

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.test.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.test.tsx
@@ -232,12 +232,18 @@ describe('includedColumnsForCustomizationFilter', () => {
         expect(includedColumnsForCustomizationFilter(col, false)).toBeFalsy();
         expect(includedColumnsForCustomizationFilter(col, true)).toBeFalsy();
 
+        const defaultModuleContext = { ...LABKEY.moduleContext };
         LABKEY.moduleContext = { api: { moduleNames: ['api', 'core', 'premium'] } };
         expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
         expect(includedColumnsForCustomizationFilter(col, true)).toBeTruthy();
+        LABKEY.moduleContext = defaultModuleContext;
     });
 
     test('ancestor nodes', () => {
+        // test this case without premium module in context
+        const defaultModuleContext = { ...LABKEY.moduleContext };
+        LABKEY.moduleContext = { api: { moduleNames: ['api', 'core'] } };
+
         let col = new QueryColumn({ name: 'testColumn', fieldKeyPath: 'Run/SampleID/Ancestors' });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeFalsy();
 
@@ -266,12 +272,40 @@ describe('includedColumnsForCustomizationFilter', () => {
             removeFromViewCustomization: true,
         });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
+        col = new QueryColumn({
+            name: 'Protocol',
+            fieldKeyPath: 'Ancestors/Samples/SampleType/Protocol',
+            removeFromViewCustomization: true,
+        });
+        expect(includedColumnsForCustomizationFilter(col, false)).toBeFalsy();
+        col = new QueryColumn({
+            name: 'Protocol',
+            fieldKeyPath: 'Protocol',
+            removeFromViewCustomization: true,
+        });
+        expect(includedColumnsForCustomizationFilter(col, false)).toBeFalsy();
 
+        // enable premium module to check again for removeFromViewCustomization case
+        LABKEY.moduleContext = { api: { moduleNames: ['api', 'core', 'premium'] } };
+        col = new QueryColumn({
+            name: 'Protocol',
+            fieldKeyPath: 'Ancestors/RegistryAndSources/Protocol',
+            removeFromViewCustomization: true,
+        });
+        expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
         col = new QueryColumn({
             name: 'Protocol',
             fieldKeyPath: 'Ancestors/Samples/SampleType/Protocol',
             removeFromViewCustomization: true,
         });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
+        col = new QueryColumn({
+            name: 'Protocol',
+            fieldKeyPath: 'Protocol',
+            removeFromViewCustomization: true,
+        });
+        expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
+
+        LABKEY.moduleContext = defaultModuleContext;
     });
 });

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.test.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.test.tsx
@@ -258,5 +258,20 @@ describe('includedColumnsForCustomizationFilter', () => {
 
         col = new QueryColumn({ name: 'testColumn', fieldKeyPath: 'Ancestors' });
         expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
+
+        // Issue 52337. removeFromViewCustomization is set via queryMetadata, but is meant to apply to fields only, not types
+        col = new QueryColumn({
+            name: 'Protocol',
+            fieldKeyPath: 'Ancestors/RegistryAndSources/Protocol',
+            removeFromViewCustomization: true,
+        });
+        expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
+
+        col = new QueryColumn({
+            name: 'Protocol',
+            fieldKeyPath: 'Ancestors/Samples/SampleType/Protocol',
+            removeFromViewCustomization: true,
+        });
+        expect(includedColumnsForCustomizationFilter(col, false)).toBeTruthy();
     });
 });

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -19,10 +19,13 @@ export const includedColumnsForCustomizationFilter = (column: QueryColumn, showA
     // don't allow multiple levels of ancestors since the ancestor value may not be a valid rowId to join through
     const isNestedAncestor =
         column.fieldKeyPath?.indexOf('Ancestors/') !== column.fieldKeyPath?.lastIndexOf('/Ancestors') + 1;
+    // Issue 52337: queryMetadata can mark certain fields as removed that might also happen to be ancestor types. We need to include
+    // the ancestorTypes, but apply the "removeFromViewCustomization" to fields.
+    const isField = !isAncestorChild || column.fieldKeyPath?.split('/').length === 4;
     return (
         (showAllColumns || !column.hidden) &&
         !column.removeFromViews &&
-        (showPremiumFeatures() || !column.removeFromViewCustomization) &&
+        (showPremiumFeatures() || !isField || !column.removeFromViewCustomization) &&
         !isRunSampleAncestor &&
         // Issue 46870: Don't allow selection/inclusion of multi-valued lookup fields from Ancestors
         (!isAncestorChild || (!isNestedAncestor && !column.isJunctionLookup()))


### PR DESCRIPTION
#### Rationale
Issue [52337](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52337) - We generally want to exclude the `protocol` column that is part of the sample type table as it is not useful in our applications. But we don't want to exclude that name (or other system default names) for purposes of grid customization when it is the name of a type. This PR adds logic to distinguish between a field name and an ancestor type name so we can exclude the former but include the latter.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1186
- https://github.com/LabKey/labkey-ui-premium/pull/689

#### Changes
- Update logic in `includedColumnsForCustomizationFilter`
