### PR TITLE
Issue 52156: Editable grid cell with dropdown loses first input character

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.5-fb-scanner-darkly.0",
+  "version": "6.36.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.5-fb-scanner-darkly.0",
+      "version": "6.36.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.4",
+  "version": "6.36.5-fb-scanner-darkly.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.4",
+      "version": "6.36.5-fb-scanner-darkly.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.4",
+  "version": "6.36.5-fb-scanner-darkly.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.5-fb-scanner-darkly.0",
+  "version": "6.36.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.36.5
+*Released*: 18 April 2025
+- Issue 52156: Editable grid cell with dropdown loses first input character
+  - SelectInput: load async `defaultInputValue` when provided.
+  - QuerySelect: start with model, support deferred searches. No more `null` render cycles.
+  - Defer clearing cell `recordedKeys` so that they are utilized for the `defaultInputValue` of select input cells.
+
 ### version 6.36.4
 *Released*: 17 April 2025
 - Issue 52536: Sample Manager: time format HH:mm:ss.SSS issues

--- a/packages/components/src/internal/components/editable/Cell.test.tsx
+++ b/packages/components/src/internal/components/editable/Cell.test.tsx
@@ -66,7 +66,7 @@ describe('Cell', () => {
         expect(document.querySelectorAll('div.cellular-display')).toHaveLength(1);
         expect(document.querySelectorAll('div.cell-content')).toHaveLength(1);
         expect(document.querySelectorAll('span.cell-content-value')).toHaveLength(1);
-        expect(document.querySelectorAll('span.cell-content-value')[0].textContent).toBe('placeholder text');
+        expect(document.querySelectorAll('span.cell-content-value')[0]).toHaveTextContent('placeholder text');
         expect(document.querySelectorAll('textarea')).toHaveLength(0);
         expect(document.querySelectorAll('.select-input')).toHaveLength(0);
     });
@@ -113,7 +113,7 @@ describe('Cell', () => {
         render(<Cell {...defaultProps()} colIdx={3} placeholder="readOnly placeholder" readOnly rowIdx={3} />);
         expect(document.querySelectorAll('div.cellular-display')).toHaveLength(1);
         expect(document.querySelectorAll('div.cell-read-only')).toHaveLength(1);
-        expect(document.querySelectorAll('div.cell-read-only')[0].textContent).toBe('readOnly placeholder');
+        expect(document.querySelectorAll('div.cell-read-only')[0]).toHaveTextContent('readOnly placeholder');
         expect(document.querySelectorAll('textarea')).toHaveLength(0);
         expect(document.querySelectorAll('.select-input')).toHaveLength(0);
     });
