### PR TITLE
Issue 52929: App hit selection summary grid doesn't render hit selection check icon if assay name ends with colon

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.38.0",
+  "version": "6.38.0-hitSelectionRenderer52929.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.38.0",
+      "version": "6.38.0-hitSelectionRenderer52929.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.38.0-hitSelectionRenderer52929.0",
+  "version": "6.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.38.0-hitSelectionRenderer52929.0",
+      "version": "6.38.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.38.0",
+  "version": "6.38.0-hitSelectionRenderer52929.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.38.0-hitSelectionRenderer52929.0",
+  "version": "6.38.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.38.1
+*Released*: 24 April 2025
 - Issue 52929: App hit selection summary grid doesn't render hit selection check icon if assay name ends with colon
 
 ### version 6.38.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 52929: App hit selection summary grid doesn't render hit selection check icon if assay name ends with colon
+
 ### version 6.38.0
 *Released*: 23 April 2025
 - Issue 52326: Copy/paste of date values across cells changes date formats

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -321,7 +321,8 @@ function applyColumnMetadata(schemaQuery: SchemaQuery, rawColumn: any): QueryCol
         }
 
         if (lcFieldKey.indexOf('::') > -1) {
-            const lcPivotFieldKey = lcFieldKey.split('::')[1];
+            // Issue 52929: account for a fieldKey ending with a colon char
+            const lcPivotFieldKey = lcFieldKey.substring(lcFieldKey.lastIndexOf('::') + 2);
             const pivotColumnMeta = metadata.getIn([
                 'schema',
                 schemaQuery.schemaName.toLowerCase(),


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52929

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1361

#### Changes
- change fieldKey parsing for pivot columns to find lastIndexOf :: instead of splitting on it
