### PR TITLE
Issue 52814: Assure details page is displayed for entities filtered out of default view

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.6-filteredFromDetailPage.0",
+  "version": "6.36.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.6-filteredFromDetailPage.0",
+      "version": "6.36.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.4",
+  "version": "6.36.5-filteredFromDetailPage.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.36.4",
+      "version": "6.36.5-filteredFromDetailPage.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.4",
+  "version": "6.36.5-filteredFromDetailPage.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.36.6-filteredFromDetailPage.0",
+  "version": "6.36.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Fix `SchemaQuery.parseSelectionKey` to account for view name in selection key
+
 ### version 6.36.4
 *Released*: 17 April 2025
 - Issue 52536: Sample Manager: time format HH:mm:ss.SSS issues

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.36.6
+*Released*: 21 April 2025
 - Fix `SchemaQuery.parseSelectionKey` to account for view name in selection key
 
 ### version 6.36.5

--- a/packages/components/src/public/SchemaQuery.test.ts
+++ b/packages/components/src/public/SchemaQuery.test.ts
@@ -82,4 +82,11 @@ describe('parseSelectionKey', () => {
             schemaQuery: new SchemaQuery('My.Schema', 'My/Query', 'My}View'),
         });
     });
+    test('selectionKey with view name', () => {
+        const sk = 'sample-detail|samples/biotest/$t$tdetails$t$t|~~details~~|3933964';
+        expect(SchemaQuery.parseSelectionKey(sk)).toEqual({
+            keys: '3933964',
+            schemaQuery: new SchemaQuery('samples', 'biotest', '~~details~~'),
+        });
+    });
 });

--- a/packages/components/src/public/SchemaQuery.ts
+++ b/packages/components/src/public/SchemaQuery.ts
@@ -108,7 +108,11 @@ export class SchemaQuery {
 
     static parseSelectionKey(selectionKey: string): IParsedSelectionKey {
         selectionKey = stripSelectionSnapshotId(selectionKey);
-        const [appkey /* not used */, schemaQueryKey, keys] = selectionKey.split('|');
+        const parts = selectionKey.split('|');
+        // first part will be app page model key, which we skip
+        const schemaQueryKey = parts[1];
+        // there may be a view name between the schemaQueryKey and the provided entity keys
+        const keys = parts.length > 2 ? parts[parts.length - 1] : undefined;
 
         return {
             keys,


### PR DESCRIPTION
#### Rationale
[LKSM: Filtering out samples from default grid views errors when navigating to the sample](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52814) - We need to use the Details view on details pages so we are assured entities are not filtered out of the view.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/736
- https://github.com/LabKey/limsModules/pull/1342
- https://github.com/LabKey/platform/pull/6582
- https://github.com/LabKey/testAutomation/pull/2420

#### Changes
- Fix `SchemaQuery.parseSelectionKey` to account for view name in selection key
