### PR TITLE
Editable Grid Issues

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.12",
+  "version": "6.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.12",
+      "version": "6.32.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.12",
+  "version": "6.32.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,6 +27,7 @@
     "prepublishOnly": "npm install --legacy-peer-deps && cross-env WEBPACK_STATS=errors-only npm run build",
     "test": "cross-env NODE_ENV=test jest --maxWorkers=6",
     "test-ci": "cross-env NODE_ENV=test jest --ci",
+    "test-to-file": "cross-env NODE_ENV=test jest -i --no-color 2>jest-log.txt",
     "lint": "eslint",
     "lint-fix": "eslint --fix",
     "lint-precommit": "node lint.diff.mjs",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.??.?
+*Released*: ?? March 2025
+- Issue 52253: Editable grid drag and fill removes internal zeros
+
 ### version 6.31.12
 *Released*: 21 March 2025
 - Issue 52477: Sample workflow custom fields: edit field inline with special characters

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.??.?
-*Released*: ?? March 2025
+### version 6.32.0
+*Released*: 24 March 2025
 - Add `test-to-file` script
 - `Cell`: ignore readOnly state when handling certain events
 - Update `dragFillEvent` to detect and apply padding during drag fill

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,10 +3,16 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 6.??.?
 *Released*: ?? March 2025
-- Issue 52253: Editable grid drag and fill removes internal zeros
-- Issue 51584: Editable grid does not delete values in fields if drag-select started in a read-only field
-- Issue 52347: EditableGrid: Drag filling Sample IDs doesn't resolve samples
-- Issue 52412: EditableGrid: Drag Filling Lookups with special characters doesn't work
+- Add `test-to-file` script
+- `Cell`: ignore readOnly state when handling certain events
+- Update `dragFillEvent` to detect and apply padding during drag fill
+  - Issue 52253: Editable grid drag and fill removes internal zeros
+  - Issue 51584: Editable grid does not delete values in fields if drag-select started in a read-only field
+- Update `dragFillEvent` to generate a TSV then use our underlying paste handling code to insert the drag filled data
+  - Issue 52347: EditableGrid: Drag filling Sample IDs doesn't resolve samples
+  - Issue 52412: EditableGrid: Drag Filling Lookups with special characters doesn't work
+- `EditableGrid`: pass queryFilters when rendering bulk add
+  - Issue 52371: Bulk Add Units list isn't filtered to match Sample Type when inserting samples
 
 ### version 6.31.12
 *Released*: 21 March 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ?? March 2025
 - Issue 52253: Editable grid drag and fill removes internal zeros
 - Issue 51584: Editable grid does not delete values in fields if drag-select started in a read-only field
+- Issue 52347: EditableGrid: Drag filling Sample IDs doesn't resolve samples
+- Issue 52412: EditableGrid: Drag Filling Lookups with special characters doesn't work
 
 ### version 6.31.12
 *Released*: 21 March 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 6.??.?
 *Released*: ?? March 2025
 - Issue 52253: Editable grid drag and fill removes internal zeros
+- Issue 51584: Editable grid does not delete values in fields if drag-select started in a read-only field
 
 ### version 6.31.12
 *Released*: 21 March 2025

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -330,7 +330,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
             case KEYS.Backspace:
             case KEYS.Delete:
                 // "Backspace" and "Delete" are ignored on recorded input
