### PR TITLE
Issue 52773: support clearing unresolved values

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.2",
+  "version": "6.40.3-fb-select-not-found.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.2",
+      "version": "6.40.3-fb-select-not-found.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.0",
+  "version": "6.40.3-fb-select-not-found.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.3-fb-select-not-found.0",
+      "version": "6.40.3-fb-select-not-found.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.1",
+  "version": "6.40.3-fb-select-not-found.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.3-fb-select-not-found.1",
+      "version": "6.40.3-fb-select-not-found.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.3",
+  "version": "6.40.3-fb-select-not-found.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.3-fb-select-not-found.3",
+      "version": "6.40.3-fb-select-not-found.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.2",
+  "version": "6.40.3-fb-select-not-found.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.3-fb-select-not-found.2",
+      "version": "6.40.3-fb-select-not-found.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.4",
+  "version": "6.40.3-fb-select-not-found.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.3-fb-select-not-found.4",
+      "version": "6.40.3-fb-select-not-found.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.5",
+  "version": "6.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.40.3-fb-select-not-found.5",
+      "version": "6.41.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.5",
+  "version": "6.41.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.2",
+  "version": "6.40.3-fb-select-not-found.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.4",
+  "version": "6.40.3-fb-select-not-found.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.2",
+  "version": "6.40.3-fb-select-not-found.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.3",
+  "version": "6.40.3-fb-select-not-found.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.1",
+  "version": "6.40.3-fb-select-not-found.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.40.3-fb-select-not-found.0",
+  "version": "6.40.3-fb-select-not-found.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.41.0
+*Released*: 12 May 2025
+- Issue 52773: Update `QuerySelect` to manufacture selectable items for not found results.
+- Dynamically recompute warning and continue to display until unresolved values are no longer "selected".
+- Revise`quoteValueColumnWithDelimiters` to only modify `value` and `displayValue` when necessary. Stop mutating/removing other properties.
+- `SelectInput`: Support "notFound" styling for multi-value selected options
+
 ### version 6.40.2
 *Released*: 6 May 2025
 - Issue 52773: display warning for unresolved form lookup values

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -279,6 +279,7 @@ export const gridCellSelectInputProps: Partial<SelectInputProps> = {
 
 export const gridCellQuerySelectProps: Partial<QuerySelectOwnProps> = {
     ...gridCellSelectInputProps,
+    notFoundValuesEnabled: false,
     showLoading: false,
 };
 

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -403,14 +403,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     // Issue 52773: If a value is specified, but we are unable to resolve the value then display a warning to the user.
     const warning = useMemo(() => {
         if (!hasNotFoundValues) return undefined;
-
-        let warningValue: string;
-        if (model.notFoundValues.size < 5) {
-            warningValue = model.notFoundValues.join(', ');
-        } else {
-            warningValue = `${model.notFoundValues.size} values`;
-        }
-
+        const warningValue = model.notFoundValues.size === 1 ? model.notFoundValues.first() : 'multiple values';
         return lookupValidationErrorMessage(warningValue);
     }, [hasNotFoundValues, model.notFoundValues]);
 

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -179,6 +179,7 @@ export interface QuerySelectOwnProps extends InheritedSelectInputProps {
     groupByColumn?: string;
     loadOnFocus?: boolean;
     maxRows?: number;
+    /** When enabled "not found" (i.e. unresolved) values will be processed as selectable items. */
     notFoundValuesEnabled?: boolean;
     onInitValue?: (value: any, selectedValues: List<any>) => void;
     onQSChange?: QuerySelectChange;
@@ -289,7 +290,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
         if (!autoInit) return;
         (async () => {
             try {
-                const modelProps = await initSelect({ ...props, delimiter });
+                const modelProps = await initSelect({ ...props, delimiter, notFoundValuesEnabled });
 
                 setModel(model_ => {
                     const { selectedItems } = modelProps;

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -263,7 +263,24 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
     const [searches, setSearches] = useState<Search[]>([]);
     const debounceTO = useTimeout();
     const shouldLoadOnFocus = loadOnFocus && !loadOnFocusLock;
-    const hasNotFoundValues = model.notFoundValues?.size > 0;
+    const { notFoundValues, selectedOptions } = useMemo(() => {
+        const notFoundValues_ = new Set<string | number | boolean>();
+        const options = model.isInit ? model.selectedOptions : undefined;
+
+        if (options) {
+            if (Array.isArray(options)) {
+                options.forEach(option => {
+                    if (option.notFound) {
+                        notFoundValues_.add(option.displayValue ?? option.value);
+                    }
+                });
+            } else if (options.notFound) {
+                notFoundValues_.add(options.displayValue ?? options.value);
+            }
+        }
+
+        return { notFoundValues: notFoundValues_, selectedOptions: options };
+    }, [model]);
 
     useEffect(() => {
         if (!autoInit) return;
@@ -402,10 +419,10 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
 
     // Issue 52773: If a value is specified, but we are unable to resolve the value then display a warning to the user.
     const warning = useMemo(() => {
-        if (!hasNotFoundValues) return undefined;
-        const warningValue = model.notFoundValues.size === 1 ? model.notFoundValues.first() : 'multiple values';
+        if (notFoundValues.size === 0) return undefined;
+        const warningValue = notFoundValues.size === 1 ? Array.from(notFoundValues)[0] : 'multiple values';
         return lookupValidationErrorMessage(warningValue);
-    }, [hasNotFoundValues, model.notFoundValues]);
+    }, [notFoundValues]);
 
     if (error) {
         return (
@@ -452,8 +469,8 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
             optionRenderer={optionRenderer}
             options={undefined} // prevent override
             // Issue 52773: Allow for submission of required fields whose value is not found
-            required={hasNotFoundValues ? false : required}
-            selectedOptions={model.isInit ? model.selectedOptions : undefined}
+            required={notFoundValues.size > 0 ? false : required}
+            selectedOptions={selectedOptions}
             value={getValue(model, multiple)} // needed to initialize the Formsy "value" properly
             warning={warning}
         />

--- a/packages/components/src/internal/components/forms/QuerySelect.tsx
+++ b/packages/components/src/internal/components/forms/QuerySelect.tsx
@@ -173,11 +173,13 @@ export interface QuerySelectOwnProps extends InheritedSelectInputProps {
     containerFilter?: Query.ContainerFilter;
     /** The path to the LK container that the queries should be scoped to. */
     containerPath?: string;
+    delimiter?: string;
     displayColumn?: string;
     fireQSChangeOnInit?: boolean;
     groupByColumn?: string;
     loadOnFocus?: boolean;
     maxRows?: number;
+    notFoundValuesEnabled?: boolean;
     onInitValue?: (value: any, selectedValues: List<any>) => void;
     onQSChange?: QuerySelectChange;
     preLoad?: boolean;
@@ -210,6 +212,7 @@ export const QuerySelect: FC<QuerySelectOwnProps> = memo(props => {
         groupByColumn,
         loadOnFocus = false,
         maxRows,
+        notFoundValuesEnabled = true,
         onInitValue,
         onQSChange,
         preLoad = true,

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { Component, FC, FocusEvent, KeyboardEvent, ReactNode } from 'react';
+import React, { Component, CSSProperties, FC, FocusEvent, KeyboardEvent, ReactNode } from 'react';
 import ReactSelect, { components } from 'react-select';
 import AsyncSelect from 'react-select/async';
 import AsyncCreatableSelect from 'react-select/async-creatable';
@@ -27,6 +27,9 @@ import { DELIMITER, INPUT_CONTAINER_CLASS_NAME, INPUT_LABEL_CLASS_NAME, INPUT_WR
 import { QueryColumn } from '../../../../public/QueryColumn';
 import { generateId } from '../../../util/utils';
 
+const WARN_COLOR = '#8A6D3B';
+const WARN_BG_COLOR = '#FCF8E3';
+
 const _customStyles = {
     control: (styles, props) => {
         if (props.isDisabled) {
@@ -38,22 +41,45 @@ const _customStyles = {
     // which results in layout conflicts in our apps. This reverts to the v1 value.
     menu: provided => ({ ...provided, zIndex: 1000 }),
     menuPortal: provided => ({ ...provided, zIndex: 9999 }), // Issue 45958 Safari scrollbar renders over menu
-    multiValue: (styles, state) => ({ ...styles, backgroundColor: state.isDisabled ? '#E1E1E1' : '#F2F9FC' }),
-    multiValueLabel: (styles, state) => ({ ...styles, color: state.isDisabled ? '#555' : '#08C' }),
-    multiValueRemove: (styles, state) => {
-        // Don't display the remove symbol for each option when the select is disabled.
+    multiValue: (styles, state) => {
+        let backgroundColor: string;
         if (state.isDisabled) {
-            return { ...styles, display: 'none' };
+            backgroundColor = '#E1E1E1';
+        } else if (state.data?.notFound) {
+            backgroundColor = WARN_BG_COLOR;
+        } else {
+            backgroundColor = '#F2F9FC';
         }
 
-        return {
-            ...styles,
-            color: '#08C',
-            ':hover': {
-                backgroundColor: '#2980B9',
-                color: 'white',
-            },
-        };
+        return { ...styles, backgroundColor };
+    },
+    multiValueLabel: (styles, state) => {
+        let color: string;
+        if (state.isDisabled) {
+            color = '#555';
+        } else if (state.data?.notFound) {
+            color = WARN_COLOR;
+        } else {
+            color = '#08C';
+        }
+
+        return { ...styles, color };
+    },
+    multiValueRemove: (styles, state) => {
+        const style: CSSProperties = {};
+
+        if (state.isDisabled) {
+            // Don't display the remove symbol for each option when the select is disabled.
+            style.display = 'none';
+        } else if (state.data?.notFound) {
+            style.color = WARN_COLOR;
+            style[':hover'] = { backgroundColor: WARN_COLOR, color: WARN_BG_COLOR };
+        } else {
+            style.color = '#08C';
+            style[':hover'] = { backgroundColor: '#2980B9', color: '#FFF' };
+        }
+
+        return { ...styles, ...style };
     },
     placeholder: (styles, props) => {
         if (props.isDisabled) {
@@ -104,6 +130,7 @@ const CustomOption = props => {
 export interface SelectInputOption extends Record<string, any> {
     data?: any;
     label?: string;
+    notFound?: boolean;
     options?: SelectInputOption[];
     value?: any;
 }

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -417,7 +417,7 @@ function initSelectedItems(
 }
 
 export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<QuerySelectModelProps>> {
-    const { delimiter, multiple, value } = props;
+    const { delimiter, multiple, notFoundValuesEnabled, value } = props;
     const { queryInfo, valueColumn, displayColumn, groupByColumn } = await initQueryInfoWithColumns(props);
 
     let selectedItems: ISelectRowsResult;
@@ -427,7 +427,7 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
         selectedItems = await initSelectedItems(props, queryInfo, valueColumn, displayColumn, groupByColumn, filter);
         const selectedRows = selectedItems.models[selectedItems.key];
 
-        if (Object.keys(selectedRows).length !== expectedValueCount) {
+        if (notFoundValuesEnabled && Object.keys(selectedRows).length !== expectedValueCount) {
             const notFoundValues = findNotFoundValues(selectedRows, filter, valueColumn);
             notFoundValues.forEach(v => {
                 if (!selectedRows.hasOwnProperty(v)) {

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -376,17 +376,21 @@ export function findNotFoundValues(
     valueColumn: string
 ): string[] {
     const filterValue = filter.getValue();
-    if (filterValue === undefined || filterValue === null) return [];
+    if (!validValue(filterValue)) return [];
 
     const rawValues = Array.isArray(filterValue) ? filterValue : [filterValue];
-    const expectedValues = new Set(rawValues.filter(v => v !== undefined && v !== null).map(v => v.toString()));
+    const expectedValues = new Set(rawValues.filter(validValue).map(v => v.toString()));
 
     Object.values(selectedRows)
         .map(item => caseInsensitive(item, valueColumn)?.value)
-        .filter(value => value !== undefined && value !== null)
+        .filter(validValue)
         .forEach(value => expectedValues.delete(value.toString()));
 
     return Array.from(expectedValues).sort(naturalSort);
+}
+
+function validValue(value: any): boolean {
+    return value !== undefined && value !== null && value !== '';
 }
 
 function initSelectedItems(
@@ -421,7 +425,7 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
     let selectedItems: ISelectRowsResult;
     let notFoundValues: List<any>;
 
-    if (value !== undefined && value !== null) {
+    if (validValue(value)) {
         const { expectedValueCount, filter } = buildValueFilter(value, valueColumn, multiple, delimiter);
         selectedItems = await initSelectedItems(props, queryInfo, valueColumn, displayColumn, groupByColumn, filter);
         const selectedRows = selectedItems.models[selectedItems.key];

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -48,10 +48,16 @@ function formatOption(model: QuerySelectModel, result: any): SelectInputOption {
     const labelCol = model.queryInfo.getColumn(displayColumn) ?? model.queryInfo.getColumnFromName(displayColumn);
     const labelField = result.get(labelCol.name) ?? result.get(labelCol.fieldKey) ?? valueField;
 
-    return {
+    const option: SelectInputOption = {
         label: resolveDetailFieldLabel(labelField) as string,
         value: resolveDetailFieldValue(valueField),
     };
+
+    if (valueField?.has('notFound')) {
+        option.notFound = valueField.get('notFound');
+    }
+
+    return option;
 }
 
 export function formatResults(model: QuerySelectModel, results: Map<string, any>, token?: string): SelectInputOption[] {
@@ -424,6 +430,12 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
             const notFoundValuesArray = findNotFoundValues(selectedRows, filter, valueColumn);
             if (notFoundValuesArray) {
                 notFoundValues = List(notFoundValuesArray);
+
+                notFoundValuesArray.forEach(v => {
+                    if (!selectedRows.hasOwnProperty(v)) {
+                        selectedRows[v] = { [valueColumn]: { displayValue: `<${v}>`, notFound: true, value: v } };
+                    }
+                });
             }
         }
     }

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -179,8 +179,6 @@ export function setSelection(model: QuerySelectModel, rawSelectedValue: any): Qu
     const selectedItems = getSelectedOptions(model, rawSelectedValue);
 
     return model.merge({
-        // Issue 52773: Unset notFoundValues once a value has been selected
-        notFoundValues: undefined,
         rawSelectedValue,
         selectedItems,
         selectedQuery: parseSelectedQuery(model, selectedItems),
@@ -423,7 +421,6 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
     const { queryInfo, valueColumn, displayColumn, groupByColumn } = await initQueryInfoWithColumns(props);
 
     let selectedItems: ISelectRowsResult;
-    let notFoundValues: List<any>;
 
     if (validValue(value)) {
         const { expectedValueCount, filter } = buildValueFilter(value, valueColumn, multiple, delimiter);
@@ -431,16 +428,12 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
         const selectedRows = selectedItems.models[selectedItems.key];
 
         if (Object.keys(selectedRows).length !== expectedValueCount) {
-            const notFoundValuesArray = findNotFoundValues(selectedRows, filter, valueColumn);
-            if (notFoundValuesArray) {
-                notFoundValues = List(notFoundValuesArray);
-
-                notFoundValuesArray.forEach(v => {
-                    if (!selectedRows.hasOwnProperty(v)) {
-                        selectedRows[v] = { [valueColumn]: { displayValue: `<${v}>`, notFound: true, value: v } };
-                    }
-                });
-            }
+            const notFoundValues = findNotFoundValues(selectedRows, filter, valueColumn);
+            notFoundValues.forEach(v => {
+                if (!selectedRows.hasOwnProperty(v)) {
+                    selectedRows[v] = { [valueColumn]: { displayValue: `<${v}>`, notFound: true, value: v } };
+                }
+            });
         }
     }
 
@@ -448,7 +441,6 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
         displayColumn,
         groupByColumn,
         isInit: true,
-        notFoundValues,
         queryInfo,
         selectedItems: selectedItems
             ? fromJS(quoteValueColumnWithDelimiters(selectedItems, valueColumn, delimiter).models[selectedItems.key])
@@ -468,7 +460,6 @@ export interface QuerySelectModelProps {
     isInit: boolean;
     maxRows: number;
     multiple: boolean;
-    notFoundValues: List<any>;
     queryFilters: List<Filter.IFilter>;
     queryInfo: QueryInfo;
     queryParams: Record<string, any>;
@@ -517,7 +508,6 @@ export class QuerySelectModel
     declare isInit: boolean;
     declare maxRows: number;
     declare multiple: boolean;
-    declare notFoundValues: List<any>;
     declare queryFilters: List<Filter.IFilter>;
     declare queryInfo: QueryInfo;
     declare queryParams: Record<string, any>;

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -427,7 +427,7 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
         selectedItems = await initSelectedItems(props, queryInfo, valueColumn, displayColumn, groupByColumn, filter);
         const selectedRows = selectedItems.models[selectedItems.key];
 
-        if (notFoundValuesEnabled && Object.keys(selectedRows).length !== expectedValueCount) {
+        if (notFoundValuesEnabled && selectedRows && Object.keys(selectedRows).length !== expectedValueCount) {
             const notFoundValues = findNotFoundValues(selectedRows, filter, valueColumn);
             notFoundValues.forEach(v => {
                 if (!selectedRows.hasOwnProperty(v)) {

--- a/packages/components/src/internal/query/api.test.ts
+++ b/packages/components/src/internal/query/api.test.ts
@@ -142,8 +142,8 @@ describe('api', () => {
             key: 'test',
             models: {
                 test: {
-                    1: { Name: { value: 'one', url: 'http://one/test' } },
-                    2: { Name: { value: 'with, comma', url: 'http://with, comma/test' } },
+                    1: { Name: { value: 'one', url: 'http://one/test', randomProperty: 123 } },
+                    2: { Name: { value: 'with, comma', url: 'http://with, comma/test', displayValue: 'with, comma' } },
                     4: { Name: { value: 'with "quotes", and comma' } },
                     3: { NoName: { value: 'nonesuch', url: 'http://with, comma/test' } },
                     5: { Name: { value: ', comma first', displayValue: ',', url: 'http://with, comma/test' } },
@@ -158,7 +158,7 @@ describe('api', () => {
                 key: 'test',
                 models: {
                     test: {
-                        1: { Name: { value: 'one', url: 'http://one/test', displayValue: 'one' } },
+                        1: { Name: { value: 'one', url: 'http://one/test', randomProperty: 123 } },
                         2: {
                             Name: {
                                 value: '"with, comma"',
@@ -169,8 +169,6 @@ describe('api', () => {
                         4: {
                             Name: {
                                 value: '"with ""quotes"", and comma"',
-                                url: undefined,
-                                displayValue: 'with "quotes", and comma',
                             },
                         },
                         3: { NoName: { value: 'nonesuch', url: 'http://with, comma/test' } },

--- a/packages/components/src/internal/query/api.test.ts
+++ b/packages/components/src/internal/query/api.test.ts
@@ -70,8 +70,8 @@ describe('api', () => {
 
         interface ModuleContextOptions {
             allFolderLookups?: boolean;
-            isProductFoldersEnabled?: boolean;
             folderDataScoped?: boolean;
+            isProductFoldersEnabled?: boolean;
         }
 
         function moduleContext(options?: ModuleContextOptions): ModuleContext {

--- a/packages/components/src/internal/query/api.test.ts
+++ b/packages/components/src/internal/query/api.test.ts
@@ -143,7 +143,7 @@ describe('api', () => {
             models: {
                 test: {
                     1: { Name: { value: 'one', url: 'http://one/test', randomProperty: 123 } },
-                    2: { Name: { value: 'with, comma', url: 'http://with, comma/test', displayValue: 'with, comma' } },
+                    2: { Name: { value: 'with, comma', url: 'http://with, comma/test' } },
                     4: { Name: { value: 'with "quotes", and comma' } },
                     3: { NoName: { value: 'nonesuch', url: 'http://with, comma/test' } },
                     5: { Name: { value: ', comma first', displayValue: ',', url: 'http://with, comma/test' } },

--- a/packages/components/src/internal/query/api.test.ts
+++ b/packages/components/src/internal/query/api.test.ts
@@ -158,7 +158,7 @@ describe('api', () => {
                 key: 'test',
                 models: {
                     test: {
-                        1: { Name: { value: 'one', url: 'http://one/test', randomProperty: 123 } },
+                        1: { Name: { value: 'one', url: 'http://one/test', displayValue: 'one', randomProperty: 123 } },
                         2: {
                             Name: {
                                 value: '"with, comma"',
@@ -169,6 +169,7 @@ describe('api', () => {
                         4: {
                             Name: {
                                 value: '"with ""quotes"", and comma"',
+                                displayValue: 'with "quotes", and comma',
                             },
                         },
                         3: { NoName: { value: 'nonesuch', url: 'http://with, comma/test' } },

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -716,17 +716,14 @@ export function quoteValueColumnWithDelimiters(
     delimiter: string
 ): ISelectRowsResult {
     const rowMap = selectRowsResult.models[selectRowsResult.key];
-    Object.keys(rowMap).forEach(key => {
-        if (rowMap[key][valueColumn]) {
-            Object.assign(rowMap[key], {
-                [valueColumn]: {
-                    value: quoteValueWithDelimiters(rowMap[key][valueColumn].value, delimiter),
-                    displayValue: rowMap[key][valueColumn].displayValue ?? rowMap[key][valueColumn].value,
-                    url: rowMap[key][valueColumn].url,
-                },
-            });
+
+    Object.values(rowMap).forEach(row => {
+        const cell = row[valueColumn];
+        if (Utils.isString(cell?.value)) {
+            cell.value = quoteValueWithDelimiters(cell.value, delimiter);
         }
     });
+
     return selectRowsResult;
 }
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -720,6 +720,7 @@ export function quoteValueColumnWithDelimiters(
     Object.values(rowMap).forEach(row => {
         const cell = row[valueColumn];
         if (Utils.isString(cell?.value)) {
+            cell.displayValue = cell.displayValue ?? cell.value;
             cell.value = quoteValueWithDelimiters(cell.value, delimiter);
         }
     });


### PR DESCRIPTION
#### Rationale
This adds support for clearing unresolved values in `QuerySelect` drop-downs. What this means is that we need to manufacture selectable items for unresolved values so that they can be manipulated by the user. This is supported for both single and multi-value configurations. This is follow-up work for [Issue 52773](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52773).

Single value:
<img width="600" alt="SingleEdit" src="https://github.com/user-attachments/assets/fcb57dfa-a388-46b3-b1a9-491ebf41ab4f" />

Multiple value:
<img width="725" alt="MultiEdit" src="https://github.com/user-attachments/assets/940c3521-54ac-4fde-8db9-035fa3ddb8a6" />

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1397

#### Changes
- Update `QuerySelect` to manufacture selectable items for not found results.
- Dynamically recompute warning and continue to display until unresolved values are no longer "selected".
- Revise`quoteValueColumnWithDelimiters` to only modify `value` and `displayValue` when necessary. Stop mutating/removing other properties.
- `SelectInput`: Support "notFound" styling for multi-value selected options
