### PR TITLE
LabelPrintingContextProvider: default canPrintLabels to false in tests

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.8",
+  "version": "6.31.9-fb-label-provider-jest.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.8",
+      "version": "6.31.9-fb-label-provider-jest.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.9-fb-label-provider-jest.0",
+  "version": "6.31.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.9-fb-label-provider-jest.0",
+      "version": "6.31.9",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.9-fb-label-provider-jest.0",
+  "version": "6.31.9",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.8",
+  "version": "6.31.9-fb-label-provider-jest.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.31.9
+*Release*: 18 March 2025
+- Expose `enabled` as a public property on `LabelPrintingContextProps`. Default test environment context to `false`.
+- Support initialization of `enabled` in `LabelPrintingContextProvider`.
+- Default `canPrintLabels` to `false`
+
 ### version 6.31.8
 *Release*: 18 March 2025
 - Issue 52264: Include `viewName` when building query parameters for QueryController selectX actions

--- a/packages/components/src/internal/components/domainproperties/DataTypeFoldersPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeFoldersPanel.tsx
@@ -169,7 +169,6 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                     {!relatedFolderConfigurableDataType && (
                         <div className="col-xs-12 bottom-padding">
                             <DataTypeSelector
-                                api={api}
                                 entityDataType={entityDataType}
                                 allDataCounts={allDataCounts}
                                 allDataTypes={childFolders}
@@ -188,7 +187,6 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                         <>
                             <div className="col-xs-6 bottom-padding">
                                 <DataTypeSelector
-                                    api={api}
                                     entityDataType={entityDataType}
                                     allDataCounts={allDataCounts}
                                     allDataTypes={childFolders}
@@ -202,7 +200,6 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                             </div>
                             <div className="col-xs-6 bottom-padding">
                                 <DataTypeSelector
-                                    api={api}
                                     dataTypePrefix="Dashboard"
                                     entityDataType={entityDataType}
                                     allDataTypes={allContainers}

--- a/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/DateTimeFieldOptions.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { act } from '@testing-library/react';
-
 import { userEvent } from '@testing-library/user-event';
 
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 
 import { isValidAltDateTimeFormatOptions } from '../../util/Date';
+
+import { AppContextTestProviderProps } from '../../test/testHelpers';
 
 import { createFormInputId } from './utils';
 import { DOMAIN_FIELD_FORMAT, DOMAIN_FIELD_NOT_LOCKED } from './constants';
@@ -21,22 +21,16 @@ const DEFAULT_PROP = {
     type: 'dateTime',
 };
 
-const APP_CONTEXT = {
-    container: {
-        formats: {
-            dateFormat: 'yyyy-MM-dd',
-            dateTimeFormat: 'yyyy-MM-dd HH:mm',
-            timeFormat: 'HH:mm',
-        },
-    },
-};
-
-const APP_CONTEXT_INVALID = {
-    container: {
-        formats: {
-            dateFormat: 'yyyy-MM-DD',
-            dateTimeFormat: 'yyyy MM dd HH:mm aa',
-            timeFormat: 'hh:mm aa',
+const CONTEXT: AppContextTestProviderProps = {
+    serverContext: {
+        // @ts-expect-error partial container properties
+        container: {
+            formats: {
+                dateFormat: 'yyyy-MM-dd',
+                dateTimeFormat: 'yyyy-MM-dd HH:mm',
+                numberFormat: undefined,
+                timeFormat: 'HH:mm',
+            },
         },
     },
 };
@@ -48,15 +42,19 @@ function verifyInputs(
     time: string = 'HH:mm',
     dateInvalid?: boolean,
     timeInvalid?: boolean
-) {
-    expect(document.querySelector('.domain-field-section-heading').textContent).toBe(DEFAULT_PROP.label);
+): void {
+    expect(document.querySelector('.domain-field-section-heading')).toHaveTextContent(DEFAULT_PROP.label);
     const inheritCheckboxId = createFormInputId(
         DOMAIN_FIELD_FORMAT + '_inherit' + type,
         DEFAULT_PROP.domainIndex,
         DEFAULT_PROP.index
     );
     const checkbox = document.getElementById(inheritCheckboxId);
-    expect(checkbox.hasAttribute('checked')).toEqual(inherit);
+    if (inherit) {
+        expect(checkbox).toBeChecked();
+    } else {
+        expect(checkbox).not.toBeChecked();
+    }
 
     const selectInputs = document.querySelectorAll('.select-input__control');
     expect(selectInputs.length).toEqual(type === 'dateTime' ? 2 : 1);
@@ -80,187 +78,96 @@ function verifyInputs(
 }
 
 describe('DateTimeFieldOptions', () => {
-    test('DateTime type, no format', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            type: 'dateTime',
-        };
+    function clickCheckbox(): Promise<void> {
+        return userEvent.click(document.querySelector('input[type="checkbox"]'));
+    }
 
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+    test('DateTime type, no format', async () => {
+        renderWithAppContext(<DateTimeFieldOptions {...DEFAULT_PROP} format={undefined} type="dateTime" />, CONTEXT);
 
         verifyInputs('dateTime', true);
 
-        const checkbox = document.querySelector('input[type="checkbox"]');
-        await act(() => userEvent.click(checkbox));
+        await clickCheckbox();
         expect(DEFAULT_PROP.onChange).toHaveBeenCalledTimes(1);
     });
 
-    test('DateTime type, with valid format', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'yyyy-MMM-dd hh:mm a',
-            type: 'dateTime',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+    test('DateTime type, with valid format', () => {
+        renderWithAppContext(
+            <DateTimeFieldOptions {...DEFAULT_PROP} format="yyyy-MMM-dd hh:mm a" type="dateTime" />,
+            CONTEXT
+        );
 
         verifyInputs('dateTime', false, 'yyyy-MMM-dd', 'hh:mm a', false, false);
     });
 
     test('DateTime type, with invalid date format', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'yyyy/MM/dd hh:mm a',
-            type: 'dateTime',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+        renderWithAppContext(
+            <DateTimeFieldOptions {...DEFAULT_PROP} format="yyyy/MM/dd hh:mm a" type="dateTime" />,
+            CONTEXT
+        );
 
         verifyInputs('dateTime', false, 'yyyy/MM/dd hh:mm a', '', true, false);
 
         // toggle to inherit, should get rid of warning
-        const checkbox = document.querySelector('input[type="checkbox"]');
-        await act(() => userEvent.click(checkbox));
+        await clickCheckbox();
         expect(DEFAULT_PROP.onChange).toHaveBeenCalledTimes(2);
         expect(document.querySelectorAll('.fa-exclamation-circle')).toHaveLength(0);
     });
 
     test('DateTime type, with invalid time format', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'yyyy-MMM-dd hh:mm aa',
-            type: 'dateTime',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+        renderWithAppContext(
+            <DateTimeFieldOptions {...DEFAULT_PROP} format="yyyy-MMM-dd hh:mm aa" type="dateTime" />,
+            CONTEXT
+        );
 
         verifyInputs('dateTime', false, 'yyyy-MMM-dd hh:mm aa', '', true, false);
 
         // toggle to inherit, should get rid of warning
-        const checkbox = document.querySelector('input[type="checkbox"]');
-        await act(() => userEvent.click(checkbox));
+        await clickCheckbox();
         expect(DEFAULT_PROP.onChange).toHaveBeenCalledTimes(3);
         expect(document.querySelectorAll('.fa-exclamation-circle')).toHaveLength(0);
     });
 
-    test('DateTime type, with valid date and empty time', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'yyyy-MMM-dd',
-            type: 'dateTime',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+    test('DateTime type, with valid date and empty time', () => {
+        renderWithAppContext(<DateTimeFieldOptions {...DEFAULT_PROP} format="yyyy-MMM-dd" type="dateTime" />, CONTEXT);
 
         verifyInputs('dateTime', false, 'yyyy-MMM-dd', '');
     });
 
-    test('Date type, with override', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'ddMMMyyyy',
-            type: 'date',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+    test('Date type, with override', () => {
+        renderWithAppContext(<DateTimeFieldOptions {...DEFAULT_PROP} format="ddMMMyyyy" type="date" />, CONTEXT);
 
         verifyInputs('date', false, 'ddMMMyyyy', null, false, false);
     });
 
     test('Date type, with invalid override', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'ddMMM-yyyy',
-            type: 'date',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+        renderWithAppContext(<DateTimeFieldOptions {...DEFAULT_PROP} format="ddMMM-yyyy" type="date" />, CONTEXT);
 
         verifyInputs('date', false, 'ddMMM-yyyy', null, true, false);
         // toggle to inherit, should get rid of warning
-        const checkbox = document.querySelector('input[type="checkbox"]');
-        await act(() => userEvent.click(checkbox));
+        await clickCheckbox();
         expect(DEFAULT_PROP.onChange).toHaveBeenCalledTimes(4);
         expect(document.querySelectorAll('.fa-exclamation-circle')).toHaveLength(0);
     });
 
-    test('Date type, with alternative format override', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'dateTime',
-            type: 'date',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+    test('Date type, with alternative format override', () => {
+        renderWithAppContext(<DateTimeFieldOptions {...DEFAULT_PROP} format="dateTime" type="date" />, CONTEXT);
 
         verifyInputs('date', false, 'dateTime', null, false, false);
     });
 
     test('Time type, with invalid override', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: 'kk:mm',
-            type: 'time',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+        renderWithAppContext(<DateTimeFieldOptions {...DEFAULT_PROP} format="kk:mm" type="time" />, CONTEXT);
 
         verifyInputs('time', false, null, 'kk:mm', false, true);
         // toggle to inherit, should get rid of warning
-        const checkbox = document.querySelector('input[type="checkbox"]');
-        await act(() => userEvent.click(checkbox));
+        await clickCheckbox();
         expect(DEFAULT_PROP.onChange).toHaveBeenCalledTimes(5);
         expect(document.querySelectorAll('.fa-exclamation-circle')).toHaveLength(0);
     });
 
-    test('Time type, with empty time', async () => {
-        const props = {
-            ...DEFAULT_PROP,
-            format: '',
-            type: 'time',
-        };
-
-        await act(async () => {
-            renderWithAppContext(<DateTimeFieldOptions {...props} />, {
-                appContext: APP_CONTEXT,
-            });
-        });
+    test('Time type, with empty time', () => {
+        renderWithAppContext(<DateTimeFieldOptions {...DEFAULT_PROP} format="" type="time" />, CONTEXT);
 
         verifyInputs('time', true, null, 'HH:mm');
     });

--- a/packages/components/src/internal/components/entities/DataTypeSelector.test.tsx
+++ b/packages/components/src/internal/components/entities/DataTypeSelector.test.tsx
@@ -1,11 +1,13 @@
-import React, { act } from 'react';
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { getTestAPIWrapper } from '../../APIWrapper';
 import { getQueryTestAPIWrapper } from '../../query/APIWrapper';
 
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
+
+import { AppContextTestProviderProps } from '../../test/testHelpers';
 
 import { AssayRunDataType, DataClassDataType, SampleTypeDataType } from './constants';
 import {
@@ -88,23 +90,23 @@ describe('getUncheckedEntityWarning', () => {
 
 describe('filterDataTypeHiddenEntity', () => {
     test('no hiddenEntities', () => {
-        expect(filterDataTypeHiddenEntity({ rowId: 1 }, undefined)).toBe(true);
-        expect(filterDataTypeHiddenEntity({ rowId: 1 }, [])).toBe(true);
+        expect(filterDataTypeHiddenEntity({ rowId: 1 } as DataTypeEntity, undefined)).toBe(true);
+        expect(filterDataTypeHiddenEntity({ rowId: 1 } as DataTypeEntity, [])).toBe(true);
     });
 
     test('hiddenEntities', () => {
-        expect(filterDataTypeHiddenEntity({ rowId: 1 }, [1])).toBe(false);
-        expect(filterDataTypeHiddenEntity({ rowId: 1 }, [2])).toBe(true);
-        expect(filterDataTypeHiddenEntity({ rowId: 1 }, [2, 3])).toBe(true);
-        expect(filterDataTypeHiddenEntity({ rowId: 1 }, [1, 2])).toBe(false);
+        expect(filterDataTypeHiddenEntity({ rowId: 1 } as DataTypeEntity, [1])).toBe(false);
+        expect(filterDataTypeHiddenEntity({ rowId: 1 } as DataTypeEntity, [2])).toBe(true);
+        expect(filterDataTypeHiddenEntity({ rowId: 1 } as DataTypeEntity, [2, 3])).toBe(true);
+        expect(filterDataTypeHiddenEntity({ rowId: 1 } as DataTypeEntity, [1, 2])).toBe(false);
     });
 
     test('by lsid', () => {
-        expect(filterDataTypeHiddenEntity({ lsid: 'test1' }, [1])).toBe(true);
-        expect(filterDataTypeHiddenEntity({ lsid: 'test1' }, ['test'])).toBe(true);
-        expect(filterDataTypeHiddenEntity({ lsid: 'test1' }, ['test1'])).toBe(false);
-        expect(filterDataTypeHiddenEntity({ lsid: 'test1' }, ['test1', 'test2'])).toBe(false);
-        expect(filterDataTypeHiddenEntity({ lsid: 'test1' }, ['test0', 'test2'])).toBe(true);
+        expect(filterDataTypeHiddenEntity({ lsid: 'test1' } as DataTypeEntity, [1])).toBe(true);
+        expect(filterDataTypeHiddenEntity({ lsid: 'test1' } as DataTypeEntity, ['test'])).toBe(true);
+        expect(filterDataTypeHiddenEntity({ lsid: 'test1' } as DataTypeEntity, ['test1'])).toBe(false);
+        expect(filterDataTypeHiddenEntity({ lsid: 'test1' } as DataTypeEntity, ['test1', 'test2'])).toBe(false);
+        expect(filterDataTypeHiddenEntity({ lsid: 'test1' } as DataTypeEntity, ['test0', 'test2'])).toBe(true);
     });
 });
 
@@ -161,97 +163,105 @@ describe('DataTypeSelector', () => {
         }),
     });
 
+    function defaultContext(api = apiWithNoResults): AppContextTestProviderProps {
+        return {
+            appContext: { api },
+        };
+    }
+
     function defaultProps(): DataTypeSelectorProps {
         return {
-            api: apiWithNoResults,
             entityDataType: SampleTypeDataType,
             uncheckedEntitiesDB: [],
             updateUncheckedTypes: jest.fn(),
         };
     }
 
-    test('data types blank', async () => {
-        await act(async () => {
-            renderWithAppContext(<DataTypeSelector {...defaultProps()} />);
+    function waitForLoaded(): Promise<void> {
+        return waitFor(() => {
+            expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
         });
-        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-        expect(document.querySelector('.content-group-label').textContent).toBe('Sample Types');
-        expect(document.querySelector('.help-block').textContent).toBe('No sample types');
+    }
+
+    test('data types blank', async () => {
+        renderWithAppContext(<DataTypeSelector {...defaultProps()} />, defaultContext());
+
+        await waitForLoaded();
+        expect(document.querySelector('.content-group-label')).toHaveTextContent('Sample Types');
+        expect(document.querySelector('.help-block')).toHaveTextContent('No sample types');
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(0);
     });
 
     test('with data types', async () => {
-        await act(async () => {
-            renderWithAppContext(<DataTypeSelector {...defaultProps()} api={apiWithResults} />);
-        });
+        renderWithAppContext(<DataTypeSelector {...defaultProps()} />, defaultContext(apiWithResults));
+
+        await waitForLoaded();
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[0].textContent).toBe('Blood');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[0].getAttribute('checked')).toBe('');
-        expect(document.querySelectorAll('.folder-faceted-data-type')[1].textContent).toBe('DNA');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[1].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[0]).toHaveTextContent('Blood');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[0]).toBeChecked();
+        expect(document.querySelectorAll('.folder-faceted-data-type')[1]).toHaveTextContent('DNA');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[1]).toBeChecked();
         expect(document.querySelectorAll('.col-xs-12')).toHaveLength(2); // outer col + 1 inner col
         expect(document.querySelectorAll('.col-md-6')).toHaveLength(0);
-
-        const archivedSectionHeader = document.querySelectorAll('.container-expandable');
-        expect(archivedSectionHeader.length).toBe(0);
+        expect(document.querySelector('.container-expandable')).not.toBeInTheDocument();
     });
 
     test('with inactive data types', async () => {
-        await act(async () => {
-            renderWithAppContext(<DataTypeSelector {...defaultProps()} api={apiWithInactiveResults} />);
-        });
+        renderWithAppContext(<DataTypeSelector {...defaultProps()} />, defaultContext(apiWithInactiveResults));
+
+        await waitForLoaded();
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[0].textContent).toBe('Blood');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[0].getAttribute('checked')).toBe('');
-        expect(document.querySelectorAll('.folder-faceted-data-type')[1].textContent).toBe('DNA');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[1].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[0]).toHaveTextContent('Blood');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[0]).toBeChecked();
+        expect(document.querySelectorAll('.folder-faceted-data-type')[1]).toHaveTextContent('DNA');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[1]).toBeChecked();
         expect(document.querySelectorAll('.col-xs-12')).toHaveLength(2); // outer col + 1 inner col
         expect(document.querySelectorAll('.col-md-6')).toHaveLength(0);
 
-        const archivedSectionHeader = document.querySelectorAll('.container-expandable');
-        expect(archivedSectionHeader.length).toBe(1);
+        expect(document.querySelector('.container-expandable')).toBeInTheDocument();
         await userEvent.click(document.querySelector('.container-expandable__inactive'));
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(3);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[2].textContent).toBe('PBMC');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[2].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[2]).toHaveTextContent('PBMC');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[2]).toBeChecked();
         await userEvent.click(document.querySelector('.container-expandable-child__inactive'));
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
     });
 
     test('with only inactive data types', async () => {
-        await act(async () => {
-            renderWithAppContext(<DataTypeSelector {...defaultProps()} api={apiWithOnlyInactiveResults} />);
-        });
-        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-        expect(document.querySelector('.content-group-label').textContent).toBe('Sample Types');
-        expect(document.querySelector('.help-block').textContent).toBe('No sample types');
+        renderWithAppContext(<DataTypeSelector {...defaultProps()} />, defaultContext(apiWithOnlyInactiveResults));
+
+        await waitForLoaded();
+        expect(document.querySelector('.content-group-label')).toHaveTextContent('Sample Types');
+        expect(document.querySelector('.help-block')).toHaveTextContent('No sample types');
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(0);
 
-        const archivedSectionHeader = document.querySelectorAll('.container-expandable');
-        expect(archivedSectionHeader.length).toBe(1);
+        expect(document.querySelector('.container-expandable')).toBeInTheDocument();
         await userEvent.click(document.querySelector('.container-expandable__inactive'));
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(1);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[0].textContent).toBe('PBMC');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[0].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[0]).toHaveTextContent('PBMC');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[0]).toBeChecked();
     });
 
     test('with 2 columns', async () => {
-        await act(async () => {
-            renderWithAppContext(<DataTypeSelector {...defaultProps()} api={apiWithResults} columns={2} />);
-        });
+        renderWithAppContext(<DataTypeSelector {...defaultProps()} columns={2} />, defaultContext(apiWithResults));
+
+        await waitForLoaded();
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[0].textContent).toBe('Blood');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[0].getAttribute('checked')).toBe('');
-        expect(document.querySelectorAll('.folder-faceted-data-type')[1].textContent).toBe('DNA');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[1].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[0]).toHaveTextContent('Blood');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[0]).toBeChecked();
+        expect(document.querySelectorAll('.folder-faceted-data-type')[1]).toHaveTextContent('DNA');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[1]).toBeChecked();
         expect(document.querySelectorAll('.col-xs-12')).toHaveLength(3); // outer col + 2 inner col
         expect(document.querySelectorAll('.col-md-6')).toHaveLength(2);
     });
 
     test('with 2 columns and with inactive data types', async () => {
-        await act(async () => {
-            renderWithAppContext(<DataTypeSelector {...defaultProps()} api={apiWithInactiveResults} columns={2} />);
-        });
+        renderWithAppContext(
+            <DataTypeSelector {...defaultProps()} columns={2} />,
+            defaultContext(apiWithInactiveResults)
+        );
+
+        await waitForLoaded();
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
         expect(document.querySelectorAll('.col-xs-12')).toHaveLength(3); // outer col + 2 inner col
         expect(document.querySelectorAll('.col-md-6')).toHaveLength(2);
@@ -260,33 +270,37 @@ describe('DataTypeSelector', () => {
         expect(archivedSectionHeader.length).toBe(1);
         await userEvent.click(document.querySelector('.container-expandable__inactive'));
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(3);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[2].textContent).toBe('PBMC');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[2]).toHaveTextContent('PBMC');
     });
 
     test('toggleSelectAll = false', async () => {
-        await act(async () => {
-            renderWithAppContext(<DataTypeSelector {...defaultProps()} api={apiWithResults} toggleSelectAll={false} />);
-        });
+        renderWithAppContext(
+            <DataTypeSelector {...defaultProps()} toggleSelectAll={false} />,
+            defaultContext(apiWithResults)
+        );
+
+        await waitForLoaded();
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[0].textContent).toBe('Blood');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[0].getAttribute('checked')).toBe('');
-        expect(document.querySelectorAll('.folder-faceted-data-type')[1].textContent).toBe('DNA');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[1].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[0]).toHaveTextContent('Blood');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[0]).toBeChecked();
+        expect(document.querySelectorAll('.folder-faceted-data-type')[1]).toHaveTextContent('DNA');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[1]).toBeChecked();
         expect(document.querySelectorAll('.col-xs-12')).toHaveLength(1);
         expect(document.querySelectorAll('.col-md-6')).toHaveLength(0);
     });
 
     test('with uncheckedEntitiesDB', async () => {
-        await act(async () => {
-            renderWithAppContext(
-                <DataTypeSelector {...defaultProps()} api={apiWithResults} uncheckedEntitiesDB={[56]} />
-            );
-        });
+        renderWithAppContext(
+            <DataTypeSelector {...defaultProps()} uncheckedEntitiesDB={[56]} />,
+            defaultContext(apiWithResults)
+        );
+
+        await waitForLoaded();
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[0].textContent).toBe('Blood');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[0].getAttribute('checked')).toBe(null);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[1].textContent).toBe('DNA');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[1].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[0]).toHaveTextContent('Blood');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[0]).not.toBeChecked();
+        expect(document.querySelectorAll('.folder-faceted-data-type')[1]).toHaveTextContent('DNA');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[1]).toBeChecked();
         expect(document.querySelectorAll('.col-xs-12')).toHaveLength(2);
         expect(document.querySelectorAll('.col-md-6')).toHaveLength(0);
     });
