### PR TITLE
Issue 52535: Don't match lineage columns to raw column captions

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.6-ancestorInputsAndAliases.0",
+  "version": "6.26.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.6-ancestorInputsAndAliases.0",
+      "version": "6.26.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.5",
+  "version": "6.26.6-ancestorInputsAndAliases.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.5",
+      "version": "6.26.6-ancestorInputsAndAliases.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.5",
+  "version": "6.26.6-ancestorInputsAndAliases.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.6-ancestorInputsAndAliases.0",
+  "version": "6.26.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.26.X
+*Released*: TBD
+- Issue 52535: Don't match lineage columns to raw column captions
+
 ### version 6.26.5
 *Released*: 7 March 2025
 - Issue 52477: Sample workflow custom fields: edit field inline from Job Overview page doesn't save lookup fields with special characters

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.26.X
-*Released*: TBD
+### version 6.26.6
+*Released*: 18 March 2025
 - Issue 52535: Don't match lineage columns to raw column captions
 
 ### version 6.26.5

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -271,6 +271,7 @@ export class QueryColumn implements IQueryColumn {
         }
     }
 
+    static ANCESTORS_PREFIX = 'Ancestors';
     static DATA_INPUTS = 'DataInputs';
     static MATERIAL_INPUTS = 'MaterialInputs';
     static ALIQUOTED_FROM = 'AliquotedFrom';
@@ -323,6 +324,14 @@ export class QueryColumn implements IQueryColumn {
 
     isExpInput(checkLookup = true): boolean {
         return this.isDataInput(checkLookup) || this.isMaterialInput(checkLookup);
+    }
+
+    isAncestorInput(checkLookup = true): boolean {
+        return (
+            this.name &&
+            this.name.toLowerCase().indexOf(QueryColumn.ANCESTORS_PREFIX.toLowerCase() + '/') === 0 &&
+            (!checkLookup || this.isLookup())
+        );
     }
 
     isDataInput(checkLookup = true): boolean {
@@ -431,9 +440,10 @@ export class QueryColumn implements IQueryColumn {
         if (!importName) return false;
 
         const lcName = importName.toLowerCase().trim();
+        const isLineageLookup = this.isAncestorInput() || this.isExpInput();
         return (
-            this.caption?.toLowerCase() === lcName ||
-            this.caption?.replaceAll(' ', '').toLowerCase() === lcName || // Issue 52193: allow for "SampleID" when caption is "Sample ID", but don't match for simply fewer spaces
+            (!isLineageLookup && this.caption?.toLowerCase() === lcName) ||
+            (!isLineageLookup && this.caption?.replaceAll(' ', '').toLowerCase() === lcName) || // Issue 52193: allow for "SampleID" when caption is "Sample ID", but don't match for simply fewer spaces
             this.name?.toLowerCase() === lcName ||
             this.fieldKey?.toLowerCase() === lcName
         );

--- a/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
+++ b/packages/components/src/public/QueryModel/CustomizeGridViewModal.tsx
@@ -39,7 +39,7 @@ export const getExpandQueryInfo = async (queryInfo: QueryInfo, column: QueryColu
         schemaQuery: queryInfo.schemaQuery,
     });
     // For data classes, we want to limit the Ancestor filters to exclude 'Samples'
-    if (column.index === 'Ancestors' && queryInfo.schemaQuery.schemaName === SCHEMAS.DATA_CLASSES.SCHEMA) {
+    if (column.index === QueryColumn.ANCESTORS_PREFIX && queryInfo.schemaQuery.schemaName === SCHEMAS.DATA_CLASSES.SCHEMA) {
         fkQueryInfo.columns = fkQueryInfo.columns.filter(
             col => col.fieldKey !== 'Samples' && col.fieldKey !== 'MediaSamples'
         );


### PR DESCRIPTION
#### Rationale
Issue [52535](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52535): When supplying lineage data during an import, the column headers must either be an import alias or include the "DataInputs" or "MaterialInputs" prefix. Using the name of the parent type by itself is not sufficient and we need to assure we properly warn about this during file import.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1247

#### Changes
- Update `QueryColumn.isIdentifiedByImportName` to not match lineage columns on raw caption. 
