### PR TITLE
Issues 52587, 52637

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.3-fb-nick-issue-255.0",
+  "version": "6.36.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.3-fb-nick-issue-255.0",
+      "version": "6.36.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.2",
+  "version": "6.36.3-fb-nick-issue-255.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.2",
+      "version": "6.36.3-fb-nick-issue-255.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.3-fb-nick-issue-255.0",
+  "version": "6.36.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.2",
+  "version": "6.36.3-fb-nick-issue-255.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.36.1
+### version 6.36.3
+*Released*: 15 April 2025
+- Use `fromZonedTime` from `date-fns` package to compare dates against server dates in `isDateTimeInPast` utility function.
+- Check legend data exists in `HorizontalBarSection`
+- Convert `ItemsLegend` to a functional component
+
+### version 6.36.2
 *Released*: 11 April 2025
 - Issue 52321: LKSM/LKB: Edit Lineage grid should show Parent or Source columns with aliases by default
   - add `additionalParentTypes` param to `getOriginalParentsFromLineage`

--- a/packages/components/src/internal/components/chart/HorizontalBarSection.test.tsx
+++ b/packages/components/src/internal/components/chart/HorizontalBarSection.test.tsx
@@ -1,19 +1,49 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 
 import { HorizontalBarSection } from './HorizontalBarSection';
