### PR TITLE
Issue 47595: Manage Sample Statuses page in LKS should not allow adding new status in child folder

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.5-fb-issue47595.1",
+  "version": "6.34.5-fb-issue47595.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.5-fb-issue47595.1",
+      "version": "6.34.5-fb-issue47595.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.5-fb-issue47595.2",
+  "version": "6.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.5-fb-issue47595.2",
+      "version": "6.35.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.4",
+  "version": "6.34.5-fb-issue47595.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.4",
+      "version": "6.34.5-fb-issue47595.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.5-fb-issue47595.1",
+  "version": "6.34.5-fb-issue47595.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.5-fb-issue47595.2",
+  "version": "6.35.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.4",
+  "version": "6.34.5-fb-issue47595.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X April 2025
+- Issue 47595: Manage Sample Statuses page in LKS should not allow adding new status in child folder
+- Add null check for ConfirmImportTypes
+
 ### version 6.34.4
 *Released*: 2 April 2025
 - Issue 52050: App chart builder modal to handle field names with special characters in input selection

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X April 2025
+### version 6.35.0
+*Released*: 4 April 2025
 - Issue 47595: Manage Sample Statuses page in LKS should not allow adding new status in child folder
 - Add null check for ConfirmImportTypes
 

--- a/packages/components/src/internal/components/domainproperties/ConfirmImportTypes.tsx
+++ b/packages/components/src/internal/components/domainproperties/ConfirmImportTypes.tsx
@@ -27,7 +27,7 @@ export default class ConfirmImportTypes extends PureComponent<Props> {
                         There was an error importing this file. To import this data now, check your file for issues or
                         resolve the error below:
                     </p>
-                    <ul>{error && error.errors.map((error, index) => <li key={index}>{error.exception}</li>)}</ul>
+                    <ul>{error && error.errors?.map((error, index) => <li key={index}>{error.exception}</li>)}</ul>
                     <p>
                         If you create this {designerType} without resolving the error, no file data will be imported at
                         this time.{' '}

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.test.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.test.tsx
@@ -36,7 +36,7 @@ describe('ManageSampleStatusesPanel', () => {
 
     test('initial state', async () => {
         await act(async () => {
-            renderWithAppContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} projectContainer={TEST_PROJECT_CONTAINER} />);
+            renderWithAppContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} homeContainer={TEST_PROJECT_CONTAINER} />);
         });
         validate();
     });
