### PR TITLE
Issue 52311: Mark unresolved lookup values in editable grid with a warning

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.0",
+  "version": "6.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.0",
+      "version": "6.34.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.0",
+  "version": "6.34.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.34.1
+*Released*: 28 March 2025
+- Issue 52311: Mark unresolved lookup values in editable grid with a warning
+
 ### version 6.34.0
 *Released*: 28 March 2025
 - Add `createSnapshotSelectionKey`

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -35,7 +35,13 @@ import { Popover } from '../../Popover';
 import { CellMessage, EditableColumnMetadata, ValueDescriptor } from './models';
 
 import { CellActions, MODIFICATION_TYPES, SELECTION_TYPES } from './constants';
-import { EDIT_GRID_INPUT_CELL_CLASS, gridCellSelectInputProps, onCellSelectChange } from './utils';
+import {
+    EDIT_GRID_INPUT_CELL_CLASS,
+    gridCellSelectInputProps,
+    isCellError,
+    isCellWarning,
+    onCellSelectChange,
+} from './utils';
 import { LookupCell } from './LookupCell';
 import { DateInputCell } from './DateInputCell';
 
@@ -106,12 +112,13 @@ const DisplayCell: FC<DisplayCellProps> = memo(props => {
         'cell-border-right': borderMaskRight,
         'cell-border-bottom': borderMaskBottom,
         'cell-border-left': borderMaskLeft,
+        'cell-error': isCellError(message),
         'cell-menu': showMenu,
         'cell-placeholder': displayValue.length === 0 && placeholder !== undefined,
         'cell-read-only': isReadOnly,
         'cell-selected': selected,
         'cell-selection': selection,
-        'cell-warning': message !== undefined,
+        'cell-warning': isCellWarning(message),
     });
     const value = displayValue.length === 0 && placeholder ? placeholder : displayValue;
     let body;

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -235,7 +235,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
     }
 
     get isReadOnly(): boolean {
-        return this.props.readOnly || this.props.col.readOnly
+        return this.props.readOnly || this.props.col.readOnly;
     }
 
     componentDidUpdate(prevProps: Readonly<CellProps>): void {

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -421,10 +421,6 @@ describe('generateColumnFillValues', () => {
         rowCount: 10,
     }) as EditorModel;
 
-    beforeAll(() => {
-        global.console.warn = jest.fn();
-    });
-
     test('single initialSelection', () => {
         const cellValues = generateColumnFillValues(editorModel, [genCellKey(lookupFk, 0)], undefined, [
             genCellKey(lookupFk, 1),
@@ -1072,7 +1068,7 @@ describe('loadEditorModelData', () => {
         ];
 
         const result = await loadEditorModelData(orderedRows, rows, columns, false);
-        expect(result.toJS()).toStrictEqual({
+        expect(result.cellValues.toJS()).toStrictEqual({
             'name&&0': [{ display: 'S-20-3', raw: 'S-20-3' }],
             'name&&1': [{ display: 'S-26', raw: 'S-26' }],
             'aliqandparent$d$c$p$s&&0': [{ display: '456', raw: '456' }],

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -1098,30 +1098,41 @@ describe('loadEditorModelData', () => {
     test('get column by index', async () => {
         const api = getTestApi();
         const result = await loadEditorModelData(orderedRows, rows, columns, false, api);
+        // eslint-disable-next-line no-warning-comments
+        // FIXME: Re-enable commented out lines with fix for Issue 52634
         expect(result.cellValues.toJS()).toStrictEqual({
             'name&&0': [{ display: 'S-20-3', raw: 'S-20-3' }],
             'name&&1': [{ display: 'S-26', raw: 'S-26' }],
             'aliqandparent$d$c$p$s&&0': [{ display: '456', raw: '456' }],
-            'samplefield$p$s$c$d$a&&0': [{ display: '<2675720>', raw: 2675720 }],
             'aliqandparent$d$c$p$s&&1': [{ display: '888', raw: '888' }],
-            'samplefield$p$s$c$d$a&&1': [{ display: '10-1-1', raw: 117334 }],
+
+            'samplefield$p$s$c$d$a&&0': [{ display: '00401', raw: 2675720 }],
+            // 'samplefield$p$s$c$d$a&&0': [{ display: '<2675720>', raw: 2675720 }],
+
+            'samplefield$p$s$c$d$a&&1': [{ display: 117334, raw: 117334 }],
+            // 'samplefield$p$s$c$d$a&&1': [{ display: '10-1-1', raw: 117334 }],
+
             'intfield$p$s$c$d$a&&0': [{ display: 3, raw: 3 }],
             'dtfield$p$s$c$d$a&&0': [{ display: '04Feb2025', raw: '2025-02-04 00:00:00.000' }],
             'intfield$p$s$c$d$a&&1': [{ display: 333, raw: 333 }],
             'aliqfield$d$c$p$s&&0': [{ display: '123', raw: '123' }],
             'dtfield$p$s$c$d$a&&1': [{ display: '07Feb2025', raw: '2025-02-07 00:00:00.000' }],
             'aliqfield$d$c$p$s&&1': [{ display: undefined, raw: undefined }],
-            'lkfield$p$s$c$d$a&&0': [{ display: 'DAS Testing', raw: 42876 }],
-            'lkfield$p$s$c$d$a&&1': [{ display: '<37721>', raw: 37721 }],
+
+            'lkfield$p$s$c$d$a&&0': [{ display: 42876, raw: 42876 }],
+            // 'lkfield$p$s$c$d$a&&0': [{ display: 'DAS Testing', raw: 42876 }],
+
+            'lkfield$p$s$c$d$a&&1': [{ display: 'Assay Required File', raw: 37721 }],
+            // 'lkfield$p$s$c$d$a&&1': [{ display: '<37721>', raw: 37721 }],
         });
 
-        // Issue 52311: Expect lookup validation warnings
-        expect(result.cellMessages.toJS()).toStrictEqual({
-            'lkfield$p$s$c$d$a&&1': { message: 'Could not find 37721', isWarning: true },
-            'samplefield$p$s$c$d$a&&0': { message: 'Could not find 2675720', isWarning: true },
-        });
-
-        // Expect both lookup columns to have been validated
-        expect(api.query.selectRows).toHaveBeenCalledTimes(2);
+        // // Issue 52311: Expect lookup validation warnings
+        // expect(result.cellMessages.toJS()).toStrictEqual({
+        //     'lkfield$p$s$c$d$a&&1': { message: 'Could not find 37721', isWarning: true },
+        //     'samplefield$p$s$c$d$a&&0': { message: 'Could not find 2675720', isWarning: true },
+        // });
+        //
+        // // Expect both lookup columns to have been validated
+        // expect(api.query.selectRows).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -1064,7 +1064,7 @@ describe('loadEditorModelData', () => {
             'aliqAndParent$,./': '456',
             StoredAmount: 3,
             Description: 'desc',
-            'sampleField./,$&': [{ displayValue: '00401', value: 2675720 }],
+            'sampleField./,$&': 2675720,
             'BoolField./,$&': true,
             'userField./,$&': [{ displayValue: 'editorwithoutdelete', value: 5027 }],
             'flagField./,$&': '555',
@@ -1098,41 +1098,34 @@ describe('loadEditorModelData', () => {
     test('get column by index', async () => {
         const api = getTestApi();
         const result = await loadEditorModelData(orderedRows, rows, columns, false, api);
-        // eslint-disable-next-line no-warning-comments
-        // FIXME: Re-enable commented out lines with fix for Issue 52634
+
         expect(result.cellValues.toJS()).toStrictEqual({
             'name&&0': [{ display: 'S-20-3', raw: 'S-20-3' }],
             'name&&1': [{ display: 'S-26', raw: 'S-26' }],
             'aliqandparent$d$c$p$s&&0': [{ display: '456', raw: '456' }],
             'aliqandparent$d$c$p$s&&1': [{ display: '888', raw: '888' }],
-
-            'samplefield$p$s$c$d$a&&0': [{ display: '00401', raw: 2675720 }],
-            // 'samplefield$p$s$c$d$a&&0': [{ display: '<2675720>', raw: 2675720 }],
-
-            'samplefield$p$s$c$d$a&&1': [{ display: 117334, raw: 117334 }],
-            // 'samplefield$p$s$c$d$a&&1': [{ display: '10-1-1', raw: 117334 }],
-
+            'samplefield$p$s$c$d$a&&0': [{ display: '<2675720>', raw: 2675720 }],
+            'samplefield$p$s$c$d$a&&1': [{ display: '10-1-1', raw: 117334 }],
             'intfield$p$s$c$d$a&&0': [{ display: 3, raw: 3 }],
             'dtfield$p$s$c$d$a&&0': [{ display: '04Feb2025', raw: '2025-02-04 00:00:00.000' }],
             'intfield$p$s$c$d$a&&1': [{ display: 333, raw: 333 }],
             'aliqfield$d$c$p$s&&0': [{ display: '123', raw: '123' }],
             'dtfield$p$s$c$d$a&&1': [{ display: '07Feb2025', raw: '2025-02-07 00:00:00.000' }],
             'aliqfield$d$c$p$s&&1': [{ display: undefined, raw: undefined }],
-
-            'lkfield$p$s$c$d$a&&0': [{ display: 42876, raw: 42876 }],
-            // 'lkfield$p$s$c$d$a&&0': [{ display: 'DAS Testing', raw: 42876 }],
-
+            'lkfield$p$s$c$d$a&&0': [{ display: 'DAS Testing', raw: 42876 }],
             'lkfield$p$s$c$d$a&&1': [{ display: 'Assay Required File', raw: 37721 }],
-            // 'lkfield$p$s$c$d$a&&1': [{ display: '<37721>', raw: 37721 }],
         });
 
-        // // Issue 52311: Expect lookup validation warnings
-        // expect(result.cellMessages.toJS()).toStrictEqual({
-        //     'lkfield$p$s$c$d$a&&1': { message: 'Could not find 37721', isWarning: true },
-        //     'samplefield$p$s$c$d$a&&0': { message: 'Could not find 2675720', isWarning: true },
-        // });
-        //
-        // // Expect both lookup columns to have been validated
-        // expect(api.query.selectRows).toHaveBeenCalledTimes(2);
+        // Issue 52311: Expect lookup validation warnings
+        expect(result.cellMessages.toJS()).toStrictEqual({
+            'lkfield$p$s$c$d$a&&1': {
+                message: 'Assay Required File is no longer a valid value. Data may have moved.',
+                isWarning: true,
+            },
+            'samplefield$p$s$c$d$a&&0': { message: 'Could not find 2675720', isWarning: true },
+        });
+
+        // Expect both lookup columns to have been validated
+        expect(api.query.selectRows).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -16,6 +16,7 @@ import {
     changeColumn,
     detectPadLength,
     loadEditorModelData,
+    lookupValidationError,
     parseIntIfNumber,
     parsePastedLookup,
     removeColumn,
@@ -1071,32 +1072,27 @@ describe('loadEditorModelData', () => {
         },
     };
 
-    function getTestApi(): ComponentsAPIWrapper {
+    function getTestApi(selectRows = jest.fn()): ComponentsAPIWrapper {
         const testApi = getTestAPIWrapper(jest.fn);
-
-        return {
-            ...testApi,
-            query: {
-                ...testApi.query,
-                selectRows: jest.fn().mockImplementation(({ schemaQuery }) => {
-                    const rows_: Row[] = [];
-
-                    if (schemaQuery.queryName === 'AssayList') {
-                        // Resolve lookup value for lkField./,$&
-                        rows_.push({ Name: { value: 'DAS Testing' }, RowId: { value: 42876 } });
-                    } else if (schemaQuery.queryName === 'Materials') {
-                        // Resolve lookup value for sampleField./,$&
-                        rows_.push({ Name: { value: '10-1-1' }, RowId: { value: 117334 } });
-                    }
-
-                    return { rows: rows_ };
-                }),
-            },
-        };
+        return { ...testApi, query: { ...testApi.query, selectRows } };
     }
 
-    test('get column by index', async () => {
-        const api = getTestApi();
+    test('getLookupValueDescriptors', async () => {
+        const selectRows = jest.fn().mockImplementation(({ schemaQuery }) => {
+            const rows_: Row[] = [];
+
+            if (schemaQuery.queryName === 'AssayList') {
+                // Resolve lookup value for lkField./,$&
+                rows_.push({ Name: { value: 'DAS Testing' }, RowId: { value: 42876 } });
+            } else if (schemaQuery.queryName === 'Materials') {
+                // Resolve lookup value for sampleField./,$&
+                rows_.push({ Name: { value: '10-1-1' }, RowId: { value: 117334 } });
+            }
+
+            return { rows: rows_ };
+        });
+
+        const api = getTestApi(selectRows);
         const result = await loadEditorModelData(orderedRows, rows, columns, false, api);
 
         expect(result.cellValues.toJS()).toStrictEqual({
@@ -1119,13 +1115,70 @@ describe('loadEditorModelData', () => {
         // Issue 52311: Expect lookup validation warnings
         expect(result.cellMessages.toJS()).toStrictEqual({
             'lkfield$p$s$c$d$a&&1': {
-                message: 'Assay Required File is no longer a valid value. Data may have moved.',
                 isWarning: true,
+                message: 'Assay Required File is no longer a valid value. Data may have been moved or deleted.',
             },
-            'samplefield$p$s$c$d$a&&0': { message: 'Could not find 2675720', isWarning: true },
+            'samplefield$p$s$c$d$a&&0': {
+                isWarning: true,
+                message: 'Could not find 2675720. Data may have been moved or deleted.',
+            },
         });
 
         // Expect both lookup columns to have been validated
         expect(api.query.selectRows).toHaveBeenCalledTimes(2);
+    });
+
+    test('getLookupValueDescriptors failed lookup request', async () => {
+        const selectRows = jest.fn().mockRejectedValue('Who goes there?!');
+
+        const api = getTestApi(selectRows);
+        const result = await loadEditorModelData(orderedRows, rows, columns, false, api);
+
+        // Issue 52311: Expect lookup validation warnings
+        expect(result.cellMessages.toJS()).toStrictEqual({
+            'lkfield$p$s$c$d$a&&0': {
+                isWarning: true,
+                message: 'Failed to resolves values for column lkField./,$&. Who goes there?!',
+            },
+            'lkfield$p$s$c$d$a&&1': {
+                isWarning: true,
+                message: 'Failed to resolves values for column lkField./,$&. Who goes there?!',
+            },
+            'samplefield$p$s$c$d$a&&0': {
+                isWarning: true,
+                message: 'Failed to resolves values for column sampleField./,$&. Who goes there?!',
+            },
+            'samplefield$p$s$c$d$a&&1': {
+                isWarning: true,
+                message: 'Failed to resolves values for column sampleField./,$&. Who goes there?!',
+            },
+        });
+
+        // Expect both lookup columns to have been validated
+        expect(api.query.selectRows).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('lookupValidationError', () => {
+    test('value only', () => {
+        expect(lookupValidationError('s').message).toEqual('Could not find s. Data may have been moved or deleted.');
+        expect(lookupValidationError(1.4).message).toEqual('Could not find 1.4. Data may have been moved or deleted.');
+        expect(lookupValidationError(false).message).toEqual(
+            'Could not find false. Data may have been moved or deleted.'
+        );
+    });
+
+    test('fromPaste', () => {
+        expect(lookupValidationError(false, true).message).toEqual('Could not find false');
+        expect(lookupValidationError('beep', true).message).toEqual('Could not find beep');
+        expect(lookupValidationError('"sara", "pete"', true).message).toEqual(
+            'Could not find "sara", "pete". Please make sure values that contain commas are properly quoted.'
+        );
+    });
+
+    test('with displayValue', () => {
+        expect(lookupValidationError('beep,', false, 'vw').message).toEqual(
+            'vw is no longer a valid value. Data may have been moved or deleted.'
+        );
     });
 });

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -7,6 +7,10 @@ import { makeTestQueryModel } from '../../../public/QueryModel/testUtils';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import sampleSet2QueryInfo from '../../../test/data/sampleSet2-getQueryDetails.json';
 
+import { ComponentsAPIWrapper, getTestAPIWrapper } from '../../APIWrapper';
+
+import { Row } from '../../query/selectRows';
+
 import {
     addColumns,
     changeColumn,
@@ -929,7 +933,78 @@ describe('insertPastedData', () => {
 });
 
 describe('loadEditorModelData', () => {
+    const columns = [
+        new QueryColumn({
+            fieldKey: 'Name',
+            fieldKeyArray: ['Name'],
+            fieldKeyPath: 'Name',
+            derivationDataScope: null,
+            name: 'Name',
+        }),
+        new QueryColumn({
+            fieldKey: 'DtField$P$S$C$D$A',
+            fieldKeyArray: ['DtField./,$&'],
+            fieldKeyPath: 'DtField$P$S$C$D$A',
+            derivationDataScope: 'ParentOnly',
+            name: 'DtField./,$&',
+        }),
+        new QueryColumn({
+            fieldKey: 'IntField$P$S$C$D$A',
+            fieldKeyArray: ['IntField./,$&'],
+            fieldKeyPath: 'IntField$P$S$C$D$A',
+            derivationDataScope: 'ParentOnly',
+            name: 'IntField./,$&',
+        }),
+        new QueryColumn({
+            fieldKey: 'lkField$P$S$C$D$A',
+            fieldKeyArray: ['lkField./,$&'],
+            fieldKeyPath: 'lkField$P$S$C$D$A',
+            name: 'lkField./,$&',
+            derivationDataScope: 'ParentOnly',
+            lookup: {
+                displayColumn: 'Name',
+                isPublic: true,
+                keyColumn: 'RowId',
+                public: true,
+                queryName: 'AssayList',
+                schema: 'assay',
+                schemaName: 'assay',
+            },
+        }),
+        new QueryColumn({
+            fieldKey: 'sampleField$P$S$C$D$A',
+            fieldKeyArray: ['sampleField./,$&'],
+            fieldKeyPath: 'sampleField$P$S$C$D$A',
+            name: 'sampleField./,$&',
+            derivationDataScope: 'ParentOnly',
+            lookup: {
+                displayColumn: 'Name',
+                isPublic: true,
+                keyColumn: 'RowId',
+                public: true,
+                queryName: 'Materials',
+                schema: 'exp',
+                schemaName: 'exp',
+            },
+        }),
+        new QueryColumn({
+            fieldKey: 'aliqField$D$C$P$S',
+            fieldKeyArray: ['aliqField$,./'],
+            fieldKeyPath: 'aliqField$D$C$P$S',
+            name: 'aliqField$,./',
+            derivationDataScope: 'ChildOnly',
+        }),
+        new QueryColumn({
+            fieldKey: 'aliqAndParent$D$C$P$S',
+            fieldKeyArray: ['aliqAndParent$,./'],
+            fieldKeyPath: 'aliqAndParent$D$C$P$S',
+            name: 'aliqAndParent$,./',
+            derivationDataScope: 'All',
+        }),
+    ];
+
     const orderedRows = ['2811466', '2805931'];
+
     const rows = {
         '2805931': {
             'TimeField./,$&': '16:10',
@@ -954,7 +1029,7 @@ describe('loadEditorModelData', () => {
             'aliqAndParent$,./': '888',
             StoredAmount: 99,
             Description: '111',
-            'sampleField./,$&': [{ displayValue: '10-1-1', value: 117334 }],
+            'sampleField./,$&': [{ value: 117334 }], // displayValue: '10-1-1'
             'BoolField./,$&': false,
             'userField./,$&': [{ displayValue: 'assaytypedesigner', value: 14688 }],
             'flagField./,$&': '555',
@@ -983,7 +1058,7 @@ describe('loadEditorModelData', () => {
             Alias: [],
             'aliqField$,./': '123',
             'DtTimeField./,$&': [{ displayValue: '2025-01-29 24:00', value: '2025-01-29 00:00:00.000' }],
-            'lkField./,$&': [{ displayValue: 'DAS Testing', value: 42876 }],
+            'lkField./,$&': [{ value: 42876 }], // displayValue: 'DAS Testing'
             RowId: 2811466,
             'DecField./,$&': 22,
             'aliqAndParent$,./': '456',
@@ -996,83 +1071,38 @@ describe('loadEditorModelData', () => {
         },
     };
 
-    test('get column by index', async () => {
-        const columns = [
-            new QueryColumn({
-                fieldKey: 'Name',
-                fieldKeyArray: ['Name'],
-                fieldKeyPath: 'Name',
-                derivationDataScope: null,
-                name: 'Name',
-            }),
-            new QueryColumn({
-                fieldKey: 'DtField$P$S$C$D$A',
-                fieldKeyArray: ['DtField./,$&'],
-                fieldKeyPath: 'DtField$P$S$C$D$A',
-                derivationDataScope: 'ParentOnly',
-                name: 'DtField./,$&',
-            }),
-            new QueryColumn({
-                fieldKey: 'IntField$P$S$C$D$A',
-                fieldKeyArray: ['IntField./,$&'],
-                fieldKeyPath: 'IntField$P$S$C$D$A',
-                derivationDataScope: 'ParentOnly',
-                name: 'IntField./,$&',
-            }),
-            new QueryColumn({
-                fieldKey: 'lkField$P$S$C$D$A',
-                fieldKeyArray: ['lkField./,$&'],
-                fieldKeyPath: 'lkField$P$S$C$D$A',
-                name: 'lkField./,$&',
-                derivationDataScope: 'ParentOnly',
-                lookup: {
-                    displayColumn: 'Name',
-                    isPublic: true,
-                    keyColumn: 'RowId',
-                    public: true,
-                    queryName: 'AssayList',
-                    schema: 'assay',
-                    schemaName: 'assay',
-                },
-            }),
-            new QueryColumn({
-                fieldKey: 'sampleField$P$S$C$D$A',
-                fieldKeyArray: ['sampleField./,$&'],
-                fieldKeyPath: 'sampleField$P$S$C$D$A',
-                name: 'sampleField./,$&',
-                derivationDataScope: 'ParentOnly',
-                lookup: {
-                    displayColumn: 'Name',
-                    isPublic: true,
-                    keyColumn: 'RowId',
-                    public: true,
-                    queryName: 'Materials',
-                    schema: 'exp',
-                    schemaName: 'exp',
-                },
-            }),
-            new QueryColumn({
-                fieldKey: 'aliqField$D$C$P$S',
-                fieldKeyArray: ['aliqField$,./'],
-                fieldKeyPath: 'aliqField$D$C$P$S',
-                name: 'aliqField$,./',
-                derivationDataScope: 'ChildOnly',
-            }),
-            new QueryColumn({
-                fieldKey: 'aliqAndParent$D$C$P$S',
-                fieldKeyArray: ['aliqAndParent$,./'],
-                fieldKeyPath: 'aliqAndParent$D$C$P$S',
-                name: 'aliqAndParent$,./',
-                derivationDataScope: 'All',
-            }),
-        ];
+    function getTestApi(): ComponentsAPIWrapper {
+        const testApi = getTestAPIWrapper(jest.fn);
 
-        const result = await loadEditorModelData(orderedRows, rows, columns, false);
+        return {
+            ...testApi,
+            query: {
+                ...testApi.query,
+                selectRows: jest.fn().mockImplementation(({ schemaQuery }) => {
+                    const rows_: Row[] = [];
+
+                    if (schemaQuery.queryName === 'AssayList') {
+                        // Resolve lookup value for lkField./,$&
+                        rows_.push({ Name: { value: 'DAS Testing' }, RowId: { value: 42876 } });
+                    } else if (schemaQuery.queryName === 'Materials') {
+                        // Resolve lookup value for sampleField./,$&
+                        rows_.push({ Name: { value: '10-1-1' }, RowId: { value: 117334 } });
+                    }
+
+                    return { rows: rows_ };
+                }),
+            },
+        };
+    }
+
+    test('get column by index', async () => {
+        const api = getTestApi();
+        const result = await loadEditorModelData(orderedRows, rows, columns, false, api);
         expect(result.cellValues.toJS()).toStrictEqual({
             'name&&0': [{ display: 'S-20-3', raw: 'S-20-3' }],
             'name&&1': [{ display: 'S-26', raw: 'S-26' }],
             'aliqandparent$d$c$p$s&&0': [{ display: '456', raw: '456' }],
-            'samplefield$p$s$c$d$a&&0': [{ display: '00401', raw: 2675720 }],
+            'samplefield$p$s$c$d$a&&0': [{ display: '<2675720>', raw: 2675720 }],
             'aliqandparent$d$c$p$s&&1': [{ display: '888', raw: '888' }],
             'samplefield$p$s$c$d$a&&1': [{ display: '10-1-1', raw: 117334 }],
             'intfield$p$s$c$d$a&&0': [{ display: 3, raw: 3 }],
@@ -1082,7 +1112,16 @@ describe('loadEditorModelData', () => {
             'dtfield$p$s$c$d$a&&1': [{ display: '07Feb2025', raw: '2025-02-07 00:00:00.000' }],
             'aliqfield$d$c$p$s&&1': [{ display: undefined, raw: undefined }],
             'lkfield$p$s$c$d$a&&0': [{ display: 'DAS Testing', raw: 42876 }],
-            'lkfield$p$s$c$d$a&&1': [{ display: 'Assay Required File', raw: 37721 }],
+            'lkfield$p$s$c$d$a&&1': [{ display: '<37721>', raw: 37721 }],
         });
+
+        // Issue 52311: Expect lookup validation warnings
+        expect(result.cellMessages.toJS()).toStrictEqual({
+            'lkfield$p$s$c$d$a&&1': { message: 'Could not find 37721', isWarning: true },
+            'samplefield$p$s$c$d$a&&0': { message: 'Could not find 2675720', isWarning: true },
+        });
+
+        // Expect both lookup columns to have been validated
+        expect(api.query.selectRows).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -21,6 +21,8 @@ import { getContainerFilterForLookups } from '../../query/api';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
+import { resolveErrorMessage } from '../../util/messaging';
+
 import {
     CellMessage,
     EditableColumnMetadata,
@@ -279,6 +281,8 @@ const findLookupValues = async (options: FindLookupValuesOptions): Promise<Value
     }, []);
 };
 
+// Resolves the folder path for a row during initialization.
+// If a folder path is not explicitly resolved, then it defaults to the current folder.
 function getRowFolderPath(row: Record<string, any>): string {
     const rowValue = caseInsensitive(row, 'Folder') ?? caseInsensitive(row, 'Container');
     const currentFolder = getServerContext().container;
@@ -313,8 +317,10 @@ async function getLookupValueDescriptors(
         .map(async col => {
             const allValues = new Set<number>();
             const valueFolderMap: Record<string, Set<number>> = {};
-            const valueDisplayValueMap: Record<number, any> = {};
+            const displayValueMap: Record<number, any> = {};
 
+            // The same value for a column may be set in rows from different folders. We need to validate each value
+            // for each folder where that value is utilized. Due to this we end up making a request per folder/column/value.
             const processValue = (val: number, row: Record<string, any>): void => {
                 const folderPath = getRowFolderPath(row);
                 if (!valueFolderMap[folderPath]) valueFolderMap[folderPath] = new Set<number>();
@@ -326,31 +332,51 @@ async function getLookupValueDescriptors(
                 const row = rows[id];
                 const value = row?.[col.fieldKey] ?? row?.[col.name];
 
-                if (Array.isArray(value)) {
+                if (Utils.isNumber(value)) {
+                    processValue(value, row);
+                } else if (Array.isArray(value)) {
                     value.forEach(val => {
                         if (Utils.isNumber(val?.value)) {
                             processValue(val?.value, row);
                             if (val?.displayValue) {
-                                valueDisplayValueMap[val.value] = val.displayValue;
+                                displayValueMap[val.value] = val.displayValue;
                             }
                         }
                     });
-                } else if (Utils.isNumber(value)) {
-                    processValue(value, row);
                 }
             }
 
             if (allValues.size > 0) {
+                // Collect errors made when attempting to resolve lookup values so we can at least tell the user
+                // something went awry when trying to validate the values. This is expected to be an uncommon scenario.
+                const errorMap: Record<number, string> = {};
+
                 const results = await Promise.all(
-                    Object.entries(valueFolderMap).map(([containerPath, values]) =>
-                        findLookupValues({
-                            api,
-                            column: col,
-                            containerPath,
-                            forUpdate,
-                            lookupKeyValues: Array.from(values),
-                        })
-                    )
+                    // This must be async as returning the result directly avoids the try/catch handling
+                    Object.entries(valueFolderMap).map(async ([containerPath, values]) => {
+                        let descriptors_: ValueDescriptor[];
+                        try {
+                            descriptors_ = await findLookupValues({
+                                api,
+                                column: col,
+                                containerPath,
+                                forUpdate,
+                                lookupKeyValues: Array.from(values),
+                            });
+                        } catch (e) {
+                            let errorMsg = `Failed to resolves values for column ${col.caption ?? col.name}.`;
+                            const resolved = resolveErrorMessage(e);
+                            if (resolved) {
+                                errorMsg += ' ' + resolved;
+                            }
+                            values.forEach(value => {
+                                errorMap[value] = errorMsg;
+                            });
+                            descriptors_ = [];
+                        }
+
+                        return descriptors_;
+                    })
                 );
 
                 const messageAndValues: MessageAndValue[] = [];
@@ -365,18 +391,14 @@ async function getLookupValueDescriptors(
 
                 // Issue 52311: Mark unresolved lookup values with a warning.
                 for (const value of allValues) {
-                    let message: string;
-                    const display = valueDisplayValueMap[value];
-
-                    if (display !== undefined) {
-                        message = `${display} is no longer a valid value. Data may have moved.`;
-                    } else {
-                        message = lookupValidationError(value).message;
-                    }
+                    const displayValue = displayValueMap[value];
 
                     messageAndValues.push({
-                        message: { message, isWarning: true },
-                        valueDescriptor: { display: valueDisplayValueMap[value] ?? `<${value}>`, raw: value },
+                        message: {
+                            isWarning: true,
+                            message: errorMap[value] ?? lookupValidationError(value, false, displayValue).message,
+                        },
+                        valueDescriptor: { display: displayValue ?? `<${value}>`, raw: value },
                     });
                 }
 
@@ -388,12 +410,22 @@ async function getLookupValueDescriptors(
     return lookupValues;
 }
 
-function lookupValidationError(value: string | number | boolean, fromPaste?: boolean): CellMessage {
-    let suffix = '';
-    if (fromPaste && typeof value === 'string' && value.toString().indexOf(',') > -1) {
-        suffix = '. Please make sure values that contain commas are properly quoted.';
+export function lookupValidationError(
+    value: string | number | boolean,
+    fromPaste?: boolean,
+    displayValue?: any
+): CellMessage {
+    let message = displayValue !== undefined ? `${displayValue} is no longer a valid value` : `Could not find ${value}`;
+
+    if (fromPaste) {
+        if (typeof value === 'string' && value.toString().indexOf(',') > -1) {
+            message += '. Please make sure values that contain commas are properly quoted.';
+        }
+    } else {
+        message += '. Data may have been moved or deleted.';
     }
-    return { message: `Could not find ${value}${suffix}` };
+
+    return { message };
 }
 
 async function getLookupDisplayValue(column: QueryColumn, value: any, containerPath: string): Promise<MessageAndValue> {

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -299,18 +299,27 @@ async function getLookupValueDescriptors(
                 const value = row?.[col.fieldKey] ?? row?.[col.name];
                 if (Utils.isNumber(value)) {
                     values.add(value);
-                } else if (Array.isArray(value)) {
-                    value.forEach(val => {
-                        if (Utils.isNumber(val?.value)) {
-                            values.add(val.value);
-                        } else if (Utils.isNumber(val)) {
-                            values.add(val);
-                        }
-                    });
                 }
+
+                // eslint-disable-next-line no-warning-comments
+                // FIXME: Issue 52634: Resolve lookup values against array-based results.
+                // Previously, this had been looking for List.isList(value) which is no longer viable as Lists are no
+                // longer passed into this function. When re-enabling this behavior I encountered multiple issues.
+                //
+                // } else if (Array.isArray(value)) {
+                //     value.forEach(val => {
+                //         if (Utils.isNumber(val?.value)) {
+                //             values.add(val.value);
+                //         }
+                //     });
+                // }
             });
 
             if (values.size > 0) {
+                // eslint-disable-next-line no-warning-comments
+                // FIXME: Issue 52634: Respect folder of the row. Aggregate lookup value requests by folder.
+                // This does not respect the folder/container of the row which results in unresolved lookups because
+                // the request container is incorrect.
                 const descriptors = await findLookupValues({
                     api,
                     column: col,

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -44,9 +44,10 @@ export const loadEditorModelData = async (
     rows: Record<string, any>,
     columns: QueryColumn[],
     forUpdate: boolean
-): Promise<CellValues> => {
-    const lookupValueDescriptors = await getLookupValueDescriptors(columns, rows, orderedRows, forUpdate);
-    let cellValues = Map<string, List<ValueDescriptor>>();
+): Promise<{ cellMessages: CellMessages; cellValues: CellValues }> => {
+    const lookupValues = await getLookupValueDescriptors(columns, rows, orderedRows, forUpdate);
+    const cellMessages = Map<string, CellMessage>().asMutable();
+    const cellValues = Map<string, List<ValueDescriptor>>().asMutable();
 
     // data is initialized in column order
     columns.forEach(col => {
@@ -61,15 +62,23 @@ export const loadEditorModelData = async (
 
             if (Array.isArray(value)) {
                 // assume to be list of {displayValue, value} objects
-                cellValues = cellValues.set(
+                cellValues.set(
                     cellKey,
                     value.reduce((list, v) => {
                         if (col.isLookup() && Utils.isNumber(v)) {
-                            const descriptors = lookupValueDescriptors[col.lookupKey];
-                            if (descriptors) {
-                                const desc = descriptors.filter(descriptor => descriptor.raw === v);
-                                if (desc) {
-                                    return list.push(...desc);
+                            const lookupValue = lookupValues[col.lookupKey];
+                            if (lookupValue) {
+                                const messageAndValues = lookupValue.filter(lv => lv.valueDescriptor.raw === v);
+                                if (messageAndValues) {
+                                    const descriptors: ValueDescriptor[] = [];
+                                    for (let i = 0; i < messageAndValues.length; i++) {
+                                        if (messageAndValues[i].message) {
+                                            cellMessages.set(cellKey, messageAndValues[i].message);
+                                        }
+                                        descriptors.push(messageAndValues[i].valueDescriptor);
+                                    }
+
+                                    return list.push(...descriptors);
                                 }
                             }
                         }
@@ -90,18 +99,29 @@ export const loadEditorModelData = async (
 
                 // Issue 37833: try resolving the value for the lookup to get the displayValue to show in the grid cell
                 if (col.isLookup() && Utils.isNumber(raw)) {
-                    const descriptors = lookupValueDescriptors[col.lookupKey];
-                    if (descriptors) {
-                        cellValue = List(descriptors.filter(descriptor => descriptor.raw === raw));
+                    const lookupValue = lookupValues[col.lookupKey];
+                    if (lookupValue) {
+                        const messageAndValues = lookupValue.filter(lv => lv.valueDescriptor.raw === raw);
+                        if (messageAndValues) {
+                            const descriptors: ValueDescriptor[] = [];
+                            for (let i = 0; i < messageAndValues.length; i++) {
+                                if (messageAndValues[i].message) {
+                                    cellMessages.set(cellKey, messageAndValues[i].message);
+                                }
+                                descriptors.push(messageAndValues[i].valueDescriptor);
+                            }
+
+                            cellValue = List(descriptors);
+                        }
                     }
                 }
 
-                cellValues = cellValues.set(cellKey, cellValue);
+                cellValues.set(cellKey, cellValue);
             }
         });
     });
 
-    return cellValues;
+    return { cellMessages: cellMessages.asImmutable(), cellValues: cellValues.asImmutable() };
 };
 
 export const initEditorModel = async (
@@ -175,7 +195,7 @@ export const initEditorModel = async (
     }
 
     // TODO: Move initEditorModel, loadEditorModelData, and getLookupValueDescriptors to EditorModel as static methods
-    const cellValues = await loadEditorModelData(orderedRows, rows, columns, forUpdate);
+    const { cellMessages, cellValues } = await loadEditorModelData(orderedRows, rows, columns, forUpdate);
 
     if (columnMetadata) {
         // If columnMetadata is present force it to use lowercase keys
@@ -185,6 +205,7 @@ export const initEditorModel = async (
     }
 
     return new EditorModel({
+        cellMessages,
         cellValues,
         columnMetadata,
         columnMap: fromJS(columnMap),
@@ -210,8 +231,6 @@ const resolveDisplayField = (column: QueryColumn): string => {
     return column.lookup.displayColumnFieldKey;
 };
 
-type ColumnLoaderPromise = Promise<{ column: QueryColumn; descriptors: ValueDescriptor[] }>;
-
 const findLookupValues = async (
     column: QueryColumn,
     lookupKeyValues?: any[],
@@ -219,7 +238,7 @@ const findLookupValues = async (
     lookupValueFilters?: Filter.IFilter[],
     forUpdate?: boolean,
     containerPath?: string
-): ColumnLoaderPromise => {
+): Promise<ValueDescriptor[]> => {
     const { lookup } = column;
     const { keyColumn } = lookup;
     const displayColumnFieldKey = resolveDisplayField(column);
@@ -242,7 +261,7 @@ const findLookupValues = async (
         viewName: ViewInfo.DETAIL_NAME, // Use the detail view so values that may be filtered out of the default view show up.
     });
 
-    const descriptors = results.rows.reduce<ValueDescriptor[]>((desc, row) => {
+    return results.rows.reduce<ValueDescriptor[]>((desc, row) => {
         const key = caseInsensitive(row, keyColumn)?.value;
         if (key !== undefined && key !== null) {
             const displayRow = caseInsensitive(row, displayColumnFieldKey) ?? caseInsensitive(row, QueryKey.decodePart(displayColumnFieldKey));
@@ -250,8 +269,6 @@ const findLookupValues = async (
         }
         return desc;
     }, []);
-
-    return { column, descriptors };
 };
 
 async function getLookupValueDescriptors(
@@ -259,38 +276,47 @@ async function getLookupValueDescriptors(
     rows: Record<string, Record<string, any>>,
     ids: string[],
     forUpdate?: boolean
-): Promise<{ [colKey: string]: ValueDescriptor[] }> {
+): Promise<{ [colKey: string]: MessageAndValue[] }> {
     const descriptorMap = {};
     // for each lookup column, find the unique values in the rows and query for those values when they look like ids
     for (let cn = 0; cn < columns.length; cn++) {
         const col = columns[cn];
-        let values = new Set<number>();
+        const values = new Set<number>();
 
         if (col.isPublicLookup()) {
             ids.forEach(id => {
                 const row = rows[id];
                 const value = row?.[col.fieldKey] ?? row?.[col.name];
                 if (Utils.isNumber(value)) {
-                    values = values.add(value);
+                    values.add(value);
                 } else if (List.isList(value)) {
                     value.forEach(val => {
                         if (Map.isMap(val)) {
-                            values = values.add(val.get('value'));
+                            values.add(val.get('value'));
                         } else {
-                            values = values.add(val);
+                            values.add(val);
                         }
                     });
                 }
             });
             if (values.size > 0) {
-                const { descriptors } = await findLookupValues(
-                    col,
-                    Array.from(values),
-                    undefined,
-                    undefined,
-                    forUpdate
-                );
-                descriptorMap[col.lookupKey] = descriptors;
+                const descriptors = await findLookupValues(col, Array.from(values), undefined, undefined, forUpdate);
+                const messageAndValues: MessageAndValue[] = [];
+
+                descriptors.forEach(desc => {
+                    values.delete(desc.raw);
+                    messageAndValues.push({ valueDescriptor: desc });
+                });
+
+                // Issue 52311: Mark unresolved lookup values with a warning.
+                for (const value of values.values()) {
+                    messageAndValues.push({
+                        message: { ...lookupValidationError(value), isWarning: true },
+                        valueDescriptor: { display: `<${value}>`, raw: value },
+                    });
+                }
+
+                descriptorMap[col.lookupKey] = messageAndValues;
             }
         }
     }
@@ -318,7 +344,7 @@ async function getLookupDisplayValue(column: QueryColumn, value: any, containerP
 
     let message: CellMessage;
 
-    const { descriptors } = await findLookupValues(column, [value], undefined, undefined, false, containerPath);
+    const descriptors = await findLookupValues(column, [value], undefined, undefined, false, containerPath);
     if (!descriptors.length) {
         message = lookupValidationError(value);
     }
@@ -1012,7 +1038,7 @@ async function getParsedLookup(
             columnMetadata?.lookupValueFilters,
             forUpdate,
             containerPath
-        ).then(response => response.descriptors);
+        );
     }
 
     const descriptors = await lookupValueCache[cacheKey];

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1,4 +1,4 @@
-import { Filter, QueryKey, Utils } from '@labkey/api';
+import { Filter, getServerContext, QueryKey, Utils } from '@labkey/api';
 import { fromJS, List, Map, OrderedMap } from 'immutable';
 import { addDays, subDays } from 'date-fns';
 
@@ -279,6 +279,25 @@ const findLookupValues = async (options: FindLookupValuesOptions): Promise<Value
     }, []);
 };
 
+function getRowFolderPath(row: Record<string, any>): string {
+    const rowValue = caseInsensitive(row, 'Folder') ?? caseInsensitive(row, 'Container');
+    const currentFolder = getServerContext().container;
+    let folderPath: string;
+
+    if (Array.isArray(rowValue)) {
+        folderPath = rowValue[0]?.value;
+    } else {
+        folderPath = rowValue?.value;
+    }
+
+    // If the value is the current folder's entityId, then return the current folder's path
+    if (folderPath !== undefined && folderPath !== currentFolder.id) {
+        return folderPath;
+    }
+
+    return currentFolder.path;
+}
+
 async function getLookupValueDescriptors(
     columns: QueryColumn[],
     rows: Record<string, Record<string, any>>,
@@ -292,52 +311,72 @@ async function getLookupValueDescriptors(
     const lookupPromises = columns
         .filter(col => col.isPublicLookup())
         .map(async col => {
-            const values = new Set<number>();
+            const allValues = new Set<number>();
+            const valueFolderMap: Record<string, Set<number>> = {};
+            const valueDisplayValueMap: Record<number, any> = {};
 
-            ids.forEach(id => {
+            const processValue = (val: number, row: Record<string, any>): void => {
+                const folderPath = getRowFolderPath(row);
+                if (!valueFolderMap[folderPath]) valueFolderMap[folderPath] = new Set<number>();
+                valueFolderMap[folderPath].add(val);
+                allValues.add(val);
+            };
+
+            for (const id of ids) {
                 const row = rows[id];
                 const value = row?.[col.fieldKey] ?? row?.[col.name];
-                if (Utils.isNumber(value)) {
-                    values.add(value);
+
+                if (Array.isArray(value)) {
+                    value.forEach(val => {
+                        if (Utils.isNumber(val?.value)) {
+                            processValue(val?.value, row);
+                            if (val?.displayValue) {
+                                valueDisplayValueMap[val.value] = val.displayValue;
+                            }
+                        }
+                    });
+                } else if (Utils.isNumber(value)) {
+                    processValue(value, row);
                 }
+            }
 
-                // eslint-disable-next-line no-warning-comments
-                // FIXME: Issue 52634: Resolve lookup values against array-based results.
-                // Previously, this had been looking for List.isList(value) which is no longer viable as Lists are no
-                // longer passed into this function. When re-enabling this behavior I encountered multiple issues.
-                //
-                // } else if (Array.isArray(value)) {
-                //     value.forEach(val => {
-                //         if (Utils.isNumber(val?.value)) {
-                //             values.add(val.value);
-                //         }
-                //     });
-                // }
-            });
+            if (allValues.size > 0) {
+                const results = await Promise.all(
+                    Object.entries(valueFolderMap).map(([containerPath, values]) =>
+                        findLookupValues({
+                            api,
+                            column: col,
+                            containerPath,
+                            forUpdate,
+                            lookupKeyValues: Array.from(values),
+                        })
+                    )
+                );
 
-            if (values.size > 0) {
-                // eslint-disable-next-line no-warning-comments
-                // FIXME: Issue 52634: Respect folder of the row. Aggregate lookup value requests by folder.
-                // This does not respect the folder/container of the row which results in unresolved lookups because
-                // the request container is incorrect.
-                const descriptors = await findLookupValues({
-                    api,
-                    column: col,
-                    forUpdate,
-                    lookupKeyValues: Array.from(values),
-                });
                 const messageAndValues: MessageAndValue[] = [];
-
-                descriptors.forEach(desc => {
-                    values.delete(desc.raw);
-                    messageAndValues.push({ valueDescriptor: desc });
+                results.forEach(descriptors => {
+                    descriptors.forEach(valueDescriptor => {
+                        if (allValues.has(valueDescriptor.raw)) {
+                            allValues.delete(valueDescriptor.raw);
+                            messageAndValues.push({ valueDescriptor });
+                        }
+                    });
                 });
 
                 // Issue 52311: Mark unresolved lookup values with a warning.
-                for (const value of values) {
+                for (const value of allValues) {
+                    let message: string;
+                    const display = valueDisplayValueMap[value];
+
+                    if (display !== undefined) {
+                        message = `${display} is no longer a valid value. Data may have moved.`;
+                    } else {
+                        message = lookupValidationError(value).message;
+                    }
+
                     messageAndValues.push({
-                        message: { ...lookupValidationError(value), isWarning: true },
-                        valueDescriptor: { display: `<${value}>`, raw: value },
+                        message: { message, isWarning: true },
+                        valueDescriptor: { display: valueDisplayValueMap[value] ?? `<${value}>`, raw: value },
                     });
                 }
 

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -23,14 +23,11 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 import {
     CellMessage,
-    CellMessages,
-    CellValues,
     EditableColumnMetadata,
     EditableGridLoader,
     EditorMode,
     EditorModel,
     EditorModelProps,
-    MessageAndValue,
     ValueDescriptor,
 } from './models';
 
@@ -46,10 +43,10 @@ export const loadEditorModelData = async (
     columns: QueryColumn[],
     forUpdate: boolean,
     api?: ComponentsAPIWrapper
-): Promise<{ cellMessages: CellMessages; cellValues: CellValues }> => {
+): Promise<Partial<EditorModel>> => {
     const lookupValues = await getLookupValueDescriptors(columns, rows, orderedRows, forUpdate, api);
-    const cellMessages = Map<string, CellMessage>().asMutable();
-    const cellValues = Map<string, List<ValueDescriptor>>().asMutable();
+    const cellMessages: Record<string, CellMessage> = {};
+    const cellValues: Record<string, List<ValueDescriptor>> = {};
 
     // data is initialized in column order
     columns.forEach(col => {
@@ -61,70 +58,23 @@ export const loadEditorModelData = async (
             // rows objects keyed by column name for base table columns and by fieldKey for lookup columns
             // (see comments in QueryColumn index()).
             const value = row[col.index];
+            let descriptors: ValueDescriptor[];
 
             if (Array.isArray(value)) {
-                // assume to be list of {displayValue, value} objects
-                cellValues.set(
-                    cellKey,
-                    value.reduce((list, v) => {
-                        const raw = v.value ?? v;
-                        if (col.isLookup() && Utils.isNumber(raw)) {
-                            const lookupValue = lookupValues[col.lookupKey];
-                            if (lookupValue) {
-                                const messageAndValues = lookupValue.filter(lv => lv.valueDescriptor.raw === raw);
-                                if (messageAndValues) {
-                                    const descriptors: ValueDescriptor[] = [];
-                                    for (let i = 0; i < messageAndValues.length; i++) {
-                                        if (messageAndValues[i].message) {
-                                            cellMessages.set(cellKey, messageAndValues[i].message);
-                                        }
-                                        descriptors.push(messageAndValues[i].valueDescriptor);
-                                    }
-
-                                    return list.push(...descriptors);
-                                }
-                            }
-                        }
-
-                        return list.push({ display: v.displayValue ?? v, raw });
-                    }, List<ValueDescriptor>())
-                );
+                descriptors = value.reduce<ValueDescriptor[]>((list, v) => {
+                    list.push(...resolveValueDescriptors(col, lookupValues, cellMessages, cellKey, v));
+                    return list;
+                }, []);
             } else {
-                // assume to be a {displayValue, value} object but fall back on value not being an object
-                const raw = value?.value ?? value;
-                const display = value?.displayValue ?? raw;
-                let cellValue = List([
-                    {
-                        display: display !== null ? display : undefined,
-                        raw: raw !== null ? raw : undefined,
-                    },
-                ]);
-
                 // Issue 37833: try resolving the value for the lookup to get the displayValue to show in the grid cell
-                if (col.isLookup() && Utils.isNumber(raw)) {
-                    const lookupValue = lookupValues[col.lookupKey];
-                    if (lookupValue) {
-                        const messageAndValues = lookupValue.filter(lv => lv.valueDescriptor.raw === raw);
-                        if (messageAndValues) {
-                            const descriptors: ValueDescriptor[] = [];
-                            for (let i = 0; i < messageAndValues.length; i++) {
-                                if (messageAndValues[i].message) {
-                                    cellMessages.set(cellKey, messageAndValues[i].message);
-                                }
-                                descriptors.push(messageAndValues[i].valueDescriptor);
-                            }
-
-                            cellValue = List(descriptors);
-                        }
-                    }
-                }
-
-                cellValues.set(cellKey, cellValue);
+                descriptors = resolveValueDescriptors(col, lookupValues, cellMessages, cellKey, value);
             }
+
+            cellValues[cellKey] = List(descriptors);
         });
     });
 
-    return { cellMessages: cellMessages.asImmutable(), cellValues: cellValues.asImmutable() };
+    return { cellMessages: Map(cellMessages), cellValues: Map(cellValues) };
 };
 
 export const initEditorModel = async (
@@ -234,6 +184,47 @@ const resolveDisplayField = (column: QueryColumn): string => {
     return column.lookup.displayColumnFieldKey;
 };
 
+interface MessageAndValue {
+    message?: CellMessage;
+    valueDescriptor: ValueDescriptor;
+}
+
+type MessageAndValueMap = { [colKey: string]: MessageAndValue[] };
+
+function resolveValueDescriptors(
+    col: QueryColumn,
+    lookupValues: MessageAndValueMap,
+    cellMessages: Record<string, CellMessage>,
+    cellKey: string,
+    value: any
+): ValueDescriptor[] {
+    const raw = value?.value ?? value;
+
+    if (col.isLookup() && Utils.isNumber(raw)) {
+        const messageAndValues = lookupValues[col.lookupKey]?.filter(lv => lv.valueDescriptor.raw === raw);
+        if (messageAndValues) {
+            const descriptors: ValueDescriptor[] = [];
+            for (let i = 0; i < messageAndValues.length; i++) {
+                if (messageAndValues[i].message) {
+                    cellMessages[cellKey] = messageAndValues[i].message;
+                }
+                descriptors.push(messageAndValues[i].valueDescriptor);
+            }
+
+            return descriptors;
+        }
+    }
+
+    const display = value?.displayValue ?? raw;
+
+    return [
+        {
+            display: display !== null ? display : undefined,
+            raw: raw !== null ? raw : undefined,
+        },
+    ];
+}
+
 type FindLookupValuesOptions = {
     api?: ComponentsAPIWrapper;
     column: QueryColumn;
@@ -294,8 +285,8 @@ async function getLookupValueDescriptors(
     ids: string[],
     forUpdate: boolean,
     api?: ComponentsAPIWrapper
-): Promise<{ [colKey: string]: MessageAndValue[] }> {
-    const descriptorMap = {};
+): Promise<MessageAndValueMap> {
+    const lookupValues: MessageAndValueMap = {};
 
     // for each lookup column, find the unique values in the rows and query for those values when they look like ids
     const lookupPromises = columns
@@ -341,13 +332,12 @@ async function getLookupValueDescriptors(
                     });
                 }
 
-                descriptorMap[col.lookupKey] = messageAndValues;
+                lookupValues[col.lookupKey] = messageAndValues;
             }
         });
 
     await Promise.all(lookupPromises);
-
-    return descriptorMap;
+    return lookupValues;
 }
 
 function lookupValidationError(value: string | number | boolean, fromPaste?: boolean): CellMessage {

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -295,11 +295,11 @@ async function getLookupValueDescriptors(
     api?: ComponentsAPIWrapper
 ): Promise<{ [colKey: string]: MessageAndValue[] }> {
     const descriptorMap = {};
-    // for each lookup column, find the unique values in the rows and query for those values when they look like ids
-    for (let cn = 0; cn < columns.length; cn++) {
-        const col = columns[cn];
 
-        if (col.isPublicLookup()) {
+    // for each lookup column, find the unique values in the rows and query for those values when they look like ids
+    const lookupPromises = columns
+        .filter(col => col.isPublicLookup())
+        .map(async col => {
             const values = new Set<number>();
 
             ids.forEach(id => {
@@ -333,7 +333,7 @@ async function getLookupValueDescriptors(
                 });
 
                 // Issue 52311: Mark unresolved lookup values with a warning.
-                for (const value of values.values()) {
+                for (const value of values) {
                     messageAndValues.push({
                         message: { ...lookupValidationError(value), isWarning: true },
                         valueDescriptor: { display: `<${value}>`, raw: value },
@@ -342,8 +342,9 @@ async function getLookupValueDescriptors(
 
                 descriptorMap[col.lookupKey] = messageAndValues;
             }
-        }
-    }
+        });
+
+    await Promise.all(lookupPromises);
 
     return descriptorMap;
 }

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -17,9 +17,9 @@ import {
 } from '../../util/utils';
 import { ViewInfo } from '../../ViewInfo';
 
-import { selectRows } from '../../query/selectRows';
-
 import { getContainerFilterForLookups } from '../../query/api';
+
+import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 import {
     CellMessage,
@@ -43,9 +43,10 @@ export const loadEditorModelData = async (
     orderedRows: string[],
     rows: Record<string, any>,
     columns: QueryColumn[],
-    forUpdate: boolean
+    forUpdate: boolean,
+    api?: ComponentsAPIWrapper
 ): Promise<{ cellMessages: CellMessages; cellValues: CellValues }> => {
-    const lookupValues = await getLookupValueDescriptors(columns, rows, orderedRows, forUpdate);
+    const lookupValues = await getLookupValueDescriptors(columns, rows, orderedRows, forUpdate, api);
     const cellMessages = Map<string, CellMessage>().asMutable();
     const cellValues = Map<string, List<ValueDescriptor>>().asMutable();
 
@@ -65,10 +66,11 @@ export const loadEditorModelData = async (
                 cellValues.set(
                     cellKey,
                     value.reduce((list, v) => {
-                        if (col.isLookup() && Utils.isNumber(v)) {
+                        const raw = v.value ?? v;
+                        if (col.isLookup() && Utils.isNumber(raw)) {
                             const lookupValue = lookupValues[col.lookupKey];
                             if (lookupValue) {
-                                const messageAndValues = lookupValue.filter(lv => lv.valueDescriptor.raw === v);
+                                const messageAndValues = lookupValue.filter(lv => lv.valueDescriptor.raw === raw);
                                 if (messageAndValues) {
                                     const descriptors: ValueDescriptor[] = [];
                                     for (let i = 0; i < messageAndValues.length; i++) {
@@ -83,7 +85,7 @@ export const loadEditorModelData = async (
                             }
                         }
 
-                        return list.push({ display: v.displayValue ?? v, raw: v.value ?? v });
+                        return list.push({ display: v.displayValue ?? v, raw });
                     }, List<ValueDescriptor>())
                 );
             } else {
@@ -231,19 +233,31 @@ const resolveDisplayField = (column: QueryColumn): string => {
     return column.lookup.displayColumnFieldKey;
 };
 
-const findLookupValues = async (
-    column: QueryColumn,
-    lookupKeyValues?: any[],
-    lookupValues?: any[],
-    lookupValueFilters?: Filter.IFilter[],
-    forUpdate?: boolean,
-    containerPath?: string
-): Promise<ValueDescriptor[]> => {
+type FindLookupValuesOptions = {
+    api?: ComponentsAPIWrapper;
+    column: QueryColumn;
+    containerPath?: string;
+    forUpdate?: boolean;
+    lookupKeyValues?: any[];
+    lookupValueFilters?: Filter.IFilter[];
+    lookupValues?: any[];
+};
+
+const findLookupValues = async (options: FindLookupValuesOptions): Promise<ValueDescriptor[]> => {
+    const {
+        api = getDefaultAPIWrapper(),
+        column,
+        containerPath,
+        forUpdate,
+        lookupKeyValues,
+        lookupValueFilters,
+        lookupValues,
+    } = options;
     const { lookup } = column;
     const { keyColumn } = lookup;
     const displayColumnFieldKey = resolveDisplayField(column);
 
-    const results = await selectRows({
+    const results = await api.query.selectRows({
         columns: [displayColumnFieldKey, keyColumn],
         containerPath: lookup.containerPath ?? containerPath,
         containerFilter: lookup.containerFilter ?? getContainerFilterForLookups(),
@@ -264,7 +278,9 @@ const findLookupValues = async (
     return results.rows.reduce<ValueDescriptor[]>((desc, row) => {
         const key = caseInsensitive(row, keyColumn)?.value;
         if (key !== undefined && key !== null) {
-            const displayRow = caseInsensitive(row, displayColumnFieldKey) ?? caseInsensitive(row, QueryKey.decodePart(displayColumnFieldKey));
+            const displayRow =
+                caseInsensitive(row, displayColumnFieldKey) ??
+                caseInsensitive(row, QueryKey.decodePart(displayColumnFieldKey));
             desc.push({ display: displayRow?.displayValue || displayRow?.value, raw: key });
         }
         return desc;
@@ -275,32 +291,40 @@ async function getLookupValueDescriptors(
     columns: QueryColumn[],
     rows: Record<string, Record<string, any>>,
     ids: string[],
-    forUpdate?: boolean
+    forUpdate: boolean,
+    api?: ComponentsAPIWrapper
 ): Promise<{ [colKey: string]: MessageAndValue[] }> {
     const descriptorMap = {};
     // for each lookup column, find the unique values in the rows and query for those values when they look like ids
     for (let cn = 0; cn < columns.length; cn++) {
         const col = columns[cn];
-        const values = new Set<number>();
 
         if (col.isPublicLookup()) {
+            const values = new Set<number>();
+
             ids.forEach(id => {
                 const row = rows[id];
                 const value = row?.[col.fieldKey] ?? row?.[col.name];
                 if (Utils.isNumber(value)) {
                     values.add(value);
-                } else if (List.isList(value)) {
+                } else if (Array.isArray(value)) {
                     value.forEach(val => {
-                        if (Map.isMap(val)) {
-                            values.add(val.get('value'));
-                        } else {
+                        if (Utils.isNumber(val?.value)) {
+                            values.add(val.value);
+                        } else if (Utils.isNumber(val)) {
                             values.add(val);
                         }
                     });
                 }
             });
+
             if (values.size > 0) {
-                const descriptors = await findLookupValues(col, Array.from(values), undefined, undefined, forUpdate);
+                const descriptors = await findLookupValues({
+                    api,
+                    column: col,
+                    forUpdate,
+                    lookupKeyValues: Array.from(values),
+                });
                 const messageAndValues: MessageAndValue[] = [];
 
                 descriptors.forEach(desc => {
@@ -344,7 +368,7 @@ async function getLookupDisplayValue(column: QueryColumn, value: any, containerP
 
     let message: CellMessage;
 
-    const descriptors = await findLookupValues(column, [value], undefined, undefined, false, containerPath);
+    const descriptors = await findLookupValues({ column, containerPath, forUpdate: false, lookupKeyValues: [value] });
     if (!descriptors.length) {
         message = lookupValidationError(value);
     }
@@ -1031,14 +1055,13 @@ async function getParsedLookup(
     if (!lookupValueCache.hasOwnProperty(cacheKey)) {
         const columnMetadata = editorModel.getColumnMetadata(column.fieldKey);
 
-        lookupValueCache[cacheKey] = findLookupValues(
+        lookupValueCache[cacheKey] = findLookupValues({
             column,
-            undefined,
-            display,
-            columnMetadata?.lookupValueFilters,
+            containerPath,
             forUpdate,
-            containerPath
-        );
+            lookupValueFilters: columnMetadata?.lookupValueFilters,
+            lookupValues: display,
+        });
     }
 
     const descriptors = await lookupValueCache[cacheKey];

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -23,6 +23,7 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
 import {
     CellMessage,
+    CellMessages,
     CellValues,
     EditableColumnMetadata,
     EditableGridLoader,

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -31,6 +31,7 @@ import {
     genCellKey,
     genCellKeyPrefix,
     getValidatedEditableGridValue,
+    isCellError,
     isSparseSelection,
     parseCellKey,
     sortCellKeys,
@@ -61,6 +62,7 @@ export interface ValueDescriptor {
 }
 
 export interface CellMessage {
+    isWarning?: boolean;
     message: string;
 }
 
@@ -264,7 +266,7 @@ export class EditorModel
     }
 
     get hasErrors(): boolean {
-        return this.cellMessages?.some(cm => cm?.message !== undefined);
+        return this.cellMessages?.some(isCellError);
     }
 
     getMessage(fieldKey: string, rowIdx: number): CellMessage {

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -828,7 +828,7 @@ export class EditorModel
                             // We have to compare displayValues for ExpInput columns for name expressions to work
                             // row values were processed with quoteValueWithDelimiters, originalValue should be compared using the same process
                             originalValue = originalValue
-                                .sortBy((v) => v.displayValue)
+                                .sortBy(v => v.displayValue)
                                 .map(v =>
                                     isQuotedWithDelimiters(v.displayValue, ',')
                                         ? v.displayValue

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -943,8 +943,3 @@ export interface EditableGridLoader extends GridLoader {
     queryInfo: QueryInfo;
     requiredColumns?: string[];
 }
-
-export interface MessageAndValue {
-    message?: CellMessage;
-    valueDescriptor: ValueDescriptor;
-}

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -150,6 +150,14 @@ export function decimalDifference(first, second, subtract = true): number {
     return (first * multiplier + (subtract ? -1 : 1) * second * multiplier) / multiplier;
 }
 
+export function isCellError(cm: CellMessage): boolean {
+    return cm && cm.message !== undefined && !cm.isWarning;
+}
+
+export function isCellWarning(cm: CellMessage): boolean {
+    return cm && cm.message !== undefined && cm.isWarning;
+}
+
 /**
  * Returns true if the selection is sparse. A sparse selection is one where a continuous set of cells in a rectangle are
  * not selected. It may look something like this:

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -1,4 +1,4 @@
-import { Filter, QueryKey, Utils } from '@labkey/api';
+import { Filter, Utils } from '@labkey/api';
 
 import { Operation, QueryColumn } from '../../../public/QueryColumn';
 

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -339,43 +339,39 @@ $table-cell-padding: 4px 2px;
 
     .cell-error, .cell-warning {
       position: relative;
-      background-color: $panel-danger-heading-bg;
 
       &:after {
         content: '';
         display: block;
         height: 8px;
         width: 8px;
-        background-image: linear-gradient(225deg, $brand-danger, $brand-danger 6px, transparent 6px, transparent);
         position: absolute;
         top: 1px;
         right: -1px;
       }
+    }
 
+    .cell-error {
+      background-color: $panel-danger-heading-bg;
+
+      &:after {
+        background-image: linear-gradient(225deg, $brand-danger, $brand-danger 6px, transparent 6px, transparent);
+      }
       &.cell-selected {
         background-color: $state-danger-bg;
       }
     }
 
-      .cell-warning {
-          position: relative;
-          background-color: $panel-warning-heading-bg;
+    .cell-warning {
+      background-color: $panel-warning-heading-bg;
 
-          &:after {
-              content: '';
-              display: block;
-              height: 8px;
-              width: 8px;
-              background-image: linear-gradient(225deg, $brand-warning, $brand-warning 6px, transparent 6px, transparent);
-              position: absolute;
-              top: 1px;
-              right: -1px;
-          }
-
-          &.cell-selected {
-              background-color: $state-warning-bg;
-          }
+      &:after {
+        background-image: linear-gradient(225deg, $brand-warning, $brand-warning 6px, transparent 6px, transparent);
       }
+      &.cell-selected {
+        background-color: $state-warning-bg;
+      }
+    }
 
     .cell-menu {
         position: relative;

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -337,7 +337,7 @@ $table-cell-padding: 4px 2px;
       justify-content: flex-end;
     }
 
-    .cell-warning {
+    .cell-error, .cell-warning {
       position: relative;
       background-color: $panel-danger-heading-bg;
 
@@ -353,9 +353,29 @@ $table-cell-padding: 4px 2px;
       }
 
       &.cell-selected {
-        background-color: $state-warning-bg;
+        background-color: $state-danger-bg;
       }
     }
+
+      .cell-warning {
+          position: relative;
+          background-color: $panel-warning-heading-bg;
+
+          &:after {
+              content: '';
+              display: block;
+              height: 8px;
+              width: 8px;
+              background-image: linear-gradient(225deg, $brand-warning, $brand-warning 6px, transparent 6px, transparent);
+              position: absolute;
+              top: 1px;
+              right: -1px;
+          }
+
+          &.cell-selected {
+              background-color: $state-warning-bg;
+          }
+      }
 
     .cell-menu {
         position: relative;


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52311](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52311) by adding a cell warning to lookups that fail to resolve upon grid initialization. This cell warning is differentiated now from a cell error.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1754
- https://github.com/LabKey/labkey-ui-premium/pull/722
- https://github.com/LabKey/limsModules/pull/1271
- https://github.com/LabKey/platform/pull/6477
- https://github.com/LabKey/testAutomation/pull/2370

#### Changes
- Add `isWarning` optional property on `CellMessage` to allow for warning level messages. Default is error.
- Generate cell warning for lookups that fail to resolve upon initialization.
- Centralize logic for cell error/warning in `isCellError` and `isCellWarning` utilities
- Update `findLookupValues` to just return `ValueDescriptor[]` as nothing needs the column to be handed thru.
