### PR TITLE
Bump version number to correct number

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.27.0",
+  "version": "6.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.27.0",
+      "version": "6.28.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.27.0",
+  "version": "6.28.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
#### Rationale
Somehow the commit to bump version number got dropped on my [previous PR](https://github.com/LabKey/labkey-ui-components/pull/1734).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1734

#### Changes
- Fix the version number for the ui-components package