@@ -313,21 +327,22 @@ describe('DataTypeSelector', () => {
             '12047': 0,
         };
 
-        await act(async () => {
-            renderWithAppContext(
-                <DataTypeSelector
-                    {...defaultProps()}
-                    allDataTypes={allDataTypes}
-                    allDataCounts={allDataCounts}
-                    dataTypeLabel="storage"
-                />
-            );
-        });
+        renderWithAppContext(
+            <DataTypeSelector
+                {...defaultProps()}
+                allDataTypes={allDataTypes}
+                allDataCounts={allDataCounts}
+                dataTypeLabel="storage"
+            />,
+            defaultContext()
+        );
+
+        await waitForLoaded();
         expect(document.querySelectorAll('.folder-faceted-data-type')).toHaveLength(2);
-        expect(document.querySelectorAll('.folder-faceted-data-type')[0].textContent).toBe('freezer1Floor1/Room2');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[0].getAttribute('checked')).toBe('');
-        expect(document.querySelectorAll('.folder-faceted-data-type')[1].textContent).toBe('freezer2');
-        expect(document.querySelectorAll('.filter-faceted__checkbox')[1].getAttribute('checked')).toBe('');
+        expect(document.querySelectorAll('.folder-faceted-data-type')[0]).toHaveTextContent('freezer1Floor1/Room2');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[0]).toBeChecked();
+        expect(document.querySelectorAll('.folder-faceted-data-type')[1]).toHaveTextContent('freezer2');
+        expect(document.querySelectorAll('.filter-faceted__checkbox')[1]).toBeChecked();
         expect(document.querySelectorAll('.col-xs-12')).toHaveLength(2);
         expect(document.querySelectorAll('.col-md-6')).toHaveLength(0);
     });

