### PR TITLE
Fix Issue 52326

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.37.0",
+  "version": "6.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.37.0",
+      "version": "6.38.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.37.0",
+  "version": "6.38.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,9 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version ??.??.??
-*Released*: ?? April 2025
--  Issue 52326: Copy/paste of date values across cells changes date formats
+### version 6.38.0
+*Released*: 23 April 2025
+- Issue 52326: Copy/paste of date values across cells changes date formats
+- Add deprecation comment to getSnapshotSelections
+- Add createSnapshotSelectionKey and createOrderedSnapshotSelectionKey to Query APIWrapper
 
 ### version 6.37.0
 *Released*: 21 April 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version ??.??.??
+*Released*: ?? April 2025
+-  Issue 52326: Copy/paste of date values across cells changes date formats
+
 ### version 6.37.0
 *Released*: 21 April 2025
 - Package Updates

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -571,6 +571,7 @@ export function setSnapshotSelections(
 }
 
 /**
+ * @deprecated use createSnapshotSelectionKey to create a selectionKey and getSelected to retrieve selections
  * Get the snapshot selections for a grid
  * @param key the selection key for the grid
  * @param containerPath optional path to the container for this grid.  Default is the current container path

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -803,6 +803,7 @@ describe('insertPastedData', () => {
     const pkFk = 'rowId';
     const fkOne = 'field_one';
     const fkTwo = 'field_two';
+    const dateFk = 'date';
     const queryInfo = QueryInfo.fromJsonForTests({
         pkCols: [pkFk],
         columns: {
@@ -820,6 +821,12 @@ describe('insertPastedData', () => {
                 caption: 'Field Two',
                 fieldKey: fkTwo,
                 inputType: 'string',
+            }),
+            [dateFk]: new QueryColumn({
+                caption: 'Date Field',
+                fieldKey: dateFk,
+                inputType: 'string',
+                jsonType: 'date',
             }),
         },
     });
@@ -883,9 +890,27 @@ describe('insertPastedData', () => {
                     raw: 'nm',
                 },
             ]),
+            [genCellKey(dateFk, 0)]: List<ValueDescriptor>([
+                {
+                    display: '2025-04-23',
+                    raw: '2025-04-23',
+                },
+            ]),
+            [genCellKey(dateFk, 1)]: List<ValueDescriptor>([
+                {
+                    display: '2025-04-23',
+                    raw: '2025-04-23',
+                },
+            ]),
+            [genCellKey(dateFk, 2)]: List<ValueDescriptor>([
+                {
+                    display: '2025-04-23',
+                    raw: '2025-04-23',
+                },
+            ]),
         }),
-        orderedColumns: List([fkOne, fkTwo]),
-        columnMap: [fkOne, fkTwo].reduce((result, key) => {
+        orderedColumns: List([fkOne, fkTwo, dateFk]),
+        columnMap: [fkOne, fkTwo, dateFk].reduce((result, key) => {
             return result.set(key, queryInfo.getColumn(key));
         }, Map<string, QueryColumn>()),
         queryInfo,
@@ -916,7 +941,15 @@ describe('insertPastedData', () => {
         expect(changes.selectionCells).toEqual([genCellKey(fkOne, 0), genCellKey(fkOne, 1), genCellKey(fkOne, 2)]);
 
         cellValues = (
-            await validateAndInsertPastedData(emWithPartialColumnSelected, 'one', undefined, true, true, undefined, true)
+            await validateAndInsertPastedData(
+                emWithPartialColumnSelected,
+                'one',
+                undefined,
+                true,
+                true,
+                undefined,
+                true
+            )
         ).cellValues;
         expect(cellValues.get(genCellKey(fkOne, 0))).toEqual(List([{ display: 'one', raw: 'one' }]));
         expect(cellValues.get(genCellKey(fkOne, 1))).toEqual(List([{ display: 'one', raw: 'one' }]));
@@ -1028,6 +1061,36 @@ describe('insertPastedData', () => {
         expect(cellValues.get(genCellKey(fkTwo, 2))).toEqual(List([{ display: 'nm', raw: 'nm' }]));
         // passing selectCells as false returns an emtpy array
         expect(changes.selectionCells).toEqual([]);
+    });
+
+    test('pasting dates does not change the display value', async () => {
+        // Issue 52326
+        const emWithDateColSelected = baseEditorModel.applyChanges({
+            selectionCells: [genCellKey(dateFk, 0), genCellKey(dateFk, 1), genCellKey(dateFk, 2)],
+            selectedColIdx: 2,
+            selectedRowIdx: 0,
+        });
+        const changes = await validateAndInsertPastedData(
+            emWithDateColSelected,
+            '2025-04-24\n2025-04-24\n2025-04-24',
+            undefined,
+            true,
+            true,
+            undefined,
+            true
+        );
+        // Display values should be what was pasted, raw values should be parsed and converted to JSON format expected
+        // by LKS, which includes microseconds.
+        const cellValues = changes.cellValues;
+        expect(cellValues.get(genCellKey(dateFk, 0))).toEqual(
+            List([{ display: '2025-04-24', raw: '2025-04-24 00:00:00.000' }])
+        );
+        expect(cellValues.get(genCellKey(dateFk, 1))).toEqual(
+            List([{ display: '2025-04-24', raw: '2025-04-24 00:00:00.000' }])
+        );
+        expect(cellValues.get(genCellKey(dateFk, 2))).toEqual(
+            List([{ display: '2025-04-24', raw: '2025-04-24 00:00:00.000' }])
+        );
     });
 });
 

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1487,7 +1487,14 @@ async function insertPastedData(
                     msg = message;
                 } else {
                     const { message, value } = getValidatedEditableGridValue(val, col);
-                    cv = List([{ display: value, raw: value }]);
+                    let display = value;
+
+                    // Issue 52326: Copy/paste of date values across cells changes date formats
+                    // Set display value to the pasted value, not the validated value, because for dates we use the JSON
+                    // format provided by LKS, which can include microseconds, and users probably didn't paste those.
+                    if (col?.jsonType === 'date') display = val;
+
+                    cv = List([{ display, raw: value }]);
                     msg = message;
                 }
 

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -42,6 +42,10 @@ import { QueryColumn } from '../../public/QueryColumn';
 
 import { incrementRowCountMetric } from '../components/editable/utils';
 
+import { QueryModel } from '../../public/QueryModel/QueryModel';
+
+import { createOrderedSnapshotSelectionKey, createSnapshotSelectionKey } from '../../public/QueryModel/utils';
+
 import {
     deleteRows,
     deleteRowsByContainer,
@@ -65,6 +69,8 @@ import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows'
 
 export interface QueryAPIWrapper {
     clearSelected: (options: ClearSelectedOptions) => Promise<SelectResponse>;
+    createOrderedSnapshotSelectionKey: (model: QueryModel) => Promise<string>;
+    createSnapshotSelectionKey: (model: QueryModel) => Promise<string>;
     deleteRows: (options: DeleteRowsOptions) => Promise<QueryCommandResponse>;
     deleteRowsByContainer: (options: DeleteRowsOptions, containerField: string) => Promise<QueryCommandResponse>;
     deleteView: (schemaQuery: SchemaQuery, containerPath: string, viewName?: string, revert?: boolean) => Promise<void>;
@@ -104,7 +110,7 @@ export interface QueryAPIWrapper {
         queryName?: string
     ) => Promise<SelectionResponse>;
     getServerDate: () => Promise<Date>;
-    getSnapshotSelections: (key: string, containerPath?: string) => Promise<GetSelectedResponse>;
+    getSnapshotSelections: (key: string, containerPath?: string) => Promise<GetSelectedResponse>; // deprecated
     incrementClientSideMetricCount: (featureArea: string, metricName: string) => void;
     incrementRowCountMetric: (featureArea: string, rowCount: number, isUpdate: boolean) => void;
     insertRows: (options: InsertRowsOptions) => Promise<QueryCommandResponse>;
@@ -147,7 +153,11 @@ export interface QueryAPIWrapper {
         filters?: Filter.IFilter[],
         queryParameters?: Record<string, any>
     ) => Promise<SelectResponse>;
-    setSnapshotSelections: (key: string, ids: string[] | string | number[], containerPath?: string) => Promise<SelectResponse>;
+    setSnapshotSelections: (
+        key: string,
+        ids: string[] | string | number[],
+        containerPath?: string
+    ) => Promise<SelectResponse>; // deprecated
     updateRows: (options: UpdateRowsOptions) => Promise<QueryCommandResponse>;
     updateRowsByContainer: (
         schemaQuery: SchemaQuery,
@@ -160,6 +170,8 @@ export interface QueryAPIWrapper {
 
 export class QueryServerAPIWrapper implements QueryAPIWrapper {
     clearSelected = clearSelected;
+    createOrderedSnapshotSelectionKey = createOrderedSnapshotSelectionKey;
+    createSnapshotSelectionKey = createSnapshotSelectionKey;
     deleteRows = deleteRows;
     deleteRowsByContainer = deleteRowsByContainer;
     deleteView = deleteView;
@@ -169,7 +181,7 @@ export class QueryServerAPIWrapper implements QueryAPIWrapper {
     getFolderConfigurableEntityTypeOptions = getFolderConfigurableEntityTypeOptions;
     getFolderDataTypeDataCount = getFolderDataTypeDataCount;
     getQueryDetails = getQueryDetails;
-    getSnapshotSelections = getSnapshotSelections;
+    getSnapshotSelections = getSnapshotSelections; // deprecated
     getSelection = getSelection;
     getServerDate = getServerDate;
     incrementClientSideMetricCount = incrementClientSideMetricCount;
@@ -183,7 +195,7 @@ export class QueryServerAPIWrapper implements QueryAPIWrapper {
     selectRows = selectRows;
     selectDistinctRows = selectDistinctRows;
     setSelected = setSelected;
-    setSnapshotSelections = setSnapshotSelections;
+    setSnapshotSelections = setSnapshotSelections; // deprecated
     updateRows = updateRows;
     updateRowsByContainer = updateRowsByContainer;
     getDefaultVisibleColumns = getDefaultVisibleColumns;
@@ -198,6 +210,8 @@ export function getQueryTestAPIWrapper(
 ): QueryAPIWrapper {
     return {
         clearSelected: mockFn(),
+        createOrderedSnapshotSelectionKey: mockFn(),
+        createSnapshotSelectionKey: mockFn(),
         deleteRows: mockFn(),
         deleteRowsByContainer: mockFn(),
         deleteView: mockFn(),


### PR DESCRIPTION
#### Rationale
Our EG converts pasted date values to the JSON format that our server expects, which includes microseconds. This PR sets the displayValue to the pasted value, and keeps the JSON format for the value when pasting.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1780
- https://github.com/LabKey/platform/pull/6593
- https://github.com/LabKey/limsModules/pull/1351

#### Changes
- EditableGrid: Set display value to pasted value when pasting dates
