### PR TITLE
Issue 52321 | LKSM/LKB: Support alias parent columns on Edit Lineage grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1",
+  "version": "6.35.2-fb-issue52321.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.35.1",
+      "version": "6.35.2-fb-issue52321.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.1-fb-issue52321.2",
+  "version": "6.36.1-fb-issue52321.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.1-fb-issue52321.2",
+      "version": "6.36.1-fb-issue52321.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.0",
+  "version": "6.36.1-fb-issue52321.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.0",
+      "version": "6.36.1-fb-issue52321.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.1",
+  "version": "6.36.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.1",
+      "version": "6.36.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.1-fb-issue52321.1",
+  "version": "6.36.1-fb-issue52321.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.1-fb-issue52321.1",
+      "version": "6.36.1-fb-issue52321.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.1-fb-issue52321.2",
+  "version": "6.36.1-fb-issue52321.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.35.1",
+  "version": "6.35.2-fb-issue52321.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.1-fb-issue52321.1",
+  "version": "6.36.1-fb-issue52321.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: X April 2025
 - Issue 52321: LKSM/LKB: Edit Lineage grid should show Parent or Source columns with aliases by default
   - add `additionalParentTypes` param to `getOriginalParentsFromLineage`
+  - add `omitParentAliases` to `LineageEditableGridProps`
 
 ### version 6.36.0
 *Released*: 10 April 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X April 2025
+- Issue 52321: LKSM/LKB: Edit Lineage grid should show Parent or Source columns with aliases by default
+  - add `additionalParentTypes` param to `getOriginalParentsFromLineage`
+
 ### version 6.35.1
 *Released*: 9 April 2025
 - Issue 52667: null value for amount should remain undefined

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -626,7 +626,11 @@ import { SampleTypeDesigner } from './internal/components/domainproperties/sampl
 import { ListDesignerPanels } from './internal/components/domainproperties/list/ListDesignerPanels';
 import { DataClassDesigner } from './internal/components/domainproperties/dataclasses/DataClassDesigner';
 import { DataClassModel } from './internal/components/domainproperties/dataclasses/models';
-import { deleteDataClass, fetchDataClass, getDataClassDetails } from './internal/components/domainproperties/dataclasses/actions';
+import {
+    deleteDataClass,
+    fetchDataClass,
+    getDataClassDetails,
+} from './internal/components/domainproperties/dataclasses/actions';
 import { DesignerDetailTooltip } from './internal/components/domainproperties/DesignerDetailPanel';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { RangeValidationOptionsModal } from './internal/components/domainproperties/validation/RangeValidationOptions';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -626,7 +626,7 @@ import { SampleTypeDesigner } from './internal/components/domainproperties/sampl
 import { ListDesignerPanels } from './internal/components/domainproperties/list/ListDesignerPanels';
 import { DataClassDesigner } from './internal/components/domainproperties/dataclasses/DataClassDesigner';
 import { DataClassModel } from './internal/components/domainproperties/dataclasses/models';
-import { deleteDataClass, fetchDataClass } from './internal/components/domainproperties/dataclasses/actions';
+import { deleteDataClass, fetchDataClass, getDataClassDetails } from './internal/components/domainproperties/dataclasses/actions';
 import { DesignerDetailTooltip } from './internal/components/domainproperties/DesignerDetailPanel';
 import { DomainFieldLabel } from './internal/components/domainproperties/DomainFieldLabel';
 import { RangeValidationOptionsModal } from './internal/components/domainproperties/validation/RangeValidationOptions';
