### PR TITLE
Issue 52533: LKSM: Error creating samples from details pages with Sources with a colon in the name

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.7-fb-issue52533.1",
+  "version": "6.31.7-fb-issue52533.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.7-fb-issue52533.1",
+      "version": "6.31.7-fb-issue52533.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.7-fb-issue52533.2",
+  "version": "6.31.7-fb-issue52533.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.7-fb-issue52533.2",
+      "version": "6.31.7-fb-issue52533.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.7-fb-issue52533.3",
+  "version": "6.31.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.7-fb-issue52533.3",
+      "version": "6.31.7",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.6",
+  "version": "6.31.7-fb-issue52533.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.31.6",
+      "version": "6.31.7-fb-issue52533.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.6",
+  "version": "6.31.7-fb-issue52533.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.7-fb-issue52533.3",
+  "version": "6.31.7",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.7-fb-issue52533.2",
+  "version": "6.31.7-fb-issue52533.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.31.7-fb-issue52533.1",
+  "version": "6.31.7-fb-issue52533.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X March 2025
+### version 6.31.7
+*Released*: 17 March 2025
 - Issue 52533: LKSM: Error creating samples from details pages with Sources with a colon in the name
   - Move createEntityParentKey from premium and switch to use '|' for schema|query|keyValue delimiter
   - Add parseEntityParentKey util

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X March 2025
+- Issue 52533: LKSM: Error creating samples from details pages with Sources with a colon in the name
+  - Move createEntityParentKey from premium and switch to use '|' for schema|query|keyValue delimiter
+  - Add parseEntityParentKey util
+
 ### version 6.31.6
 *Released*: 13 March 2025
 - Issue 52430: Sample Manager: sample names with newline characters

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -542,6 +542,8 @@ import {
     SAMPLE_ID_FIELD_KEY,
     sampleDeleteDependencyText,
     updateCellKeySampleIdMap,
+    createEntityParentKey,
+    parseEntityParentKey,
 } from './internal/components/entities/utils';
 import {
     ALIQUOT_CREATION,
@@ -1439,6 +1441,8 @@ export {
     getSampleIdentifyingFieldGridData,
     getCellKeyColumnMap,
     updateCellKeySampleIdMap,
+    createEntityParentKey,
+    parseEntityParentKey,
     // metric related items
     UnitModel,
     MEASUREMENT_UNITS,

--- a/packages/components/src/internal/components/entities/actions.test.ts
+++ b/packages/components/src/internal/components/entities/actions.test.ts
@@ -40,7 +40,7 @@ describe('getChosenParentData', () => {
     test('allowParents, initialParents without value', async () => {
         const result = await getChosenParentData(
             new EntityIdCreationModel({
-                originalParents: ['samples:TEST'],
+                originalParents: ['samples|TEST'],
                 selectionKey: undefined,
             }),
             PARENT_ENTITY_DATA_TYPES,

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -41,6 +41,7 @@ import {
     isAssayResultEntity,
     isDataClassEntity,
     isSampleEntity,
+    parseEntityParentKey,
     SAMPLE_ID_FIELD_KEY,
 } from './utils';
 import {
@@ -366,7 +367,7 @@ async function initParents(
         );
     } else if (initialParents?.length > 0) {
         const [parent] = initialParents;
-        const [schema, query, value] = parent.toLowerCase().split(':');
+        const [schema, query, value] = parseEntityParentKey(parent.toLowerCase());
 
         // if the parent key doesn't have a value, we don't need to make the request to getSelectedParents
         if (value === undefined) {

--- a/packages/components/src/internal/components/entities/utils.test.ts
+++ b/packages/components/src/internal/components/entities/utils.test.ts
@@ -472,6 +472,8 @@ describe('createEntityParentKey & parseEntityParentKey', () => {
     test('with id', () => {
         expect(createEntityParentKey(new SchemaQuery('schema', 'query'), 'id')).toBe('schema|query|id');
         expect(parseEntityParentKey('schema|query|id')).toEqual(['schema', 'query', 'id']);
+        expect(createEntityParentKey(new SchemaQuery('schema', 'query'), 'i|d')).toBe('schema|query|i|d');
+        expect(parseEntityParentKey('schema|query|i|d')).toEqual(['schema', 'query', 'i|d']);
     });
 });
 

--- a/packages/components/src/internal/components/entities/utils.test.ts
+++ b/packages/components/src/internal/components/entities/utils.test.ts
@@ -22,6 +22,7 @@ import { genCellKey } from '../editable/utils';
 
 import { IEntityTypeOption } from './models';
 import {
+    createEntityParentKey,
     getCellKeyColumnMap,
     getEntityDescription,
     getEntityNoun,
@@ -462,3 +463,13 @@ describe('get cell key helpers', () => {
         });
     });
 });
+
+describe('createEntityParentKey', () => {
+    test('without id', () => {
+        expect(createEntityParentKey(new SchemaQuery('schema', 'query'))).toBe('schema:query');
+    });
+    test('with id', () => {
+        expect(createEntityParentKey(new SchemaQuery('schema', 'query'), 'id')).toBe('schema:query:id');
+    });
+});
+

--- a/packages/components/src/internal/components/entities/utils.test.ts
+++ b/packages/components/src/internal/components/entities/utils.test.ts
@@ -29,7 +29,8 @@ import {
     getIdentifyingColumns,
     getInitialParentChoices,
     getJobCreationHref,
-    getSampleIdCellKey, parseEntityParentKey,
+    getSampleIdCellKey,
+    parseEntityParentKey,
     sampleDeleteDependencyText,
     updateCellKeySampleIdMap,
 } from './utils';
@@ -476,4 +477,3 @@ describe('createEntityParentKey & parseEntityParentKey', () => {
         expect(parseEntityParentKey('schema|query|i|d')).toEqual(['schema', 'query', 'i|d']);
     });
 });
-

--- a/packages/components/src/internal/components/entities/utils.test.ts
+++ b/packages/components/src/internal/components/entities/utils.test.ts
@@ -29,7 +29,7 @@ import {
     getIdentifyingColumns,
     getInitialParentChoices,
     getJobCreationHref,
-    getSampleIdCellKey,
+    getSampleIdCellKey, parseEntityParentKey,
     sampleDeleteDependencyText,
     updateCellKeySampleIdMap,
 } from './utils';
@@ -464,12 +464,14 @@ describe('get cell key helpers', () => {
     });
 });
 
-describe('createEntityParentKey', () => {
+describe('createEntityParentKey & parseEntityParentKey', () => {
     test('without id', () => {
-        expect(createEntityParentKey(new SchemaQuery('schema', 'query'))).toBe('schema:query');
+        expect(createEntityParentKey(new SchemaQuery('schema', 'query'))).toBe('schema|query');
+        expect(parseEntityParentKey('schema|query')).toEqual(['schema', 'query']);
     });
     test('with id', () => {
-        expect(createEntityParentKey(new SchemaQuery('schema', 'query'), 'id')).toBe('schema:query:id');
+        expect(createEntityParentKey(new SchemaQuery('schema', 'query'), 'id')).toBe('schema|query|id');
+        expect(parseEntityParentKey('schema|query|id')).toEqual(['schema', 'query', 'id']);
     });
 });
 

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -222,8 +222,10 @@ export function parseEntityParentKey(parentKey: string): string[] {
         return [];
 
     const allParts = parentKey.split(PARENT_KEY_DIVIDER);
-    const result = allParts.splice(0, 3);
+    // schema: allParts[0]; query: allParts[1];
+    const result = allParts.splice(0, 2);
+    // all rest is the key value (optional)
     if (allParts?.length > 0)
-        result.push(allParts.join(' '));
+        result.push(allParts.join(PARENT_KEY_DIVIDER));
     return result;
 }

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -223,6 +223,7 @@ export function parseEntityParentKey(parentKey: string): string[] {
 
     const allParts = parentKey.split(PARENT_KEY_DIVIDER);
     const result = allParts.splice(0, 3);
-    result.push(allParts.join(' '));
+    if (allParts?.length > 0)
+        result.push(allParts.join(' '));
     return result;
 }

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -23,6 +23,7 @@ import { SELECTION_KEY_TYPE } from '../samples/constants';
 import { EntityChoice, EntityDataType, IEntityTypeOption } from './models';
 
 import { ParentIdData } from './actions';
+import { SchemaQuery } from '../../../public/SchemaQuery';
 
 export function sampleDeleteDependencyText(): string {
     let deleteMsg = '';
@@ -204,4 +205,24 @@ export function updateCellKeySampleIdMap(
     });
     Object.assign(updatedCellKeyMap, cellKeyChanges.toAddOrUpdate);
     return updatedCellKeyMap;
+}
+
+const PARENT_KEY_DIVIDER = '|';
+
+export function createEntityParentKey(schemaQuery: SchemaQuery, id?: string): string {
+    const keys = [schemaQuery.schemaName, schemaQuery.queryName];
+    if (id) {
+        keys.push(id);
+    }
+    return keys.join(PARENT_KEY_DIVIDER).toLowerCase();
+}
+
+export function parseEntityParentKey(parentKey: string): string[] {
+    if (!parentKey)
+        return [];
+
+    const allParts = parentKey.split(PARENT_KEY_DIVIDER);
+    const result = allParts.splice(0, 3);
+    result.push(allParts.join(' '));
+    return result;
 }

--- a/packages/components/src/internal/components/entities/utils.ts
+++ b/packages/components/src/internal/components/entities/utils.ts
@@ -20,10 +20,11 @@ import { QueryColumn } from '../../../public/QueryColumn';
 
 import { SELECTION_KEY_TYPE } from '../samples/constants';
 
+import { SchemaQuery } from '../../../public/SchemaQuery';
+
 import { EntityChoice, EntityDataType, IEntityTypeOption } from './models';
 
 import { ParentIdData } from './actions';
-import { SchemaQuery } from '../../../public/SchemaQuery';
 
 export function sampleDeleteDependencyText(): string {
     let deleteMsg = '';
@@ -218,14 +219,12 @@ export function createEntityParentKey(schemaQuery: SchemaQuery, id?: string): st
 }
 
 export function parseEntityParentKey(parentKey: string): string[] {
-    if (!parentKey)
-        return [];
+    if (!parentKey) return [];
 
     const allParts = parentKey.split(PARENT_KEY_DIVIDER);
     // schema: allParts[0]; query: allParts[1];
     const result = allParts.splice(0, 2);
     // all rest is the key value (optional)
-    if (allParts?.length > 0)
-        result.push(allParts.join(PARENT_KEY_DIVIDER));
+    if (allParts?.length > 0) result.push(allParts.join(PARENT_KEY_DIVIDER));
     return result;
 }


### PR DESCRIPTION
#### Rationale
Issue 52533: LKSM: Error creating samples from details pages with Sources with a colon in the name
Previously, ':' is used as delimiter when generating a parent key that consist of schema/query/dataKey that's passed around in url. ':' is not a good choice as such delimiter as it's a legal character for domain names. This PR switch to use '|' as delimiter since it's not an allowed character for domain names so it should no cause conflicts with parent key parsing. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1752
- https://github.com/LabKey/labkey-ui-premium/pull/712
- https://github.com/LabKey/limsModules/pull/1248
- https://github.com/LabKey/testAutomation/pull/2354

#### Changes
  - Move createEntityParentKey from premium and switch to use '|' for schema|query|keyValue delimiter
  - Add parseEntityParentKey util
