### PR TITLE
Issue 52925: App export to csv/tsv ignores filter with column containing double quote

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.0",
+  "version": "6.44.1-fb-issue52925.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.44.0",
+      "version": "6.44.1-fb-issue52925.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.1-fb-issue52925.1",
+  "version": "6.43.1-fb-issue52925.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.43.1-fb-issue52925.1",
+      "version": "6.43.1-fb-issue52925.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.0",
+  "version": "6.43.1-fb-issue52925.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.43.0",
+      "version": "6.43.1-fb-issue52925.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.2",
+  "version": "6.44.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.44.2",
+      "version": "6.44.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.2",
+  "version": "6.43.3-fb-issue52925.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.43.2",
+      "version": "6.43.3-fb-issue52925.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.0",
+  "version": "6.43.1-fb-issue52925.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.1-fb-issue52925.1",
+  "version": "6.43.1-fb-issue52925.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X May 2025
+- Issue 52925: App export to csv/tsv ignores filter with column containing double quote
+  - Add `encodeFormDataQuote` util to encode `"` and its encoded form `%22`
+  - Encode form params for exportRows actions
+
 ### version 6.43.0
 *Released*: 22 May 2025
 - AppURL

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -19,6 +19,7 @@ import { applyURL, AppURL, buildURL, spliceURL } from './internal/url/AppURL';
 import { AppLink } from './internal/url/AppLink';
 import { useAppNavigate } from './internal/url/useAppNavigate';
 import { hasParameter, imageURL, toggleParameter } from './internal/url/ActionURL';
+import { encodeFormDataQuote } from './internal/url/utils';
 import { Container } from './internal/components/base/models/Container';
 import { hasAllPermissions, hasAnyPermissions, hasPermissions, User } from './internal/components/base/models/User';
 import { GridColumn } from './internal/components/base/models/GridColumn';
@@ -1219,6 +1220,7 @@ export {
     replaceParameters,
     hasParameter,
     toggleParameter,
+    encodeFormDataQuote,
     applyURL,
     buildURL,
     imageURL,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -267,6 +267,7 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
     Object.keys(exportParams).forEach(key => {
         const value = exportParams[key];
 
+        // Issue 52925: App export to csv/tsv ignores filter with column containing double quote
         if (value instanceof Array) {
             value.forEach(arrayValue => form.append(encodeFormDataQuote(key), arrayValue));
         } else {

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -47,6 +47,7 @@ import { ViewInfo } from './ViewInfo';
 import { createGridModelId } from './models';
 import { SAMPLES_KEY } from './app/constants';
 import { SCHEMAS } from './schemas';
+import { encodeFormDataQuote } from './url/utils';
 
 export function selectAll(
     key: string,
@@ -267,9 +268,9 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
         const value = exportParams[key];
 
         if (value instanceof Array) {
-            value.forEach(arrayValue => form.append(key, arrayValue));
+            value.forEach(arrayValue => form.append(encodeFormDataQuote(key), arrayValue));
         } else {
-            form.append(key, value);
+            form.append(encodeFormDataQuote(key), value);
         }
     });
 
@@ -295,6 +296,7 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
         throw new Error('Unknown export type: ' + type);
     }
 
+    form.append("formDataEncoded", "true");
     Ajax.request({
         url: buildURL(controller, action, undefined, { container: containerPath, returnUrl: false }),
         method: 'POST',

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -296,7 +296,7 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
         throw new Error('Unknown export type: ' + type);
     }
 
-    form.append("formDataEncoded", "true");
+    form.append('formDataEncoded', 'true');
     Ajax.request({
         url: buildURL(controller, action, undefined, { container: containerPath, returnUrl: false }),
         method: 'POST',

--- a/packages/components/src/internal/url/utils.test.ts
+++ b/packages/components/src/internal/url/utils.test.ts
@@ -1,0 +1,26 @@
+import { encodeFormDataQuote } from './utils';
+
+describe('encodeFormDataQuote', () => {
+    test('empty', () => {
+        expect(encodeFormDataQuote(null)).toBeNull();
+        expect(encodeFormDataQuote(undefined)).toBeUndefined();
+        expect(encodeFormDataQuote('')).toBe('');
+    });
+
+    test('no relevant special character', () => {
+        expect(encodeFormDataQuote('a')).toBe('a')
+        expect(encodeFormDataQuote('$')).toBe('$');
+        expect(encodeFormDataQuote('%')).toBe('%');
+        expect(encodeFormDataQuote('%2522')).toBe('%2522');
+    });
+
+    test('encoded', () => {
+        expect(encodeFormDataQuote('"')).toBe('%22')
+        expect(encodeFormDataQuote('""')).toBe('%22%22');
+        expect(encodeFormDataQuote('"22')).toBe('%2222');
+        expect(encodeFormDataQuote('"a"')).toBe('%22a%22');
+        expect(encodeFormDataQuote('a%22')).toBe('a%2522');
+        expect(encodeFormDataQuote('"a%22')).toBe('%22a%2522');
+        expect(encodeFormDataQuote('"a%222')).toBe('%22a%25222');
+    });
+});

--- a/packages/components/src/internal/url/utils.ts
+++ b/packages/components/src/internal/url/utils.ts
@@ -6,8 +6,10 @@ export function encodeListResolverPath(containerPath: string): string {
     return ['$CPS', containerPath?.toLowerCase(), '$CPE'].join('');
 }
 
+// Issue 52925, 52119
 export function encodeFormDataQuote(key: string): string {
     if (!key)
         return key;
+    // need to replace %22, before replacing " to %22
     return key?.replaceAll('%22', '%2522').replaceAll('"', '%22');
 }

--- a/packages/components/src/internal/url/utils.ts
+++ b/packages/components/src/internal/url/utils.ts
@@ -5,3 +5,7 @@ export function decodeListResolverPath(resolverPath: string): string {
 export function encodeListResolverPath(containerPath: string): string {
     return ['$CPS', containerPath?.toLowerCase(), '$CPE'].join('');
 }
+
+export function encodeFormDataQuote(key: string): string {
+    return key?.replaceAll('%22', '%2522').replaceAll('"', '%22');
+}

--- a/packages/components/src/internal/url/utils.ts
+++ b/packages/components/src/internal/url/utils.ts
@@ -7,5 +7,7 @@ export function encodeListResolverPath(containerPath: string): string {
 }
 
 export function encodeFormDataQuote(key: string): string {
+    if (!key)
+        return key;
     return key?.replaceAll('%22', '%2522').replaceAll('"', '%22');
 }


### PR DESCRIPTION
#### Rationale
Issue [52925](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52925)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1797
- https://github.com/LabKey/labkey-ui-premium/pull/759
- https://github.com/LabKey/platform/pull/6694
- https://github.com/LabKey/limsModules/pull/1426

#### Changes
  - Add `encodeFormDataQuote` util to encode `"` and its encoded form `%22`
  - Encode form params for exportRows actions
