### PR TITLE
Issue 52773: display warning for unresolved form lookup values

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.1",
+  "version": "6.40.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.1",
+      "version": "6.40.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.1",
+  "version": "6.40.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.40.2
+*Released*: 6 May 2025
+- Issue 52773: display warning for unresolved form lookup values
+
 ### version 6.40.1
 *Released*: 6 May 2025
 - Issue 52556: Add data-fieldkey attribute to grid header elements and input elements

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -16,7 +16,6 @@ import {
     changeColumn,
     detectPadLength,
     loadEditorModelData,
-    lookupValidationError,
     parseIntIfNumber,
     parsePastedLookup,
     removeColumn,
@@ -1317,29 +1316,5 @@ describe('loadEditorModelData', () => {
 
         // Expect both lookup columns to have been validated
         expect(api.query.selectRows).toHaveBeenCalledTimes(2);
-    });
-});
-
-describe('lookupValidationError', () => {
-    test('value only', () => {
-        expect(lookupValidationError('s').message).toEqual('Could not find s. Data may have been moved or deleted.');
-        expect(lookupValidationError(1.4).message).toEqual('Could not find 1.4. Data may have been moved or deleted.');
-        expect(lookupValidationError(false).message).toEqual(
-            'Could not find false. Data may have been moved or deleted.'
-        );
-    });
-
-    test('fromPaste', () => {
-        expect(lookupValidationError(false, true).message).toEqual('Could not find false');
-        expect(lookupValidationError('beep', true).message).toEqual('Could not find beep');
-        expect(lookupValidationError('"sara", "pete"', true).message).toEqual(
-            'Could not find "sara", "pete". Please make sure values that contain commas are properly quoted.'
-        );
-    });
-
-    test('with displayValue', () => {
-        expect(lookupValidationError('beep,', false, 'vw').message).toEqual(
-            'vw is no longer a valid value. Data may have been moved or deleted.'
-        );
     });
 });

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -21,7 +21,7 @@ import { getContainerFilterForLookups } from '../../query/api';
 
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
 
