### PR TITLE
Issues 52014, 52275 and 52667: styling update for grid view names and display update for stored amount

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.5-reserveMoreNames.0",
+  "version": "6.34.5-reserveMoreNames.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.5-reserveMoreNames.0",
+      "version": "6.34.5-reserveMoreNames.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.4",
+  "version": "6.34.5-reserveMoreNames.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.4",
+      "version": "6.34.5-reserveMoreNames.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1-reserveMoreNames.1",
+  "version": "6.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.35.1-reserveMoreNames.1",
+      "version": "6.35.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.5-reserveMoreNames.1",
+  "version": "6.35.1-reserveMoreNames.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.34.5-reserveMoreNames.1",
+      "version": "6.35.1-reserveMoreNames.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1-reserveMoreNames.1",
+  "version": "6.35.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.4",
+  "version": "6.34.5-reserveMoreNames.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.34.5-reserveMoreNames.0",
+  "version": "6.34.5-reserveMoreNames.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.35.1
+*Released*: 9 April 2025
 - Issue 52667: null value for amount should remain undefined
 - Add spacing between file icon and name in `FileAttachmentEntry` and `FileInput` components
 - Issue 52275: Limit length of custom label on fields to 200

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 52667: null value for amount should remain undefined
+- Add spacing between file icon and name in `FileAttachmentEntry` and `FileInput` components
+
 ### version 6.34.4
 *Released*: 2 April 2025
 - Issue 52050: App chart builder modal to handle field names with special characters in input selection

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD
 - Issue 52667: null value for amount should remain undefined
 - Add spacing between file icon and name in `FileAttachmentEntry` and `FileInput` components
+- Issue 52275: Limit length of custom label on fields to 200
 
 ### version 6.34.4
 *Released*: 2 April 2025

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -19,6 +19,8 @@ import { LoadingSpinner } from './base/LoadingSpinner';
 type ExpandedColumnFilter = (column: QueryColumn, showAllColumns: boolean) => boolean;
 type QueryColumnHandler = (column: QueryColumn) => void;
 
+const MAX_LABEL_LENGTH = 200;
+
 interface FieldLabelDisplayProps {
     column: QueryColumn;
     editing?: boolean;
@@ -66,6 +68,7 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
                 onBlur={onBlur}
                 onChange={onChange}
                 type="text"
+                maxLength={MAX_LABEL_LENGTH}
             />
         );
     }

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -20,7 +20,7 @@ describe('UnitModel', () => {
         expect(new UnitModel(99999.13345678, 'mg').as('kg').toString()).toBe('0.099999133457 kg');
         expect(new UnitModel(10, 'mL').as('L').toString()).toBe('0.01 L');
         expect(new UnitModel(10, 'mL').add(10, 'uL').toString()).toBe('10.01 mL');
-        expect(new UnitModel(undefined, 'mL').as('L').toString()).toBe('0 L');
+        expect(new UnitModel(undefined, 'mL').as('L').toString()).toBe('undefined L');
 
         expect(new UnitModel(10, 'mL').compareTo(new UnitModel(9, 'mL')) > 0).toBeTruthy();
         expect(new UnitModel(10, 'mL').compareTo(new UnitModel(9, 'L')) > 0).toBeFalsy();

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -42,7 +42,7 @@ export class UnitModel {
         }
 
         if (this.value == null) {
-            return new UnitModel(0, newUnit.label.toLowerCase());
+            return new UnitModel(undefined, newUnit.label.toLowerCase());
         }
 
         const newValue = this.value * (this.unit.ratio / newUnit.ratio);

--- a/packages/components/src/theme/fileupload.scss
+++ b/packages/components/src/theme/fileupload.scss
@@ -52,6 +52,10 @@
   z-index: -1;
 }
 
+.attached-file--icon {
+    margin-right: 5px;
+}
+
 .attached-file__remove-icon {
     cursor: pointer;
     font-size: 20px;

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -555,6 +555,10 @@ $table-cell-padding: 4px 2px;
   margin-left: 10px;
 }
 
+.view-header {
+    overflow-wrap: break-word;
+}
+
 .view-menu .dropdown-menu {
     max-width: 600px;
     width: max-content;


### PR DESCRIPTION
#### Rationale
Issue  52014 - [Grid views with long names render awkwardly](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52014)
Issue 52667 - [LKSM: Storage on sample's Overview page shows 0 volume when value is unset](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52667)
Issue 52275 - [Identifying fields should be limited to 200 characters in length.](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52275)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1318
- https://github.com/LabKey/labkey-ui-premium/pull/732

#### Changes
- Issue 52667: null value for amount should remain undefined
- Add spacing between file icon and name in `FileAttachmentEntry` and `FileInput` components
- Issue 52275: Limit length of custom label on fields to 200