### PR TITLE
Issue 52780: URLResolver assay fix for handling splitting of assay URL to account for protocol name with consecutive periods or ending in period

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1-plateSpecCharTesting.0",
+  "version": "6.35.1-plateSpecCharTesting.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.35.1-plateSpecCharTesting.0",
+      "version": "6.35.1-plateSpecCharTesting.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1",
+  "version": "6.35.1-plateSpecCharTesting.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.35.1",
+      "version": "6.35.1-plateSpecCharTesting.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.0",
+  "version": "6.36.0-plateSpecCharTesting.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.0",
+      "version": "6.36.0-plateSpecCharTesting.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.0-plateSpecCharTesting.0",
+  "version": "6.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.0-plateSpecCharTesting.0",
+      "version": "6.36.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.2",
+  "version": "6.35.2-plateSpecCharTesting.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.35.2",
+      "version": "6.35.2-plateSpecCharTesting.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.0",
+  "version": "6.35.0-plateSpecCharTesting.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.35.0",
+      "version": "6.35.0-plateSpecCharTesting.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.0",
+  "version": "6.35.0-plateSpecCharTesting.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1",
+  "version": "6.35.1-plateSpecCharTesting.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.2",
+  "version": "6.35.2-plateSpecCharTesting.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.0-plateSpecCharTesting.0",
+  "version": "6.36.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.0",
+  "version": "6.36.0-plateSpecCharTesting.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1-plateSpecCharTesting.0",
+  "version": "6.35.1-plateSpecCharTesting.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.36.1
+*Released*: 11 April 2025
 - Issue 52780: URLResolver assay fix for handling splitting of assay URL to account for protocol name with consecutive periods or ending in period
 
 ### version 6.36.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 52780: URLResolver assay fix for handling splitting of assay URL to account for protocol name with consecutive periods or ending in period
+
 ### version 6.35.0
 *Released*: 4 April 2025
 - Issue 47595: Manage Sample Statuses page in LKS should not allow adding new status in child folder

--- a/packages/components/src/internal/url/URLResolver.test.ts
+++ b/packages/components/src/internal/url/URLResolver.test.ts
@@ -13,7 +13,7 @@ import { SearchHit, SearchResult } from '../components/search/actions';
 import { TEST_PROJECT_CONTAINER } from '../containerFixtures';
 
 import { AppURL } from './AppURL';
-import { LookupMapper, URLResolver } from './URLResolver';
+import { LookupMapper, URLResolver, URLService } from './URLResolver';
 
 beforeAll(() => {
     LABKEY.container = {
@@ -26,6 +26,34 @@ beforeAll(() => {
 });
 
 describe('URLResolver', () => {
+    function resolveUrl(url: string, schemaName: string): AppURL | string | boolean {
+        return URLService.getUrlMappers()
+            .toSeq()
+            .map(m => m.resolve(url, fromJS({ url }), undefined, schemaName, undefined))
+            .filter(v => v !== undefined)
+            .first();
+    }
+
+    describe('ActionMapper', () => {
+        test('assayRuns', () => {
+            let url = '/Biologics%20Example/assay-assayOther.view?rowId=636&Runs.Batch%2FRowId~eq=6169';
+            let result = resolveUrl(url, 'assay.General.testProtocol');
+            expect(result).toBe(undefined);
+
+            url = '/Biologics%20Example/assay-assayRuns.view?rowId=636&Runs.Run%2FRowId~eq=6169';
+            result = resolveUrl(url, 'assay.General.testProtocol');
+            expect(result).toBe(undefined);
+
+            url = '/Biologics%20Example/assay-assayRuns.view?rowId=636&Runs.Batch%2FRowId~eq=6169';
+            result = resolveUrl(url, 'assay.General.testProtocol');
+            expect(result.toString()).toBe('/assays/General/testProtocol/batches/6169');
+
+            url = '/Biologics%20Example/assay-assayRuns.view?rowId=636&Runs.Batch%2FRowId~eq=6169';
+            result = resolveUrl(url, 'assay.General.test,./Protocol..');
+            expect(result.toString()).toBe('/assays/General/test%2C.%2FProtocol../batches/6169');
+        });
+    });
+
     describe('resolveSearchUsingIndex', () => {
         const resolver = new URLResolver();
 

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -199,12 +199,11 @@ const ASSAY_MAPPERS = [
                         // expecting a schema of assay.<provider>.<protocol>
                         if (schema.indexOf('assay.') === 0) {
                             const parts = schema.split('.');
-                            const baseType = parts[0];
                             const provider = parts[1];
                             // Issue 52780: the rest of the parts make up the protocol name, which may contain . chars
                             const protocol = parts.slice(2).join('.');
 
-                            const url = [baseType, provider, protocol];
+                            const url = ['assays', provider, protocol];
                             url.push('batches', rowId);
                             return AppURL.create(...url);
                         }

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -198,9 +198,14 @@ const ASSAY_MAPPERS = [
 
                         // expecting a schema of assay.<provider>.<protocol>
                         if (schema.indexOf('assay.') === 0) {
-                            const url = ['assays'].concat(schema.replace('assay.', '').split('.'));
-                            url.push('batches', rowId);
+                            const parts = schema.split('.');
+                            const baseType = parts[0];
+                            const provider = parts[1];
+                            // Issue 52780: the rest of the parts make up the protocol name, which may contain . chars
+                            const protocol = parts.slice(2).join('.');
 
+                            const url = [baseType, provider, protocol];
+                            url.push('batches', rowId);
                             return AppURL.create(...url);
                         }
                     }


### PR DESCRIPTION
#### Rationale
Issue [52780](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52780): App assay protocol name with two consecutive period in name causes error when parsing the provider and protocol name in URLResolver

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1322
- https://github.com/LabKey/labkey-ui-premium/pull/734

#### Changes
- URLResolver assay fix for handling splitting of assay URL to account for protocol name with consecutive periods or ending in period
