### PR TITLE
EntityCreationModal Refactor

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.2",
+  "version": "6.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.35.2",
+      "version": "6.36.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.2",
+  "version": "6.36.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - FolderAPIWrapper.getMultipleDataTypeExcludedContainers: return cache friendly result
 - createSnapshotSelectionKey: use a separator between the original key and the uuid
 - SchemaQuery.parseSelectionKey: Support snapshot selections
+- Remove saveOrderedSnapshotSelection
 
 ### version 6.35.2
 *Released*: 10 April 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: 10 April 2025
 - FolderAPIWrapper.getMultipleDataTypeExcludedContainers: return cache friendly result
 - createSnapshotSelectionKey: use a separator between the original key and the uuid
+- Add createOrderedSnapshotSelectionKey
 - SchemaQuery.parseSelectionKey: Support snapshot selections
 - Remove saveOrderedSnapshotSelection
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.36.0
+*Released*: 10 April 2025
+- FolderAPIWrapper.getMultipleDataTypeExcludedContainers: return cache friendly result
+
 ### version 6.35.2
 *Released*: 10 April 2025
 - Merge from release25.4-SNAPSHOT to develop

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version 6.36.0
 *Released*: 10 April 2025
 - FolderAPIWrapper.getMultipleDataTypeExcludedContainers: return cache friendly result
