### PR TITLE
Fix undefined error on UI

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.9",
+  "version": "6.26.10-fb-issue-52616.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.26.9",
+      "version": "6.26.10-fb-issue-52616.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.26.9",
+  "version": "6.26.10-fb-issue-52616.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.26.X
+*Released*: X 2025
+- Fix ConfirmImportTypes null error
+
 ### version 6.26.9
 *Released*: 31 March 2025
 - Issue 52616: LKSM: When two lineage alias columns are in a file we silently ignore one

--- a/packages/components/src/internal/components/domainproperties/ConfirmImportTypes.tsx
+++ b/packages/components/src/internal/components/domainproperties/ConfirmImportTypes.tsx
@@ -27,7 +27,7 @@ export default class ConfirmImportTypes extends PureComponent<Props> {
                         There was an error importing this file. To import this data now, check your file for issues or
                         resolve the error below:
                     </p>
-                    <ul>{error && error.errors.map((error, index) => <li key={index}>{error.exception}</li>)}</ul>
+                    <ul>{error && error.errors?.map((error, index) => <li key={index}>{error.exception}</li>)}</ul>
                     <p>
                         If you create this {designerType} without resolving the error, no file data will be imported at
                         this time.{' '}


### PR DESCRIPTION
#### Rationale
A change has been made to the data iterator to throw error when duplicate columns are provided, which resulted in inferring list domain field actions to also throw exception. The UI is not handling the exception well. 
[ListTest.testIgnoreReservedFieldNames](https://teamcity.labkey.org/viewLog.html?buildId=3447805&tab=buildResultsDiv&buildTypeId=LabKey_253Release_Premium_CommunitySqlserver_DailyDSqlserver#testNameId-6594495420183568951)

#### Related Pull Requests
#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6519
- https://github.com/LabKey/labkey-ui-components/pull/1768

- https://github.com/LabKey/platform/pull/6496

#### Changes
- add null check