@@ -130,7 +130,7 @@ describe('Cell', () => {
         expect(document.querySelectorAll('.cell-menu')).toHaveLength(focused ? 0 : 1);
         expect(document.querySelectorAll('.cell-menu-selector')).toHaveLength(focused || readOnly ? 0 : 1);
         expect(document.querySelectorAll('.' + CELL_SELECTION_HANDLE_CLASSNAME)).toHaveLength(0);
-        expect(document.querySelectorAll('.select-input')).toHaveLength(0);
+        expect(document.querySelectorAll('.select-input')).toHaveLength(focused ? 1 : 0);
     };
 
     test('col is lookup, public', () => {
@@ -138,7 +138,7 @@ describe('Cell', () => {
         expectLookup();
     });
 
-    test('col is lookup, public and focused', async () => {
+    test('col is lookup, public and focused', () => {
         render(<Cell {...defaultProps()} col={publicLookupCol} focused selected />);
         expectLookup(true);
     });
@@ -187,7 +187,7 @@ describe('Cell', () => {
             if (focused) {
                 expect(document.querySelectorAll('input.date-input-cell')[0].getAttribute('value')).toEqual(value);
             } else {
-                expect(document.querySelectorAll('.cellular-display')[0].textContent).toEqual(value);
+                expect(document.querySelectorAll('.cellular-display')[0]).toHaveTextContent(value);
             }
         }
     };

--- a/packages/components/src/internal/components/editable/Cell.test.tsx
+++ b/packages/components/src/internal/components/editable/Cell.test.tsx
@@ -37,6 +37,7 @@ describe('Cell', () => {
             },
             col: queryColumn,
             colIdx: 1,
+            columnMetadata: undefined,
             forUpdate: false,
             rowIdx: 2,
         };

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -570,8 +570,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
                         placeholder={placeholder}
                         selected={selected}
                         selection={selection}
-                        // FIXME: We should not be referring to specific implementations of inputRenderer
-                        showMenu={showLookup || (col.inputRenderer && col.inputRenderer !== 'AppendUnitsInput')}
+                        showMenu={showLookup}
                         targetRef={this.displayEl}
                     />
                     {renderDragHandle && !this.isReadOnly && (
@@ -591,6 +590,8 @@ export class Cell extends React.PureComponent<CellProps, State> {
                     onSelectChange={this.onSelectChange}
                     selectInputProps={{
                         ...gridCellSelectInputProps,
+                        defaultInputValue: this.recordedKeys,
+                        disabled: this.isReadOnly,
                         onBlur: this.handleSelectionBlur,
                         onKeyDown: this.handleFocusedDropdownKeys,
                     }}

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -199,6 +199,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
     private preFocusDOMRect: React.MutableRefObject<DOMRect>;
     private recordedKeys: string;
     private recordingTO: number;
+    private recordingClearTO: number;
 
     static defaultProps = {
         borderMaskBottom: false,
@@ -402,6 +403,20 @@ export class Cell extends React.PureComponent<CellProps, State> {
         }
     };
 
+    clearRecordedKeys = (immediate: boolean): void => {
+        clearTimeout(this.recordingClearTO);
+
+        if (immediate) {
+            this.recordedKeys = undefined;
+            return;
+        }
+
+        this.recordingClearTO = window.setTimeout(() => {
+            this.recordingClearTO = undefined;
+            this.recordedKeys = undefined;
+        }, 100);
+    };
+
     // Issue 49779: Support barcode scanners "streaming" input keys
     recordKeys = (event: React.KeyboardEvent<HTMLElement>): void => {
         clearTimeout(this.recordingTO);
@@ -427,11 +442,16 @@ export class Cell extends React.PureComponent<CellProps, State> {
             if (this.recordedKeys.indexOf('\n') > -1) {
                 fillText(colIdx, rowIdx, this.recordedKeys);
                 selectCell(colIdx, rowIdx + 1);
+                this.clearRecordedKeys(true);
             } else {
                 this.focusCell(colIdx, rowIdx, !this.isReadOnly);
+
+                // Issue 52156: Do not clear the recordedKeys immediately to allow the next render cycle to
+                // resolve the value when rendering the focused cell. The focused cell is then able to utilize the
+                // recordedKeys for the initial input value.
+                this.clearRecordedKeys(false);
             }
 
-            this.recordedKeys = undefined;
             // Wait for a very brief amount of time as automated input is
             // expected to quickly input subsequent characters
         }, 25);
@@ -523,11 +543,8 @@ export class Cell extends React.PureComponent<CellProps, State> {
             containerPath,
         } = this.props;
 
-        const { filteredLookupKeys } = this.state;
         const alignRight = col.align === 'right';
-        const isDateTimeField = this.isDateTimeField;
         const showLookup = this.isLookup;
-        const showMenu = showLookup || (col.inputRenderer && col.inputRenderer !== 'AppendUnitsInput');
 
         if (!focused) {
             const displayValue = values
@@ -553,7 +570,8 @@ export class Cell extends React.PureComponent<CellProps, State> {
                         placeholder={placeholder}
                         selected={selected}
                         selection={selection}
-                        showMenu={showMenu}
+                        // FIXME: We should not be referring to specific implementations of inputRenderer
+                        showMenu={showLookup || (col.inputRenderer && col.inputRenderer !== 'AppendUnitsInput')}
                         targetRef={this.displayEl}
                     />
                     {renderDragHandle && !this.isReadOnly && (
@@ -583,6 +601,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
             );
         }
 
+        const isDateTimeField = this.isDateTimeField;
         if (showLookup && !isDateTimeField) {
             return (
                 <LookupCell
@@ -593,7 +612,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
                     defaultInputValue={this.recordedKeys}
                     disabled={this.isReadOnly}
                     lookupValueFilters={columnMetadata?.lookupValueFilters}
-                    filteredLookupKeys={filteredLookupKeys}
+                    filteredLookupKeys={this.state.filteredLookupKeys}
                     filteredLookupValues={columnMetadata?.filteredLookupValues}
                     forUpdate={forUpdate}
                     modifyCell={cellActions.modifyCell}

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -570,7 +570,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
                         placeholder={placeholder}
                         selected={selected}
                         selection={selection}
-                        showMenu={showLookup}
+                        showMenu={showLookup || !!col.inputRenderer}
                         targetRef={this.displayEl}
                     />
                     {renderDragHandle && !this.isReadOnly && (

--- a/packages/components/src/internal/components/editable/LookupCell.test.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.test.tsx
@@ -23,7 +23,7 @@ describe('LookupCell', () => {
             colIdx: 0,
             forUpdate: false,
             modifyCell: jest.fn(),
-            row: undefined,
+            onBlur: jest.fn(),
             rowIdx: 0,
             select: jest.fn(),
             values: List.of({ raw: 'a' } as ValueDescriptor, { raw: 'b' } as ValueDescriptor, {} as ValueDescriptor),
@@ -31,20 +31,33 @@ describe('LookupCell', () => {
     }
 
     test('col with validValues', () => {
+        render(<LookupCell {...defaultProps()} col={new QueryColumn({ validValues: ['a', 'b'] })} />);
+
+        expect(document.querySelectorAll('.select-input-cell')).toHaveLength(1);
+        expect(document.querySelector('.select-input__single-value')).toHaveTextContent('a');
+
+        const options = document.querySelectorAll('.select-input__option');
+        expect(options).toHaveLength(2);
+        expect(options[0]).toHaveTextContent('a');
+        expect(options[1]).toHaveTextContent('b');
+    });
+
+    test('col with defaultInputValue', () => {
         render(
             <LookupCell
                 {...defaultProps()}
-                col={
-                    new QueryColumn({
-                        validValues: ['a', 'b'],
-                    })
-                }
+                col={new QueryColumn({ validValues: ['aa', 'ab', 'bb', 'ca'] })}
+                defaultInputValue="a"
             />
         );
+
         expect(document.querySelectorAll('.select-input-cell')).toHaveLength(1);
-        expect(document.querySelector('.select-input__single-value').textContent).toBe('a');
-        expect(document.querySelectorAll('.select-input__option')).toHaveLength(2);
-        expect(document.querySelectorAll('.select-input__option')[0].textContent).toBe('a');
-        expect(document.querySelectorAll('.select-input__option')[1].textContent).toBe('b');
+        expect(document.querySelector('.select-input__input')).toHaveValue('a');
+
+        const options = document.querySelectorAll('.select-input__option');
+        expect(options).toHaveLength(3);
+        expect(options[0]).toHaveTextContent('aa');
+        expect(options[1]).toHaveTextContent('ab');
+        expect(options[2]).toHaveTextContent('ca');
     });
 });

--- a/packages/components/src/internal/components/editable/LookupCell.tsx
+++ b/packages/components/src/internal/components/editable/LookupCell.tsx
@@ -129,7 +129,19 @@ const QueryLookupCell: FC<QueryLookupCellProps> = memo(props => {
 QueryLookupCell.displayName = 'QueryLookupCell';
 
 export const LookupCell: FC<LookupCellProps> = memo(props => {
-    const { col, colIdx, disabled, modifyCell, onBlur, onKeyDown, rowIdx, select, values, containerPath } = props;
+    const {
+        col,
+        colIdx,
+        defaultInputValue,
+        disabled,
+        modifyCell,
+        onBlur,
+        onKeyDown,
+        rowIdx,
+        select,
+        values,
+        containerPath,
+    } = props;
 
     const onSelectChange = useCallback<SelectInputChange>(
         (fieldName, formValue, options, props_) => {
@@ -152,6 +164,7 @@ export const LookupCell: FC<LookupCellProps> = memo(props => {
             <TextChoiceInput
                 {...gridCellSelectInputProps}
                 autoFocus
+                defaultInputValue={defaultInputValue}
                 disabled={disabled}
                 onBlur={onBlur}
                 onChange={onSelectChange}

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ComponentType, FC, memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ComponentType, FC, memo, useCallback, useEffect, useState } from 'react';
 import { List, Map } from 'immutable';
 import { Filter, Query, Utils } from '@labkey/api';
 
@@ -27,12 +27,16 @@ import { QueryInfo } from '../../../public/QueryInfo';
 
 import { isTestEnv } from '../../util/utils';
 
+import { useTimeout } from '../../hooks';
+
 import { SelectInputOption, SelectInput, SelectInputProps, SelectInputChange } from './input/SelectInput';
 import { resolveDetailFieldLabel } from './utils';
 import {
     fetchSearchResults,
+    formatResults,
     formatSavedResults,
     initSelect,
+    parseSelectedQuery,
     QuerySelectModel,
     saveSearchResults,
     setSelection,
@@ -187,6 +191,12 @@ export interface QuerySelectOwnProps extends InheritedSelectInputProps {
 
 type DefaultOptions = boolean | SelectInputOption[];
 
+type Search = {
+    input: string;
+    reject: (reason?: any) => any;
+    resolve: (value: SelectInputOption[] | PromiseLike<SelectInputOption[]>) => void;
+};
+
 export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     const {
         OptionComponent,
@@ -216,7 +226,6 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
         containerClass,
         customTheme,
         customStyles,
-        defaultInputValue,
         description,
         formsy,
         helpTipRenderer,
@@ -230,6 +239,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
         onToggleDisable,
         openMenuOnFocus,
         required,
+        value,
     } = selectInputProps;
     const [defaultOptions, setDefaultOptions] = useState<DefaultOptions>(() =>
         // See note in onFocus() regarding support for "loadOnFocus"
@@ -237,85 +247,112 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     );
     const [error, setError] = useState<string>();
     const [loadOnFocusLock, setLoadOnFocusLock] = useState<boolean>(false);
-    const [initialLoad, setInitialLoad] = useState<boolean>(true);
     const [isLoading, setIsLoading] = useState<boolean>(undefined);
-    const [model, setModel] = useState<QuerySelectModel>();
-    const lastRequest = useRef<Record<string, string>>(undefined);
-    const querySelectTimer = useRef(undefined);
+    const [model, setModel] = useState<QuerySelectModel>(
+        () => new QuerySelectModel({ ...props, delimiter, isInit: false })
+    );
+    // This persists all searches done prior to the select being fully initialized. Once initialized,
+    // these searches are cleared out and resolved. The reason we need to retain these is the underlying
+    // SelectInput retains these search results, however, we need be fully initialized to complete a search.
+    const [searches, setSearches] = useState<Search[]>([]);
+    const debounceTO = useTimeout();
     const shouldLoadOnFocus = loadOnFocus && !loadOnFocusLock;
 
-    const clear = useCallback(() => {
-        clearTimeout(querySelectTimer.current);
-        querySelectTimer.current = undefined;
-    }, []);
-
     useEffect(() => {
-        if (!autoInit) return clear;
-
+        if (!autoInit) return;
         (async () => {
             try {
-                const model_ = await initSelect({
-                    ...props,
-                    delimiter,
-                    fireQSChangeOnInit,
-                    loadOnFocus,
-                    preLoad,
-                    showLoading,
+                const modelProps = await initSelect({ ...props, delimiter });
+
+                setModel(model_ => {
+                    const { selectedItems } = modelProps;
+
+                    if (selectedItems.size) {
+                        model_ = model_.merge({
+                            allResults: model_.allResults.merge(selectedItems),
+                            selectedQuery: parseSelectedQuery(model_, selectedItems),
+                        }) as QuerySelectModel;
+                    }
+
+                    return model_.merge(modelProps) as QuerySelectModel;
                 });
-                setModel(model_);
             } catch (e) {
                 setError(resolveErrorMessage(e) ?? 'Failed to initialize.');
             }
         })();
-
-        return clear;
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [autoInit]);
 
-    const loadOptions = useCallback(
-        (input: string): Promise<SelectInputOption[]> => {
-            let input_: string;
+    useEffect(() => {
+        if (!model.isInit || value === undefined || value === null) return;
 
-            if (initialLoad) {
-                // If a "defaultInputValue" is supplied and the initial load is an empty search,
-                // then search with the "defaultInputValue"
-                input_ = input ? input : (defaultInputValue ?? '');
-                setInitialLoad(false);
-            } else {
-                input_ = input;
+        // The following logic is only reached once after the model has been initialized.
+        const { rawSelectedValue, selectedItems } = model;
+
+        if (fireQSChangeOnInit && Utils.isFunction(onQSChange)) {
+            let selectOptions: SelectInputOption | SelectInputOption[] = formatResults(model, selectedItems);
+
+            // mimic ReactSelect in that it will return a single option if multiple is not true
+            if (multiple === false) {
+                selectOptions = selectOptions[0];
             }
 
-            const request = (lastRequest.current = {});
-            clear();
+            onQSChange(name, rawSelectedValue, selectOptions, props, selectedItems);
+        }
 
+        // fire listener if given an initial value and a listener function
+        if (rawSelectedValue) {
+            onInitValue?.(rawSelectedValue, selectedItems.toList());
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- should only ever depend on model.isInit
+    }, [model.isInit]);
+
+    const fetchResults = useCallback((model_: QuerySelectModel, search: Search): void => {
+        const { input, reject, resolve } = search;
+        fetchSearchResults(model_, input)
+            .then(data => {
+                resolve(formatSavedResults(model_, data, input));
+                setModel(m => saveSearchResults(m, data));
+            })
+            .catch(e => {
+                const errorMsg = resolveErrorMessage(e) ?? 'Failed to retrieve search results.';
+                console.error(errorMsg, e);
+                reject(errorMsg);
+                setError(errorMsg);
+            });
+    }, []);
+
+    // Any searches (i.e. calls to loadOptions()) made prior to the select being fully
+    // initialized are resolved here after the model has been initialized.
+    useEffect(() => {
+        if (model.isInit && searches.length > 0) {
+            setSearches([]);
+            searches.forEach(s => fetchResults(model, s));
+        }
+    }, [fetchResults, model, searches]);
+
+    const loadOptions = useCallback(
+        (input: string): Promise<SelectInputOption[]> => {
             // If loadOptions occurs prior to call to "onFocus" then there is no need to "loadOnFocus".
             if (shouldLoadOnFocus) {
                 setLoadOnFocusLock(true);
             }
 
+            debounceTO.clear();
+
             return new Promise((resolve, reject): void => {
-                querySelectTimer.current = setTimeout(async () => {
-                    clear();
+                const search: Search = { input, reject, resolve };
 
-                    try {
-                        const data = await fetchSearchResults(model, input_);
-
-                        // Issue 46816: Skip processing stale requests
-                        if (request !== lastRequest.current) return;
-                        lastRequest.current = undefined;
-
-                        resolve(formatSavedResults(model, data, input_));
-                        setModel(saveSearchResults(model, data));
-                    } catch (e) {
-                        const errorMsg = resolveErrorMessage(e) ?? 'Failed to retrieve search results.';
-                        console.error(errorMsg, e);
-                        reject(errorMsg);
-                        setError(errorMsg);
-                    }
-                }, 250);
+                // If the model is already initialized, then debounce the searches
+                if (model.isInit) {
+                    debounceTO.set(() => fetchResults(model, search), 250);
+                } else {
+                    // Otherwise, persist the search to be resolved after the model is initialized
+                    setSearches(s => [...s, search]);
+                }
             });
         },
-        [clear, defaultInputValue, initialLoad, model, shouldLoadOnFocus]
+        [debounceTO, fetchResults, model, shouldLoadOnFocus]
     );
 
     const onChange = useCallback<SelectInputChange>(
@@ -383,55 +420,26 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
         );
     }
 
-    if (model?.isInit) {
-        return (
-            <SelectInput
-                filterOption={noopFilterOptions}
-                label={label !== undefined ? label : model.queryInfo.title}
-                {...selectInputProps}
-                allowCreate={false}
-                autoValue={false} // QuerySelect directly controls value of SelectInput via "selectedOptions"
-                cacheOptions
-                defaultOptions={defaultOptions}
-                delimiter={delimiter}
-                isLoading={isLoading}
-                loadOptions={loadOptions}
-                onChange={onChange}
-                onFocus={onFocus}
-                optionRenderer={optionRenderer}
-                options={undefined} // prevent override
-                selectedOptions={model.selectedOptions}
-                value={getValue(model, multiple)} // needed to initialize the Formsy "value" properly
-            />
-        );
-    }
-
-    if (showLoading) {
-        return (
-            <SelectInput
-                allowDisable={allowDisable}
-                containerClass={containerClass}
-                customStyles={customStyles}
-                customTheme={customTheme}
-                description={description}
-                disabled
-                formsy={formsy}
-                helpTipRenderer={helpTipRenderer}
-                initiallyDisabled={initiallyDisabled}
-                label={label}
-                labelClass={labelClass}
-                menuPosition={menuPosition}
-                multiple={multiple}
-                name={name}
-                onToggleDisable={onToggleDisable}
-                openMenuOnFocus={openMenuOnFocus}
-                placeholder="Loading..."
-                required={required}
-                value={undefined}
-            />
-        );
-    }
-
-    return null;
+    return (
+        <SelectInput
+            disabled={showLoading && !model.isInit}
+            filterOption={noopFilterOptions}
+            label={label !== undefined ? label : model.queryInfo?.title}
+            {...selectInputProps}
+            allowCreate={false}
+            autoValue={false} // QuerySelect directly controls value of SelectInput via "selectedOptions"
+            cacheOptions
+            defaultOptions={defaultOptions}
+            delimiter={delimiter}
+            isLoading={isLoading}
+            loadOptions={loadOptions}
+            onChange={onChange}
+            onFocus={onFocus}
+            optionRenderer={optionRenderer}
+            options={undefined} // prevent override
+            selectedOptions={model.isInit ? model.selectedOptions : undefined}
+            value={getValue(model, multiple)} // needed to initialize the Formsy "value" properly
+        />
+    );
 });
 QuerySelect.displayName = 'QuerySelect';

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -249,7 +249,13 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     const [loadOnFocusLock, setLoadOnFocusLock] = useState<boolean>(false);
     const [isLoading, setIsLoading] = useState<boolean>(undefined);
     const [model, setModel] = useState<QuerySelectModel>(
-        () => new QuerySelectModel({ ...props, delimiter, isInit: false })
+        () =>
+            new QuerySelectModel({
+                ...props,
+                delimiter,
+                isInit: false,
+                rawSelectedValue: value !== null ? value : undefined,
+            })
     );
     // This persists all searches done prior to the select being fully initialized. Once initialized,
     // these searches are cleared out and resolved. The reason we need to retain these is the underlying

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -130,8 +130,7 @@ function initOptionFromPrimitive(value: string | number, props: SelectInputProps
             subResult = optionGroup?.options?.find(o => o[valueKey] === value);
         });
 
-        if (!!subResult)
-            return subResult;
+        if (subResult) return subResult;
     }
 
     return { [labelKey]: value, [valueKey]: value };
@@ -284,6 +283,7 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
 
     private readonly _id: string;
     private _isMounted: boolean;
+    private _defaultValueLoaded = false;
     private CHANGE_LOCK = false;
     private reactSelect: React.RefObject<any>;
 
@@ -539,12 +539,35 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
 
     getOptionValue = (option: SelectInputOption): any => option[this.props.valueKey];
 
-    Input = inputProps => (
+    Input = inputProps => {
+        // React-select in an async configuration has a bug where when a defaultInputValue prop is supplied it
+        // does not fire an onChange event on the underlying input which results in loadOptions() never being called
+        // with the supplied value. Here we simulate an onChange() event ourselves to induce the expected loading logic.
+        // See https://github.com/JedWatson/react-select/issues/3047
+        if (!this._defaultValueLoaded) {
+            this._defaultValueLoaded = true;
+            if (this.props.defaultInputValue && this.isAsync()) {
+                // To avoid performing updates during the render cycle utilize a setTimeout() to defer execution.
+                // Normally, this could be done in componentDidMount(), however, we need access to the inputProps.
+                setTimeout(() => {
+                    const inputEl = document.getElementById(inputProps.id);
+                    if (inputEl) {
+                        // If the input element has a different value than the defaultInputValue, then skip simulating
+                        // the event as the react-select will induce loadOption() appropriately. This only really occurs
+                        // when someone types exceedingly fast into the input.
+                        if ((inputEl as HTMLInputElement).value === this.props.defaultInputValue) {
+                            inputProps.onChange?.({ currentTarget: { value: this.props.defaultInputValue } });
+                        }
+                    }
+                }, 0);
+            }
+        }
+
         // Marking input as "required" is not natively supported by react-select post-v1. Here we can mark
         // the underlying input as required, however, this is not the value input but rather the user visible
         // input so we manually check if a value is set.
-        <components.Input {...inputProps} required={!!this.props.required && !inputProps.selectProps?.value} />
-    );
+        return <components.Input {...inputProps} required={!!this.props.required && !inputProps.selectProps?.value} />;
+    };
 
     Option = optionProps => <CustomOption {...optionProps}>{this.props.optionRenderer(optionProps)}</CustomOption>;
 

--- a/packages/components/src/internal/components/forms/model.test.ts
+++ b/packages/components/src/internal/components/forms/model.test.ts
@@ -1,5 +1,10 @@
 import { fromJS } from 'immutable';
-import { parseSelectedQuery, QuerySelectModel } from './model';
+
+import { QueryInfo } from '../../../public/QueryInfo';
+import { ExtendedMap } from '../../../public/ExtendedMap';
+import { QueryColumn } from '../../../public/QueryColumn';
+
+import { parseSelectedQuery, QuerySelectModel, queryColumnNames } from './model';
 
 describe('form actions', () => {
     const setSelectionModel = new QuerySelectModel({
@@ -48,5 +53,43 @@ describe('form actions', () => {
 
         expect(parsed).toBe('C-1');
         expect(parsed2).toBe('Ron Swanson;Swan Ronson');
+    });
+
+    test('queryColumnNames', () => {
+        const displayColumn = 'display';
+        const valueColumn = 'value';
+        let queryInfo = new QueryInfo({ pkCols: ['pkCol1', 'pkCol2'] });
+        expect(queryColumnNames(queryInfo, displayColumn, valueColumn, [], undefined).sort()).toEqual([
+            displayColumn,
+            'pkCol1',
+            'pkCol2',
+            valueColumn,
+        ]);
+
+        const lookupColumn = 'colA';
+        queryInfo = queryInfo.mutate({
+            columns: new ExtendedMap({
+                [lookupColumn]: new QueryColumn({ fieldKey: lookupColumn, shownInLookupView: true }),
+            }),
+        });
+        expect(queryColumnNames(queryInfo, displayColumn, valueColumn, [], undefined).sort()).toEqual([
+            'colA',
+            displayColumn,
+            'pkCol1',
+            'pkCol2',
+            valueColumn,
+        ]);
+
+        const groupByColumn = 'grouper';
+        const someRequiredColumn = `${valueColumn}/${displayColumn}`;
+        expect(
+            queryColumnNames(
+                queryInfo,
+                displayColumn,
+                valueColumn,
+                [displayColumn, someRequiredColumn, valueColumn],
+                groupByColumn
+            ).sort()
+        ).toEqual(['colA', displayColumn, groupByColumn, 'pkCol1', 'pkCol2', valueColumn, someRequiredColumn]);
     });
 });

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -50,7 +50,7 @@ function formatOption(model: QuerySelectModel, result: any): SelectInputOption {
     };
 }
 
-function formatResults(model: QuerySelectModel, results: Map<string, any>, token?: string): SelectInputOption[] {
+export function formatResults(model: QuerySelectModel, results: Map<string, any>, token?: string): SelectInputOption[] {
     const { displayColumn, groupByColumn, queryInfo } = model;
 
     if (!queryInfo || !results) {
@@ -198,7 +198,7 @@ export function fetchSearchResults(model: QuerySelectModel, input: any): Promise
         allFilters = allFilters.concat(queryFilters.toArray());
     }
 
-    // 35112: Explicitly request exact matches -- can be disabled via QuerySelectModel.addExactFilter = false
+    // Issue 35112: Explicitly request exact matches -- can be disabled via QuerySelectModel.addExactFilter = false
     return searchRows(
         {
             containerFilter: model.containerFilter,
@@ -300,24 +300,37 @@ function initGroupByColumn(queryInfo: QueryInfo, column?: string): string {
     return groupByColumn;
 }
 
-export async function initSelect(props: QuerySelectOwnProps): Promise<QuerySelectModel> {
+function queryColumnNames(
+    queryInfo: QueryInfo,
+    displayColumn: string,
+    valueColumn: string,
+    requiredColumns: string[],
+    groupByColumn: string
+): string[] {
+    const queryColumns = queryInfo.pkCols.concat([displayColumn, valueColumn].concat(requiredColumns));
+    const lookupViewColumns = queryInfo.getLookupViewColumns();
+
+    if (groupByColumn) {
+        queryColumns.push(groupByColumn);
+    }
+
+    if (lookupViewColumns.length > 0) {
+        return lookupViewColumns.map(c => c.fieldKey).concat(queryColumns);
+    }
+
+    // Remove duplicates
+    return Array.from(new Set(queryColumns));
+}
+
+export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<QuerySelectModelProps>> {
     const { containerFilter, containerPath, schemaQuery, queryFilters } = props;
-    const { queryName, schemaName, viewName } = schemaQuery;
-    const filters = queryFilters ? queryFilters.toArray() : [];
 
     const queryInfo = await getQueryDetails({ containerPath, schemaQuery });
     const valueColumn = initValueColumn(queryInfo, props.valueColumn);
     const displayColumn = initDisplayColumn(queryInfo, valueColumn, props.displayColumn);
     const groupByColumn = initGroupByColumn(queryInfo, props.groupByColumn);
-
-    let model = new QuerySelectModel({
-        ...props,
-        displayColumn,
-        groupByColumn,
-        isInit: true,
-        queryInfo,
-        valueColumn,
-    });
+    let rawSelectedValue: string;
+    let selectedItems = Map<string, any>();
 
     if (props.value !== undefined && props.value !== null) {
         let filter: Filter.IFilter;
@@ -339,50 +352,37 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<QuerySelec
         if (!filter) {
             filter = Filter.create(valueColumn, props.value);
         }
+
+        const filters = queryFilters ? queryFilters.toArray() : [];
         filters.push(filter);
 
+        const { queryName, schemaName, viewName } = schemaQuery;
         const data = await selectRowsDeprecated({
-            columns: model.queryColumnNames,
+            columns: queryColumnNames(queryInfo, displayColumn, valueColumn, props.requiredColumns, groupByColumn),
             containerFilter,
             containerPath,
             filterArray: filters,
-            parameters: model.queryParams,
+            parameters: props.queryParams,
             queryName,
             schemaName,
             viewName,
         });
 
-        const selectedItems = fromJS(
+        rawSelectedValue = props.value;
+        selectedItems = fromJS(
             quoteValueColumnWithDelimiters(data, props.valueColumn, props.delimiter).models[data.key]
         );
-
-        model = model.merge({ rawSelectedValue: props.value, selectedItems }) as QuerySelectModel;
-
-        if (selectedItems.size) {
-            model = model.merge({
-                allResults: model.allResults.merge(selectedItems),
-                selectedQuery: parseSelectedQuery(model, selectedItems),
-            }) as QuerySelectModel;
-        }
-
-        if (props.fireQSChangeOnInit && Utils.isFunction(props.onQSChange)) {
-            let selectOptions: SelectInputOption | SelectInputOption[] = formatResults(model, model.selectedItems);
-
-            // mimic ReactSelect in that it will return a single option if multiple is not true
-            if (props.multiple === false) {
-                selectOptions = selectOptions[0];
-            }
-
-            props.onQSChange(props.name, model.rawSelectedValue, selectOptions, props, model.selectedItems);
-        }
-
-        // fire listener if given an initial value and a listener function
-        if (model.rawSelectedValue) {
-            props.onInitValue?.(model.rawSelectedValue, model.selectedItems.toList());
-        }
     }
 
-    return model;
+    return {
+        displayColumn,
+        groupByColumn,
+        isInit: true,
+        queryInfo,
+        rawSelectedValue,
+        selectedItems,
+        valueColumn,
+    };
 }
 
 export interface QuerySelectModelProps {
@@ -474,19 +474,13 @@ export class QuerySelectModel
     }
 
     get queryColumnNames(): string[] {
-        const { displayColumn, groupByColumn, queryInfo, requiredColumns, valueColumn } = this;
-        const queryColumns = queryInfo.pkCols.concat([displayColumn, valueColumn].concat(requiredColumns));
-        const lookupViewColumns = queryInfo.getLookupViewColumns();
-
-        if (groupByColumn) {
-            queryColumns.push(groupByColumn);
-        }
-
-        if (lookupViewColumns.length > 0) {
-            return lookupViewColumns.map(c => c.fieldKey).concat(queryColumns);
-        }
-
-        return queryColumns;
+        return queryColumnNames(
+            this.queryInfo,
+            this.displayColumn,
+            this.valueColumn,
+            this.requiredColumns,
+            this.groupByColumn
+        );
     }
 }
 

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -300,14 +300,14 @@ function initGroupByColumn(queryInfo: QueryInfo, column?: string): string {
     return groupByColumn;
 }
 
-function queryColumnNames(
+export function queryColumnNames(
     queryInfo: QueryInfo,
     displayColumn: string,
     valueColumn: string,
     requiredColumns: string[],
     groupByColumn: string
 ): string[] {
-    const queryColumns = queryInfo.pkCols.concat([displayColumn, valueColumn].concat(requiredColumns));
+    let queryColumns = queryInfo.pkCols.concat([displayColumn, valueColumn].concat(requiredColumns));
     const lookupViewColumns = queryInfo.getLookupViewColumns();
 
     if (groupByColumn) {
@@ -315,7 +315,7 @@ function queryColumnNames(
     }
 
     if (lookupViewColumns.length > 0) {
-        return lookupViewColumns.map(c => c.fieldKey).concat(queryColumns);
+        queryColumns = lookupViewColumns.map(c => c.fieldKey).concat(queryColumns);
     }
 
     // Remove duplicates

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -329,7 +329,6 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
     const valueColumn = initValueColumn(queryInfo, props.valueColumn);
     const displayColumn = initDisplayColumn(queryInfo, valueColumn, props.displayColumn);
     const groupByColumn = initGroupByColumn(queryInfo, props.groupByColumn);
-    let rawSelectedValue: string;
     let selectedItems = Map<string, any>();
 
     if (props.value !== undefined && props.value !== null) {
@@ -368,7 +367,6 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
             viewName,
         });
 
-        rawSelectedValue = props.value;
         selectedItems = fromJS(
             quoteValueColumnWithDelimiters(data, props.valueColumn, props.delimiter).models[data.key]
         );
@@ -379,7 +377,6 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
         groupByColumn,
         isInit: true,
         queryInfo,
-        rawSelectedValue,
         selectedItems,
         valueColumn,
     };


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52156](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52156) by deferring clearing of the recorded keys to allow for the render cycle to utilize the value when configuring lookup components `defaultInputValue`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1777
- https://github.com/LabKey/limsModules/pull/1338
- https://github.com/LabKey/platform/pull/6573

#### Changes
- SelectInput: load async `defaultInputValue` when provided.
- QuerySelect: start with model, support deferred searches. No more `null` render cycles.
- Defer clearing cell `recordedKeys` so that they are utilized for the `defaultInputValue` of select input cells.
- Remove defunct logic around `AppendUnitsInput` as this input is no longer configured for editable grids.
- Streamline `Cell` render logic to compute as little as necessary.
