### PR TITLE
Alan's 25.4 Issues

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.33.0",
+  "version": "6.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.33.0",
+      "version": "6.34.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.33.0",
+  "version": "6.34.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.??.??
-*Released*: ??
+### version 6.34.0
+*Released*: 28 March 2025
 - Add `createSnapshotSelectionKey`
   - Used to snapshot selections for a given QueryModel without needing to use the server side snapshot API or
   useSnapshotSelections flag

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.??.??
+*Released*: ??
+- Issue 52332: Editing a Parent field that contains a mix of resolved and unresolved parents deletes all references
+
 ### version 6.33.0
 *Released*: 28 March 2025
 - Issue 52068: Filtering on a value with a semicolon is incorrectly displayed in the filter modal facet filter listing

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,6 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 6.??.??
 *Released*: ??
-- Issue 52332: Editing a Parent field that contains a mix of resolved and unresolved parents deletes all references
 - Add `createSnapshotSelectionKey`
   - Used to snapshot selections for a given QueryModel without needing to use the server side snapshot API or
   useSnapshotSelections flag

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 6.??.??
 *Released*: ??
 - Issue 52332: Editing a Parent field that contains a mix of resolved and unresolved parents deletes all references
+- Add `createSnapshotSelectionKey`
+  - Used to snapshot selections for a given QueryModel without needing to use the server side snapshot API or
+  useSnapshotSelections flag
 
 ### version 6.33.0
 *Released*: 28 March 2025

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -562,7 +562,11 @@ import { DEFAULT_ALIQUOT_NAMING_PATTERN, SampleTypeModel } from './internal/comp
 
 import { EditableDetailPanel } from './public/QueryModel/EditableDetailPanel';
 import { Pagination } from './internal/components/pagination/Pagination';
-import { getQueryModelExportParams, runDetailsColumnsForQueryModel } from './public/QueryModel/utils';
+import {
+    createSnapshotSelectionKey,
+    getQueryModelExportParams,
+    runDetailsColumnsForQueryModel,
+} from './public/QueryModel/utils';
 import { CONFIRM_MESSAGE, useRouteLeave } from './internal/util/RouteLeave';
 import { useRequestHandler } from './internal/util/RequestHandler';
 import { HorizontalBarSection } from './internal/components/chart/HorizontalBarSection';
@@ -1778,6 +1782,7 @@ export {
     EditableDetailPanel,
     TabbedGridPanel,
     runDetailsColumnsForQueryModel,
+    createSnapshotSelectionKey,
     flattenValuesFromRow,
     Pagination,
     makeTestActions,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -541,6 +541,7 @@ export function replaceSelected(options: ReplaceSelectedOptions): Promise<Select
 }
 
 /**
+ * @deprecated use QueryModel/utils.ts createSnapshotSelectionKey instead
  * Set the snapshot selections for a grid
  * @param key the selection key for the grid
  * @param ids ids to change selection for

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { FC, memo, useCallback, useMemo, KeyboardEvent } from 'react';
-import { Filter, Query, Utils } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 import { List } from 'immutable';
 
 import { QueryColumn } from '../../../public/QueryColumn';
@@ -97,16 +97,6 @@ const QueryLookupCell: FC<QueryLookupCellProps> = memo(props => {
     );
 
     let selectValue = isMultiple ? rawValues : rawValues[0];
-
-    if (isMultiple) {
-        // Issue 52332
-        // If the cell supports multiple values, then all the values should be numbers. Any non-numeric value means we
-        // were not able to resolve the rowId. If we pass string values and numeric values in an IN filter LKS will
-        // return 0 rows, even if some of the values are valid. e.g. an IN filter for [123, 'S-124'] will return 0 rows,
-        // even if 123 is a valid rowId. This results in the dropdown having no value when the user tries to edit the
-        // cell.
-        selectValue = selectValue.filter(value => Utils.isNumber(value));
-    }
 
     // Issue 49502: Some column types have special handling of raw data, i.e. StoredAmount and Units
     if (columnRenderer) {

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { FC, memo, useCallback, useMemo, KeyboardEvent } from 'react';
-import { Filter, Query } from '@labkey/api';
+import { Filter, Query, Utils } from '@labkey/api';
 import { List } from 'immutable';
 
 import { QueryColumn } from '../../../public/QueryColumn';
@@ -97,6 +97,16 @@ const QueryLookupCell: FC<QueryLookupCellProps> = memo(props => {
     );
 
     let selectValue = isMultiple ? rawValues : rawValues[0];
+
+    if (isMultiple) {
+        // Issue 52332
+        // If the cell supports multiple values, then all the values should be numbers. Any non-numeric value means we
+        // were not able to resolve the rowId. If we pass string values and numeric values in an IN filter LKS will
+        // return 0 rows, even if some of the values are valid. e.g. an IN filter for [123, 'S-124'] will return 0 rows,
+        // even if 123 is a valid rowId. This results in the dropdown having no value when the user tries to edit the
+        // cell.
+        selectValue = selectValue.filter(value => Utils.isNumber(value));
+    }
 
     // Issue 49502: Some column types have special handling of raw data, i.e. StoredAmount and Units
     if (columnRenderer) {

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -163,7 +163,7 @@ export async function createSnapshotSelectionKey(model: QueryModel): Promise<str
         key,
         true,
         Array.from(model.selections),
-        model.containerPath,
+        model.selectionContainerPath,
         false,
         model.schemaName,
         model.queryName

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -3,11 +3,11 @@
  * @param value
  * @param defaultValue
  */
-import { Filter } from '@labkey/api';
+import { Filter, Utils } from '@labkey/api';
 
 import { List } from 'immutable';
 
-import { ExportOptions, getExportParams } from '../../internal/actions';
+import { ExportOptions, getExportParams, setSelected } from '../../internal/actions';
 
 import { QuerySort } from '../QuerySort';
 
@@ -148,4 +148,25 @@ export function getSelectRowCountColumnsStr(
         typeof rawColumns === 'string' ? rawColumns.split(',').map(col => col.trim()) : rawColumns;
 
     return columns[0];
+}
+
+/**
+ * Creates a new selection key with the current selections for a given model. Use this when calling an API that takes
+ * a selectionKey in order to prevent taking action on values that have been filtered out of the view (See Issue 52393
+ * as an example) . Using this method is not compatible with the useSnapshotSelections param supported by some of our
+ * APIs. If you use this do not set the useSnapshotSelections flag in your API call.
+ * @param model the QueryModel used to create a snapshot selection key
+ */
+export async function createSnapshotSelectionKey(model: QueryModel): Promise<string> {
+    const key = model.selectionKey + Utils.generateUUID();
+    await setSelected(
+        key,
+        true,
+        Array.from(model.selections),
+        model.containerPath,
+        false,
+        model.schemaName,
+        model.queryName
+    );
+    return key;
 }


### PR DESCRIPTION
#### Rationale
This PR addresses some of my open 25.4 issues

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1758
- https://github.com/LabKey/labkey-ui-premium/pull/719
- https://github.com/LabKey/platform/pull/6488
- https://github.com/LabKey/limsModules/pull/1284

#### Changes
- Add createSnapshotSelectionKey
  - Used to snapshot selections for a given QueryModel without needing to use the server side snapshot API or useSnapshotSelection flag