@@ -1349,6 +1349,7 @@ export {
     DataClassModel,
     deleteDataClass,
     fetchDataClass,
+    getDataClassDetails,
     isSampleOperationPermitted,
     isSamplesSchema,
     isAllSamplesSchema,

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -9,6 +9,8 @@ import { InsertOptions } from '../../query/api';
 
 import { QueryModel } from '../../../public/QueryModel/QueryModel';
 
+import { SchemaQuery } from '../../../public/SchemaQuery';
+
 import {
     getDataOperationConfirmationData,
     GetDeleteConfirmationDataOptions,
@@ -41,7 +43,6 @@ import {
     OperationConfirmationData,
     FolderConfigurableDataType,
 } from './models';
-import { SchemaQuery } from '../../../public/SchemaQuery';
 
 export interface EntityAPIWrapper {
     getCrossFolderSelectionResult: (

--- a/packages/components/src/internal/components/entities/APIWrapper.ts
+++ b/packages/components/src/internal/components/entities/APIWrapper.ts
@@ -41,6 +41,7 @@ import {
     OperationConfirmationData,
     FolderConfigurableDataType,
 } from './models';
+import { SchemaQuery } from '../../../public/SchemaQuery';
 
 export interface EntityAPIWrapper {
     getCrossFolderSelectionResult: (
@@ -92,6 +93,7 @@ export interface EntityAPIWrapper {
     getOriginalParentsFromLineage: (
         lineage: Record<string, any>,
         parentDataTypes: EntityDataType[],
+        additionalParentTypes?: SchemaQuery[],
         containerPath?: string
     ) => Promise<{
         originalParents: Record<string, List<EntityChoice>>;

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -948,12 +948,12 @@ export const getOriginalParentsFromLineage = async (
         // filter out additional parent alias columns that's already added
         const additionalParentTypeSchemaQueryKeys = [];
         additionalParentTypes?.forEach(parentType => {
-            additionalParentTypeSchemaQueryKeys.push(parentType.schemaName.toLowerCase() + '-' + parentType.queryName.toLowerCase())
+            additionalParentTypeSchemaQueryKeys.push(parentType.schemaName.toLowerCase() + '|' + parentType.queryName.toLowerCase())
         });
         parentTypeOptions = parentTypeOptions.set(
             dataType.typeListingSchemaQuery.queryName,
             validParentTypeOptions.filter(option => {
-                const schemaQueryKey = option.entityDataType.instanceSchemaName.toLowerCase() + "-" + option.query.toLowerCase();
+                const schemaQueryKey = option.entityDataType.instanceSchemaName.toLowerCase() + '|' + option.query.toLowerCase();
                 return originalParentTypeLsids.indexOf(option.lsid) === -1 && additionalParentTypeSchemaQueryKeys.indexOf(schemaQueryKey) === -1;
             }).toList()
         );

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -945,14 +945,22 @@ export const getOriginalParentsFromLineage = async (
         // filter out additional parent alias columns that's already added
         const additionalParentTypeSchemaQueryKeys = [];
         additionalParentTypes?.forEach(parentType => {
-            additionalParentTypeSchemaQueryKeys.push(parentType.schemaName.toLowerCase() + '|' + parentType.queryName.toLowerCase())
+            additionalParentTypeSchemaQueryKeys.push(
+                parentType.schemaName.toLowerCase() + '|' + parentType.queryName.toLowerCase()
+            );
         });
         parentTypeOptions = parentTypeOptions.set(
             dataType.typeListingSchemaQuery.queryName,
-            validParentTypeOptions.filter(option => {
-                const schemaQueryKey = option.entityDataType.instanceSchemaName.toLowerCase() + '|' + option.query.toLowerCase();
-                return originalParentTypeLsids.indexOf(option.lsid) === -1 && additionalParentTypeSchemaQueryKeys.indexOf(schemaQueryKey) === -1;
-            }).toList()
+            validParentTypeOptions
+                .filter(option => {
+                    const schemaQueryKey =
+                        option.entityDataType.instanceSchemaName.toLowerCase() + '|' + option.query.toLowerCase();
+                    return (
+                        originalParentTypeLsids.indexOf(option.lsid) === -1 &&
+                        additionalParentTypeSchemaQueryKeys.indexOf(schemaQueryKey) === -1
+                    );
+                })
+                .toList()
         );
     });
 

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -893,6 +893,7 @@ export const getParentTypeDataForLineage: GetParentTypeDataForLineage = async (
 export const getOriginalParentsFromLineage = async (
     lineage: Record<string, any>,
     parentDataTypes: EntityDataType[],
+    additionalParentTypes?: SchemaQuery[],
     containerPath?: string
 ): Promise<{
     originalParents: Record<string, List<EntityChoice>>;
@@ -943,9 +944,18 @@ export const getOriginalParentsFromLineage = async (
         Object.values(originalParents).forEach((parentTypes: List<EntityChoice>) => {
             originalParentTypeLsids.push(...parentTypes.map(parentType => parentType.type.lsid).toArray());
         });
+
+        // filter out additional parent alias columns that's already added
+        const additionalParentTypeSchemaQueryKeys = [];
+        additionalParentTypes?.forEach(parentType => {
+            additionalParentTypeSchemaQueryKeys.push(parentType.schemaName.toLowerCase() + '-' + parentType.queryName.toLowerCase())
+        });
         parentTypeOptions = parentTypeOptions.set(
             dataType.typeListingSchemaQuery.queryName,
-            validParentTypeOptions.filter(option => originalParentTypeLsids.indexOf(option.lsid) === -1).toList()
+            validParentTypeOptions.filter(option => {
+                const schemaQueryKey = option.entityDataType.instanceSchemaName.toLowerCase() + "-" + option.query.toLowerCase();
+                return originalParentTypeLsids.indexOf(option.lsid) === -1 && additionalParentTypeSchemaQueryKeys.indexOf(schemaQueryKey) === -1;
+            }).toList()
         );
     });
 

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -946,7 +946,7 @@ export const getOriginalParentsFromLineage = async (
         const additionalParentTypeSchemaQueryKeys = [];
         additionalParentTypes?.forEach(parentType => {
             additionalParentTypeSchemaQueryKeys.push(
-                parentType.schemaName.toLowerCase() + '|' + parentType.queryName.toLowerCase()
+                parentType.toString().toLowerCase()
             );
         });
         parentTypeOptions = parentTypeOptions.set(
@@ -954,7 +954,7 @@ export const getOriginalParentsFromLineage = async (
             validParentTypeOptions
                 .filter(option => {
                     const schemaQueryKey =
-                        option.entityDataType.instanceSchemaName.toLowerCase() + '|' + option.query.toLowerCase();
+                        new SchemaQuery(option.entityDataType.instanceSchemaName, option.query).toString().toLowerCase();
                     return (
                         originalParentTypeLsids.indexOf(option.lsid) === -1 &&
                         additionalParentTypeSchemaQueryKeys.indexOf(schemaQueryKey) === -1

--- a/packages/components/src/internal/sampleModels.ts
+++ b/packages/components/src/internal/sampleModels.ts
@@ -51,6 +51,7 @@ export type SampleGridButton = ComponentType<SampleGridButtonProps & RequiresMod
 // This interface stores app-wide settings passed to the LineageEditableGrid
 export interface LineageEditableGridProps {
     parentDataTypes: EntityDataType[];
+    omitParentAliases?: (schemaQuery: SchemaQuery) => boolean;
 }
 
 // This interface stores app-wide settings that get passed to our SamplesEditableGrid. It extends


### PR DESCRIPTION
#### Rationale
When creating an entity, the parent types that are configured for the sample type as import alias are automatically included as parent input columns in the grid. This PR similarly add those columns to edit lineage grid.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1773
- https://github.com/LabKey/labkey-ui-premium/pull/735
- https://github.com/LabKey/limsModules/pull/1325

#### Changes
- add `additionalParentTypes` param to `getOriginalParentsFromLineage`