@@ -46,7 +46,7 @@ describe('ManageSampleStatusesPanel', () => {
             renderWithAppContext(
                 <ManageSampleStatusesPanel
                     {...DEFAULT_PROPS}
-                    projectContainer={TEST_PROJECT_CONTAINER}
+                    homeContainer={TEST_PROJECT_CONTAINER}
                     api={getTestAPIWrapper(jest.fn, {
                         samples: getSamplesTestAPIWrapper(jest.fn, {
                             getSampleStatuses: jest.fn().mockResolvedValue([]),
@@ -64,7 +64,7 @@ describe('ManageSampleStatusesPanel', () => {
             renderWithAppContext(
                 <ManageSampleStatusesPanel
                     {...DEFAULT_PROPS}
-                    projectContainer={TEST_PROJECT_CONTAINER}
+                    homeContainer={TEST_PROJECT_CONTAINER}
                     api={getTestAPIWrapper(jest.fn, {
                         samples: getSamplesTestAPIWrapper(jest.fn, {
                             getSampleStatuses: () => Promise.reject({ exception: 'Failure' }),

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.test.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.test.tsx
@@ -36,7 +36,7 @@ describe('ManageSampleStatusesPanel', () => {
 
     test('initial state', async () => {
         await act(async () => {
-            renderWithAppContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} container={TEST_PROJECT_CONTAINER} />);
+            renderWithAppContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} projectContainer={TEST_PROJECT_CONTAINER} />);
         });
         validate();
     });
@@ -46,7 +46,7 @@ describe('ManageSampleStatusesPanel', () => {
             renderWithAppContext(
                 <ManageSampleStatusesPanel
                     {...DEFAULT_PROPS}
-                    container={TEST_PROJECT_CONTAINER}
+                    projectContainer={TEST_PROJECT_CONTAINER}
                     api={getTestAPIWrapper(jest.fn, {
                         samples: getSamplesTestAPIWrapper(jest.fn, {
                             getSampleStatuses: jest.fn().mockResolvedValue([]),
@@ -64,7 +64,7 @@ describe('ManageSampleStatusesPanel', () => {
             renderWithAppContext(
                 <ManageSampleStatusesPanel
                     {...DEFAULT_PROPS}
-                    container={TEST_PROJECT_CONTAINER}
+                    projectContainer={TEST_PROJECT_CONTAINER}
                     api={getTestAPIWrapper(jest.fn, {
                         samples: getSamplesTestAPIWrapper(jest.fn, {
                             getSampleStatuses: () => Promise.reject({ exception: 'Failure' }),

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -33,6 +33,8 @@ import { SampleState } from './models';
 import { getSampleStatusColor, getSampleStatusLockedMessage } from './utils';
 import { SampleStatusTag } from './SampleStatusTag';
 import { SAMPLE_STATUS_COLORS, SampleStateType } from './constants';
+import { isAppHomeFolder } from '../../app/utils';
+import { useServerContext } from '../base/ServerContext';
 
 const TITLE = 'Manage Sample Statuses';
 const STATE_TYPE_SQ = new SchemaQuery('exp', 'SampleStateType');
@@ -402,15 +404,18 @@ SampleStatusesList.displayName = 'SampleStatusesList';
 
 interface ManageSampleStatusesPanelProps extends InjectedRouteLeaveProps {
     api?: ComponentsAPIWrapper;
-    container?: Container;
+    projectContainer?: Container;
+    addFromHomeOnly?: boolean;
 }
 
 export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = memo(props => {
-    const { api = getDefaultAPIWrapper(), setIsDirty, container } = props;
+    const { api = getDefaultAPIWrapper(), setIsDirty, projectContainer, addFromHomeOnly} = props;
     const [states, setStates] = useState<Record<string, SampleState[]>>();
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
     const [selectedGroup, setSelectedGroup] = useState<string>();
+    const { container, moduleContext } = useServerContext();
+    const showAdd = !addFromHomeOnly || isAppHomeFolder(container, moduleContext);
     const addNew = useMemo(() => selected === NEW_STATUS_INDEX, [selected]);
 
     const querySampleStatuses = useCallback(
@@ -418,7 +423,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
             setError(undefined);
 
             api.samples
-                .getSampleStatuses(true, container?.path)
+                .getSampleStatuses(true, projectContainer?.path)
                 .then(statuses => {
                     const statesByType: Record<string, SampleState[]> = {};
                     statuses
@@ -442,7 +447,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                     setError('Error: Unable to load sample statuses.');
                 });
         },
-        [api, container]
+        [api, projectContainer]
     );
 
     useEffect(() => {
@@ -486,7 +491,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                                 selectedGroup={selectedGroup}
                                 onSelect={onSetSelected}
                             />
-                            <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />
+                            {showAdd && <AddEntityButton onClick={onAddState} entity="New Status" disabled={addNew} />}
                         </div>
                         <div className="col-lg-8 col-md-6">
                             <SampleStatusDetail
@@ -495,7 +500,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                                 addNew={addNew}
                                 onActionComplete={onActionComplete}
                                 onChange={onChange}
-                                container={container}
+                                container={projectContainer}
                             />
                         </div>
                     </div>

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -404,12 +404,12 @@ SampleStatusesList.displayName = 'SampleStatusesList';
 
 interface ManageSampleStatusesPanelProps extends InjectedRouteLeaveProps {
     api?: ComponentsAPIWrapper;
-    projectContainer?: Container;
+    homeContainer?: Container;
     addFromHomeOnly?: boolean;
 }
 
 export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = memo(props => {
-    const { api = getDefaultAPIWrapper(), setIsDirty, projectContainer, addFromHomeOnly} = props;
+    const { api = getDefaultAPIWrapper(), setIsDirty, homeContainer, addFromHomeOnly} = props;
     const [states, setStates] = useState<Record<string, SampleState[]>>();
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
@@ -423,7 +423,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
             setError(undefined);
 
             api.samples
-                .getSampleStatuses(true, projectContainer?.path)
+                .getSampleStatuses(true, homeContainer?.path)
                 .then(statuses => {
                     const statesByType: Record<string, SampleState[]> = {};
                     statuses
@@ -447,7 +447,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                     setError('Error: Unable to load sample statuses.');
                 });
         },
-        [api, projectContainer]
+        [api, homeContainer]
     );
 
     useEffect(() => {
@@ -500,7 +500,7 @@ export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = mem
                                 addNew={addNew}
                                 onActionComplete={onActionComplete}
                                 onChange={onChange}
-                                container={projectContainer}
+                                container={homeContainer}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1769
- https://github.com/LabKey/labkey-ui-premium/pull/729
- https://github.com/LabKey/limsModules/pull/1306
- https://github.com/LabKey/testAutomation/pull/2392

#### Changes
- Add `addFromHomeOnly` prop so `ManageSampleStatusesPanel` can hide add button when in child folder in LKS.
