### PR TITLE
Issue 53055: Check for multiple values in single value column

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.0",
+  "version": "6.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.43.0",
+      "version": "6.43.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.0",
+  "version": "6.43.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.43.1
+*Released*: 22 May 2025
+- Issue 53055: Check for multiple values in single value column
+
 ### version 6.43.0
 *Released*: 22 May 2025
 - AppURL

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -722,7 +722,8 @@ describe('parsePastedLookup', () => {
         });
         expect(parsePastedLookup(stringLookupCol, stringLookupValues, 'b,C,value D')).toStrictEqual({
             message: {
-                message: 'Could not find "b,C,value D". Please make sure values that contain commas are properly quoted.',
+                message:
+                    'Could not find "b,C,value D". Please make sure values that contain commas are properly quoted.',
             },
             valueDescriptors: List([{ display: 'b,C,value D', raw: 'b,C,value D' }]),
         });
@@ -733,7 +734,8 @@ describe('parsePastedLookup', () => {
         });
         expect(parsePastedLookup(stringLookupCol, stringLookupValues, 'abc, valueD')).toStrictEqual({
             message: {
-                message: 'Could not find "abc, valueD". Please make sure values that contain commas are properly quoted.',
+                message:
+                    'Could not find "abc, valueD". Please make sure values that contain commas are properly quoted.',
             },
             valueDescriptors: List([{ display: 'abc, valueD', raw: 'abc, valueD' }]),
         });
@@ -761,7 +763,8 @@ describe('parsePastedLookup', () => {
         });
         expect(parsePastedLookup(intLookupCol, intLookupValues, 'abc, valueD')).toStrictEqual({
             message: {
-                message: 'Could not find "abc, valueD". Please make sure values that contain commas are properly quoted.',
+                message:
+                    'Could not find "abc, valueD". Please make sure values that contain commas are properly quoted.',
             },
             valueDescriptors: List([{ display: 'abc, valueD', raw: 'abc, valueD' }]),
         });

--- a/packages/components/src/internal/components/editable/actions.test.ts
+++ b/packages/components/src/internal/components/editable/actions.test.ts
@@ -670,6 +670,12 @@ describe('parsePastedLookup', () => {
         lookup: new QueryLookup({ isPublic: true }),
         required: true,
     });
