### PR TITLE
Fix Issue 52895

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.3",
+  "version": "6.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.43.3",
+      "version": "6.44.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.3",
+  "version": "6.44.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.??.?
-*Released*: ?? May 2025
+### version 6.44.0
+*Released*: 27 May 2025
 - QueryModel/QueryConfig change useSavedSettings from boolean to enum SavedSettings
   - Consumers can now opt into 'none', 'all', or 'noFilters'
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.??.?
+*Released*: ?? May 2025
+- QueryModel/QueryConfig change useSavedSettings from boolean to enum SavedSettings
+  - Consumers can now opt into 'none', 'all', or 'noFilters'
+
 ### version 6.43.3
 *Released*: 26 May 2025
 - Migrate `isSetEqual` to `@labkey/components`. Extend with additional support for deep comparison.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -640,7 +640,7 @@ import {
     wrapDraggable,
 } from './internal/test/testHelpers';
 import { renderWithAppContext } from './internal/test/reactTestLibraryHelpers';
-import { flattenValuesFromRow, QueryModel } from './public/QueryModel/QueryModel';
+import { flattenValuesFromRow, QueryModel, SavedSettings } from './public/QueryModel/QueryModel';
 import { getExpandQueryInfo, includedColumnsForCustomizationFilter } from './public/QueryModel/CustomizeGridViewModal';
 import { ChangeType, withQueryModels } from './public/QueryModel/withQueryModels';
 import { GridPanel, GridPanelWithModel } from './public/QueryModel/GridPanel';
@@ -1776,6 +1776,7 @@ export {
     // QueryModel
     GRID_CHECKBOX_OPTIONS,
     QueryModel,
+    SavedSettings,
     ChangeType,
     withQueryModels,
     GridPanel,

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -10,7 +10,7 @@ import { SetURLSearchParams, useSearchParams } from 'react-router-dom';
 
 import { getSelected } from '../../actions';
 
-import { QueryModel } from '../../../public/QueryModel/QueryModel';
+import { QueryModel, SavedSettings } from '../../../public/QueryModel/QueryModel';
 import { removeParameters } from '../../util/URL';
 
 import { UserLimitSettings } from '../permissions/actions';
@@ -134,7 +134,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                 bindURL: true,
                 urlPrefix: usersView, // each model needs to have its own urlPrefix for paging to work across models
                 includeTotalCount: true,
-                useSavedSettings: true,
+                useSavedSettings: SavedSettings.all,
             },
             true,
             true

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -103,6 +103,12 @@ export interface GridMessage {
     type?: string;
 }
 
+export enum SavedSettings {
+    all = 'all', // Restores filters, maxRows, sorts, and view
+    noFilters = 'noFilters', // Restores maxRows and sorts only
+    none = 'none',
+}
+
 export interface QueryConfig {
     /**
      * An array of base [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html)
@@ -209,12 +215,17 @@ export interface QueryConfig {
     urlPrefix?: string;
 
     /**
-     * If true we will load filters, sorts, pageSize, and viewName from localStorage when initially loading the model,
-     * but only if there are no settings on the URL. Important: If you are using this flag you must ensure your grid id
-     * is stable and unique. It must be stable between page loads/visits, or we won't be able to fetch the settings. It
-     * must be unique, or we'll override settings for other grid models.
+     * Used to optionally load saved settings from localStorage when initially loading the model, but only if there are
+     * no settings on the URL.
+     *  - 'all' will load filters, sorts, pageSize, and viewName
+     *  - 'noFilters' will load sorts and pageSize
+     *  - 'none' disables this feature
+     *
+     * Important: If you are using this flag you must ensure your grid id is stable and unique. It must be stable
+     * between page loads/visits, or we won't be able to fetch the settings. It must be unique, or we'll override other
+     * grid models.
      */
-    useSavedSettings?: boolean;
+    useSavedSettings?: SavedSettings;
 }
 
 export const DEFAULT_OFFSET = 0;
