### PR TITLE
Issue 52477: Sample workflow custom fields: edit field inline from Job Overview page doesn't save lookup fields with special characters

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.5-fb-issue52477.1",
+  "version": "6.26.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.5-fb-issue52477.1",
+      "version": "6.26.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.4",
+  "version": "6.26.5-fb-issue52477.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.4",
+      "version": "6.26.5-fb-issue52477.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.4",
+  "version": "6.26.5-fb-issue52477.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.5-fb-issue52477.1",
+  "version": "6.26.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.26.X
-*Released*: X March 2025
+### version 6.26.5
+*Released*: 7 March 2025
 - Issue 52477: Sample workflow custom fields: edit field inline from Job Overview page doesn't save lookup fields with special characters
 
 ### version 6.26.4

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.26.X
+*Released*: X March 2025
+- Issue 52477: Sample workflow custom fields: edit field inline from Job Overview page doesn't save lookup fields with special characters
+
 ### version 6.26.4
 *Released*: 5 March 2025
 - Issue 51091: Product menu endpoints return objects

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -156,7 +156,7 @@ export const EditInlineField: FC<Props> = memo(props => {
 
     const onFormsyColumnChange = useCallback(
         (data: Record<string, any>) => {
-            setColumnBasedValue(data[column.fieldKey]);
+            setColumnBasedValue(data[column.fieldKey] ?? data[column.name]);
         },
         [column]
     );


### PR DESCRIPTION
#### Rationale
EditInlineField uses DetailDisplay.resolveDetailEditRenderer to render edit fields, which currently uses `col.name` as input name. The util in EditInlineField only checks for data values using fieldKey. When the fieldKey doesn't match the field name, the change is lost. EditableDetailPanel also uses DetailDisplay.resolveDetailEditRenderer, but it uses `extractChanges` util, which checks both column's fieldKey and name. For this PR, a more localized solution limited to EditInlineField is added to check value using both `fieldKey` and `name`. The related [PR](https://github.com/LabKey/labkey-ui-components/pull/1740) that's targeting develop will make the change in DetailDisplay.resolveDetailEditRenderer to use fieldKey as input name. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1741
- https://github.com/LabKey/labkey-ui-premium/pull/699
- https://github.com/LabKey/limsModules/pull/1223

- https://github.com/LabKey/labkey-ui-components/pull/1740

#### Changes
- Update EditInlineField is added to check value using both `fieldKey` and `name`
- Defer DetailDisplay.resolveDetailEditRenderer update to develop
