### PR TITLE
Issue 51982: QueryModel useSavedSettings requires containerPath to be set

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.6",
+  "version": "6.31.6-useSavedSettings51982.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.6",
+      "version": "6.31.6-useSavedSettings51982.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.10-useSavedSettings51982.0",
+  "version": "6.31.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.10-useSavedSettings51982.0",
+      "version": "6.31.11",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.8",
+  "version": "6.31.8-useSavedSettings51982.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.8",
+      "version": "6.31.8-useSavedSettings51982.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.10",
+  "version": "6.31.10-useSavedSettings51982.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.10",
+      "version": "6.31.10-useSavedSettings51982.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.8",
+  "version": "6.31.8-useSavedSettings51982.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.6",
+  "version": "6.31.6-useSavedSettings51982.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.10",
+  "version": "6.31.10-useSavedSettings51982.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.10-useSavedSettings51982.0",
+  "version": "6.31.11",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.31.11
+*Release*: 19 March 2025
 - Issue 51982: QueryModel useSavedSettings requires containerPath to be set
   - to prevent inadvertent cross-folder saved settings from being applied
   - applySavedSettings in withQueryModels for both the initModels case and the addModel case

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Issue 51982: QueryModel useSavedSettings requires containerPath to be set
   - to prevent inadvertent cross-folder saved settings from being applied
   - applySavedSettings in withQueryModels for both the initModels case and the addModel case
+- Issue 52509: TemplateDownloadButton fix to pass openInTab = true
+- Issue 52147: Customize View modal fix to get out of column title edit mode to allow for column reorder
 
 ### version 6.31.8
 *Release*: 18 March 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 51982: QueryModel useSavedSettings requires containerPath to be set
+  - to prevent inadvertent cross-folder saved settings from being applied
+  - applySavedSettings in withQueryModels for both the initModels case and the addModel case
+
 ### version 6.31.6
 *Released*: 13 March 2025
 - Issue 52430: Sample Manager: sample names with newline characters

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -279,9 +279,7 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
     const _onUpdateTitle = useCallback(
         (col: QueryColumn, title: string) => {
             setEditing(false);
-            if (col && title) {
-                onUpdateTitle(col, title);
-            }
+            onUpdateTitle(col, title);
         },
         [onUpdateTitle]
     );