+    const multiValueLookup = new QueryColumn({
+        jsonType: 'string',
+        caption: 'MultiValueLookupCol',
+        lookup: new QueryLookup({ isPublic: true, multiValued: 'junction' }),
+        multiValue: true,
+    });
 
     const intLookupValues = [
         { display: 'A', raw: 1 },
@@ -683,24 +689,20 @@ describe('parsePastedLookup', () => {
     ];
 
     test('empty', () => {
-        [undefined, null, '', ' '].forEach(val => {
+        const emptyValues = [undefined, null, '', ' '];
+        emptyValues.forEach(val => {
             expect(parsePastedLookup(intLookupCol, intLookupValues, val)).toStrictEqual({
-                valueDescriptors: List([
-                    {
-                        display: val,
-                        raw: val,
-                    },
-                ]),
+                valueDescriptors: List([{ display: val, raw: val }]),
             });
         });
-        [undefined, null, '', ' '].forEach(val => {
+        emptyValues.forEach(val => {
             expect(parsePastedLookup(stringLookupCol, stringLookupValues, val)).toStrictEqual({
-                valueDescriptors: List([
-                    {
-                        display: val,
-                        raw: val,
-                    },
-                ]),
+                valueDescriptors: List([{ display: val, raw: val }]),
+            });
+        });
+        emptyValues.forEach(val => {
+            expect(parsePastedLookup(multiValueLookup, stringLookupValues, val)).toStrictEqual({
+                valueDescriptors: List([{ display: val, raw: val }]),
             });
         });
     });
@@ -719,12 +721,10 @@ describe('parsePastedLookup', () => {
             valueDescriptors: List([{ display: 'value D', raw: 'd' }]),
         });
         expect(parsePastedLookup(stringLookupCol, stringLookupValues, 'b,C,value D')).toStrictEqual({
-            message: undefined,
-            valueDescriptors: List([
-                { display: 'b', raw: 'B' },
-                { display: 'C', raw: 'C' },
-                { display: 'value D', raw: 'd' },
-            ]),
+            message: {
+                message: 'Could not find "b,C,value D". Please make sure values that contain commas are properly quoted.',
+            },
+            valueDescriptors: List([{ display: 'b,C,value D', raw: 'b,C,value D' }]),
         });
 
         expect(parsePastedLookup(stringLookupCol, stringLookupValues, 'abc')).toStrictEqual({
@@ -733,13 +733,9 @@ describe('parsePastedLookup', () => {
         });
         expect(parsePastedLookup(stringLookupCol, stringLookupValues, 'abc, valueD')).toStrictEqual({
             message: {
-                message:
-                    'Could not find "abc", "valueD". Please make sure values that contain commas are properly quoted.',
+                message: 'Could not find "abc, valueD". Please make sure values that contain commas are properly quoted.',
             },
-            valueDescriptors: List([
-                { display: 'abc', raw: 'abc' },
-                { display: 'valueD', raw: 'valueD' },
-            ]),
+            valueDescriptors: List([{ display: 'abc, valueD', raw: 'abc, valueD' }]),
         });
     });
 
@@ -753,12 +749,10 @@ describe('parsePastedLookup', () => {
             valueDescriptors: List([{ display: 'A', raw: 1 }]),
         });
         expect(parsePastedLookup(intLookupCol, intLookupValues, 'A,B,b')).toStrictEqual({
-            message: undefined,
-            valueDescriptors: List([
-                { display: 'A', raw: 1 },
-                { display: 'b', raw: 2 },
-                { display: 'b', raw: 2 },
-            ]),
+            message: {
+                message: 'Could not find "A,B,b". Please make sure values that contain commas are properly quoted.',
+            },
+            valueDescriptors: List([{ display: 'A,B,b', raw: 'A,B,b' }]),
         });
 
         expect(parsePastedLookup(intLookupCol, intLookupValues, 'abc')).toStrictEqual({
@@ -767,13 +761,9 @@ describe('parsePastedLookup', () => {
         });
         expect(parsePastedLookup(intLookupCol, intLookupValues, 'abc, valueD')).toStrictEqual({
             message: {
-                message:
-                    'Could not find "abc", "valueD". Please make sure values that contain commas are properly quoted.',
+                message: 'Could not find "abc, valueD". Please make sure values that contain commas are properly quoted.',
             },
-            valueDescriptors: List([
-                { display: 'abc', raw: 'abc' },
-                { display: 'valueD', raw: 'valueD' },
-            ]),
+            valueDescriptors: List([{ display: 'abc, valueD', raw: 'abc, valueD' }]),
         });
     });
 
@@ -784,16 +774,41 @@ describe('parsePastedLookup', () => {
         });
         [undefined, null, ''].forEach(val => {
             expect(parsePastedLookup(requiredLookupCol, stringLookupValues, val)).toStrictEqual({
-                message: {
-                    message: 'ReqLookCol is required.',
-                },
-                valueDescriptors: List([
-                    {
-                        display: val,
-                        raw: val,
-                    },
-                ]),
+                message: { message: 'ReqLookCol is required.' },
+                valueDescriptors: List([{ display: val, raw: val }]),
             });
+        });
+    });
+
+    test('multi-value column', () => {
+        expect(parsePastedLookup(multiValueLookup, stringLookupValues, 'A')).toStrictEqual({
+            message: undefined,
+            valueDescriptors: List([{ display: 'A', raw: 'a' }]),
+        });
+        expect(parsePastedLookup(multiValueLookup, stringLookupValues, 'a')).toStrictEqual({
+            message: undefined,
+            valueDescriptors: List([{ display: 'A', raw: 'a' }]),
+        });
+        expect(parsePastedLookup(multiValueLookup, stringLookupValues, 'value D')).toStrictEqual({
+            message: undefined,
+            valueDescriptors: List([{ display: 'value D', raw: 'd' }]),
+        });
+        expect(parsePastedLookup(multiValueLookup, stringLookupValues, 'b,C,value D')).toStrictEqual({
+            message: undefined,
+            valueDescriptors: List([
+                { display: 'b', raw: 'B' },
+                { display: 'C', raw: 'C' },
+                { display: 'value D', raw: 'd' },
+            ]),
+        });
+        expect(parsePastedLookup(multiValueLookup, stringLookupValues, 'b,C,value D,404')).toStrictEqual({
+            message: { message: 'Could not find "404"' },
+            valueDescriptors: List([
+                { display: 'b', raw: 'B' },
+                { display: 'C', raw: 'C' },
+                { display: 'value D', raw: 'd' },
+                { display: '404', raw: '404' },
+            ]),
         });
     });
 });

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -1057,7 +1057,7 @@ export function parsePastedLookup(
     let parsedValues: string[];
 
     // Issue 53055: only split raw values for multi-value columns
-    if (column.multiValue && column.isJunctionLookup()) {
+    if (column.isJunctionLookup()) {
         // parse pasted strings to split properly around quoted values.
         // Remove the quotes for storing the actual values in the grid.
         parsedValues = parseCsvString(value, ',', true);

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -14,6 +14,7 @@ import {
     parseCsvString,
     parseScientificInt,
     quoteValueWithDelimiters,
+    unquote,
 } from '../../util/utils';
 import { ViewInfo } from '../../ViewInfo';
 
@@ -1015,11 +1016,11 @@ export function generateFillCellKeys(
         end = initialMinRow - 1;
     }
 
-    const fillCellKeys = [];
+    const fillCellKeys: string[][] = [];
 
     // Construct arrays of columns, because we're going to generate fill sequences for columns
     for (let colIdx = minCol; colIdx <= maxCol; colIdx++) {
-        const columnKeys = [];
+        const columnKeys: string[] = [];
 
         for (let rowIdx = start; rowIdx <= end; rowIdx++) {
             columnKeys.push(genCellKey(editorModel.orderedColumns.get(colIdx), rowIdx));
@@ -1036,12 +1037,7 @@ export function parsePastedLookup(
     descriptors: ValueDescriptor[],
     value: string[] | string
 ): CellData {
-    const originalValues = List([
-        {
-            display: value,
-            raw: value,
-        },
-    ]);
+    const originalValues = List([{ display: value, raw: value }]);
 
     if (column.required && (value == null || value === '')) {
         return {
@@ -1058,24 +1054,28 @@ export function parsePastedLookup(
 
     let message: CellMessage;
     const unmatched: string[] = [];
+    let parsedValues: string[];
 
-    // parse pasted strings to split properly around quoted values.
-    // Remove the quotes for storing the actual values in the grid.
-    const values = parseCsvString(value, ',', true)
-        .map(v => {
-            const vt = v.trim();
-            if (vt.length > 0) {
-                const vl = vt.toLowerCase();
-                const vd = descriptors.find(d => d.display && d.display.toString().toLowerCase() === vl);
-                if (!vd) {
-                    unmatched.push(vt);
-                    return { display: vt, raw: vt };
-                } else {
-                    return vd;
-                }
-            }
-        })
-        .filter(v => v !== undefined);
+    // Issue 53055: only split raw values for multi-value columns
+    if (column.multiValue && column.isJunctionLookup()) {
+        // parse pasted strings to split properly around quoted values.
+        // Remove the quotes for storing the actual values in the grid.
+        parsedValues = parseCsvString(value, ',', true);
+    } else {
+        parsedValues = [unquote(value.trim())];
+    }
+
+    const values = parsedValues.flatMap(v => {
+        const vt = v.trim();
+        if (!vt) return [];
+
+        const vl = vt.toLowerCase();
+        const vd = descriptors.find(d => d.display && d.display.toString().toLowerCase() === vl);
+        if (vd) return [vd];
+
+        unmatched.push(vt);
+        return [{ display: vt, raw: vt }];
+    });
 
     if (unmatched.length) {
         const valueStr = unmatched
@@ -1085,10 +1085,7 @@ export function parsePastedLookup(
         message = { message: lookupValidationErrorMessage(valueStr, true) };
     }
 
-    return {
-        message,
-        valueDescriptors: List(values),
-    };
+    return { message, valueDescriptors: List(values) };
 }
 
 type LookupValueCache = Record<string, Promise<ValueDescriptor[]>>;

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -14,7 +14,6 @@ import {
     parseCsvString,
     parseScientificInt,
     quoteValueWithDelimiters,
-    unquote,
 } from '../../util/utils';
 import { ViewInfo } from '../../ViewInfo';
 
@@ -1053,29 +1052,31 @@ export function parsePastedLookup(
     }
 
     let message: CellMessage;
+    let values: ValueDescriptor[];
     const unmatched: string[] = [];
-    let parsedValues: string[];
 
-    // Issue 53055: only split raw values for multi-value columns
-    if (column.isJunctionLookup()) {
-        // parse pasted strings to split properly around quoted values.
-        // Remove the quotes for storing the actual values in the grid.
-        parsedValues = parseCsvString(value, ',', true);
-    } else {
-        parsedValues = [unquote(value.trim())];
-    }
+    // Parse pasted strings to split properly around quoted values.
+    // Remove the quotes for storing the actual values in the grid.
+    const parsedValues = parseCsvString(value, ',', true);
 
-    const values = parsedValues.flatMap(v => {
-        const vt = v.trim();
-        if (!vt) return [];
-
-        const vl = vt.toLowerCase();
-        const vd = descriptors.find(d => d.display && d.display.toString().toLowerCase() === vl);
-        if (vd) return [vd];
-
+    // Issue 53055: Do not attempt to resolve multiple values for a single-value column
+    if (!column.isJunctionLookup() && parsedValues.length > 1) {
+        const vt = value.trim();
         unmatched.push(vt);
-        return [{ display: vt, raw: vt }];
-    });
+        values = [{ display: vt, raw: vt }];
+    } else {
+        values = parsedValues.flatMap(v => {
+            const vt = v.trim();
+            if (!vt) return [];
+
+            const vl = vt.toLowerCase();
+            const vd = descriptors.find(d => d.display && d.display.toString().toLowerCase() === vl);
+            if (vd) return [vd];
+
+            unmatched.push(vt);
+            return [{ display: vt, raw: vt }];
+        });
+    }
 
     if (unmatched.length) {
         const valueStr = unmatched

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -47,7 +47,6 @@ import {
     toLowerSafe,
     uncapitalizeFirstChar,
     unorderedEqual,
-    unquote,
     withTransformedKeys,
 } from './utils';
 
@@ -1158,28 +1157,6 @@ describe('findMissingValues', () => {
     });
 });
 
-describe('unquote', () => {
-    test('quoting', () => {
-        expect(unquote(undefined)).toBe(undefined);
-        expect(unquote(null)).toBe(null);
-        expect(unquote('')).toBe('');
-        expect(unquote(' ')).toBe(' ');
-        expect(unquote('abc')).toBe('abc');
-        expect(unquote('a"bc')).toBe('a"bc');
-        expect(unquote('a"bc"')).toBe('a"bc"');
-        expect(unquote('"a"bc"')).toBe('a"bc');
-        expect(unquote('"abc"')).toBe('abc');
-        expect(unquote('""')).toBe('');
-        expect(unquote('"')).toBe('"');
-        expect(unquote('"\\"quoted\\""')).toBe('\\"quoted\\"');
-        expect(unquote('   "abc"   ')).toBe('   "abc"   ');
-        expect(unquote('"abc" "def"')).toBe('abc" "def');
-        expect(unquote('\'abc\'')).toBe('\'abc\'');
-        expect(unquote('\\"abc\\"')).toBe('\\"abc\\"');
-        expect(unquote('""abc""')).toBe('"abc"');
-    });
-});
-
 describe('parseCsvString', () => {
     test('no value', () => {
         expect(parseCsvString(null, ',')).toBeUndefined();
@@ -1226,6 +1203,9 @@ describe('parseCsvString', () => {
         expect(parseCsvString('"a,"123', ',', true)).toStrictEqual(['"a', '"123']);
         expect(parseCsvString('"a,"123', ', ', true)).toStrictEqual(['"a,"123']);
         expect(parseCsvString('"a, "123', ',', true)).toStrictEqual(['"a', ' "123']);
+        expect(parseCsvString('"sam"', ',', true)).toStrictEqual(['sam']);
+        expect(parseCsvString('"a""b"', ',', true)).toStrictEqual(['a"b']);
+        expect(parseCsvString('"a"b"', ',', true)).toStrictEqual(['"a"b"']);
     });
 });
 

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -47,6 +47,7 @@ import {
     toLowerSafe,
     uncapitalizeFirstChar,
     unorderedEqual,
+    unquote,
     withTransformedKeys,
 } from './utils';
 
@@ -1154,6 +1155,28 @@ describe('findMissingValues', () => {
     test('gaps everywhere', () => {
         expect(findMissingValues([2, 4, 6], ['a', 'b', 'c', 'd', 'e', 'f'])).toStrictEqual(['a', 'c', 'e']);
         expect(findMissingValues([3], ['a', 'b', 'c', 'd', 'e', 'f'])).toStrictEqual(['a', 'b', 'd', 'e', 'f']);
+    });
+});
+
+describe('unquote', () => {
+    test('quoting', () => {
+        expect(unquote(undefined)).toBe(undefined);
+        expect(unquote(null)).toBe(null);
+        expect(unquote('')).toBe('');
+        expect(unquote(' ')).toBe(' ');
+        expect(unquote('abc')).toBe('abc');
+        expect(unquote('a"bc')).toBe('a"bc');
+        expect(unquote('a"bc"')).toBe('a"bc"');
+        expect(unquote('"a"bc"')).toBe('a"bc');
+        expect(unquote('"abc"')).toBe('abc');
+        expect(unquote('""')).toBe('');
+        expect(unquote('"')).toBe('"');
+        expect(unquote('"\\"quoted\\""')).toBe('\\"quoted\\"');
+        expect(unquote('   "abc"   ')).toBe('   "abc"   ');
+        expect(unquote('"abc" "def"')).toBe('abc" "def');
+        expect(unquote('\'abc\'')).toBe('\'abc\'');
+        expect(unquote('\\"abc\\"')).toBe('\\"abc\\"');
+        expect(unquote('""abc""')).toBe('"abc"');
     });
 });
 

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -560,6 +560,13 @@ export const handleFileInputChange = (
     };
 };
 
+export function unquote(value: string): string {
+    if (value && value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+
 export function parseCsvString(value: string, delimiter: string, removeQuotes?: boolean): string[] {
     if (delimiter === '"') throw 'Unsupported delimiter: ' + delimiter;
 

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -560,13 +560,6 @@ export const handleFileInputChange = (
     };
 };
 
-export function unquote(value: string): string {
-    if (value && value.length > 1 && value.startsWith('"') && value.endsWith('"')) {
-        return value.slice(1, -1);
-    }
-    return value;
-}
-
 export function parseCsvString(value: string, delimiter: string, removeQuotes?: boolean): string[] {
     if (delimiter === '"') throw 'Unsupported delimiter: ' + delimiter;
 


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53055](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53055) which updates the processing of values pasted into an editable grid to determine if the underlying column accepts multiple values before processing pasted values.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1794
- https://github.com/LabKey/limsModules/pull/1418
- https://github.com/LabKey/platform/pull/6685
- https://github.com/LabKey/testAutomation/pull/2456

#### Changes
- Check if multiple values and the column supports multiple values when processing parsed values
- Update tests to new expectations and add multi-value lookup column coverage
