### PR TITLE
Issue 52050: App chart builder modal to handle field names with special characters in input selection

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.3",
+  "version": "6.34.3-chartModal52050.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.3",
+      "version": "6.34.3-chartModal52050.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.0",
+  "version": "6.34.0-chartModal52050.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.0",
+      "version": "6.34.0-chartModal52050.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.3-chartModal52050.0",
+  "version": "6.34.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.3-chartModal52050.0",
+      "version": "6.34.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.1",
+  "version": "6.34.1-chartModal52050.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.1",
+      "version": "6.34.1-chartModal52050.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.0",
+  "version": "6.34.0-chartModal52050.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.3-chartModal52050.0",
+  "version": "6.34.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.1",
+  "version": "6.34.1-chartModal52050.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.3",
+  "version": "6.34.3-chartModal52050.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.34.4
+*Released*: 2 April 2025
 - Issue 52050: App chart builder modal to handle field names with special characters in input selection
 
 ### version 6.34.3

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 52050: App chart builder modal to handle field names with special characters in input selection
+
 ### version 6.34.0
 *Released*: 28 March 2025
 - Add `createSnapshotSelectionKey`

--- a/packages/components/src/internal/components/chart/ChartBuilderModal.test.tsx
+++ b/packages/components/src/internal/components/chart/ChartBuilderModal.test.tsx
@@ -606,8 +606,8 @@ describe('getChartBuilderQueryConfig', () => {
 
 describe('getChartBuilderChartConfig', () => {
     const fieldValues = {
-        x: { value: 'field1', label: 'Field 1', data: { fieldKey: 'field1' } },
-        y: { value: 'field2', label: 'Field 2', data: { fieldKey: 'field2' } },
+        x: { value: 'field/1', label: 'Field 1', data: { fieldKey: 'field$S1', name: 'field/1' } },
+        y: { value: 'field2', label: 'Field 2', data: { fieldKey: 'field2', name: 'field2' } },
     };
 
     test('based on fieldValues', () => {
@@ -617,8 +617,10 @@ describe('getChartBuilderChartConfig', () => {
         expect(config.labels.main).toBe('');
         expect(config.labels.subtitle).toBe('');
         expect(config.pointType).toBe('all');
-        expect(config.measures.x.name).toBe('field1');
+        expect(config.measures.x.name).toBe('field/1');
+        expect(config.measures.x.fieldKey).toBe('field$S1');
         expect(config.measures.y.name).toBe('field2');
+        expect(config.measures.y.fieldKey).toBe('field2');
         expect(config.labels.x).toBe('Field 1');
         expect(config.labels.y).toBe('Sum of Field 2');
     });
@@ -639,7 +641,7 @@ describe('getChartBuilderChartConfig', () => {
         expect(config.labels.main).toBe('Main');
         expect(config.labels.subtitle).toBe('Subtitle');
         expect(config.pointType).toBe('outliers');
-        expect(config.measures.x.name).toBe('field1');
+        expect(config.measures.x.name).toBe('field/1');
         expect(config.measures.y.name).toBe('field2');
         expect(config.labels.x).toBe('X Label');
         expect(config.labels.y).toBe('Sum of Field 2');
@@ -664,7 +666,7 @@ describe('getChartBuilderChartConfig', () => {
         expect(config.labels.main).toBe('Main');
         expect(config.labels.subtitle).toBe('Subtitle');
         expect(config.pointType).toBe('outliers');
-        expect(config.measures.x.name).toBe('field1');
+        expect(config.measures.x.name).toBe('field/1');
         expect(config.measures.y.name).toBe('field2');
         expect(config.labels.x).toBe('X Label');
         expect(config.labels.y).toBe('Y Label');

--- a/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
+++ b/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
@@ -84,8 +84,6 @@ const ICONS = {
     line_plot: 'xy_line',
 };
 
-const toggleScaleValue = (value: string): string => (value === 'linear' ? 'log' : 'linear');
-
 export const getChartRenderMsg = (chartConfig: ChartConfig, rowCount: number, isPreview: boolean): string => {
     const msg = [];
     if (isPreview && rowCount === MAX_ROWS_PREVIEW) {
@@ -118,7 +116,7 @@ export const getChartBuilderQueryConfig = (
         viewName: savedConfig?.viewName || viewName,
         columns: Object.values(fieldValues)
             .filter(field => field?.value && typeof field.value === 'string') // just those fields with values
-            .map(field => field.value),
+            .map(field => field.data?.fieldKey ?? field.value), // Issue 52050: use fieldKey for special characters
         sort: LABKEY_VIS.GenericChartHelper.getQueryConfigSortKey(chartConfig.measures),
         filterArray: savedConfig?.filterArray ?? [],
         containerPath: savedConfig?.containerPath || containerPath,
@@ -193,7 +191,7 @@ export const getChartBuilderChartConfig = (
         if (fieldConfig?.value) {
             config.measures[field.name] = {
                 fieldKey: fieldConfig.data.fieldKey,
-                name: fieldConfig.value,
+                name: fieldConfig.data.name,
                 label: fieldConfig.label,
                 queryName: fieldConfig.data.queryName,
                 schemaName: fieldConfig.data.schemaName,

--- a/packages/components/src/internal/components/chart/ChartFieldOption.tsx
+++ b/packages/components/src/internal/components/chart/ChartFieldOption.tsx
@@ -86,6 +86,8 @@ export const ChartFieldOption: FC<ChartFieldOptionProps> = memo(props => {
             parseFloat(scale.max.toString()) <= parseFloat(scale.min.toString()),
         [scale]
     );
+    // Issue 52050: use fieldKey for special characters
+    const selectInputValue = useMemo(() => fieldValue?.data.fieldKey ?? fieldValue?.value, [fieldValue]);
 
     useEffect(() => {
         if (showFieldOptions && !scale.type) {
@@ -173,7 +175,7 @@ export const ChartFieldOption: FC<ChartFieldOptionProps> = memo(props => {
                     name={field.name}
                     options={options}
                     onChange={onSelectFieldChange_}
-                    value={fieldValue?.value}
+                    value={selectInputValue}
                 />
                 {showFieldOptions && (
                     <div className="field-option-icon">

--- a/packages/components/src/internal/components/entities/DataTypeSelector.tsx
+++ b/packages/components/src/internal/components/entities/DataTypeSelector.tsx
@@ -158,7 +158,7 @@ export const DataTypeSelectorList: FC<DataTypeSelectorListProps> = memo(props =>
                                     dataType={type}
                                     disabled={disabled}
                                     getUncheckedEntityWarning={getUncheckedEntityWarning}
-                                    key={type.lsid}
+                                    key={type.rowId}
                                     uncheckedEntities={uncheckedEntities}
                                     onChange={onChange}
                                     showUncheckedWarning={showUncheckedWarning}


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52050

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1762
- https://github.com/LabKey/limsModules/pull/1286

#### Changes
- Updating DataTypeSelector to use type.rowId as the key instead of type.lsid.
- Modifying ChartFieldOption to compute the select input value using fieldKey from the data.
- Adjusting ChartBuilderModal to use fieldKey for both query config column mapping and measure configuration, with corresponding test and release note updates.