+- createSnapshotSelectionKey: use a separator between the original key and the uuid
+- SchemaQuery.parseSelectionKey: Support snapshot selections
 
 ### version 6.35.2
 *Released*: 10 April 2025

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -517,7 +517,6 @@ import {
     getParentTypeDataForLineage,
     getSampleIdentifyingFieldGridData,
     getSampleOperationConfirmationData,
-    saveOrderedSnapshotSelection,
     updateCellValuesForSampleIds,
 } from './internal/components/entities/actions';
 import {
@@ -1140,7 +1139,6 @@ export {
     clearSelected,
     // grid functions
     getOrderedSelectedMappedKeysFromQueryModel,
-    saveOrderedSnapshotSelection,
     getSelected,
     getSelectedDataDeprecated,
     getQueryModelExportParams,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -563,6 +563,7 @@ import { EditableDetailPanel } from './public/QueryModel/EditableDetailPanel';
 import { Pagination } from './internal/components/pagination/Pagination';
 import {
     createSnapshotSelectionKey,
+    createOrderedSnapshotSelectionKey,
     getQueryModelExportParams,
     runDetailsColumnsForQueryModel,
 } from './public/QueryModel/utils';
@@ -1781,6 +1782,7 @@ export {
     TabbedGridPanel,
     runDetailsColumnsForQueryModel,
     createSnapshotSelectionKey,
+    createOrderedSnapshotSelectionKey,
     flattenValuesFromRow,
     Pagination,
     makeTestActions,

--- a/packages/components/src/internal/components/container/FolderAPIWrapper.ts
+++ b/packages/components/src/internal/components/container/FolderAPIWrapper.ts
@@ -54,7 +54,7 @@ export interface FolderAPIWrapper {
     getMultipleDataTypeExcludedContainers: (
         dataType: FolderConfigurableDataType,
         dataTypeRowIds: number[]
-    ) => Promise<string[]>;
+    ) => Promise<Record<string, string[]>>;
     renameFolder: (options: FolderSettingsOptions, containerPath?: string) => Promise<Container>;
     setAuditCommentsRequired: (isRequired: boolean, containerPath?: string) => Promise<void>;
     updateContainerDataExclusions: (options: FolderSettingsOptions, containerPath?: string) => Promise<void>;
@@ -206,29 +206,38 @@ export class ServerFolderAPIWrapper implements FolderAPIWrapper {
         });
     };
 
+    /**
+     * This is a light wrapper around getDataTypeExcludedContainers that makes it easier for us to cache results
+     */
+    getDataTypeExcludedContainersAsRecord = async (
+        dataType: FolderConfigurableDataType,
+        dataTypeRowId: number
+    ): Promise<Record<string, string[]>> => {
+        const containers = await this.getDataTypeExcludedContainers(dataType, dataTypeRowId);
+        return { [dataTypeRowId]: containers };
+    };
+
     getMultipleDataTypeExcludedContainers = (
         dataType: FolderConfigurableDataType,
         dataTypeRowIds: number[]
-    ): Promise<string[]> => {
+    ): Promise<Record<string, string[]>> => {
         if (!dataType || !dataTypeRowIds || !dataTypeRowIds.length) {
             return Promise.resolve(undefined);
         }
 
         return new Promise((resolve, reject) => {
-            const promises = [];
+            const promises: Array<Promise<Record<string, string[]>>> = [];
 
             dataTypeRowIds.forEach(id => {
-                promises.push(this.getDataTypeExcludedContainers(dataType, id));
+                promises.push(this.getDataTypeExcludedContainersAsRecord(dataType, id));
             });
-            const excludedFolderSet = new Set();
             Promise.all(promises)
                 .then(results => {
-                    results.forEach(exclusions => exclusions.forEach(e => excludedFolderSet.add(e)));
-                    const folderList = [];
-                    excludedFolderSet.forEach(f => {
-                        folderList.push(f);
-                    });
-                    resolve(folderList);
+                    resolve(
+                        results.reduce((reduction, exclusions) => {
+                            return { ...reduction, ...exclusions };
+                        }, {})
+                    );
                 })
                 .catch(reason => {
                     console.error('Unable to retrieve data type exclusions', reason);

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -359,12 +359,9 @@ async function initParents(
             filterArray.push(opFilter);
         }
 
-        return getSelectedParents(
-            schemaQuery,
-            filterArray,
-            isAliquotParent,
-            isSnapshotSelection ? selectionResponse.selected : undefined
-        );
+        // Issue 48751 -- Always pass the selectionResponse.selected as the orderedRowIds because we use
+        // createOrderedSnapshotSelectionKey when generating selectionKeys that get passed to this method
+        return getSelectedParents(schemaQuery, filterArray, isAliquotParent, selectionResponse.selected);
     } else if (initialParents?.length > 0) {
         const [parent] = initialParents;
         const [schema, query, value] = parseEntityParentKey(parent.toLowerCase());

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1258,42 +1258,6 @@ export function getOrderedSelectedMappedKeys(
     });
 }
 
-export function saveOrderedSnapshotSelection(
-    queryModel: QueryModel,
-    fromColumn: string,
-    toColumn?: string
-): Promise<number[]> {
-    return new Promise((resolve, reject) => {
-        const { queryName, queryParameters, selections, sortString, viewName, selectionKey, schemaName } = queryModel;
-        getOrderedSelectedMappedKeys(
-            fromColumn,
-            toColumn ?? fromColumn,
-            schemaName,
-            queryName,
-            Array.from(selections),
-            sortString,
-            queryParameters,
-            viewName
-        )
-            .then(result => {
-                const fromIds = result.mapFromValues;
-                const toIds = result.mapToValues;
-                setSnapshotSelections(selectionKey, fromIds)
-                    .then(result => {
-                        resolve(toIds);
-                    })
-                    .catch(reason => {
-                        console.error(reason);
-                        reject(reason);
-                    });
-            })
-            .catch(reason => {
-                console.error(reason);
-                reject(reason);
-            });
-    });
-}
-
 /**
  * Get the ordered remapped key values from a QueryModel based on grid's current selection.
  * For example, picklist grid has a "ID" PK column and a "SampleId" FK column.

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -16,6 +16,7 @@ import { EXPORT_TYPES } from '../../internal/constants';
 
 import { QueryModel } from './QueryModel';
 import { ActionValue } from './grid/actions/Action';
+import { SELECTION_SNAPSHOT_SEP } from '../SchemaQuery';
 
 export function filterToString(filter: Filter.IFilter): string {
     return `${filter.getColumnName()}-${filter.getFilterType().getURLSuffix()}-${filter.getValue()}`;
@@ -158,7 +159,7 @@ export function getSelectRowCountColumnsStr(
  * @param model the QueryModel used to create a snapshot selection key
  */
 export async function createSnapshotSelectionKey(model: QueryModel): Promise<string> {
-    const key = model.selectionKey + Utils.generateUUID();
+    const key = model.selectionKey + SELECTION_SNAPSHOT_SEP + Utils.generateUUID();
     await setSelected(
         key,
         true,

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -14,9 +14,12 @@ import { QuerySort } from '../QuerySort';
 import { QueryColumn } from '../QueryColumn';
 import { EXPORT_TYPES } from '../../internal/constants';
 
-import { QueryModel } from './QueryModel';
-import { ActionValue } from './grid/actions/Action';
 import { SELECTION_SNAPSHOT_SEP } from '../SchemaQuery';
+import { getSelectedRows } from '../../internal/query/selectRows';
+import { caseInsensitive } from '../../internal/util/utils';
+
+import { ActionValue } from './grid/actions/Action';
+import { QueryModel } from './QueryModel';
 
 export function filterToString(filter: Filter.IFilter): string {
     return `${filter.getColumnName()}-${filter.getFilterType().getURLSuffix()}-${filter.getValue()}`;
@@ -151,6 +154,13 @@ export function getSelectRowCountColumnsStr(
     return columns[0];
 }
 
+// Do not use this directly, use createSnapshotSelectionKey or createOrderedSnapshotSelectionKey below
+async function _createSnapshotSelectionKey(model: QueryModel, selections: string[]): Promise<string> {
+    const key = model.selectionKey + SELECTION_SNAPSHOT_SEP + Utils.generateUUID();
+    await setSelected(key, true, selections, model.selectionContainerPath, false, model.schemaName, model.queryName);
+    return key;
+}
+
 /**
  * Creates a new selection key with the current selections for a given model. Use this when calling an API that takes
  * a selectionKey in order to prevent taking action on values that have been filtered out of the view (See Issue 52393
@@ -158,16 +168,24 @@ export function getSelectRowCountColumnsStr(
  * APIs. If you use this do not set the useSnapshotSelections flag in your API call.
  * @param model the QueryModel used to create a snapshot selection key
  */
-export async function createSnapshotSelectionKey(model: QueryModel): Promise<string> {
-    const key = model.selectionKey + SELECTION_SNAPSHOT_SEP + Utils.generateUUID();
-    await setSelected(
-        key,
-        true,
-        Array.from(model.selections),
-        model.selectionContainerPath,
-        false,
-        model.schemaName,
-        model.queryName
-    );
-    return key;
+export function createSnapshotSelectionKey(model: QueryModel): Promise<string> {
+    return _createSnapshotSelectionKey(model, Array.from(model.selections));
+}
+
+/**
+ * Creates a new selection key via the same mechanism as createSnapshotSelectionKey, but sorts the rows via the sorts
+ * from the underlying QueryModel.
+ * @param model
+ */
+export async function createOrderedSnapshotSelectionKey(model: QueryModel): Promise<string> {
+    const pkFieldKey = model.keyColumns[0].fieldKey;
+    const { rows } = await getSelectedRows({
+        ...model.loadRowsConfig,
+        // We only need the key column for this request
+        columns: pkFieldKey,
+        includeTotalCount: false,
+        selections: model.selections,
+    });
+    const orderedRows = rows.map(row => caseInsensitive(row, pkFieldKey).value.toString());
+    return _createSnapshotSelectionKey(model, orderedRows);
 }

--- a/packages/components/src/public/QueryModel/utils.ts
+++ b/packages/components/src/public/QueryModel/utils.ts
@@ -184,6 +184,8 @@ export async function createOrderedSnapshotSelectionKey(model: QueryModel): Prom
         // We only need the key column for this request
         columns: pkFieldKey,
         includeTotalCount: false,
+        offset: 0,
+        maxRows: -1,
         selections: model.selections,
     });
     const orderedRows = rows.map(row => caseInsensitive(row, pkFieldKey).value.toString());

--- a/packages/components/src/public/SchemaQuery.test.ts
+++ b/packages/components/src/public/SchemaQuery.test.ts
@@ -48,3 +48,38 @@ describe('resolveKeyFromJson', () => {
         );
     });
 });
+
+describe('parseSelectionKey', () => {
+    test('selectionKey with Schema, Query, and View', () => {
+        expect(SchemaQuery.parseSelectionKey('some-app-key|MySchema/MyQuery/MyView')).toEqual({
+            keys: undefined,
+            schemaQuery: new SchemaQuery('MySchema', 'MyQuery', 'MyView'),
+        });
+    });
+    test('selectionKey with only Schema and Query', () => {
+        expect(SchemaQuery.parseSelectionKey('some-app-key|MySchema/MyQuery')).toEqual({
+            keys: undefined,
+            schemaQuery: new SchemaQuery('MySchema', 'MyQuery'),
+        });
+    });
+    test('selectionKey with keys', () => {
+        expect(SchemaQuery.parseSelectionKey('some-app-key|MySchema/MyQuery/MyView|one;two;three')).toEqual({
+            keys: 'one;two;three',
+            schemaQuery: new SchemaQuery('MySchema', 'MyQuery', 'MyView'),
+        });
+    });
+    test('selectionKey with encoded params', () => {
+        expect(SchemaQuery.parseSelectionKey('some-app-key|My$PSchema/My$SQuery/My$BView|one;two;three')).toEqual({
+            keys: 'one;two;three',
+            schemaQuery: new SchemaQuery('My.Schema', 'My/Query', 'My}View'),
+        });
+    });
+    test('selectionKey with snapshot ID', () => {
+        const sk =
+            'some-app-key|My$PSchema/My$SQuery/My$BView|one;two;three__snapshot__e4bdc808-f624-103d-8ba4-b314ec40030b';
+        expect(SchemaQuery.parseSelectionKey(sk)).toEqual({
+            keys: 'one;two;three',
+            schemaQuery: new SchemaQuery('My.Schema', 'My/Query', 'My}View'),
+        });
+    });
+});

--- a/packages/components/src/public/SchemaQuery.ts
+++ b/packages/components/src/public/SchemaQuery.ts
@@ -1,4 +1,16 @@
 const APP_SELECTION_PREFIX = 'appkey';
+export const SELECTION_SNAPSHOT_SEP = '__snapshot__'; // Defined in this module to prevent circular imports
+
+/**
+ * selectionKeys for snapshot selections (created via createSnapshotSelectionKey) are postfixed with __snapshot__<uuid>,
+ * this method strips the selection snapshot separator and uuid from the selectionKey.
+ * @param value
+ */
+function stripSelectionSnapshotId(value: string): string {
+    const snapshotIndex = value.indexOf(SELECTION_SNAPSHOT_SEP);
+    if (snapshotIndex > -1) return value.slice(0, snapshotIndex);
+    return value;
+}
 
 // 36009: Case-insensitive variant of QueryKey.decodePart
 export function decodePart(s: string): string {
@@ -95,6 +107,7 @@ export class SchemaQuery {
     }
 
     static parseSelectionKey(selectionKey: string): IParsedSelectionKey {
+        selectionKey = stripSelectionSnapshotId(selectionKey);
         const [appkey /* not used */, schemaQueryKey, keys] = selectionKey.split('|');
 
         return {


### PR DESCRIPTION
#### Rationale
See ui-premium PR

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1767
- https://github.com/LabKey/labkey-ui-premium/pull/728
- https://github.com/LabKey/platform/pull/6518
- https://github.com/LabKey/limsModules/pull/1295

#### Changes
- FolderAPIWrapper.getMultipleDataTypeExcludedContainers: return cache friendly result
- createSnapshotSelectionKey: use a separator between the original key and the uuid
- Add createOrderedSnapshotSelectionKey
- SchemaQuery.parseSelectionKey: Support snapshot selections
- Remove saveOrderedSnapshotSelection