-import { resolveErrorMessage } from '../../util/messaging';
+import { lookupValidationErrorMessage, resolveErrorMessage } from '../../util/messaging';
 
 import {
     CellMessage,
@@ -396,7 +396,7 @@ async function getLookupValueDescriptors(
                     messageAndValues.push({
                         message: {
                             isWarning: true,
-                            message: errorMap[value] ?? lookupValidationError(value, false, displayValue).message,
+                            message: errorMap[value] ?? lookupValidationErrorMessage(value, false, displayValue),
                         },
                         valueDescriptor: { display: displayValue ?? `<${value}>`, raw: value },
                     });
@@ -408,24 +408,6 @@ async function getLookupValueDescriptors(
 
     await Promise.all(lookupPromises);
     return lookupValues;
-}
-
-export function lookupValidationError(
-    value: string | number | boolean,
-    fromPaste?: boolean,
-    displayValue?: any
-): CellMessage {
-    let message = displayValue !== undefined ? `${displayValue} is no longer a valid value` : `Could not find ${value}`;
-
-    if (fromPaste) {
-        if (typeof value === 'string' && value.toString().indexOf(',') > -1) {
-            message += '. Please make sure values that contain commas are properly quoted.';
-        }
-    } else {
-        message += '. Data may have been moved or deleted.';
-    }
-
-    return { message };
 }
 
 async function getLookupDisplayValue(column: QueryColumn, value: any, containerPath: string): Promise<MessageAndValue> {
@@ -442,7 +424,7 @@ async function getLookupDisplayValue(column: QueryColumn, value: any, containerP
 
     const descriptors = await findLookupValues({ column, containerPath, forUpdate: false, lookupKeyValues: [value] });
     if (!descriptors.length) {
-        message = lookupValidationError(value);
+        message = { message: lookupValidationErrorMessage(value) };
     }
 
     return {
@@ -1100,7 +1082,7 @@ export function parsePastedLookup(
             .slice(0, 4)
             .map(u => '"' + u + '"')
             .join(', ');
-        message = lookupValidationError(valueStr, true);
+        message = { message: lookupValidationErrorMessage(valueStr, true) };
     }
 
     return {

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ComponentType, FC, memo, useCallback, useEffect, useState } from 'react';
+import React, { ComponentType, FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { List, Map } from 'immutable';
 import { Filter, Query, Utils } from '@labkey/api';
 
 import { SchemaQuery } from '../../../public/SchemaQuery';
 
-import { resolveErrorMessage } from '../../util/messaging';
+import { lookupValidationErrorMessage, resolveErrorMessage } from '../../util/messaging';
 
 import { Row } from '../../query/selectRows';
 
@@ -263,6 +263,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     const [searches, setSearches] = useState<Search[]>([]);
     const debounceTO = useTimeout();
     const shouldLoadOnFocus = loadOnFocus && !loadOnFocusLock;
+    const hasNotFoundValues = model.notFoundValues?.size > 0;
 
     useEffect(() => {
         if (!autoInit) return;
@@ -399,6 +400,20 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
         [OptionComponent, model]
     );
 
+    // Issue 52773: If a value is specified, but we are unable to resolve the value then display a warning to the user.
+    const warning = useMemo(() => {
+        if (!hasNotFoundValues) return undefined;
+
+        let warningValue: string;
+        if (model.notFoundValues.size < 5) {
+            warningValue = model.notFoundValues.join(', ');
+        } else {
+            warningValue = `${model.notFoundValues.size} values`;
+        }
+
+        return lookupValidationErrorMessage(warningValue);
+    }, [hasNotFoundValues, model.notFoundValues]);
+
     if (error) {
         return (
             <SelectInput
@@ -444,12 +459,10 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
             optionRenderer={optionRenderer}
             options={undefined} // prevent override
             // Issue 52773: Allow for submission of required fields whose value is not found
-            required={model.initialValueNotFound ? false : required}
+            required={hasNotFoundValues ? false : required}
             selectedOptions={model.isInit ? model.selectedOptions : undefined}
             value={getValue(model, multiple)} // needed to initialize the Formsy "value" properly
-            warning={
-                model.initialValueNotFound ? `Could not find ${value}. Data may have been moved or deleted.` : undefined
-            }
+            warning={warning}
         />
     );
 });

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -443,8 +443,13 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
             onFocus={onFocus}
             optionRenderer={optionRenderer}
             options={undefined} // prevent override
+            // Issue 52773: Allow for submission of required fields whose value is not found
+            required={model.initialValueNotFound ? false : required}
             selectedOptions={model.isInit ? model.selectedOptions : undefined}
             value={getValue(model, multiple)} // needed to initialize the Formsy "value" properly
+            warning={
+                model.initialValueNotFound ? `Could not find ${value}. Data may have been moved or deleted.` : undefined
+            }
         />
     );
 });

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -18,6 +18,7 @@ import ReactSelect, { components } from 'react-select';
 import AsyncSelect from 'react-select/async';
 import AsyncCreatableSelect from 'react-select/async-creatable';
 import CreatableSelect from 'react-select/creatable';
+import classNames from 'classnames';
 import { Utils } from '@labkey/api';
 
 import { FieldLabel } from '../FieldLabel';
@@ -237,6 +238,7 @@ export interface SelectInputProps {
     value?: any;
     valueKey?: string;
     valueRenderer?: any;
+    warning?: ReactNode;
 }
 
 type SelectInputImplProps = SelectInputProps & FormsyInjectedProps<any>;
@@ -713,20 +715,22 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
     };
 
     render() {
-        const { containerClass, errorMessage, formsy, help, inputClass } = this.props;
+        const { containerClass, errorMessage, formsy, help, inputClass, warning } = this.props;
         const hasError = formsy && !!errorMessage;
+        const hasWarning = !hasError && !!warning;
+
+        const className = classNames('select-input-container', containerClass, {
+            'has-error': hasError,
+            'has-warning': hasWarning,
+        });
 
         return (
-            <div className={`select-input-container ${containerClass}`}>
+            <div className={className}>
                 {this.renderLabel()}
                 <div className={inputClass}>
                     {this.renderSelect()}
-                    {hasError && (
-                        <div className="has-error">
-                            <span className="error-message help-block">{errorMessage}</span>
-                        </div>
-                    )}
-                    {!hasError && !!help && <span className="help-block">{help}</span>}
+                    {hasError && <span className="help-block">{errorMessage}</span>}
+                    {!hasError && (hasWarning || !!help) && <span className="help-block">{warning ?? help}</span>}
                 </div>
             </div>
         );

--- a/packages/components/src/internal/components/forms/model.test.ts
+++ b/packages/components/src/internal/components/forms/model.test.ts
@@ -1,10 +1,11 @@
 import { fromJS } from 'immutable';
+import { Filter } from '@labkey/api';
 
 import { QueryInfo } from '../../../public/QueryInfo';
 import { ExtendedMap } from '../../../public/ExtendedMap';
 import { QueryColumn } from '../../../public/QueryColumn';
 
-import { parseSelectedQuery, QuerySelectModel, queryColumnNames } from './model';
+import { buildValueFilter, findNotFoundValues, parseSelectedQuery, QuerySelectModel, queryColumnNames } from './model';
 
 describe('form actions', () => {
     const setSelectionModel = new QuerySelectModel({
@@ -91,5 +92,117 @@ describe('form actions', () => {
                 groupByColumn
             ).sort()
         ).toEqual(['colA', displayColumn, groupByColumn, 'pkCol1', 'pkCol2', valueColumn, someRequiredColumn]);
+    });
+
+    describe('buildValueFilter', () => {
+        const col = 'id';
+        const delimiter = ',';
+
+        test('handles single non-array, non-string value with multiple = false', () => {
+            const result = buildValueFilter('abc', col, false, delimiter);
+            expect(result.expectedValueCount).toBe(1);
+            expect(result.filter.getValue()).toBe('abc');
+            expect(result.filter.getColumnName()).toBe(col);
+        });
+
+        test('handles array input when multiple = true', () => {
+            const result = buildValueFilter(['a', 'b', 'b'], col, true, delimiter);
+            expect(result.expectedValueCount).toBe(2); // unique values
+            expect(result.filter.getValue()).toEqual(['a', 'b', 'b']);
+            expect(result.filter.getColumnName()).toBe(col);
+        });
+
+        test('handles delimited string input when multiple = true', () => {
+            const result = buildValueFilter('x,y,y,z', col, true, ',');
+            expect(result.expectedValueCount).toBe(3);
+            expect(result.filter.getValue()).toEqual(['x', 'y', 'y', 'z']);
+        });
+
+        test('handles string value when multiple = false', () => {
+            const result = buildValueFilter('foo', col, false, delimiter);
+            expect(result.expectedValueCount).toBe(1);
+            expect(result.filter.getValue()).toBe('foo');
+        });
+
+        test('handles non-string scalar values correctly', () => {
+            const result = buildValueFilter(123, col, false, delimiter);
+            expect(result.expectedValueCount).toBe(1);
+            expect(result.filter.getValue()).toBe(123);
+        });
+
+        test('defaults to non-IN filter if multiple = true but value is not string or array', () => {
+            const result = buildValueFilter(true, col, true, delimiter);
+            expect(result.expectedValueCount).toBe(1);
+            expect(result.filter.getValue()).toBe(true);
+        });
+    });
+
+    describe('findNotFoundValues', () => {
+        const EMPTY_ITEMS = fromJS({});
+
+        function filter(value: any): Filter.IFilter {
+            return Filter.create('col', value, Filter.Types.IN);
+        }
+
+        test('returns empty array when filter value is undefined or null', () => {
+            expect(findNotFoundValues(EMPTY_ITEMS, filter(undefined), 'id')).toHaveLength(0);
+            expect(findNotFoundValues(EMPTY_ITEMS, filter(null), 'id')).toHaveLength(0);
+            expect(findNotFoundValues(EMPTY_ITEMS, filter([undefined, null]), 'id')).toHaveLength(0);
+        });
+
+        test('returns single value as array when filter has a single value', () => {
+            expect(findNotFoundValues(EMPTY_ITEMS, filter('abc'), 'id')).toEqual(['abc']);
+            expect(findNotFoundValues(EMPTY_ITEMS, filter(['abc']), 'id')).toEqual(['abc']);
+        });
+
+        test('returns all values when no items are selected', () => {
+            const filterValues = ['x', 'y', 'z'];
+            expect(findNotFoundValues(EMPTY_ITEMS, filter(filterValues), 'id')).toEqual(filterValues);
+        });
+
+        test('returns missing values when some items are matched', () => {
+            const selectedItems = fromJS({ one: { id: { value: 'x' } }, two: { id: { value: 'z' } } });
+            expect(findNotFoundValues(selectedItems, filter(['x', 'y', 'z']), 'id')).toEqual(['y']);
+        });
+
+        test('returns empty array when all values are found in selected items', () => {
+            const selectedAll = fromJS({
+                one: { id: { value: 'x' } },
+                two: { id: { value: 'y' } },
+                three: { id: { value: 'z' } },
+            });
+            expect(findNotFoundValues(selectedAll, filter(['x', 'y', 'z']), 'id')).toEqual([]);
+        });
+
+        test('handles mixed types and converts to string for comparison', () => {
+            const mixedItems = fromJS({ one: { id: { value: 1 } }, two: { id: { value: 3 } } });
+            expect(findNotFoundValues(mixedItems, filter([1, 2, 3]), 'id')).toEqual(['2']);
+        });
+
+        test('ignores items missing the valueColumn', () => {
+            const incompleteItems = fromJS({
+                one: { id: { value: 'x' } },
+                two: { other: { value: 'y' } }, // missing 'id'
+            });
+            expect(findNotFoundValues(incompleteItems, filter(['x', 'y']), 'id')).toEqual(['y']);
+        });
+
+        test('ignores null or undefined item values', () => {
+            const nullItemValues = fromJS({
+                one: { id: { value: 'x' } },
+                two: { id: { value: null } },
+                three: { id: { value: undefined } },
+            });
+            expect(findNotFoundValues(nullItemValues, filter(['x', 'y']), 'id')).toEqual(['y']);
+        });
+
+        test('handles duplicate values in filter input', () => {
+            expect(findNotFoundValues(EMPTY_ITEMS, filter(['a', 'a', 'b']), 'id')).toEqual(['a', 'b']);
+        });
+
+        test('handles mixed string/number types across filters and item values', () => {
+            const mixedTypes = fromJS({ one: { id: { value: '1' } }, two: { id: { value: 2 } } });
+            expect(findNotFoundValues(mixedTypes, filter([1, 2, 3]), 'id')).toEqual(['3']);
+        });
     });
 });

--- a/packages/components/src/internal/components/forms/model.test.ts
+++ b/packages/components/src/internal/components/forms/model.test.ts
@@ -138,7 +138,7 @@ describe('form actions', () => {
     });
 
     describe('findNotFoundValues', () => {
-        const EMPTY_ITEMS = fromJS({});
+        const EMPTY_ITEMS = {};
 
         function filter(value: any): Filter.IFilter {
             return Filter.create('col', value, Filter.Types.IN);
@@ -161,38 +161,38 @@ describe('form actions', () => {
         });
 
         test('returns missing values when some items are matched', () => {
-            const selectedItems = fromJS({ one: { id: { value: 'x' } }, two: { id: { value: 'z' } } });
+            const selectedItems = { one: { id: { value: 'x' } }, two: { id: { value: 'z' } } };
             expect(findNotFoundValues(selectedItems, filter(['x', 'y', 'z']), 'id')).toEqual(['y']);
         });
 
         test('returns empty array when all values are found in selected items', () => {
-            const selectedAll = fromJS({
+            const selectedAll = {
                 one: { id: { value: 'x' } },
                 two: { id: { value: 'y' } },
                 three: { id: { value: 'z' } },
-            });
+            };
             expect(findNotFoundValues(selectedAll, filter(['x', 'y', 'z']), 'id')).toEqual([]);
         });
 
         test('handles mixed types and converts to string for comparison', () => {
-            const mixedItems = fromJS({ one: { id: { value: 1 } }, two: { id: { value: 3 } } });
+            const mixedItems = { one: { id: { value: 1 } }, two: { id: { value: 3 } } };
             expect(findNotFoundValues(mixedItems, filter([1, 2, 3]), 'id')).toEqual(['2']);
         });
 
         test('ignores items missing the valueColumn', () => {
-            const incompleteItems = fromJS({
+            const incompleteItems = {
                 one: { id: { value: 'x' } },
                 two: { other: { value: 'y' } }, // missing 'id'
-            });
+            };
             expect(findNotFoundValues(incompleteItems, filter(['x', 'y']), 'id')).toEqual(['y']);
         });
 
         test('ignores null or undefined item values', () => {
-            const nullItemValues = fromJS({
+            const nullItemValues = {
                 one: { id: { value: 'x' } },
                 two: { id: { value: null } },
                 three: { id: { value: undefined } },
-            });
+            };
             expect(findNotFoundValues(nullItemValues, filter(['x', 'y']), 'id')).toEqual(['y']);
         });
 
@@ -201,7 +201,7 @@ describe('form actions', () => {
         });
 
         test('handles mixed string/number types across filters and item values', () => {
-            const mixedTypes = fromJS({ one: { id: { value: '1' } }, two: { id: { value: 2 } } });
+            const mixedTypes = { one: { id: { value: '1' } }, two: { id: { value: 2 } } };
             expect(findNotFoundValues(mixedTypes, filter([1, 2, 3]), 'id')).toEqual(['3']);
         });
     });

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -28,9 +28,11 @@ import {
     selectRowsDeprecated,
 } from '../../query/api';
 import { similaritySortFactory } from '../../util/similaritySortFactory';
-import { parseCsvString } from '../../util/utils';
+import { caseInsensitive, parseCsvString } from '../../util/utils';
 
 import { naturalSort } from '../../../public/sort';
+
+import { Row } from '../../query/selectRows';
 
 import { SelectInputOption } from './input/SelectInput';
 import { DELIMITER } from './constants';
@@ -363,7 +365,7 @@ export function buildValueFilter(
 }
 
 export function findNotFoundValues(
-    selectedItems: Map<string, any>,
+    selectedRows: Record<string, Row>,
     filter: Filter.IFilter,
     valueColumn: string
 ): string[] {
@@ -373,27 +375,28 @@ export function findNotFoundValues(
     const rawValues = Array.isArray(filterValue) ? filterValue : [filterValue];
     const expectedValues = new Set(rawValues.filter(v => v !== undefined && v !== null).map(v => v.toString()));
 
-    selectedItems
-        .map(item => item.getIn([valueColumn, 'value']))
+    Object.values(selectedRows)
+        .map(item => caseInsensitive(item, valueColumn)?.value)
         .filter(value => value !== undefined && value !== null)
         .forEach(value => expectedValues.delete(value.toString()));
 
     return Array.from(expectedValues).sort(naturalSort);
 }
 
-async function initSelectedItems(
+function initSelectedItems(
     props: QuerySelectOwnProps,
     queryInfo: QueryInfo,
     valueColumn: string,
     displayColumn: string,
     groupByColumn: string,
     filter: Filter.IFilter
-): Promise<Map<string, any>> {
+): Promise<ISelectRowsResult> {
     const filters = props.queryFilters ? props.queryFilters.toArray() : [];
     filters.push(filter);
 
     const { queryName, schemaName, viewName } = props.schemaQuery;
-    const data = await selectRowsDeprecated({
+
+    return selectRowsDeprecated({
         columns: queryColumnNames(queryInfo, displayColumn, valueColumn, props.requiredColumns, groupByColumn),
         containerFilter: props.containerFilter,
         containerPath: props.containerPath,
@@ -403,23 +406,22 @@ async function initSelectedItems(
         schemaName,
         viewName,
     });
-
-    return fromJS(quoteValueColumnWithDelimiters(data, props.valueColumn, props.delimiter).models[data.key]);
 }
 
 export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<QuerySelectModelProps>> {
     const { delimiter, multiple, value } = props;
     const { queryInfo, valueColumn, displayColumn, groupByColumn } = await initQueryInfoWithColumns(props);
 
-    let selectedItems = Map<string, any>();
+    let selectedItems: ISelectRowsResult;
     let notFoundValues: List<any>;
 
     if (value !== undefined && value !== null) {
         const { expectedValueCount, filter } = buildValueFilter(value, valueColumn, multiple, delimiter);
         selectedItems = await initSelectedItems(props, queryInfo, valueColumn, displayColumn, groupByColumn, filter);
+        const selectedRows = selectedItems.models[selectedItems.key];
 
-        if (selectedItems.size !== expectedValueCount) {
-            const notFoundValuesArray = findNotFoundValues(selectedItems, filter, valueColumn);
+        if (Object.keys(selectedRows).length !== expectedValueCount) {
+            const notFoundValuesArray = findNotFoundValues(selectedRows, filter, valueColumn);
             if (notFoundValuesArray) {
                 notFoundValues = List(notFoundValuesArray);
             }
@@ -432,7 +434,9 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
         isInit: true,
         notFoundValues,
         queryInfo,
-        selectedItems,
+        selectedItems: selectedItems
+            ? fromJS(quoteValueColumnWithDelimiters(selectedItems, valueColumn, delimiter).models[selectedItems.key])
+            : Map<string, any>(),
         valueColumn,
     };
 }

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { fromJS, List, Map, OrderedMap, Record as ImmutableRecord } from 'immutable';
-import { Filter, Query, Utils } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { QueryInfo } from '../../../public/QueryInfo';
 
@@ -29,6 +29,8 @@ import {
 } from '../../query/api';
 import { similaritySortFactory } from '../../util/similaritySortFactory';
 import { parseCsvString } from '../../util/utils';
+
+import { naturalSort } from '../../../public/sort';
 
 import { SelectInputOption } from './input/SelectInput';
 import { DELIMITER } from './constants';
@@ -169,8 +171,8 @@ export function setSelection(model: QuerySelectModel, rawSelectedValue: any): Qu
     const selectedItems = getSelectedOptions(model, rawSelectedValue);
 
     return model.merge({
-        // Issue 52773: Unset initialValueNotFound once a value has been selected
-        initialValueNotFound: false,
+        // Issue 52773: Unset notFoundValues once a value has been selected
+        notFoundValues: undefined,
         rawSelectedValue,
         selectedItems,
         selectedQuery: parseSelectedQuery(model, selectedItems),
@@ -324,66 +326,113 @@ export function queryColumnNames(
     return Array.from(new Set(queryColumns));
 }
 
-export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<QuerySelectModelProps>> {
-    const { containerFilter, containerPath, schemaQuery, queryFilters } = props;
-
+async function initQueryInfoWithColumns(props: QuerySelectOwnProps): Promise<Partial<QuerySelectModelProps>> {
+    const { containerPath, schemaQuery } = props;
     const queryInfo = await getQueryDetails({ containerPath, schemaQuery });
+
     const valueColumn = initValueColumn(queryInfo, props.valueColumn);
     const displayColumn = initDisplayColumn(queryInfo, valueColumn, props.displayColumn);
     const groupByColumn = initGroupByColumn(queryInfo, props.groupByColumn);
+
+    return { queryInfo, valueColumn, displayColumn, groupByColumn };
+}
+
+export function buildValueFilter(
+    value: any,
+    valueColumn: string,
+    multiple: boolean,
+    delimiter: string
+): { expectedValueCount: number; filter: Filter.IFilter } {
+    let filter: Filter.IFilter;
+    let expectedValueCount = 1;
+
+    if (multiple) {
+        if (Array.isArray(value)) {
+            filter = Filter.create(valueColumn, value, Filter.Types.IN);
+            expectedValueCount = new Set(value).size;
+        } else if (typeof value === 'string') {
+            const parsed = parseCsvString(value, delimiter, true);
+            filter = Filter.create(valueColumn, parsed, Filter.Types.IN);
+            expectedValueCount = new Set(parsed).size;
+        }
+    }
+
+    if (!filter) {
+        filter = Filter.create(valueColumn, value);
+    }
+
+    return { expectedValueCount, filter };
+}
+
+export function findNotFoundValues(
+    selectedItems: Map<string, any>,
+    filter: Filter.IFilter,
+    valueColumn: string
+): string[] {
+    const filterValue = filter.getValue();
+    if (filterValue === undefined || filterValue === null) return [];
+
+    const rawValues = Array.isArray(filterValue) ? filterValue : [filterValue];
+    const uniqueValues = new Set(rawValues.filter(v => v !== undefined && v !== null).map(v => v.toString()));
+
+    selectedItems
+        .map(item => item.getIn([valueColumn, 'value']))
+        .filter(v => v !== undefined && v !== null)
+        .forEach(itemValue => uniqueValues.delete(itemValue.toString()));
+
+    return Array.from(uniqueValues).sort(naturalSort);
+}
+
+async function initSelectedItems(
+    props: QuerySelectOwnProps,
+    queryInfo: QueryInfo,
+    valueColumn: string,
+    displayColumn: string,
+    groupByColumn: string,
+    filter: Filter.IFilter
+): Promise<Map<string, any>> {
+    const filters = props.queryFilters ? props.queryFilters.toArray() : [];
+    filters.push(filter);
+
+    const { queryName, schemaName, viewName } = props.schemaQuery;
+    const data = await selectRowsDeprecated({
+        columns: queryColumnNames(queryInfo, displayColumn, valueColumn, props.requiredColumns, groupByColumn),
+        containerFilter: props.containerFilter,
+        containerPath: props.containerPath,
+        filterArray: filters,
+        parameters: props.queryParams,
+        queryName,
+        schemaName,
+        viewName,
+    });
+
+    return fromJS(quoteValueColumnWithDelimiters(data, props.valueColumn, props.delimiter).models[data.key]);
+}
+
+export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<QuerySelectModelProps>> {
+    const { delimiter, multiple, value } = props;
+    const { queryInfo, valueColumn, displayColumn, groupByColumn } = await initQueryInfoWithColumns(props);
+
     let selectedItems = Map<string, any>();
-    let initialValueNotFound: boolean = false;
+    let notFoundValues: List<any>;
 
-    if (props.value !== undefined && props.value !== null) {
-        let filter: Filter.IFilter;
+    if (value !== undefined && value !== null) {
+        const { expectedValueCount, filter } = buildValueFilter(value, valueColumn, multiple, delimiter);
+        selectedItems = await initSelectedItems(props, queryInfo, valueColumn, displayColumn, groupByColumn, filter);
 
-        if (props.multiple) {
-            if (Array.isArray(props.value)) {
-                filter = Filter.create(valueColumn, props.value, Filter.Types.IN);
-            } else if (typeof props.value === 'string') {
-                // Allow for setting multiValue value.
-                // This requires updating the filter and the string
-                filter = Filter.create(
-                    valueColumn,
-                    parseCsvString(props.value, props.delimiter, true),
-                    Filter.Types.IN
-                );
+        if (selectedItems.size !== expectedValueCount) {
+            const notFoundValuesArray = findNotFoundValues(selectedItems, filter, valueColumn);
+            if (notFoundValuesArray) {
+                notFoundValues = List(notFoundValuesArray);
             }
         }
-
-        if (!filter) {
-            filter = Filter.create(valueColumn, props.value);
-        }
-
-        const filters = queryFilters ? queryFilters.toArray() : [];
-        filters.push(filter);
-
-        const { queryName, schemaName, viewName } = schemaQuery;
-        const data = await selectRowsDeprecated({
-            columns: queryColumnNames(queryInfo, displayColumn, valueColumn, props.requiredColumns, groupByColumn),
-            containerFilter,
-            containerPath,
-            filterArray: filters,
-            parameters: props.queryParams,
-            queryName,
-            schemaName,
-            viewName,
-        });
-
-        selectedItems = fromJS(
-            quoteValueColumnWithDelimiters(data, props.valueColumn, props.delimiter).models[data.key]
-        );
-
-        // Issue 52773: If a value is specified, but we are unable to resolve the value then display
-        // a warning to the user.
-        initialValueNotFound = selectedItems.size === 0;
     }
 
     return {
         displayColumn,
         groupByColumn,
-        initialValueNotFound,
         isInit: true,
+        notFoundValues,
         queryInfo,
         selectedItems,
         valueColumn,
@@ -398,10 +447,10 @@ export interface QuerySelectModelProps {
     delimiter: string;
     displayColumn: string;
     groupByColumn: string;
-    initialValueNotFound: boolean;
     isInit: boolean;
     maxRows: number;
     multiple: boolean;
+    notFoundValues: List<any>;
     queryFilters: List<Filter.IFilter>;
     queryInfo: QueryInfo;
     queryParams: Record<string, any>;
@@ -423,10 +472,10 @@ export class QuerySelectModel
         displayColumn: undefined,
         delimiter: DELIMITER,
         groupByColumn: undefined,
-        initialValueNotFound: false,
         isInit: false,
         maxRows: 20,
         multiple: false,
+        notFoundValues: undefined,
         queryFilters: undefined,
         queryInfo: undefined,
         queryParams: undefined,
@@ -447,10 +496,10 @@ export class QuerySelectModel
     declare displayColumn: string;
     declare delimiter: string;
     declare groupByColumn: string;
-    declare initialValueNotFound: boolean;
     declare isInit: boolean;
     declare maxRows: number;
     declare multiple: boolean;
+    declare notFoundValues: List<any>;
     declare queryFilters: List<Filter.IFilter>;
     declare queryInfo: QueryInfo;
     declare queryParams: Record<string, any>;

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -169,6 +169,8 @@ export function setSelection(model: QuerySelectModel, rawSelectedValue: any): Qu
     const selectedItems = getSelectedOptions(model, rawSelectedValue);
 
     return model.merge({
+        // Issue 52773: Unset initialValueNotFound once a value has been selected
+        initialValueNotFound: false,
         rawSelectedValue,
         selectedItems,
         selectedQuery: parseSelectedQuery(model, selectedItems),
@@ -330,6 +332,7 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
     const displayColumn = initDisplayColumn(queryInfo, valueColumn, props.displayColumn);
     const groupByColumn = initGroupByColumn(queryInfo, props.groupByColumn);
     let selectedItems = Map<string, any>();
+    let initialValueNotFound: boolean = false;
 
     if (props.value !== undefined && props.value !== null) {
         let filter: Filter.IFilter;
@@ -370,11 +373,16 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
         selectedItems = fromJS(
             quoteValueColumnWithDelimiters(data, props.valueColumn, props.delimiter).models[data.key]
         );
+
+        // Issue 52773: If a value is specified, but we are unable to resolve the value then display
+        // a warning to the user.
+        initialValueNotFound = selectedItems.size === 0;
     }
 
     return {
         displayColumn,
         groupByColumn,
+        initialValueNotFound,
         isInit: true,
         queryInfo,
         selectedItems,
@@ -390,6 +398,7 @@ export interface QuerySelectModelProps {
     delimiter: string;
     displayColumn: string;
     groupByColumn: string;
+    initialValueNotFound: boolean;
     isInit: boolean;
     maxRows: number;
     multiple: boolean;
@@ -414,6 +423,7 @@ export class QuerySelectModel
         displayColumn: undefined,
         delimiter: DELIMITER,
         groupByColumn: undefined,
+        initialValueNotFound: false,
         isInit: false,
         maxRows: 20,
         multiple: false,
@@ -437,6 +447,7 @@ export class QuerySelectModel
     declare displayColumn: string;
     declare delimiter: string;
     declare groupByColumn: string;
+    declare initialValueNotFound: boolean;
     declare isInit: boolean;
     declare maxRows: number;
     declare multiple: boolean;

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -182,7 +182,7 @@ export function setSelection(model: QuerySelectModel, rawSelectedValue: any): Qu
 export function fetchSearchResults(model: QuerySelectModel, input: any): Promise<ISelectRowsResult> {
     const { addExactFilter, displayColumn, maxRows, queryFilters, schemaQuery, selectedItems, valueColumn } = model;
 
-    let allFilters = [];
+    let allFilters: Filter.IFilter[] = [];
     const filterVal = input.trim();
 
     // fetch additional options and exclude previously selected so user can see more
@@ -224,37 +224,39 @@ export function fetchSearchResults(model: QuerySelectModel, input: any): Promise
     );
 }
 
+function initErrorMsg(queryInfo: QueryInfo, suffix?: string): string {
+    const msg = `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}).`;
+    if (suffix) return msg + ' ' + suffix;
+    return msg;
+}
+
 function initValueColumn(queryInfo: QueryInfo, column?: string): string {
-    // determine 'valueColumn'
-    let valueColumn: string;
     if (column) {
-        valueColumn = column;
-        const valueCol = queryInfo.getColumn(valueColumn) ?? queryInfo.getColumnFromName(valueColumn);
+        const valueCol = queryInfo.getColumn(column) ?? queryInfo.getColumnFromName(column);
 
         if (!valueCol) {
-            throw new Error(
-                `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). The "valueColumn" "${valueColumn}" does not exist.`
-            );
+            throw new Error(initErrorMsg(queryInfo, `The specified "valueColumn" "${column}" does not exist.`));
         }
-        valueColumn = valueCol.fieldKey;
-    } else {
-        const pkCols = queryInfo.getPkCols();
 
-        if (pkCols.length === 1) {
-            valueColumn = pkCols[0].fieldKey;
-        } else if (pkCols.length > 0) {
-            throw new Error(
-                `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). Set "valueColumn" explicitly to any of ` +
-                    pkCols.map(col => col.fieldKey).join(', ')
-            );
-        } else {
-            throw new Error(
-                `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). Set "valueColumn" explicitly as this query does not have any primary keys.`
-            );
-        }
+        return valueCol.fieldKey;
     }
 
-    return valueColumn;
+    const pkCols = queryInfo.getPkCols();
+
+    if (pkCols.length === 0) {
+        throw new Error(
+            initErrorMsg(queryInfo, 'Set "valueColumn" explicitly as this query does not have any primary keys.')
+        );
+    }
+
+    if (pkCols.length > 1) {
+        const availablePkKeys = pkCols.map(col => `"${col.fieldKey}"`).join(', ');
+        throw new Error(
+            initErrorMsg(queryInfo, `Set "valueColumn" explicitly to any of the primary keys: ${availablePkKeys}`)
+        );
+    }
+
+    return pkCols[0].fieldKey;
 }
 
 function initDisplayColumn(queryInfo: QueryInfo, valueColumn: string, column?: string): string {
@@ -263,9 +265,7 @@ function initDisplayColumn(queryInfo: QueryInfo, valueColumn: string, column?: s
     if (column) {
         const col = queryInfo.getColumn(column) ?? queryInfo.getColumnFromName(column);
         if (!col) {
-            console.warn(
-                `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). The display column "${column}" does not exist.`
-            );
+            console.warn(initErrorMsg(queryInfo, `The display column "${column}" does not exist.`));
         } else {
             displayColumn = col.fieldKey;
         }
@@ -293,9 +293,7 @@ function initGroupByColumn(queryInfo: QueryInfo, column?: string): string {
 
     if (column) {
         if (!queryInfo.getColumn(column)) {
-            console.warn(
-                `Unable to initialize QuerySelect for (${queryInfo.schemaName}.${queryInfo.name}). The group by column "${column}" does not exist.`
-            );
+            console.warn(initErrorMsg(queryInfo, `The group by column "${column}" does not exist.`));
         } else {
             groupByColumn = column;
         }
@@ -373,14 +371,14 @@ export function findNotFoundValues(
     if (filterValue === undefined || filterValue === null) return [];
 
     const rawValues = Array.isArray(filterValue) ? filterValue : [filterValue];
-    const uniqueValues = new Set(rawValues.filter(v => v !== undefined && v !== null).map(v => v.toString()));
+    const expectedValues = new Set(rawValues.filter(v => v !== undefined && v !== null).map(v => v.toString()));
 
     selectedItems
         .map(item => item.getIn([valueColumn, 'value']))
-        .filter(v => v !== undefined && v !== null)
-        .forEach(itemValue => uniqueValues.delete(itemValue.toString()));
+        .filter(value => value !== undefined && value !== null)
+        .forEach(value => expectedValues.delete(value.toString()));
 
-    return Array.from(uniqueValues).sort(naturalSort);
+    return Array.from(expectedValues).sort(naturalSort);
 }
 
 async function initSelectedItems(

--- a/packages/components/src/internal/util/messaging.test.ts
+++ b/packages/components/src/internal/util/messaging.test.ts
@@ -1,4 +1,9 @@
-import { getPermissionRestrictionMessage, makePresentParticiple, resolveErrorMessage } from './messaging';
+import {
+    getPermissionRestrictionMessage,
+    lookupValidationErrorMessage,
+    makePresentParticiple,
+    resolveErrorMessage,
+} from './messaging';
 
 describe('makePresentParticiple', () => {
     test('no verb', () => {
@@ -367,6 +372,30 @@ describe('getPermissionRestrictionMessage', () => {
         );
         expect(getPermissionRestrictionMessage(2, 1, 'dog', 'dogs', 'walk', ' around the block')).toBe(
             'Selection includes 1 dog that you do not have permission to walk around the block. Only the dogs that you have permission for will be updated.'
+        );
+    });
+});
+
+describe('lookupValidationErrorMessage', () => {
+    test('value only', () => {
+        expect(lookupValidationErrorMessage('s')).toEqual('Could not find s. Data may have been moved or deleted.');
+        expect(lookupValidationErrorMessage(1.4)).toEqual('Could not find 1.4. Data may have been moved or deleted.');
+        expect(lookupValidationErrorMessage(false)).toEqual(
+            'Could not find false. Data may have been moved or deleted.'
+        );
+    });
+
+    test('fromPaste', () => {
+        expect(lookupValidationErrorMessage(false, true)).toEqual('Could not find false');
+        expect(lookupValidationErrorMessage('beep', true)).toEqual('Could not find beep');
+        expect(lookupValidationErrorMessage('"sara", "pete"', true)).toEqual(
+            'Could not find "sara", "pete". Please make sure values that contain commas are properly quoted.'
+        );
+    });
+
+    test('with displayValue', () => {
+        expect(lookupValidationErrorMessage('beep,', false, 'vw')).toEqual(
+            'vw is no longer a valid value. Data may have been moved or deleted.'
         );
     });
 });

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -232,3 +232,21 @@ export function getPermissionRestrictionMessage(
     const notPermittedNoun = Utils.pluralize(noPermissionCount, nounSingular, nounPlural);
     return `Selection includes ${notPermittedNoun} that you do not have permission to ${verb}${verbSuffix ?? ''}. Only the ${nounPlural} that you have permission for will be updated.`;
 }
+
+export function lookupValidationErrorMessage(
+    value: string | number | boolean,
+    fromPaste?: boolean,
+    displayValue?: any
+): string {
+    let message = displayValue !== undefined ? `${displayValue} is no longer a valid value` : `Could not find ${value}`;
+
+    if (fromPaste) {
+        if (typeof value === 'string' && value.toString().indexOf(',') > -1) {
+            message += '. Please make sure values that contain commas are properly quoted.';
+        }
+    } else {
+        message += '. Data may have been moved or deleted.';
+    }
+
+    return message;
+}

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -432,3 +432,15 @@ textarea.form-control {
 .modal-footer .inline-comment .inline-comment-label {
     margin-bottom: 0;
 }
+
+.has-error .select-input__control,
+.has-error .form-control,
+.has-error .form-control:focus {
+    border-color: $red-border;
+    box-shadow: inset 0 0 3px 0 $red-shadow, 0 0 3px 0 $red-shadow;
+}
+
+.has-warning .select-input__control,
+.has-warning .select-input__control:hover {
+    border-color: $brand-warning;
+}

--- a/packages/components/src/theme/samples.scss
+++ b/packages/components/src/theme/samples.scss
@@ -61,11 +61,6 @@
     padding-top: 7px;
 }
 
-.has-error .select-input__control, .has-error .form-control, .has-error .form-control:focus {
-    border-color: $red-border;
-    box-shadow: inset 0 0 3px 0 $red-shadow, 0 0 3px 0 $red-shadow;
-}
-
 .container--removal-icon:hover {
     color: #D0021B
 }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52773](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52773) by adding a warning message to query-backed drop-downs in forms.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1788
- https://github.com/LabKey/limsModules/pull/1385
- https://github.com/LabKey/testAutomation/pull/2435

#### Changes
- Update `SelectInput` to accept a `warning: ReactNode` prop and display warnings using `has-warning`.
- Update `QuerySelect` to determine if the initial value is not found and display a warning.