--- a/packages/components/src/internal/components/entities/DataTypeSelector.tsx
+++ b/packages/components/src/internal/components/entities/DataTypeSelector.tsx
@@ -4,13 +4,13 @@ import { Alert } from '../base/Alert';
 import { resolveErrorMessage } from '../../util/messaging';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-
 import { ColorIcon } from '../base/ColorIcon';
 
 import { Container } from '../base/models/Container';
 
 import { ExpandableContainer } from '../ExpandableContainer';
+
+import { useAppContext } from '../../AppContext';
 
 import { DataTypeEntity, EntityDataType, FolderConfigurableDataType } from './models';
 
@@ -21,7 +21,6 @@ export const filterDataTypeHiddenEntity = (dataType: DataTypeEntity, hiddenEntit
 export interface DataTypeSelectorProps {
     allDataCounts?: Record<string, number>;
     allDataTypes?: DataTypeEntity[]; // either use allDataTypes to pass in dataTypes, or specify entityDataType to query dataTypes
-    api?: ComponentsAPIWrapper;
     columns?: number; // partition list to N columns
     container?: Container;
     dataTypeKey?: string;
@@ -176,7 +175,6 @@ DataTypeSelectorList.displayName = 'DataTypeSelectorList';
 
 export const DataTypeSelector: FC<DataTypeSelectorProps> = memo(props => {
     const {
-        api = getDefaultAPIWrapper(),
         toggleSelectAll = true,
         disabled,
         entityDataType,
@@ -198,12 +196,12 @@ export const DataTypeSelector: FC<DataTypeSelectorProps> = memo(props => {
     const [dataTypes, setDataTypes] = useState<DataTypeEntity[]>();
     const [activeDataTypes, setActiveDataTypes] = useState<DataTypeEntity[]>([]);
     const [inactiveDataTypes, setInactiveDataTypes] = useState<DataTypeEntity[]>([]);
-
     const [dataType, setDataType] = useState<FolderConfigurableDataType>();
     const [error, setError] = useState<string>();
     const [loading, setLoading] = useState<boolean>(false);
     const [dataCounts, setDataCounts] = useState<Record<string, number>>();
     const [uncheckedEntities, setUncheckedEntities] = useState<any[] /* number[] | string[]*/>();
+    const { api } = useAppContext();
 
     const loadDataTypes = useCallback(async () => {
         try {

--- a/packages/components/src/internal/components/labelPrinting/LabelPrintingContextProvider.tsx
+++ b/packages/components/src/internal/components/labelPrinting/LabelPrintingContextProvider.tsx
@@ -17,7 +17,7 @@ export interface LabelPrintingContext {
     printServiceUrl: string;
 }
 
-export type LabelPrintingContextProps = Omit<LabelPrintingContext, 'canPrintLabels' | 'error'>;
+export type LabelPrintingContextProps = Omit<LabelPrintingContext, 'error'>;
 
 interface LabelPrintingContextProviderProps extends PropsWithChildren {
     initialContext?: LabelPrintingContextProps;
@@ -34,13 +34,13 @@ export const LabelPrintingContextProvider: FC<LabelPrintingContextProviderProps>
     const { moduleContext, user } = useServerContext();
     const { api } = useAppContext();
     const [labelContext, setLabelContext] = useState<LabelPrintingContext>(() => ({
-        canPrintLabels: userCanPrintLabels(user),
+        canPrintLabels: initialContext?.canPrintLabels ?? userCanPrintLabels(user),
         defaultLabel: initialContext?.defaultLabel,
         printServiceUrl: initialContext?.printServiceUrl,
     }));
 
     useEffect(() => {
-        if (!userCanPrintLabels(user) || !isSampleManagerEnabled(moduleContext)) return;
+        if (!labelContext.canPrintLabels || !userCanPrintLabels(user) || !isSampleManagerEnabled(moduleContext)) return;
 
         (async () => {
             try {
@@ -65,6 +65,7 @@ export const LabelPrintingContextProvider: FC<LabelPrintingContextProviderProps>
                 });
             }
         })();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- do not add labelContext or any of its properties
     }, [api, moduleContext, user]);
 
     return <Context.Provider value={labelContext}>{children}</Context.Provider>;

--- a/packages/components/src/internal/components/labelPrinting/LabelPrintingContextProvider.tsx
+++ b/packages/components/src/internal/components/labelPrinting/LabelPrintingContextProvider.tsx
@@ -34,13 +34,13 @@ export const LabelPrintingContextProvider: FC<LabelPrintingContextProviderProps>
     const { moduleContext, user } = useServerContext();
     const { api } = useAppContext();
     const [labelContext, setLabelContext] = useState<LabelPrintingContext>(() => ({
-        canPrintLabels: initialContext?.canPrintLabels ?? userCanPrintLabels(user),
+        canPrintLabels: initialContext?.canPrintLabels ?? false,
         defaultLabel: initialContext?.defaultLabel,
         printServiceUrl: initialContext?.printServiceUrl,
     }));
 
     useEffect(() => {
-        if (!labelContext.canPrintLabels || !userCanPrintLabels(user) || !isSampleManagerEnabled(moduleContext)) return;
+        if (!userCanPrintLabels(user) || !isSampleManagerEnabled(moduleContext)) return;
 
         (async () => {
             try {

--- a/packages/components/src/internal/components/labelPrinting/LabelPrintingContextProvider.tsx
+++ b/packages/components/src/internal/components/labelPrinting/LabelPrintingContextProvider.tsx
@@ -13,6 +13,7 @@ import { userCanPrintLabels } from './utils';
 export interface LabelPrintingContext {
     canPrintLabels: boolean;
     defaultLabel: number;
+    enabled: boolean;
     error?: string;
     printServiceUrl: string;
 }
@@ -36,11 +37,13 @@ export const LabelPrintingContextProvider: FC<LabelPrintingContextProviderProps>
     const [labelContext, setLabelContext] = useState<LabelPrintingContext>(() => ({
         canPrintLabels: initialContext?.canPrintLabels ?? false,
         defaultLabel: initialContext?.defaultLabel,
+        enabled: initialContext?.enabled ?? true,
         printServiceUrl: initialContext?.printServiceUrl,
     }));
+    const { enabled } = labelContext;
 
     useEffect(() => {
-        if (!userCanPrintLabels(user) || !isSampleManagerEnabled(moduleContext)) return;
+        if (!enabled || !userCanPrintLabels(user) || !isSampleManagerEnabled(moduleContext)) return;
 
         (async () => {
             try {
@@ -49,24 +52,26 @@ export const LabelPrintingContextProvider: FC<LabelPrintingContextProviderProps>
                     api.labelprinting.ensureLabelTemplatesList(user),
                 ]);
 
-                setLabelContext({
+                setLabelContext(context => ({
+                    ...context,
                     canPrintLabels: !!btConfiguration.serviceURL && templates?.length > 0,
                     defaultLabel: btConfiguration.defaultLabel,
                     printServiceUrl: btConfiguration.serviceURL,
-                });
+                }));
             } catch (e) {
-                setLabelContext({
+                setLabelContext(context => ({
+                    ...context,
                     canPrintLabels: false,
                     defaultLabel: undefined,
                     error: `Failed to initialize label printing context: "${
                         resolveErrorMessage(e) ?? 'Unknown error'
                     }"`,
                     printServiceUrl: undefined,
-                });
+                }));
             }
         })();
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- do not add labelContext or any of its properties
-    }, [api, moduleContext, user]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- do not add labelContext
+    }, [api, enabled, moduleContext, user]);
 
     return <Context.Provider value={labelContext}>{children}</Context.Provider>;
 });

--- a/packages/components/src/internal/components/navigation/ProductMenu.test.tsx
+++ b/packages/components/src/internal/components/navigation/ProductMenu.test.tsx
@@ -1,9 +1,8 @@
-import React, { act, createRef } from 'react';
+import React, { createRef } from 'react';
+import { waitFor } from '@testing-library/react';
 import { List, Map } from 'immutable';
 
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
-
-import { AppContext } from '../../AppContext';
 
 import { getTestAPIWrapper } from '../../APIWrapper';
 import { TEST_ARCHIVED_FOLDER_CONTAINER, TEST_FOLDER_CONTAINER, TEST_PROJECT_CONTAINER } from '../../containerFixtures';
@@ -16,7 +15,9 @@ import { TEST_LKS_STARTER_MODULE_CONTEXT } from '../../productFixtures';
 
 import { Container } from '../base/models/Container';
 
-import { getNavigationTestAPIWrapper, NavigationAPIWrapper } from './NavigationAPIWrapper';
+import { AppContextTestProviderProps } from '../../test/testHelpers';
+
+import { getNavigationTestAPIWrapper } from './NavigationAPIWrapper';
 
 import { FolderMenuItem } from './FolderMenu';
 
@@ -35,7 +36,7 @@ import { HOME_PATH, HOME_TITLE } from './constants';
 function getDefaultServerContext(): Partial<ServerContext> {
     return {
         container: TEST_PROJECT_CONTAINER,
-        moduleContext: { ...TEST_LKS_STARTER_MODULE_CONTEXT },
+        moduleContext: TEST_LKS_STARTER_MODULE_CONTEXT,
     };
 }
 
@@ -145,18 +146,7 @@ sectionConfigs = sectionConfigs.push(twoSectionConfig);
 const HOME_PROJECT = new Container({ id: '12345', path: HOME_PATH, title: 'home' });
 
 describe('ProductMenuButton', () => {
-    function getDefaultAppContext(overrides?: Partial<SecurityAPIWrapper>): Partial<AppContext> {
-        return {
-            api: getTestAPIWrapper(jest.fn, {
-                security: getSecurityTestAPIWrapper(jest.fn, {
-                    fetchContainers: jest.fn().mockResolvedValue([TEST_PROJECT_CONTAINER, TEST_FOLDER_CONTAINER]),
-                    ...overrides,
-                }),
-            }),
-        };
-    }
-
-    function getDefaultProps(): ProductMenuButtonProps {
+    function defaultProps(): ProductMenuButtonProps {
         return {
             appProperties: SAMPLE_MANAGER_APP_PROPERTIES,
             sectionConfigs,
@@ -164,132 +154,122 @@ describe('ProductMenuButton', () => {
         };
     }
 
-    test('default props', async () => {
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenuButton {...getDefaultProps()} />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        expect(document.querySelectorAll('.product-menu-button')).toHaveLength(1);
-        expect(document.querySelector('.product-menu-button').getAttribute('aria-expanded')).toBe("false");
-        expect(document.querySelectorAll('div.title')).toHaveLength(1);
-        expect(document.querySelectorAll('.product-menu-content')).toHaveLength(0);
-        expect(document.querySelectorAll('.with-col-folders')).toHaveLength(0);
-
-    });
-
-    test('ProductMenuButtonTitle without items', async () => {
-        const location = { pathname: '/admin' };
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenuButtonTitle container={TEST_FOLDER_CONTAINER} folderItems={[]} location={location as any} />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        expect(document.querySelector('div.title').textContent).toBe('Menu');
-        expect(document.querySelector('.subtitle').textContent).toBe('Administration');
-    });
-
-    test('ProductMenuButtonTitle with items', async () => {
-        const location = { pathname: '/items' };
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenuButtonTitle
-                    container={TEST_FOLDER_CONTAINER}
-                    folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
-                    location={location as any}
-                />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        expect(document.querySelector('div.title').textContent).toBe(TEST_FOLDER_CONTAINER.title);
-        expect(document.querySelector('.subtitle').textContent).toBe('Storage');
-    });
-
-    test('ProductMenuButtonTitle without routes', async () => {
-        const location = { pathname: '/' };
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenuButtonTitle
-                    container={TEST_FOLDER_CONTAINER}
-                    folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
-                    location={location as any}
-                />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        expect(document.querySelector('div.title').textContent).toBe(TEST_FOLDER_CONTAINER.title);
-        expect(document.querySelector('.subtitle').textContent).toBe('Dashboard');
-
-    });
-
-    test('ProductMenuButtonTitle home', async () => {
-        const location = { pathname: '/' };
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenuButtonTitle
-                    container={HOME_PROJECT}
-                    folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
-                    location={location as any}
-                />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        expect(document.querySelector('div.title').textContent).toBe(HOME_TITLE);
-        expect(document.querySelector('.subtitle').textContent).toBe('Dashboard');
-    });
-
-    test('ProductMenuButtonTitle archived', async () => {
-        const location = { pathname: '/' };
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenuButtonTitle
-                    container={TEST_ARCHIVED_FOLDER_CONTAINER}
-                    folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
-                    location={location as any}
-                />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        expect(document.querySelector('div.title').textContent).toBe(TEST_ARCHIVED_FOLDER_CONTAINER.title + "Archived");
-        expect(document.querySelector('.subtitle').textContent).toBe('Dashboard');
-        expect(document.querySelectorAll('.product-menu_archived-tag')).toHaveLength(1);
-    });
-
-});
-
-describe('ProductMenu', () => {
-    function getDefaultAppContext(overrides?: Partial<NavigationAPIWrapper>): Partial<AppContext> {
+    function defaultContext(overrides?: Partial<SecurityAPIWrapper>): AppContextTestProviderProps {
         return {
-            api: getTestAPIWrapper(jest.fn, {
-                navigation: getNavigationTestAPIWrapper(jest.fn, {
-                    initMenuModel: jest.fn().mockResolvedValue(model),
-                    ...overrides,
+            appContext: {
+                api: getTestAPIWrapper(jest.fn, {
+                    security: getSecurityTestAPIWrapper(jest.fn, {
+                        fetchContainers: jest.fn().mockResolvedValue([TEST_PROJECT_CONTAINER, TEST_FOLDER_CONTAINER]),
+                        ...overrides,
+                    }),
                 }),
-            }),
+            },
+            serverContext: getDefaultServerContext(),
         };
     }
 
-    function getDefaultProps(): ProductMenuProps {
+    test('default props', async () => {
+        renderWithAppContext(<ProductMenuButton {...defaultProps()} />, defaultContext());
+
+        await waitFor(() => {
+            expect(document.querySelectorAll('.product-menu-button')).toHaveLength(1);
+        });
+        expect(document.querySelector('.product-menu-button').getAttribute('aria-expanded')).toBe('false');
+        expect(document.querySelectorAll('div.title')).toHaveLength(1);
+        expect(document.querySelectorAll('.product-menu-content')).toHaveLength(0);
+        expect(document.querySelectorAll('.with-col-folders')).toHaveLength(0);
+    });
+
+    test('ProductMenuButtonTitle without items', () => {
+        const location = { pathname: '/admin' };
+        renderWithAppContext(
+            <ProductMenuButtonTitle container={TEST_FOLDER_CONTAINER} folderItems={[]} location={location as any} />,
+            defaultContext()
+        );
+
+        expect(document.querySelector('div.title')).toHaveTextContent('Menu');
+        expect(document.querySelector('.subtitle')).toHaveTextContent('Administration');
+    });
+
+    test('ProductMenuButtonTitle with items', () => {
+        const location = { pathname: '/items' };
+        renderWithAppContext(
+            <ProductMenuButtonTitle
+                container={TEST_FOLDER_CONTAINER}
+                folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
+                location={location as any}
+            />,
+            defaultContext()
+        );
+
+        expect(document.querySelector('div.title')).toHaveTextContent(TEST_FOLDER_CONTAINER.title);
+        expect(document.querySelector('.subtitle')).toHaveTextContent('Storage');
+    });
+
+    test('ProductMenuButtonTitle without routes', () => {
+        const location = { pathname: '/' };
+        renderWithAppContext(
+            <ProductMenuButtonTitle
+                container={TEST_FOLDER_CONTAINER}
+                folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
+                location={location as any}
+            />,
+            defaultContext()
+        );
+
+        expect(document.querySelector('div.title')).toHaveTextContent(TEST_FOLDER_CONTAINER.title);
+        expect(document.querySelector('.subtitle')).toHaveTextContent('Dashboard');
+    });
+
+    test('ProductMenuButtonTitle home', () => {
+        const location = { pathname: '/' };
+        renderWithAppContext(
+            <ProductMenuButtonTitle
+                container={HOME_PROJECT}
+                folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
+                location={location as any}
+            />,
+            defaultContext()
+        );
+
+        expect(document.querySelector('div.title')).toHaveTextContent(HOME_TITLE);
+        expect(document.querySelector('.subtitle')).toHaveTextContent('Dashboard');
+    });
+
+    test('ProductMenuButtonTitle archived', () => {
+        const location = { pathname: '/' };
+        renderWithAppContext(
+            <ProductMenuButtonTitle
+                container={TEST_ARCHIVED_FOLDER_CONTAINER}
+                folderItems={[{} as FolderMenuItem, {} as FolderMenuItem]}
+                location={location as any}
+            />,
+            defaultContext()
+        );
+
+        expect(document.querySelector('div.title')).toHaveTextContent(
+            TEST_ARCHIVED_FOLDER_CONTAINER.title + 'Archived'
+        );
+        expect(document.querySelector('.subtitle')).toHaveTextContent('Dashboard');
+        expect(document.querySelectorAll('.product-menu_archived-tag')).toHaveLength(1);
+    });
+});
+
+describe('ProductMenu', () => {
+    function defaultContext(): AppContextTestProviderProps {
+        return {
+            appContext: {
+                api: getTestAPIWrapper(jest.fn, {
+                    navigation: getNavigationTestAPIWrapper(jest.fn, {
+                        initMenuModel: jest.fn().mockResolvedValue(model),
+                    }),
+                }),
+            },
+            serverContext: getDefaultServerContext(),
+        };
+    }
+
+    function defaultProps(): ProductMenuProps {
         return {
             appProperties: SAMPLE_MANAGER_APP_PROPERTIES,
             error: undefined,
@@ -301,8 +281,10 @@ describe('ProductMenu', () => {
         };
     }
 
-    function validate(hasError = false, showFolderMenu = true, contentSections = 2): void {
-        expect(document.querySelectorAll('.product-menu-content')).toHaveLength(1);
+    async function validate(hasError = false, showFolderMenu = true, contentSections = 2): Promise<void> {
+        await waitFor(() => {
+            expect(document.querySelectorAll('.product-menu-content')).toHaveLength(1);
+        });
         expect(document.querySelectorAll('.navbar-connector')).toHaveLength(1);
         expect(document.querySelectorAll('.alert')).toHaveLength(hasError ? 1 : 0);
         expect(document.querySelectorAll('.menu-section.col-folders')).toHaveLength(showFolderMenu ? 1 : 0);
@@ -313,44 +295,19 @@ describe('ProductMenu', () => {
     }
 
     test('default props', async () => {
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenu {...getDefaultProps()} />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        validate();
+        renderWithAppContext(<ProductMenu {...defaultProps()} />, defaultContext());
+        await validate();
     });
 
     test('error', async () => {
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenu {...getDefaultProps()} error="Test Error" />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        validate(true);
+        renderWithAppContext(<ProductMenu {...defaultProps()} error="Test Error" />, defaultContext());
+        await validate(true);
     });
 
     test('showFolderMenu false', async () => {
-        await act(async () => {
-            renderWithAppContext(
-                <ProductMenu {...getDefaultProps()} showFolderMenu={false} />,
-                {
-                    appContext: getDefaultAppContext(),
-                    serverContext: getDefaultServerContext()
-                }
-            );
-        });
-        validate(false, false);
+        renderWithAppContext(<ProductMenu {...defaultProps()} showFolderMenu={false} />, defaultContext());
+        await validate(false, false);
     });
-
 });
 
 describe('createFolderItem', () => {

--- a/packages/components/src/internal/test/testHelpers.tsx
+++ b/packages/components/src/internal/test/testHelpers.tsx
@@ -32,7 +32,7 @@ export const AppContextTestProvider: FC<AppContextTestProviderProps> = props => 
     const { appContext, children, serverContext = {}, notificationContext, printLabelsContext } = props;
     const initialAppContext = useMemo(() => ({ api: getTestAPIWrapper(), ...appContext }), [appContext]);
     const initialPrintLabelsContext = useMemo(
-        () => ({ canPrintLabels: false, ...printLabelsContext }),
+        () => ({ canPrintLabels: false, ...printLabelsContext }) as LabelPrintingContextProps,
         [printLabelsContext]
     );
 
@@ -41,9 +41,7 @@ export const AppContextTestProvider: FC<AppContextTestProviderProps> = props => 
             <AppContextProvider initialContext={initialAppContext}>
                 <GlobalStateContextProvider>
                     <NotificationsContextProvider initialContext={notificationContext as NotificationsContextState}>
-                        <LabelPrintingContextProvider
-                            initialContext={initialPrintLabelsContext as LabelPrintingContextProps}
-                        >
+                        <LabelPrintingContextProvider initialContext={initialPrintLabelsContext}>
                             {children}
                         </LabelPrintingContextProvider>
                     </NotificationsContextProvider>
@@ -52,6 +50,7 @@ export const AppContextTestProvider: FC<AppContextTestProviderProps> = props => 
         </ServerContextProvider>
     );
 };
+AppContextTestProvider.displayName = 'AppContextTestProvider';
 
 /**
  * Instantiates a QueryInfo from a captured query details response payload. Cannot be used until you've called

--- a/packages/components/src/internal/test/testHelpers.tsx
+++ b/packages/components/src/internal/test/testHelpers.tsx
@@ -31,13 +31,19 @@ export interface AppContextTestProviderProps<A = AppContext> extends PropsWithCh
 export const AppContextTestProvider: FC<AppContextTestProviderProps> = props => {
     const { appContext, children, serverContext = {}, notificationContext, printLabelsContext } = props;
     const initialAppContext = useMemo(() => ({ api: getTestAPIWrapper(), ...appContext }), [appContext]);
+    const initialPrintLabelsContext = useMemo(
+        () => ({ canPrintLabels: false, ...printLabelsContext }),
+        [printLabelsContext]
+    );
 
     return (
         <ServerContextProvider initialContext={serverContext as ServerContext}>
             <AppContextProvider initialContext={initialAppContext}>
                 <GlobalStateContextProvider>
                     <NotificationsContextProvider initialContext={notificationContext as NotificationsContextState}>
-                        <LabelPrintingContextProvider initialContext={printLabelsContext as LabelPrintingContextProps}>
+                        <LabelPrintingContextProvider
+                            initialContext={initialPrintLabelsContext as LabelPrintingContextProps}
+                        >
                             {children}
                         </LabelPrintingContextProvider>
                     </NotificationsContextProvider>

--- a/packages/components/src/internal/test/testHelpers.tsx
+++ b/packages/components/src/internal/test/testHelpers.tsx
@@ -32,7 +32,7 @@ export const AppContextTestProvider: FC<AppContextTestProviderProps> = props => 
     const { appContext, children, serverContext = {}, notificationContext, printLabelsContext } = props;
     const initialAppContext = useMemo(() => ({ api: getTestAPIWrapper(), ...appContext }), [appContext]);
     const initialPrintLabelsContext = useMemo(
-        () => ({ canPrintLabels: false, ...printLabelsContext }) as LabelPrintingContextProps,
+        () => ({ enabled: false, ...printLabelsContext }) as LabelPrintingContextProps,
         [printLabelsContext]
     );
 

--- a/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.spec.tsx
@@ -23,7 +23,9 @@ import { QueryModel } from './QueryModel';
 
 import { RowsResponse } from './QueryModelLoader';
 
-const rrd = require('react-router-dom') as any;
+// @ts-expect-error Need to use require() for mocking
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rrd = require('react-router-dom');
 
 /**
  * Note: All of the tests in this file look a tad weird. We create a component that resets local variables on render


### PR DESCRIPTION
#### Rationale
Update the test wrapper furnishing `LabelPrintingContextProvider` to default to `canPrintLabels=false` to avoid superfluous label printing configuration in tests.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1745
- https://github.com/LabKey/labkey-ui-premium/pull/706
- https://github.com/LabKey/limsModules/pull/1235

#### Changes
- Expose `canPrintLabels` as a public property on `LabelPrintingContextProps`
- Support initialization of `canPrintLabels` in `LabelPrintingContextProvider`