-                if (!focused && selected && !isRecording && !this.isReadOnly) {
+                if (!focused && selected && !isRecording) {
                     cancelEvent(event);
                     modifyCell(colIdx, rowIdx, undefined, MODIFICATION_TYPES.REMOVE_ALL);
                 }
@@ -368,14 +368,14 @@ export class Cell extends React.PureComponent<CellProps, State> {
                 }
                 break;
             case KEYS.D:
-                if (!focused && isFillDown(event) && !this.isReadOnly) {
+                if (!focused && isFillDown(event)) {
                     cancelEvent(event);
                     fillDown();
                     break;
                 }
             // eslint-disable-next-line no-fallthrough
             case KEYS.A:
-                if (!focused && isSelectAll(event) && !this.isReadOnly) {
+                if (!focused && isSelectAll(event)) {
                     cancelEvent(event);
                     selectCell(colIdx, rowIdx, SELECTION_TYPES.ALL);
                     break;

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Query, Utils } from '@labkey/api';
+import { Query } from '@labkey/api';
 import classNames from 'classnames';
 import { List, Map, OrderedMap, Set } from 'immutable';
 import React, { ChangeEvent, PureComponent, ReactNode } from 'react';
@@ -1536,7 +1536,6 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
 
     renderBulkUpdate = (): ReactNode => {
         const { addControlProps, bulkUpdateProps, editorModel, forUpdate, showAsTab, containerPath } = this.props;
-        editorModel.columnMetadata.values()[0]
 
         return (
             <BulkAddUpdateForm

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -281,14 +281,6 @@ export interface BulkAddData {
     validationMsg?: ReactNode;
 }
 
-export interface BulkUpdateQueryInfoFormProps extends QueryInfoFormProps {
-    applyBulkUpdateBtnText?: string;
-    excludeRowIdx?: number[]; // the row ind to exclude for bulk update, row might be readonly or locked
-    onBulkUpdateFormDataChange?: (pendingBulkFormData?: any) => void;
-    onClickBulkUpdate?: (selected: Set<number>) => Promise<boolean>;
-    warning?: string;
-}
-
 export interface BulkAddQueryInfoFormProps extends QueryInfoFormProps {
     readOnlyGridFields?: string[];
 }
@@ -303,7 +295,7 @@ export interface SharedEditableGridProps {
     allowBulkUpdate?: boolean;
     allowSelection?: boolean;
     bulkAddProps?: Partial<BulkAddQueryInfoFormProps>;
-    bulkUpdateProps?: Partial<BulkUpdateQueryInfoFormProps>;
+    bulkUpdateProps?: Partial<QueryInfoFormProps>;
     containerFilter?: Query.ContainerFilter;
     containerPath?: string;
     disabled?: boolean;
@@ -324,15 +316,6 @@ export interface SharedEditableGridProps {
     rowNumColumn?: GridColumn;
     showAsTab?: boolean; // Toggle "Edit in Grid" and "Edit in Bulk" as tabs
     tabContainerCls?: string;
-}
-
-export interface EditableGridBtnProps {
-    caption?: string;
-    cls?: string;
-    disabled?: boolean;
-    onClick?: (pendingBulkFormData?: OrderedMap<string, any>, editorModelChanges?: Partial<EditorModelProps>) => void;
-    placement?: PlacementType;
-    show?: boolean;
 }
 
 export type EditableGridChange = (
@@ -1272,30 +1255,11 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     toggleBulkUpdate = (): void => {
-        const { bulkUpdateProps } = this.props;
-        if (bulkUpdateProps?.onClickBulkUpdate) {
-            bulkUpdateProps
-                .onClickBulkUpdate(this.state.selected)
-                .then(canEdit => {
-                    // the selected rows might not be updatable, for examples, all selected are readonly
-                    if (!canEdit) return;
-
-                    this.setState(
-                        state => ({ showBulkUpdate: !state.showBulkUpdate }),
-                        // Issue 38420: Without this, the BulkUpdate button always retains focus after modal is shown
-                        blurActiveElement
-                    );
-                })
-                .catch(error => {
-                    console.error(error);
-                });
-        } else {
-            this.setState(
-                state => ({ showBulkUpdate: !state.showBulkUpdate }),
-                // Issue 38420: Without this, the BulkUpdate button always retains focus after modal is shown
-                blurActiveElement
-            );
-        }
+        this.setState(
+            state => ({ showBulkUpdate: !state.showBulkUpdate })
+            // Issue 38420: Without this, the BulkUpdate button always retains focus after modal is shown
+            // blurActiveElement
+        );
     };
 
     getSelectedRowIndices = (): List<number> => {
@@ -1383,7 +1347,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             editorModel,
             updatedData,
             selectedIndices,
-            bulkUpdateProps?.excludeRowIdx,
+            undefined,
             bulkUpdateProps?.isIncludedColumn,
             containerPath
         );
@@ -1542,9 +1506,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     }
 
     onBulkUpdateFormDataChange = (pendingBulkFormData?: any): void => {
-        const { showAsTab, bulkUpdateProps } = this.props;
-
-        bulkUpdateProps?.onBulkUpdateFormDataChange?.(pendingBulkFormData);
+        const { showAsTab } = this.props;
 
         if (showAsTab) {
             this.setState({ pendingBulkFormData });
@@ -1562,62 +1524,35 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
     };
 
     onTabChange = (newTabKey: string): void => {
-        const { bulkUpdateProps } = this.props;
         const { activeEditTab } = this.state;
 
         if (newTabKey === EditableGridTabs.Grid && activeEditTab === EditableGridTabs.BulkUpdate) {
             this.applyPendingBulkFormData();
         } else if (newTabKey === EditableGridTabs.BulkUpdate && activeEditTab === EditableGridTabs.Grid) {
-            if (bulkUpdateProps?.onClickBulkUpdate) {
-                bulkUpdateProps
-                    .onClickBulkUpdate(this.state.selected)
-                    .then(canEdit => {
-                        if (!canEdit) return;
-
-                        this.setState({ activeEditTab: newTabKey });
-                    })
-                    .catch(error => {
-                        console.error(error);
-                    });
-            } else {
-                this.setState({ activeEditTab: newTabKey });
-            }
+            this.setState({ activeEditTab: newTabKey });
         }
     };
 
     renderBulkUpdate = (): ReactNode => {
         const { addControlProps, bulkUpdateProps, editorModel, forUpdate, showAsTab, containerPath } = this.props;
-        const { pendingBulkFormData } = this.state;
+        editorModel.columnMetadata.values()[0]
 
         return (
-            <>
-                {bulkUpdateProps?.applyBulkUpdateBtnText && (
-                    <button
-                        className="btn btn-primary"
-                        disabled={Utils.isEmptyObj(pendingBulkFormData?.toJS())}
-                        onClick={this.applyPendingBulkFormData}
-                        type="button"
-                    >
-                        {bulkUpdateProps.applyBulkUpdateBtnText}
-                    </button>
-                )}
-                <BulkAddUpdateForm
-                    asModal={!showAsTab}
-                    columnFilter={bulkUpdateProps?.columnFilter}
-                    containerPath={containerPath}
-                    editorModel={editorModel}
-                    onFormChangeWithData={showAsTab ? this.onBulkUpdateFormDataChange : undefined}
-                    onHide={this.toggleBulkUpdate}
-                    onSubmitForEdit={this.bulkUpdate}
-                    onSuccess={this.toggleBulkUpdate}
-                    operation={forUpdate ? Operation.update : Operation.insert}
-                    pluralNoun={addControlProps?.nounPlural}
-                    queryFilters={bulkUpdateProps?.queryFilters}
-                    selectedRowIndexes={this.getSelectedRowIndices()}
-                    singularNoun={addControlProps?.nounSingular}
-                    warning={bulkUpdateProps?.warning}
-                />
-            </>
+            <BulkAddUpdateForm
+                asModal={!showAsTab}
+                columnFilter={bulkUpdateProps?.columnFilter}
+                containerPath={containerPath}
+                editorModel={editorModel}
+                onFormChangeWithData={showAsTab ? this.onBulkUpdateFormDataChange : undefined}
+                onHide={this.toggleBulkUpdate}
+                onSubmitForEdit={this.bulkUpdate}
+                onSuccess={this.toggleBulkUpdate}
+                operation={forUpdate ? Operation.update : Operation.insert}
+                pluralNoun={addControlProps?.nounPlural}
+                queryFilters={bulkUpdateProps?.queryFilters}
+                selectedRowIndexes={this.getSelectedRowIndices()}
+                singularNoun={addControlProps?.nounSingular}
+            />
         );
     };
 

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -1469,6 +1469,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 operation={forUpdate ? Operation.update : Operation.insert}
                 onSuccess={this.toggleBulkAdd}
                 queryInfo={queryInfo.getInsertQueryInfo()}
+                queryFilters={bulkAddProps?.queryFilters}
                 header={
                     !!bulkAddProps?.header && <div className="editable-grid__bulk-header">{bulkAddProps.header}</div>
                 }

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -9,7 +9,7 @@ import sampleSet2QueryInfo from '../../../test/data/sampleSet2-getQueryDetails.j
 
 import {
     addColumns,
-    changeColumn,
+    changeColumn, detectPadLength, detectPaddingInPrefixedNumbers,
     fillColumnCells,
     loadEditorModelData,
     parseIntIfNumber,
@@ -697,7 +697,10 @@ describe('splitPrefixedNumber', () => {
         expect(splitPrefixedNumber('ABC')).toEqual(['ABC', undefined]);
         expect(splitPrefixedNumber('ABC-')).toEqual(['ABC-', undefined]);
         expect(splitPrefixedNumber('123')).toEqual([undefined, '123']);
-        expect(splitPrefixedNumber('123.45')).toEqual([undefined, '123.45']);
+        expect(splitPrefixedNumber('00.45')).toEqual([undefined, '00.45']);
+        expect(splitPrefixedNumber('001')).toEqual([undefined, '001']);
+        expect(splitPrefixedNumber('ABC001')).toEqual(['ABC', '001']);
+        expect(splitPrefixedNumber('ABC00.45')).toEqual(['ABC', '00.45']);
     });
 
     test('param as number', () => {
@@ -708,6 +711,17 @@ describe('splitPrefixedNumber', () => {
         expect(splitPrefixedNumber(undefined)).toEqual([undefined, undefined]);
         expect(splitPrefixedNumber(null)).toEqual([undefined, undefined]);
         expect(splitPrefixedNumber('')).toEqual([undefined, undefined]);
+    });
+});
+
+describe('detectPadSize', () => {
+    test('detects padding correctly', () => {
+        expect(detectPadLength(undefined)).toEqual(undefined);
+        expect(detectPadLength('')).toEqual(undefined);
+        expect(detectPadLength('123')).toEqual(undefined);
+        expect(detectPadLength('000.123')).toEqual(undefined);
+        expect(detectPadLength('0000123')).toEqual(7);
+        expect(detectPadLength('0001234')).toEqual(7);
     });
 });
 

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -9,8 +9,8 @@ import sampleSet2QueryInfo from '../../../test/data/sampleSet2-getQueryDetails.j
 
 import {
     addColumns,
-    changeColumn, detectPadLength, detectPaddingInPrefixedNumbers,
-    fillColumnCells,
+    changeColumn,
+    detectPadLength,
     loadEditorModelData,
     parseIntIfNumber,
     parsePastedLookup,
@@ -18,6 +18,7 @@ import {
     removeColumns,
     splitPrefixedNumber,
     validateAndInsertPastedData,
+    generateColumnFillValues,
 } from './actions';
 import { CellMessage, EditorModel, ValueDescriptor } from './models';
 import { genCellKey } from './utils';
@@ -327,18 +328,35 @@ describe('column mutation actions', () => {
     });
 });
 
-describe('fillColumnCells', () => {
+describe('generateColumnFillValues', () => {
+    // Makes cellValues where the values have the same display and raw value
+    function makeCellValues(fk: string, rows: string[][]): Record<string, List<ValueDescriptor>> {
+        return rows.reduce((result, values, rowIdx) => {
+            result[genCellKey(fk, rowIdx)] = List<ValueDescriptor>(
+                values.map(value => ({
+                    raw: value,
+                    display: value,
+                }))
+            );
+            return result;
+        }, {});
+    }
+    const queryInfo = QueryInfo.fromJsonForTests(sampleSet2QueryInfo);
     const lookupFk = 'lookup';
     const intFk = 'int';
     const floatFk = 'float';
     const dateFk = 'date';
     const datetimeFk = 'datetime';
     const strFk = 'str';
+    const quoteFk = 'quote';
+    const mvFk = 'mv';
     const editorModel = new EditorModel({}).merge({
+        queryInfo,
         cellMessages: Map<string, CellMessage>({
             '1-0': 'description 1 message',
         }),
         cellValues: Map<string, List<ValueDescriptor>>({
+            // Can't use makeCellValues for the number or lookup values because raw != display
             [genCellKey(lookupFk, 0)]: List<ValueDescriptor>([
                 {
                     display: 'S-1',
@@ -393,273 +411,183 @@ describe('fillColumnCells', () => {
                     raw: 0,
                 },
             ]),
-            [genCellKey(strFk, 0)]: List<ValueDescriptor>([
-                {
-                    display: 'qwer',
-                    raw: 'qwer',
-                },
-            ]),
-            [genCellKey(strFk, 1)]: List<ValueDescriptor>([
-                {
-                    display: 'asdf',
-                    raw: 'asdf',
-                },
-            ]),
-            [genCellKey(strFk, 2)]: List<ValueDescriptor>([
-                {
-                    display: 'zxcv',
-                    raw: 'zxcv',
-                },
-            ]),
-            [genCellKey(dateFk, 0)]: List<ValueDescriptor>([
-                {
-                    display: '2023-06-01',
-                    raw: '2023-06-01',
-                },
-            ]),
-            [genCellKey(dateFk, 1)]: List<ValueDescriptor>([
-                {
-                    display: '',
-                    raw: '',
-                },
-            ]),
-            [genCellKey(dateFk, 2)]: List<ValueDescriptor>([
-                {
-                    display: '2023-04-16',
-                    raw: '2023-04-16',
-                },
-            ]),
-            [genCellKey(datetimeFk, 0)]: List<ValueDescriptor>([
-                {
-                    display: '2023-06-01 10:42',
-                    raw: '2023-06-01 10:42',
-                },
-            ]),
-            [genCellKey(datetimeFk, 1)]: List<ValueDescriptor>([
-                {
-                    display: '',
-                    raw: '',
-                },
-            ]),
-            [genCellKey(datetimeFk, 2)]: List<ValueDescriptor>([
-                {
-                    display: '2023-04-16 11:11',
-                    raw: '2023-04-16 11:11',
-                },
-            ]),
+            ...makeCellValues(strFk, [['qwer'], ['asdf'], ['zxcv']]),
+            ...makeCellValues(dateFk, [['2023-06-01'], [''], ['2023-04-16']]),
+            ...makeCellValues(datetimeFk, [['2023-06-01 10:42'], [''], ['2023-04-16 11:11']]),
+            ...makeCellValues(quoteFk, [['S,1'], ['S,2'], ['']]),
+            ...makeCellValues(mvFk, [['S,1', 'S,2'], ['S2', 'S3'], [''], ['']]),
         }),
         orderedColumns: List([lookupFk, intFk, floatFk, strFk, dateFk, datetimeFk]),
         rowCount: 10,
     }) as EditorModel;
 
-    const textCol = new QueryColumn({
-        fieldKey: 'textCol',
-        lookup: undefined,
-    });
-
     beforeAll(() => {
         global.console.warn = jest.fn();
     });
 
-    test('single initialSelection', async () => {
-        const { cellValues } = await fillColumnCells(
-            editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
-            [genCellKey(lookupFk, 0)],
-            [genCellKey(lookupFk, 1), genCellKey(lookupFk, 2), genCellKey(lookupFk, 3)],
-            true,
-            undefined
-        );
-        // Filled values should be copies of the initial selection
-        for (let i = 1; i <= 3; i++) {
-            expect(cellValues.get(genCellKey(lookupFk, i)).get(0).display).toEqual('S-1');
-            expect(cellValues.get(genCellKey(lookupFk, i)).get(0).raw).toEqual(1);
-        }
+    test('single initialSelection', () => {
+        const cellValues = generateColumnFillValues(editorModel, [genCellKey(lookupFk, 0)], undefined, [
+            genCellKey(lookupFk, 1),
+            genCellKey(lookupFk, 2),
+            genCellKey(lookupFk, 3),
+        ]);
+        expect(cellValues).toEqual(['S-1', 'S-1', 'S-1']);
     });
 
-    test('prefixed number, multi initialSelection', async () => {
-        const { cellValues } = await fillColumnCells(
+    test('prefixed number, multi initialSelection', () => {
+        const cellValues = generateColumnFillValues(
             editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
             [genCellKey(lookupFk, 0), genCellKey(lookupFk, 1), genCellKey(lookupFk, 2)],
-            [genCellKey(lookupFk, 3), genCellKey(lookupFk, 4)],
-            true,
-            undefined
+            undefined,
+            [genCellKey(lookupFk, 3), genCellKey(lookupFk, 4)]
         );
-        expect(cellValues.get(genCellKey(lookupFk, 3)).get(0).display).toEqual('S-4');
-        expect(cellValues.get(genCellKey(lookupFk, 3)).get(0).raw).toEqual('S-4');
-        expect(cellValues.get(genCellKey(lookupFk, 4)).get(0).display).toEqual('S-5');
-        expect(cellValues.get(genCellKey(lookupFk, 4)).get(0).raw).toEqual('S-5');
+        expect(cellValues).toEqual(['S-4', 'S-5']);
     });
 
-    test('integer, multi initialSelection, forward', async () => {
-        const { cellValues } = await fillColumnCells(
+    test('integer, multi initialSelection, forward', () => {
+        const cellValues = generateColumnFillValues(
             editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
             [genCellKey(intFk, 0), genCellKey(intFk, 1), genCellKey(intFk, 2)],
-            [genCellKey(intFk, 3), genCellKey(intFk, 4)],
-            true,
-            undefined
+            undefined,
+            [genCellKey(intFk, 3), genCellKey(intFk, 4)]
         );
-        expect(cellValues.get(genCellKey(intFk, 3)).get(0).display).toEqual('7');
-        expect(cellValues.get(genCellKey(intFk, 3)).get(0).raw).toEqual(7);
-        expect(cellValues.get(genCellKey(intFk, 4)).get(0).display).toEqual('9');
-        expect(cellValues.get(genCellKey(intFk, 4)).get(0).raw).toEqual(9);
+        expect(cellValues).toEqual(['7', '9']);
     });
 
-    test('integer, multi initialSelection, backward', async () => {
-        const { cellValues } = await fillColumnCells(
+    test('integer, multi initialSelection, backward', () => {
+        const cellValues = generateColumnFillValues(
             editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
             [genCellKey(intFk, 1), genCellKey(intFk, 2)],
-            [genCellKey(intFk, 0)],
-            true,
-            undefined
+            undefined,
+            [genCellKey(intFk, 0)]
         );
-        expect(cellValues.get(genCellKey(intFk, 0)).get(0).display).toEqual('1');
-        expect(cellValues.get(genCellKey(intFk, 0)).get(0).raw).toEqual(1);
+        expect(cellValues).toEqual(['1']);
     });
 
-    test('float, multi initialSelection, forward', async () => {
-        const { cellValues } = await fillColumnCells(
+    test('float, multi initialSelection, forward', () => {
+        const cellValues = generateColumnFillValues(
             editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
             [genCellKey(floatFk, 0), genCellKey(floatFk, 1), genCellKey(floatFk, 2)],
-            [genCellKey(floatFk, 3), genCellKey(floatFk, 4)],
-            true,
-            undefined
+            undefined,
+            [genCellKey(floatFk, 3), genCellKey(floatFk, 4)]
         );
-        expect(cellValues.get(genCellKey(floatFk, 3)).get(0).display).toEqual('-1.5');
-        expect(cellValues.get(genCellKey(floatFk, 3)).get(0).raw).toEqual(-1.5);
-        expect(cellValues.get(genCellKey(floatFk, 4)).get(0).display).toEqual('-3');
-        expect(cellValues.get(genCellKey(floatFk, 4)).get(0).raw).toEqual(-3);
+        expect(cellValues).toEqual(['-1.5', '-3']);
     });
 
-    test('float, multi initialSelection, backward', async () => {
-        const { cellValues } = await fillColumnCells(
+    test('float, multi initialSelection, backward', () => {
+        const cellValues = generateColumnFillValues(
             editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
             [genCellKey(floatFk, 1), genCellKey(floatFk, 2)],
-            [genCellKey(floatFk, 0)],
-            true,
-            undefined
+            undefined,
+            [genCellKey(floatFk, 0)]
         );
-        expect(cellValues.get(genCellKey(floatFk, 0)).get(0).display).toEqual('3');
-        expect(cellValues.get(genCellKey(floatFk, 0)).get(0).raw).toEqual(3);
+        expect(cellValues).toEqual(['3']);
     });
 
-    test('date, single row initialSelection, forward', async () => {
-        const { cellValues } = await fillColumnCells(
-            editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
-            [genCellKey(dateFk, 0)],
-            [genCellKey(dateFk, 1), genCellKey(dateFk, 2), genCellKey(dateFk, 3)],
-            true,
-            undefined
-        );
+    test('date, single row initialSelection, forward', () => {
+        const cellValues = generateColumnFillValues(editorModel, [genCellKey(dateFk, 0)], undefined, [
+            genCellKey(dateFk, 1),
+            genCellKey(dateFk, 2),
+            genCellKey(dateFk, 3),
+        ]);
         // Filled values should be copies of the initial selection
+        const expected = [];
         for (let i = 1; i <= 3; i++) {
-            expect(cellValues.get(genCellKey(dateFk, i)).get(0).display).toEqual(`2023-06-0${i + 1}`);
-            expect(cellValues.get(genCellKey(dateFk, i)).get(0).raw).toEqual(`2023-06-0${i + 1}`);
+            expected.push(`2023-06-0${i + 1}`);
         }
+        expect(cellValues).toEqual(expected);
     });
 
-    test('date, single row initialSelection, backward', async () => {
-        const { cellValues } = await fillColumnCells(
-            editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
-            [genCellKey(dateFk, 2)],
-            [genCellKey(dateFk, 0), genCellKey(dateFk, 1)],
-            true,
-            undefined
-        );
-        // Filled values should be copies of the initial selection
-        for (let i = 0; i <= 2; i++) {
-            expect(cellValues.get(genCellKey(dateFk, i)).get(0).display).toEqual(`2023-04-${14 + i}`);
-            expect(cellValues.get(genCellKey(dateFk, i)).get(0).raw).toEqual(`2023-04-${14 + i}`);
+    test('date, single row initialSelection, backward', () => {
+        const cellValues = generateColumnFillValues(editorModel, [genCellKey(dateFk, 2)], undefined, [
+            genCellKey(dateFk, 0),
+            genCellKey(dateFk, 1),
+        ]);
+        // Filled values decrement by one day
+        const expected = [];
+        for (let i = 0; i < 2; i++) {
+            expected.push(`2023-04-${15 - i}`);
         }
+        expect(cellValues).toEqual(expected);
     });
 
-    test('datetime, single row initialSelection, forward', async () => {
-        const { cellValues } = await fillColumnCells(
-            editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
-            [genCellKey(datetimeFk, 0)],
-            [genCellKey(datetimeFk, 1), genCellKey(datetimeFk, 2), genCellKey(datetimeFk, 3)],
-            true,
-            undefined
-        );
-        // Filled values should be copies of the initial selection
+    test('datetime, single row initialSelection, forward', () => {
+        const cellValues = generateColumnFillValues(editorModel, [genCellKey(datetimeFk, 0)], undefined, [
+            genCellKey(datetimeFk, 1),
+            genCellKey(datetimeFk, 2),
+            genCellKey(datetimeFk, 3),
+        ]);
+        // Filled values should increment by one day
+        const expected = [];
         for (let i = 1; i <= 3; i++) {
-            expect(cellValues.get(genCellKey(datetimeFk, i)).get(0).display).toEqual(`2023-06-0${i + 1} 10:42`);
-            expect(cellValues.get(genCellKey(datetimeFk, i)).get(0).raw).toEqual(`2023-06-0${i + 1} 10:42`);
+            expected.push(`2023-06-0${i + 1} 10:42`);
         }
+
+        expect(cellValues).toEqual(expected);
     });
 
-    test('datetime, single row initialSelection, backward', async () => {
-        const { cellValues } = await fillColumnCells(
-            editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
-            [genCellKey(datetimeFk, 2)],
-            [genCellKey(datetimeFk, 0), genCellKey(datetimeFk, 1)],
-            true,
-            undefined
-        );
-        // Filled values should be copies of the initial selection
-        for (let i = 0; i <= 2; i++) {
-            expect(cellValues.get(genCellKey(datetimeFk, i)).get(0).display).toEqual(`2023-04-${14 + i} 11:11`);
-            expect(cellValues.get(genCellKey(datetimeFk, i)).get(0).raw).toEqual(`2023-04-${14 + i} 11:11`);
+    test('datetime, single row initialSelection, backward', () => {
+        const cellValues = generateColumnFillValues(editorModel, [genCellKey(datetimeFk, 2)], undefined, [
+            genCellKey(datetimeFk, 0),
+            genCellKey(datetimeFk, 1),
+        ]);
+        // Filled values decrement by one day
+        const expected = [];
+        for (let i = 0; i < 2; i++) {
+            expected.push(`2023-04-${15 - i} 11:11`);
         }
+        expect(cellValues).toEqual(expected);
     });
 
-    test('text, multi initialSelection, forward', async () => {
-        const { cellValues } = await fillColumnCells(
+    test('text, multi initialSelection, forward', () => {
+        const cellValues = generateColumnFillValues(
             editorModel,
-            textCol,
-            undefined,
-            editorModel.cellMessages,
-            editorModel.cellValues,
             [genCellKey(strFk, 0), genCellKey(strFk, 1), genCellKey(strFk, 2)],
-            [genCellKey(strFk, 3), genCellKey(strFk, 4), genCellKey(strFk, 5)],
-            true,
-            undefined
+            undefined,
+            [genCellKey(strFk, 3), genCellKey(strFk, 4), genCellKey(strFk, 5)]
         );
-        expect(cellValues.get(genCellKey(strFk, 3)).get(0).display).toEqual('qwer');
-        expect(cellValues.get(genCellKey(strFk, 3)).get(0).raw).toEqual('qwer');
-        expect(cellValues.get(genCellKey(strFk, 4)).get(0).display).toEqual('asdf');
-        expect(cellValues.get(genCellKey(strFk, 4)).get(0).raw).toEqual('asdf');
-        expect(cellValues.get(genCellKey(strFk, 5)).get(0).display).toEqual('zxcv');
-        expect(cellValues.get(genCellKey(strFk, 5)).get(0).raw).toEqual('zxcv');
+        expect(cellValues).toEqual(['qwer', 'asdf', 'zxcv']);
+    });
+
+    // Issue 52412
+    test('values with commas are quoted', () => {
+        let cellValues = generateColumnFillValues(
+            editorModel,
+            [genCellKey(quoteFk, 0), genCellKey(quoteFk, 1)],
+            undefined,
+            [genCellKey(strFk, 2), genCellKey(strFk, 3), genCellKey(strFk, 4)]
+        );
+        // Incremented values with commas should be quoted
+        expect(cellValues).toEqual(['"S,3"', '"S,4"', '"S,5"']);
+
+        cellValues = generateColumnFillValues(editorModel, [genCellKey(quoteFk, 0)], undefined, [
+            genCellKey(strFk, 1),
+            genCellKey(strFk, 2),
+            genCellKey(strFk, 3),
+        ]);
+        // Copied values with commas should be quoted
+        expect(cellValues).toEqual(['"S,1"', '"S,1"', '"S,1"']);
+    });
+
+    // Issue 52412
+    test('cells with multiple values are quoted', () => {
+        let cellValues = generateColumnFillValues(editorModel, [genCellKey(mvFk, 0), genCellKey(mvFk, 1)], undefined, [
+            genCellKey(mvFk, 2),
+            genCellKey(mvFk, 3),
+            genCellKey(mvFk, 4),
+            genCellKey(mvFk, 5),
+        ]);
+        // When we copy multiple values only the ones needing quotes should be quoted
+        expect(cellValues).toEqual(['"S,1","S,2"', 'S2,S3', '"S,1","S,2"', 'S2,S3']);
+
+        cellValues = generateColumnFillValues(editorModel, [genCellKey(mvFk, 0)], undefined, [
+            genCellKey(mvFk, 1),
+            genCellKey(mvFk, 2),
+            genCellKey(mvFk, 3),
+            genCellKey(mvFk, 5),
+        ]);
+        // Copying single values should quote them as appropriate
+        expect(cellValues).toEqual(['"S,1","S,2"', '"S,1","S,2"', '"S,1","S,2"', '"S,1","S,2"']);
     });
 });
 

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -7,7 +7,14 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { cancelEvent, getPasteValue, setCopyValue } from '../../events';
 import { formatDate, formatDateTime, parseDate } from '../../util/Date';
-import { caseInsensitive, isFloat, isInteger, parseCsvString, parseScientificInt } from '../../util/utils';
+import {
+    caseInsensitive,
+    isFloat,
+    isInteger,
+    parseCsvString,
+    parseScientificInt,
+    quoteValueWithDelimiters,
+} from '../../util/utils';
 import { ViewInfo } from '../../ViewInfo';
 
 import { selectRows } from '../../query/selectRows';
@@ -16,7 +23,6 @@ import { getContainerFilterForLookups } from '../../query/api';
 
 import {
     CellMessage,
-    CellMessages,
     CellValues,
     EditableColumnMetadata,
     EditableGridLoader,
@@ -1014,38 +1020,27 @@ async function getParsedLookup(
 }
 
 /**
- * Fills a column of cells based on the initially selected values.
+ * Generates an array of string values to paste into a selection of cells based on the values of an initial selection.
+ *
  * If the initialSelection is for a single cell, the fill operation will always be a copy of that value.
  * If the initialSelection includes a range of cells and all values are numeric (or numbers prefixed with the same
  * string), fill via a generated sequence where the step/diff is based on the first and last value in the initSelection.
  * if the initialSelection is a single row, and the value is a date (as determined by the date format set by the server)
  * then we will fill via a generated sequence that increments the date by one day each row.
- * If the initialSelection includes a range of cells and not all values are numeric, fill via a copy of all of the values
+ * If the initialSelection includes a range of cells and not all values are numeric, fill via a copy of all the values
  * in initSelection.
  * @param editorModel An EditorModel object
- * @param column
- * @param columnMetadata
- * @param cellMessages The CellMessages object to mutate, we cannot use the one from EditorModel because we may need to
- * modify multiple columns of data in one event (see dragFillEvent).
- * @param cellValues The CellValues object to mutate, we cannot use the one from EditorModel because we may need to
- * modify multiple columns of data in one event (see dragFillEvent).
  * @param initialSelection An array of sorted cell keys, all from the same column that were initially selected
+ * @param readonlyRows An array of readonly rows
  * @param selectionToFill An array of sorted cell keys, all from the same column, to be filled with values based on the
  * content of initialSelection
- * @param forUpdate True if this is operating on update query filters.
- * @param targetContainerPath
  */
-export async function fillColumnCells(
+export function generateColumnFillValues(
     editorModel: EditorModel,
-    column: QueryColumn,
-    columnMetadata: EditableColumnMetadata,
-    cellMessages: CellMessages,
-    cellValues: CellValues,
     initialSelection: string[],
-    selectionToFill: string[],
-    forUpdate: boolean,
-    targetContainerPath: string
-): Promise<CellMessagesAndValues> {
+    readonlyRows: string[],
+    selectionToFill: string[]
+): string[] {
     const { direction, increment, incrementType, padLength, prefix, startingValue, initialSelectionValues } =
         inferSelectionIncrement(editorModel, initialSelection, selectionToFill);
 
@@ -1053,9 +1048,14 @@ export async function fillColumnCells(
         selectionToFill.reverse();
     }
 
-    selectionToFill.forEach((cellKey, i) => {
-        let fillValue = initialSelectionValues[i % initialSelectionValues.length];
+    return selectionToFill.map((cellKey, i) => {
+        const { fieldKey, rowIdx } = parseCellKey(cellKey);
+        const { isReadonlyCell, isReadonlyRow } = editorModel.getCellReadStatus(fieldKey, rowIdx, readonlyRows);
+        // Only need to generate blank values for read only cells, paste will ignore them
+        if (isReadonlyCell || isReadonlyRow) return '';
 
+        const initialValue = initialSelectionValues[i % initialSelectionValues.length];
+        let value = initialValue.map(v => quoteValueWithDelimiters(v.display, ',')).join(',');
         if (incrementType === IncrementType.NUMBER) {
             const amount = increment * (i + 1);
             let raw: number | string;
@@ -1071,8 +1071,8 @@ export async function fillColumnCells(
             }
 
             if (prefix !== undefined) raw = prefix + raw;
-            const display = raw.toString();
-            fillValue = List([{ raw, display }]);
+            // Issue 52412
+            value = quoteValueWithDelimiters(raw.toString(), ',');
         } else if (incrementType === IncrementType.DATE || incrementType === IncrementType.DATETIME) {
             let date = parseDate(startingValue);
 
@@ -1082,107 +1082,68 @@ export async function fillColumnCells(
                 date = subDays(date, i + 1);
             }
 
-            const raw = incrementType === IncrementType.DATE ? formatDate(date) : formatDateTime(date);
-            fillValue = List([{ raw, display: raw }]);
+            value = incrementType === IncrementType.DATE ? formatDate(date) : formatDateTime(date);
         }
 
-        cellValues = cellValues.set(cellKey, fillValue);
+        return value;
     });
-
-    const filteredLookupValues = columnMetadata?.filteredLookupValues?.toArray();
-    const lookupValueCache: LookupValueCache = {};
-    for (const cellKey of selectionToFill) {
-        // If the column is a lookup, then we need to query for the rowIds so we can set the correct raw values,
-        // otherwise insert will fail. This is most common for cross-folder sample selection (Issue 50363)
-        if (column.isPublicLookup()) {
-            const display = cellValues
-                .get(cellKey)
-                .map(v => v.display)
-                .toArray();
-
-            const { message, valueDescriptors } = await getParsedLookup(
-                column,
-                lookupValueCache,
-                display,
-                filteredLookupValues ?? display.join(','),
-                cellKey,
-                forUpdate,
-                targetContainerPath,
-                editorModel
-            );
-            cellValues = cellValues.set(cellKey, valueDescriptors);
-            cellMessages = cellMessages.set(cellKey, message);
-        } else {
-            const { message } = getValidatedEditableGridValue(cellValues.get(cellKey)?.get(0)?.display, column);
-            cellMessages = cellMessages.set(cellKey, message);
-        }
-    }
-
-    return { cellValues, cellMessages };
 }
 
-type CellMessagesAndValues = Pick<EditorModel, 'cellMessages' | 'cellValues'>;
-
 /**
- * @param editorModel
+ * @param editorModel An EditorModel object
  * @param initialSelection The initial selection before the selection was expanded
- * @param readonlyRows A list of readonly rows
+ * @param readonlyRows An array of readonly rows
  * @param forUpdate True if this is operating on update query filters.
  * @param targetContainerPath The container path to use when looking up lookup values in the forUpdate false case
  */
-export async function dragFillEvent(
+export function dragFillEvent(
     editorModel: EditorModel,
     initialSelection: string[],
     readonlyRows: string[],
     forUpdate: boolean,
     targetContainerPath: string
-): Promise<CellMessagesAndValues> {
+): Promise<Partial<EditorModel>> {
+    // Note: this method works by generating a TSV of new values and treating it as if the user pasted the TSV. This
+    // lets us reuse our paste code which is reasonably complex.
     const { columnMap, selectionCells } = editorModel;
-    let { cellMessages, cellValues } = editorModel;
+    const { cellMessages, cellValues } = editorModel;
 
     // If the selection size hasn't changed, then the selection hasn't changed, so return the existing cellValues
-    if (selectionCells.length === initialSelection.length) return { cellMessages, cellValues };
+    if (selectionCells.length === initialSelection.length) return Promise.resolve({ cellMessages, cellValues });
 
     const selectionToFill = generateFillCellKeys(editorModel, initialSelection, selectionCells);
+    const filledColumns = [];
     for (const columnCells of selectionToFill) {
         const { fieldKey } = parseCellKey(columnCells[0]);
         const initialSelectionByCol = initialSelection.filter(cellKey => parseCellKey(cellKey).fieldKey === fieldKey);
         const column = columnMap.get(fieldKey);
-        const metadata = editorModel.getColumnMetadata(fieldKey);
 
-        // Don't manipulate any values in read only columns
         if (column.readOnly) {
+            // Generate blank values for readOnly columns, they'll be ignored during paste
+            filledColumns.push(columnCells.map(() => ''));
             continue;
         }
 
-        const selectionToFillByCol = columnCells.filter(cellKey => {
-            const { fieldKey, rowIdx } = parseCellKey(cellKey);
-            const { isReadonlyCell, isReadonlyRow } = editorModel.getCellReadStatus(fieldKey, rowIdx, readonlyRows);
-            return !isReadonlyCell && !isReadonlyRow;
-        });
-
-        // if nothing to fill, i.e. read only cells, skip
-        if (selectionToFillByCol.length === 0) {
-            continue;
-        }
-
-        // eslint-disable-next-line no-await-in-loop
-        const messagesAndValues = await fillColumnCells(
-            editorModel,
-            column,
-            metadata,
-            cellMessages,
-            cellValues,
-            initialSelectionByCol,
-            selectionToFillByCol,
-            forUpdate,
-            targetContainerPath
-        );
-        cellValues = messagesAndValues.cellValues;
-        cellMessages = messagesAndValues.cellMessages;
+        filledColumns.push(generateColumnFillValues(editorModel, initialSelectionByCol, readonlyRows, columnCells));
     }
 
-    return { cellMessages, cellValues };
+    const rowStrings = [];
+    for (let rowIdx = 0; rowIdx < filledColumns[0].length; rowIdx++) {
+        rowStrings.push(filledColumns.map(column => column[rowIdx]).join('\t'));
+    }
+
+    const tsv = rowStrings.join('\n');
+
+    return validateAndInsertPastedData(
+        editorModel,
+        tsv,
+        readonlyRows,
+        true,
+        forUpdate,
+        targetContainerPath,
+        false,
+        selectionToFill
+    );
 }
 
 /**
@@ -1462,14 +1423,15 @@ function getPasteValuesByColumn(paste: PasteModel): List<List<string>> {
     return valuesByColumn.asImmutable();
 }
 
-export async function validateAndInsertPastedData(
+export function validateAndInsertPastedData(
     editorModel: EditorModel,
     value: string,
     readonlyRows: string[],
     lockRowCount: boolean,
     forUpdate: boolean,
     targetContainerPath: string,
-    selectCells: boolean
+    selectCells: boolean,
+    selectionToFill?: string[][]
 ): Promise<Partial<EditorModel>> {
     let selectedColIdx: number;
     let selectedRowIdx: number;
@@ -1478,7 +1440,7 @@ export async function validateAndInsertPastedData(
         // Issue 51359 - When pasting during multiselect we want to paste from the first cell in the selection,
         // otherwise we'll paste from the initially selected cell, which will fill the wrong area. This is most obvious
         // if you select upwards, then paste.
-        const minCellKey = editorModel.selectionCells[0];
+        const minCellKey = selectionToFill !== undefined ? selectionToFill[0][0] : editorModel.selectionCells[0];
         const { fieldKey, rowIdx } = parseCellKey(minCellKey);
         selectedRowIdx = rowIdx;
         selectedColIdx = editorModel.orderedColumns.indexOf(fieldKey);
@@ -1505,11 +1467,12 @@ export async function validateAndInsertPastedData(
     } else {
         const fieldKey = editorModel.getFieldKeyByIndex(selectedColIdx);
         const cellKey = genCellKey(fieldKey, selectedRowIdx);
-        return { cellMessages: editorModel.cellMessages.set(cellKey, { message: paste.message }) };
+        // We have to coerce this to a promise because insertPastedData returns a promise.
+        return Promise.resolve({ cellMessages: editorModel.cellMessages.set(cellKey, { message: paste.message }) });
     }
 }
 
-export async function pasteEvent(
+export function pasteEvent(
     editorModel: EditorModel,
     event: any,
     readonlyRows: string[],
@@ -1521,7 +1484,7 @@ export async function pasteEvent(
     if (editorModel && editorModel.hasSelection && !editorModel.hasFocus) {
         cancelEvent(event);
         const value = getPasteValue(event);
-        return await validateAndInsertPastedData(
+        return validateAndInsertPastedData(
             editorModel,
             value,
             readonlyRows,

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -724,6 +724,20 @@ function everyValueHasSamePrefix(values: PrefixAndNumber[]): boolean {
     return values.every(value => value[0] === prefix);
 }
 
+/**
+ * Given a string that represents a number it returns the number needed when using String.padStart. It returns undefined
+ * in the following scenarios:
+ *  - If the value is undefined
+ *  - If the value is a decimal (e.g. 001.100)
+ *  - If the value is not a padded integer (e.g. 5, 10, 34)
+ * @param value a string representing a number
+ */
+export function detectPadLength(value: string): number {
+    // We don't support padded numbers with decimals
+    if (value === undefined || value.includes('.') || value[0] !== '0') return undefined;
+    return value.length;
+}
+
 enum IncrementDirection {
     FORWARD,
     BACKWARD,
@@ -741,6 +755,7 @@ interface SelectionIncrement {
     increment?: number;
     incrementType: IncrementType;
     initialSelectionValues: Array<List<ValueDescriptor>>; // yes this is a very odd type, but we can clean it up when we rip out Immutable
+    padLength?: number;
     prefix?: string;
     startingValue: number | string;
 }
@@ -785,6 +800,7 @@ function inferSelectionIncrement(
     let prefix;
     let incrementType = IncrementType.NONE;
     let increment;
+    let padLength;
     const splitValues = displayValues.map(splitPrefixedNumber);
     const allPrefixed = everyValueHasSamePrefix(splitValues);
 
@@ -798,16 +814,27 @@ function inferSelectionIncrement(
     const isFloatSeq = values.length > 1 && displayValues.every(isFloat);
     const isIntSeq = values.length > 1 && displayValues.every(isInteger);
 
-    if (isFloatSeq) {
-        firstValue = parseFloat(firstValue);
-        lastValue = parseFloat(lastValue);
-    } else if (isIntSeq) {
+    if (isIntSeq) {
         firstValue = parseScientificInt(firstValue);
         lastValue = parseScientificInt(lastValue);
+        // Note: We only support padLength for integer sequences. This is roughly analogous to how Excel/Sheets works.
+        // It's different because what Sheets does is so wrong it's useless, so we're not even going to bother. To see
+        // what Sheets does drag fill a sequence that looks like: SP1.5000, SP1.6000, SP1.7000.
+        // Note: We determine pad length from the first value in a sequence because that is what Excel and Sheets do
+        padLength = detectPadLength(splitValues[0][1]);
+    } else if (isFloatSeq) {
+        firstValue = parseFloat(firstValue);
+        lastValue = parseFloat(lastValue);
     }
 
     if (isFloatSeq || isIntSeq) {
-        // increment -> last value minus first value divide by the number of steps in the initial selection
+        // increment = last value minus first value divide by the number of steps in the initial selection
+        // Note: our increment calculation is different from Excel/Sheets, but that's because their behavior doesn't
+        // make any sense for certain sequences, e.g.:
+        //  - 1, 3, 3, 7 increments by 1 once, then 1.8 the rest of the time
+        //  - 5, 9, 9, 11 increments by 2 once, then 1.8 the rest of the time
+        //  - 1, 1, 1, 2, 2, 2, 3, 3, 3 increments by 0.5 once, then 0.3 the rest of the time
+        // Our behavior results in a consistent increment and can be easily explained
         increment = decimalDifference(lastValue, firstValue);
         increment = increment / (displayValues.length - 1);
         incrementType = IncrementType.NUMBER;
@@ -818,6 +845,7 @@ function inferSelectionIncrement(
         increment,
         incrementType,
         initialSelectionValues: values,
+        padLength,
         prefix,
         startingValue: direction === IncrementDirection.FORWARD ? lastValue : firstValue,
     };
@@ -1018,7 +1046,7 @@ export async function fillColumnCells(
     forUpdate: boolean,
     targetContainerPath: string
 ): Promise<CellMessagesAndValues> {
-    const { direction, increment, incrementType, prefix, startingValue, initialSelectionValues } =
+    const { direction, increment, incrementType, padLength, prefix, startingValue, initialSelectionValues } =
         inferSelectionIncrement(editorModel, initialSelection, selectionToFill);
 
     if (direction === IncrementDirection.BACKWARD) {
@@ -1036,6 +1064,10 @@ export async function fillColumnCells(
                 raw = decimalDifference(amount, startingValue as number, false);
             } else {
                 raw = decimalDifference(startingValue as number, amount, true);
+            }
+
+            if (padLength !== undefined) {
+                raw = raw.toString(10).padStart(padLength, '0');
             }
 
             if (prefix !== undefined) raw = prefix + raw;


### PR DESCRIPTION
#### Rationale
This PR addresses a number of Editable Grid issues:

- [Issue 52253](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52253): Editable grid drag and fill removes internal zeros
- [Issue 51584](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51584): Editable grid does not delete values in fields if drag-select started in a read-only field
- [Issue 52412](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52412): EditableGrid: Drag Filling Lookups with special characters doesn't work 
- [Issue 52347](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52347): EditableGrid: Drag filling Sample IDs doesn't resolve samples
-  [Issue 52371](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52371): Bulk Add Units list isn't filtered to match Sample Type when inserting samples 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1751
- https://github.com/LabKey/labkey-ui-premium/pull/713
- https://github.com/LabKey/limsModules/pull/1255
- https://github.com/LabKey/platform/pull/6454

#### Changes
- Add `test-to-file` script
  - this script runs tests serially and logs the test output to jest-log.txt, useful for debugging a test run (e.g. finding `act` related errors)
- Update `dragFillEvent` to generate a TSV then use our underlying paste handling code to insert the drag filled data
  - This fixes both 52412 and 52347
- Update `dragFillEvent` to detect and apply padding during drag fill
  - This fixes 52253
- `EditableGrid`: pass queryFilters when rendering bulk add
  - This fixes 52371
- `Cell`: ignore readOnly state when handling certain events
  - Fixes 51584