+import { HorizontalBarData } from './utils';
 
 describe('HorizontalBarSection', () => {
     test('no data', () => {
         render(<HorizontalBarSection title="Test Allocation" subtitle="A description" data={[]} />);
 
-        expect(document.querySelector('.horizontal-bar--title').textContent).toBe('Test Allocation');
-        expect(document.querySelector('.horizontal-bar--subtitle').textContent).toBe('A description');
+        expect(document.querySelector('.horizontal-bar--title')).toHaveTextContent('Test Allocation');
+        expect(document.querySelector('.horizontal-bar--subtitle')).toHaveTextContent('A description');
         expect(document.querySelectorAll('.horizontal-bar-part')).toHaveLength(0);
     });
 
+    // Issue 52587: Empty tooltip content when data has a count of zero
+    test('with data no count', async () => {
+        const expectedTitle = "2 'Sample Type 1' samples";
+        const noCountData: HorizontalBarData[] = [
+            {
+                title: expectedTitle,
+                count: 0,
+                totalCount: 10,
+                percent: 20,
+                backgroundColor: 'blue',
+                href: '#/freezers/test/storageView?query.SampleType~eq=Sample Type 1&query.StorageStatus~eq=Checked out',
+                filled: true,
+            },
+        ];
+        render(<HorizontalBarSection title="Test Allocation" subtitle="A description" data={noCountData} />);
+
+        expect(document.querySelector('.horizontal-bar--title')).toHaveTextContent('Test Allocation');
+        expect(document.querySelector('.horizontal-bar--subtitle')).toHaveTextContent('A description');
+        expect(document.querySelectorAll('.horizontal-bar-part')).toHaveLength(1);
+
+        await userEvent.hover(document.querySelector('.horizontal-bar-part'));
+
+        await waitFor(() => {
+            expect(document.querySelector('.popover-content')).toBeInTheDocument();
+        });
+        expect(document.querySelector('.popover-content')).toHaveTextContent(expectedTitle);
+    });
+
     test('with data', () => {
-        const allocationData = [
+        const allocationData: HorizontalBarData[] = [
             {
                 title: "2 'Sample Type 1' samples",
                 count: 2,
@@ -42,8 +72,8 @@ describe('HorizontalBarSection', () => {
         ];
         render(<HorizontalBarSection title="Test Allocation" subtitle="A description" data={allocationData} />);
 
-        expect(document.querySelector('.horizontal-bar--title').textContent).toBe('Test Allocation');
-        expect(document.querySelector('.horizontal-bar--subtitle').textContent).toBe('A description');
+        expect(document.querySelector('.horizontal-bar--title')).toHaveTextContent('Test Allocation');
+        expect(document.querySelector('.horizontal-bar--subtitle')).toHaveTextContent('A description');
         expect(document.querySelectorAll('.horizontal-bar-part')).toHaveLength(3);
         expect(document.querySelectorAll('.horizontal-bar--linked')).toHaveLength(2);
         expect(document.querySelectorAll('.horizontal-bar--open')).toHaveLength(1);

--- a/packages/components/src/internal/components/chart/HorizontalBarSection.tsx
+++ b/packages/components/src/internal/components/chart/HorizontalBarSection.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Popover } from '../../Popover';
 import { OverlayTrigger } from '../../OverlayTrigger';
 
-import { createHorizontalBarCountLegendData, HorizontalBarData } from './utils';
+import { createHorizontalBarCountLegendData, HorizontalBarData, HorizontalBarLegendData } from './utils';
 import { ItemsLegend } from './ItemsLegend';
 
 const DEFAULT_EMPTY_TEXT = 'No data available.';
@@ -32,7 +32,7 @@ export const HorizontalBarSection: FC<Props> = memo(props => {
     let horizontalBars: ReactNode = <div className="horizontal-bar--empty-text">{emptyText ?? DEFAULT_EMPTY_TEXT}</div>;
 
     if (data?.length) {
-        let summaryLegendData = null;
+        let summaryLegendData: HorizontalBarLegendData[];
         if (showSummaryTooltip) {
             summaryLegendData = createHorizontalBarCountLegendData(
                 data,
@@ -63,7 +63,7 @@ export const HorizontalBarSection: FC<Props> = memo(props => {
 
                 const overlay = (
                     <Popover id="grid-cell-popover" placement="top" isFlexPlacement>
-                        {showSummaryTooltip ? (
+                        {showSummaryTooltip && summaryLegendData?.length > 0 ? (
                             <ItemsLegend legendData={summaryLegendData} activeIndex={index} />
                         ) : (
                             row.title

--- a/packages/components/src/internal/components/chart/ItemsLegend.test.tsx
+++ b/packages/components/src/internal/components/chart/ItemsLegend.test.tsx
@@ -4,7 +4,7 @@ import { Map } from 'immutable';
 
 import { ItemsLegend } from './ItemsLegend';
 
-describe('<ItemsLegend/>', () => {
+describe('ItemsLegend', () => {
     test('empty box', () => {
         render(
             <ItemsLegend
@@ -20,12 +20,12 @@ describe('<ItemsLegend/>', () => {
         );
 
         expect(document.querySelector('.box-viewer-legend')).toBeInTheDocument();
-        expect(document.getElementsByClassName('cell-legend-row').length).toBe(1);
-        expect(document.getElementsByClassName('cell-legend-icon').length).toBe(1);
-        expect(document.getElementsByClassName('cell-legend-icon-border').length).toBe(1);
-        expect(document.getElementsByClassName('cell-legend-circle').length).toBe(0);
-        expect(document.getElementsByClassName('cell-legend-label').length).toBe(1);
-        expect(document.getElementsByClassName('cell-legend-label')[0].innerHTML).toBe('Empty location');
+        expect(document.getElementsByClassName('cell-legend-row')).toHaveLength(1);
+        expect(document.getElementsByClassName('cell-legend-icon')).toHaveLength(1);
+        expect(document.getElementsByClassName('cell-legend-icon-border')).toHaveLength(1);
+        expect(document.getElementsByClassName('cell-legend-circle')).toHaveLength(0);
+        expect(document.getElementsByClassName('cell-legend-label')).toHaveLength(1);
+        expect(document.getElementsByClassName('cell-legend-label')[0]).toHaveTextContent('Empty location');
     });
 
     test('multiple sample types and checked out status, no selection', () => {
@@ -48,16 +48,16 @@ describe('<ItemsLegend/>', () => {
         render(<ItemsLegend legendData={MULTIPLE_SAMPLE_TYPES} />);
 
         expect(document.querySelector('.box-viewer-legend')).toBeInTheDocument();
-        expect(document.getElementsByClassName('cell-legend-row').length).toBe(5);
-        expect(document.getElementsByClassName('cell-legend-icon').length).toBe(5);
-        expect(document.getElementsByClassName('cell-legend-icon-border').length).toBe(2);
-        expect(document.getElementsByClassName('cell-legend-circle').length).toBe(3);
-        expect(document.getElementsByClassName('cell-legend-label').length).toBe(5);
-        expect(document.getElementsByClassName('cell-legend-label')[0].innerHTML).toBe('blood');
-        expect(document.getElementsByClassName('cell-legend-label')[1].innerHTML).toBe('samp18');
-        expect(document.getElementsByClassName('cell-legend-label')[2].innerHTML).toBe('sampleB');
-        expect(document.getElementsByClassName('cell-legend-label')[3].innerHTML).toBe('Checked out/Reserved');
-        expect(document.getElementsByClassName('cell-legend-label')[4].innerHTML).toBe('Empty location');
+        expect(document.getElementsByClassName('cell-legend-row')).toHaveLength(5);
+        expect(document.getElementsByClassName('cell-legend-icon')).toHaveLength(5);
+        expect(document.getElementsByClassName('cell-legend-icon-border')).toHaveLength(2);
+        expect(document.getElementsByClassName('cell-legend-circle')).toHaveLength(3);
+        expect(document.getElementsByClassName('cell-legend-label')).toHaveLength(5);
+        expect(document.getElementsByClassName('cell-legend-label')[0]).toHaveTextContent('blood');
+        expect(document.getElementsByClassName('cell-legend-label')[1]).toHaveTextContent('samp18');
+        expect(document.getElementsByClassName('cell-legend-label')[2]).toHaveTextContent('sampleB');
+        expect(document.getElementsByClassName('cell-legend-label')[3]).toHaveTextContent('Checked out/Reserved');
+        expect(document.getElementsByClassName('cell-legend-label')[4]).toHaveTextContent('Empty location');
     });
 
     test('multiple sample types with same color label', () => {
@@ -80,12 +80,12 @@ describe('<ItemsLegend/>', () => {
         render(<ItemsLegend legendData={WITH_SAME_COLOR_LABELS} />);
 
         expect(document.querySelector('.box-viewer-legend')).toBeInTheDocument();
-        expect(document.getElementsByClassName('cell-legend-row').length).toBe(5);
-        expect(document.getElementsByClassName('cell-legend-icon').length).toBe(5);
-        expect(document.getElementsByClassName('cell-legend-icon-border').length).toBe(2);
-        expect(document.getElementsByClassName('cell-legend-circle').length).toBe(3);
-        expect(document.getElementsByClassName('cell-legend-label').length).toBe(5);
-        expect(document.getElementsByClassName('cell-legend-label')[2].innerHTML).toBe('sampleB, sampleC');
+        expect(document.getElementsByClassName('cell-legend-row')).toHaveLength(5);
+        expect(document.getElementsByClassName('cell-legend-icon')).toHaveLength(5);
+        expect(document.getElementsByClassName('cell-legend-icon-border')).toHaveLength(2);
+        expect(document.getElementsByClassName('cell-legend-circle')).toHaveLength(3);
+        expect(document.getElementsByClassName('cell-legend-label')).toHaveLength(5);
+        expect(document.getElementsByClassName('cell-legend-label')[2]).toHaveTextContent('sampleB, sampleC');
     });
 
     test('with selection, locked and expired', () => {
@@ -135,16 +135,16 @@ describe('<ItemsLegend/>', () => {
         render(<ItemsLegend legendData={WITH_MIXED} />);
 
         expect(document.querySelector('.box-viewer-legend')).toBeInTheDocument();
-        expect(document.getElementsByClassName('cell-legend-row').length).toBe(10);
-        expect(document.getElementsByClassName('cell-legend-icon').length).toBe(10);
-        expect(document.getElementsByClassName('cell-legend-icon-border').length).toBe(6);
-        expect(document.getElementsByClassName('cell-legend-circle').length).toBe(6);
-        expect(document.getElementsByClassName('cell-legend-label').length).toBe(10);
-        expect(document.getElementsByClassName('cell-legend-label')[7].innerHTML).toBe('Restricted');
-        expect(document.getElementsByClassName('cell-legend-icon-margin').length).toBe(1);
-        expect(document.getElementsByClassName('cell-lock').length).toBe(1);
-        expect(document.getElementsByClassName('cell-legend-label')[8].innerHTML).toBe('Sample expired');
-        expect(document.getElementsByClassName('expired-form-field').length).toBe(1);
+        expect(document.getElementsByClassName('cell-legend-row')).toHaveLength(10);
+        expect(document.getElementsByClassName('cell-legend-icon')).toHaveLength(10);
+        expect(document.getElementsByClassName('cell-legend-icon-border')).toHaveLength(6);
+        expect(document.getElementsByClassName('cell-legend-circle')).toHaveLength(6);
+        expect(document.getElementsByClassName('cell-legend-label')).toHaveLength(10);
+        expect(document.getElementsByClassName('cell-legend-label')[7]).toHaveTextContent('Restricted');
+        expect(document.getElementsByClassName('cell-legend-icon-margin')).toHaveLength(1);
+        expect(document.getElementsByClassName('cell-lock')).toHaveLength(1);
+        expect(document.getElementsByClassName('cell-legend-label')[8]).toHaveTextContent('Sample expired');
+        expect(document.getElementsByClassName('expired-form-field')).toHaveLength(1);
     });
 
     test('with link and activeIndex', () => {
@@ -180,7 +180,7 @@ describe('<ItemsLegend/>', () => {
         ];
         render(<ItemsLegend legendData={sampleAllocationLegends} activeIndex={1} />);
         const legends = document.querySelectorAll('tr');
-        expect(legends.length).toBe(3);
+        expect(legends).toHaveLength(3);
         expect(document.querySelectorAll('a')).toHaveLength(2);
         expect(legends[0].querySelectorAll('a')).toHaveLength(1);
         expect(legends[0].querySelectorAll('.bold-text')).toHaveLength(0);

--- a/packages/components/src/internal/components/chart/ItemsLegend.tsx
+++ b/packages/components/src/internal/components/chart/ItemsLegend.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties, FC, memo } from 'react';
 import classNames from 'classnames';
 
 import { DefaultRenderer } from '../../renderers/DefaultRenderer';
@@ -13,80 +13,72 @@ interface Props {
     legendData: HorizontalBarLegendData[];
 }
 
-export class ItemsLegend extends React.PureComponent<Props> {
-    static defaultProps = {
-        title: 'Container legend',
-        emptyColor: CELL_EMPTY_COLOR,
-        asModal: true,
-    };
+export const ItemsLegend: FC<Props> = memo(props => {
+    const { legendData, emptyColor = CELL_EMPTY_COLOR, activeIndex } = props;
 
-    render() {
-        const { legendData, emptyColor, activeIndex } = this.props;
+    return (
+        <div className="box-viewer-legend">
+            <table>
+                <tbody>
+                    {legendData.map((legend, index) => {
+                        let icon;
+                        if (legend.circleColor && legend.circleColor !== 'none') {
+                            icon = (
+                                <i
+                                    className="color-icon__circle cell-legend-circle"
+                                    style={{ backgroundColor: legend.circleColor }}
+                                />
+                            );
+                        } else if (legend.locked) {
+                            icon = (
+                                <span className="cell-lock">
+                                    <span className="fa fa-lock" />
+                                </span>
+                            );
+                        }
 
-        const legendsDisplay = [];
-        legendData.forEach((legend, index) => {
-            let icon;
-            if (legend.circleColor && legend.circleColor !== 'none') {
-                icon = (
-                    <i
-                        className="color-icon__circle cell-legend-circle"
-                        style={{ backgroundColor: legend.circleColor }}
-                    />
-                );
-            } else if (legend.locked) {
-                icon = (
-                    <span className="cell-lock">
-                        <span className="fa fa-lock" />
-                    </span>
-                );
-            }
+                        const hasBackground = legend.backgroundColor !== 'none';
+                        const style: CSSProperties = {
+                            backgroundColor: hasBackground ? legend.backgroundColor : emptyColor,
+                        };
+                        if (legend.borderColor) {
+                            style.border = `3px solid ${legend.borderColor}`;
+                        }
+                        const iconClassName = classNames('cell-legend-icon', {
+                            'cell-legend-icon-margin': legend.locked,
+                            'cell-legend-icon-border': hasBackground,
+                            'expired-form-field': legend.expired,
+                        });
 
-            const key = 'cell-legend-' + index;
-            const hasBackground = legend.backgroundColor !== 'none';
-            const style = { backgroundColor: hasBackground ? legend.backgroundColor : emptyColor };
-            if (legend.borderColor) {
-                style['border'] = '3px solid ' + legend.borderColor;
-            }
-            const iconClassName = classNames('cell-legend-icon', {
-                'cell-legend-icon-margin': legend.locked,
-                'cell-legend-icon-border': hasBackground,
-                'expired-form-field': legend.expired,
-            });
-            const legendDisplay = (
-                <tr key={key} className="cell-legend-row">
-                    <td>
-                        <span className={iconClassName} style={style}>
-                            {icon}
-                        </span>
-                    </td>
-                    <td>
-                        <span
-                            className={classNames('cell-legend-label', {
-                                'bold-text': activeIndex === index,
-                            })}
-                        >
-                            {legend.legendLabel}
-                        </span>
-                    </td>
-                    {legend.data && (
-                        <td className="text-align-right">
-                            <span className="cell-legend-data">
-                                <DefaultRenderer data={legend.data} />
-                            </span>
-                        </td>
-                    )}
-                </tr>
-            );
-
-            legendsDisplay.push(legendDisplay);
-        });
-
-        return (
-            <div className="box-viewer-legend">
-                <table>
-                    <tbody>{legendsDisplay}</tbody>
-                </table>
-            </div>
-        );
-    }
-}
+                        return (
+                            <tr key={`cell-legend-${index}`} className="cell-legend-row">
+                                <td>
+                                    <span className={iconClassName} style={style}>
+                                        {icon}
+                                    </span>
+                                </td>
+                                <td>
+                                    <span
+                                        className={classNames('cell-legend-label', {
+                                            'bold-text': activeIndex === index,
+                                        })}
+                                    >
+                                        {legend.legendLabel}
+                                    </span>
+                                </td>
+                                {legend.data && (
+                                    <td className="text-align-right">
+                                        <span className="cell-legend-data">
+                                            <DefaultRenderer data={legend.data} />
+                                        </span>
+                                    </td>
+                                )}
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+});
+ItemsLegend.displayName = 'ItemsLegend';

--- a/packages/components/src/internal/components/chart/utils.test.ts
+++ b/packages/components/src/internal/components/chart/utils.test.ts
@@ -2,10 +2,6 @@ import { Map } from 'immutable';
 
 import { createHorizontalBarLegendData, createHorizontalBarCountLegendData, getFieldDataType } from './utils';
 
-beforeEach(() => {
-    LABKEY.vis = {};
-});
-
 describe('createHorizontalBarLegendData', () => {
     test('all different', () => {
         expect(

--- a/packages/components/src/internal/components/chart/utils.ts
+++ b/packages/components/src/internal/components/chart/utils.ts
@@ -50,24 +50,24 @@ export function createHorizontalBarCountLegendData(
     emptyTextSingular: string,
     emptyTextPlural: string
 ): HorizontalBarLegendData[] {
-    const legendData = [];
-    data.forEach(row => {
-        if (row.count > 0) {
+    return data
+        .filter(row => row.count > 0)
+        .reduce<HorizontalBarLegendData[]>((legendData, row) => {
             const countDisplay = row.count.toLocaleString();
-            const data = row.href ? Map.of('value', countDisplay, 'url', row.href) : Map.of('value', countDisplay);
             let legendLabel = row.name;
             if (!row.filled) {
                 legendLabel = row.count > 1 ? emptyTextPlural : emptyTextSingular;
             }
+
             legendData.push({
                 circleColor: row.backgroundColor ?? 'fff',
                 backgroundColor: 'none',
                 legendLabel,
-                data,
+                data: row.href ? Map.of('value', countDisplay, 'url', row.href) : Map.of('value', countDisplay),
             });
-        }
-    });
-    return legendData;
+
+            return legendData;
+        }, []);
 }
 
 export const getFieldDataType = (fieldData: Record<string, any>): string => {

--- a/packages/components/src/internal/util/Date.test.ts
+++ b/packages/components/src/internal/util/Date.test.ts
@@ -778,6 +778,25 @@ describe('Date Utilities', () => {
             expect(isDateTimeInPast('3000-01-01 00:01')).toBeFalsy();
             expect(isDateTimeInPast('3000-01-01 00:00:00.001')).toBeFalsy();
         });
+
+        function datePlusHours(date: Date, hours: number): string {
+            return getJsonDateTimeFormatString(new Date(date.getTime() + hours * 60 * 60 * 1000));
+        }
+
+        test('timezone', () => {
+            const utcNow = new Date();
+            const TZ = 'Europe/Moscow';
+            expect(isDateTimeInPast(datePlusHours(utcNow, -4), TZ)).toBeTruthy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, -3), TZ)).toBeTruthy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, -2), TZ)).toBeTruthy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, -1), TZ)).toBeTruthy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, 1), TZ)).toBeTruthy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, 2), TZ)).toBeTruthy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, 3), TZ)).toBeTruthy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, 4), TZ)).toBeFalsy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, 5), TZ)).toBeFalsy();
+            expect(isDateTimeInPast(datePlusHours(utcNow, 6), TZ)).toBeFalsy();
+        });
     });
 
     describe('toDateFNSFormatString', () => {

--- a/packages/components/src/internal/util/Date.test.ts
+++ b/packages/components/src/internal/util/Date.test.ts
@@ -785,7 +785,7 @@ describe('Date Utilities', () => {
 
         test('timezone', () => {
             const utcNow = new Date();
-            const TZ = 'Europe/Moscow';
+            const TZ = 'Europe/Kyiv';
             expect(isDateTimeInPast(datePlusHours(utcNow, -4), TZ)).toBeTruthy();
             expect(isDateTimeInPast(datePlusHours(utcNow, -3), TZ)).toBeTruthy();
             expect(isDateTimeInPast(datePlusHours(utcNow, -2), TZ)).toBeTruthy();
@@ -793,6 +793,8 @@ describe('Date Utilities', () => {
             expect(isDateTimeInPast(datePlusHours(utcNow, 1), TZ)).toBeTruthy();
             expect(isDateTimeInPast(datePlusHours(utcNow, 2), TZ)).toBeTruthy();
             expect(isDateTimeInPast(datePlusHours(utcNow, 3), TZ)).toBeTruthy();
+
+            // Europe/Kyiv timezone is +3 hours UTC
             expect(isDateTimeInPast(datePlusHours(utcNow, 4), TZ)).toBeFalsy();
             expect(isDateTimeInPast(datePlusHours(utcNow, 5), TZ)).toBeFalsy();
             expect(isDateTimeInPast(datePlusHours(utcNow, 6), TZ)).toBeFalsy();

--- a/packages/components/src/internal/util/Date.ts
+++ b/packages/components/src/internal/util/Date.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { addDays, format, formatDistance, isBefore, isValid, parse } from 'date-fns';
-import { format as formatTz, toZonedTime } from 'date-fns-tz';
+import { format as formatTz, fromZonedTime, toZonedTime } from 'date-fns-tz';
 import { Container, getServerContext } from '@labkey/api';
 
 import { QueryColumn } from '../../public/QueryColumn';
@@ -676,8 +676,16 @@ export function getParsedRelativeDateStr(dateVal: string): { days: number; posit
     return { days, positive };
 }
 
-/** Returns true if the date has a timestamp that is before now */
-export function isDateTimeInPast(date: Date | string | number): boolean {
+/**
+ * Returns true if the date has a timestamp that is before now.
+ * If a timezone is not provided, then it will assume the provided date is in the server's timezone
+ */
+export function isDateTimeInPast(date: Date | string | number, timezone?: string): boolean {
     const date_ = parseDate(date);
-    return isValid(date_) && date_.getTime() <= new Date().getTime();
+    if (!isValid(date_)) return false;
+
+    // Issue 52637: Convert dates from server timezone to local timezone for comparison
+    const timezone_ = timezone ?? getServerContext().timezone;
+    const zonedTime = fromZonedTime(date_, timezone_);
+    return zonedTime.getTime() <= new Date().getTime();
 }


### PR DESCRIPTION
#### Rationale
Addresses following issues:

- [Issue 52587](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52587): Empty/collapsed tooltip on Samples Checked Out in Freezer view
- [Issue 52637](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52637): Expiration date flag might be going off the local and not the server time zone

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1333

#### Changes
- Use `fromZonedTime` from `date-fns` package to compare dates against server dates in `isDateTimeInPast` utility function (addresses Issue 52637).
- Check legend data exists in `HorizontalBarSection` (addresses Issue 52587)
- Convert `ItemsLegend` to a functional component
- Add regression coverage for `isDateTimeInPast`