@@ -482,14 +480,16 @@ export const ColumnSelectionModal: FC<ColumnSelectionModalProps> = memo(props =>
 
     const onUpdateTitle = useCallback(
         (updatedColumn: QueryColumn, caption: string) => {
-            const relabeledColumn = updatedColumn.mutate({ caption });
-            const index = selectedColumns.findIndex(column => column.index === updatedColumn.index);
-            setSelectedColumns([
-                ...selectedColumns.slice(0, index),
-                relabeledColumn,
-                ...selectedColumns.slice(index + 1),
-            ]);
-            setIsDirty(true);
+            if (updatedColumn && caption) {
+                const relabeledColumn = updatedColumn.mutate({ caption });
+                const index = selectedColumns.findIndex(column => column.index === updatedColumn.index);
+                setSelectedColumns([
+                    ...selectedColumns.slice(0, index),
+                    relabeledColumn,
+                    ...selectedColumns.slice(index + 1),
+                ]);
+                setIsDirty(true);
+            }
             setEditingColumnTitle(false);
         },
         [selectedColumns]

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -1267,6 +1267,14 @@ export function saveSettingsToLocalStorage(model: QueryModel): void {
         console.error(UNIQUE_ERROR);
         return;
     }
+
+    // Issue 51982: if we don't have a containerPath on the model, we won't save settings because it can lead to
+    // settings being "applied" inadvertently cross-containers.
+    if (!model.containerPath) {
+        console.error('A model.containerPath is required to save settings to local storage: ' + model.id);
+        return;
+    }
+
     const settings = {
         filterArray: model.filterArray.map(f => ({
             columnName: f.getColumnName(),

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -243,6 +243,24 @@ const paramsEqual = (oldParams, newParams): boolean => {
     return false;
 };
 
+function applySavedSettings(id: string, model: QueryModel): QueryModel {
+    const settings = getSettingsFromLocalStorage(id, model.containerPath);
+    if (settings !== undefined) {
+        const { filterArray, maxRows, sorts, viewName } = settings;
+        let schemaQuery = model.schemaQuery;
+        if (viewName !== undefined) {
+            schemaQuery = new SchemaQuery(model.schemaName, model.queryName, viewName);
+        }
+        return model.mutate({
+            filterArray,
+            maxRows,
+            schemaQuery,
+            sorts,
+        });
+    }
+    return model;
+}
+
 /**
  * A wrapper for LabKey selectRows API. For in-depth documentation and examples see components/docs/QueryModel.md.
  * @param ComponentToWrap A component that implements generic Props and InjectedQueryModels.
@@ -265,19 +283,10 @@ export function withQueryModels<Props>(
             if (model.bindURL && hasQueryParamSettings) {
                 model = model.mutate(model.attributesForURLQueryParams(searchParams, true));
             } else if (model.useSavedSettings) {
-                const settings = getSettingsFromLocalStorage(id, model.containerPath);
-                if (settings !== undefined) {
-                    const { filterArray, maxRows, sorts, viewName } = settings;
-                    let schemaQuery = model.schemaQuery;
-                    if (viewName !== undefined) {
-                        schemaQuery = new SchemaQuery(model.schemaName, model.queryName, viewName);
-                    }
-                    model = model.mutate({
-                        filterArray,
-                        maxRows,
-                        schemaQuery,
-                        sorts,
-                    });
+                if (!model.containerPath) {
+                    console.error('A model.containerPath is required when useSavedSettings is true: ' + model.id);
+                } else {
+                    model = applySavedSettings(model.id, model);
                 }
             }
 
@@ -1039,9 +1048,14 @@ export function withQueryModels<Props>(
                     // QueryModel constructor if not set.
                     let queryModel = new QueryModel(queryConfig);
                     id = queryModel.id;
-                    if (queryModel.bindURL && searchParams) {
+
+                    const hasQueryParamSettings = locationHasQueryParamSettings(queryModel.urlPrefix, searchParams);
+                    if (queryModel.bindURL && hasQueryParamSettings) {
                         queryModel = queryModel.mutate(queryModel.attributesForURLQueryParams(searchParams));
+                    } else if (queryModel.useSavedSettings && queryModel.containerPath) {
+                        queryModel = applySavedSettings(id, queryModel);
                     }
+
                     draft.queryModels[queryModel.id] = queryModel;
                 }),
                 () => this.maybeLoad(id, load, load, loadSelections)

--- a/packages/components/src/public/files/TemplateDownloadButton.tsx
+++ b/packages/components/src/public/files/TemplateDownloadButton.tsx
@@ -78,7 +78,7 @@ const TemplateDownloadButtonImpl: FC<Props> = memo(props => {
         if (onDownloadDefault) {
             await onDownloadDefault();
         } else {
-            await downloadAttachment(defaultTemplateUrl);
+            await downloadAttachment(defaultTemplateUrl, true);
         }
         setDownloading(false);
     }, [defaultTemplateUrl, isDownloadingOrLoading, onDownloadDefault]);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51982

The useSavedSettings for the app queryModel uses the model.containerPath when stashing the settings in local storage. However, many of our usages did not pass containerPath which means that the same model name could inadvertently apply those settings to another project/container context.

Note: also includes the small fix for Issue [52509](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52509): "Leave Site" Popup Appears When Downloading Assay Import Template

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1748
- https://github.com/LabKey/labkey-ui-premium/pull/710
- https://github.com/LabKey/limsModules/pull/1243

#### Changes
- queryConfig updates to set containerPath when useSavedSettings
- applySavedSettings in withQueryModels for both the initModels case and the addModel case