@@ -345,12 +356,17 @@ export class QueryModel {
      */
     readonly urlPrefix?: string;
     /**
-     * If true we will load filters, sorts, pageSize, and viewName from localStorage when initially loading the model,
-     * but only if there are no settings on the URL. Defaults to false. Important: If you are using this flag you must
-     * ensure your grid id is stable and unique. It must be stable between page loads/visits, or we won't be able to
-     * fetch the settings. It must be unique, or we'll override settings for other grid models.
+     * Used to optionally load saved settings from localStorage when initially loading the model, but only if there are
+     * no settings on the URL.
+     *  - 'all' will load filters, sorts, pageSize, and viewName
+     *  - 'noFilters' will load sorts and pageSize
+     *  - 'none' disables this feature
+     *
+     * Important: If you are using this flag you must ensure your grid id is stable and unique. It must be stable
+     * between page loads/visits, or we won't be able to fetch the settings. It must be unique, or we'll override other
+     * grid models.
      */
-    useSavedSettings?: boolean;
+    readonly useSavedSettings?: SavedSettings;
 
     /**
      * An array of [Filter.IFilter](https://labkey.github.io/labkey-api-js/interfaces/Filter.IFilter.html)
@@ -505,7 +521,7 @@ export class QueryModel {
         this.totalCountError = undefined;
         this.totalCountLoadingState = LoadingState.INITIALIZED;
         this.urlPrefix = queryConfig.urlPrefix ?? 'query'; // match Data Region defaults
-        this.useSavedSettings = queryConfig.useSavedSettings ?? false;
+        this.useSavedSettings = queryConfig.useSavedSettings ?? SavedSettings.none;
         this.charts = undefined;
         this.chartsError = undefined;
         this.chartsLoadingState = LoadingState.INITIALIZED;

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -281,13 +281,10 @@ export function withQueryModels<Props>(
             // e.g. actions.loadNextPage(model.id) would not work.
             let model = new QueryModel({ id, ...queryConfigs[id] });
             const hasQueryParamSettings = locationHasQueryParamSettings(model.urlPrefix, searchParams);
-            console.log('initModels', id, model.bindURL, model.useSavedSettings);
 
             if (model.bindURL && hasQueryParamSettings) {
-                console.log('using query param settings');
                 model = model.mutate(model.attributesForURLQueryParams(searchParams, true));
             } else if (model.useSavedSettings !== SavedSettings.none) {
-                console.log('using saved settings', model.id);
                 if (!model.containerPath) {
                     console.error('A model.containerPath is required when useSavedSettings is true: ' + model.id);
                 } else {

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -26,6 +26,7 @@ import {
     QueryConfig,
     QueryModel,
     removeSettingsFromLocalStorage,
+    SavedSettings,
     saveSettingsToLocalStorage,
 } from './QueryModel';
 
@@ -247,16 +248,17 @@ function applySavedSettings(id: string, model: QueryModel): QueryModel {
     const settings = getSettingsFromLocalStorage(id, model.containerPath);
     if (settings !== undefined) {
         const { filterArray, maxRows, sorts, viewName } = settings;
-        let schemaQuery = model.schemaQuery;
-        if (viewName !== undefined) {
-            schemaQuery = new SchemaQuery(model.schemaName, model.queryName, viewName);
+        const mutations: Partial<Draft<QueryModel>> = { maxRows, sorts };
+
+        if (model.useSavedSettings === SavedSettings.all) {
+            mutations.filterArray = filterArray;
+
+            if (viewName !== undefined) {
+                mutations.schemaQuery = new SchemaQuery(model.schemaName, model.queryName, viewName);
+            }
         }
-        return model.mutate({
-            filterArray,
-            maxRows,
-            schemaQuery,
-            sorts,
-        });
+
+        return model.mutate(mutations as Partial<QueryModel>);
     }
     return model;
 }
@@ -279,10 +281,13 @@ export function withQueryModels<Props>(
             // e.g. actions.loadNextPage(model.id) would not work.
             let model = new QueryModel({ id, ...queryConfigs[id] });
             const hasQueryParamSettings = locationHasQueryParamSettings(model.urlPrefix, searchParams);
+            console.log('initModels', id, model.bindURL, model.useSavedSettings);
 
             if (model.bindURL && hasQueryParamSettings) {
+                console.log('using query param settings');
                 model = model.mutate(model.attributesForURLQueryParams(searchParams, true));
-            } else if (model.useSavedSettings) {
+            } else if (model.useSavedSettings !== SavedSettings.none) {
+                console.log('using saved settings', model.id);
                 if (!model.containerPath) {
                     console.error('A model.containerPath is required when useSavedSettings is true: ' + model.id);
                 } else {
@@ -1288,7 +1293,7 @@ export function withQueryModels<Props>(
         autoLoad: false,
         modelLoader: DefaultQueryModelLoader,
         queryConfigs: {},
-        useSavedSettings: false,
+        useSavedSettings: SavedSettings.none,
     };
 
     return withSearchParams(ComponentWithQueryModels) as ComponentType<Props & MakeQueryModels>;


### PR DESCRIPTION
#### Rationale
This PR changes useSavedSettings from a boolean to an enum so we can use non-filter settings in some situations. See [Issue 52895](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52895) for context.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1796
- https://github.com/LabKey/labkey-ui-premium/pull/758
- https://github.com/LabKey/platform/pull/6693
- https://github.com/LabKey/limsModules/pull/1425

#### Changes
- QueryModel/QueryConfig: Change useSavedSettings to SavedSettings enum
