### PR TITLE
Issue 53164: LKS new assay design page gives JS error if no specialty assay providers available for server

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.1",
+  "version": "6.44.1-exceptionsCAN256.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.44.1",
+      "version": "6.44.1-exceptionsCAN256.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.1-exceptionsCAN256.0",
+  "version": "6.44.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.44.1-exceptionsCAN256.0",
+      "version": "6.44.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.3",
+  "version": "6.43.3-exceptionsCAN256.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.43.3",
+      "version": "6.43.3-exceptionsCAN256.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.0",
+  "version": "6.44.0-exceptionsCAN256.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.44.0",
+      "version": "6.44.0-exceptionsCAN256.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.43.3",
+  "version": "6.43.3-exceptionsCAN256.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.0",
+  "version": "6.44.0-exceptionsCAN256.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.1-exceptionsCAN256.0",
+  "version": "6.44.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.44.1",
+  "version": "6.44.1-exceptionsCAN256.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 53164: AssayPicker.tsx gives JS error if no specialty assay providers available for server
+
 ### version 6.43.3
 *Released*: 26 May 2025
 - Migrate `isSetEqual` to `@labkey/components`. Extend with additional support for deep comparison.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.44.2
+*Released*: 28 May 2025
 - Issue 53164: AssayPicker.tsx gives JS error if no specialty assay providers available for server
 
 ### version 6.44.1

--- a/packages/components/src/internal/components/assay/AssayPicker.test.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.test.tsx
@@ -16,16 +16,18 @@ const load = (): Promise<any> => {
 
 const loadGeneralOnly = (): Promise<any> => {
     return Promise.resolve({
-        "locations" : {
-            "ea7c355b-0b2e-1039-8359-225b19643884" : "Current Folder (BiologicsAssayTest Project)",
-            "ce3fb429-92f9-1038-8523-225b19648208" : "Shared Folder"
+        locations: {
+            'ea7c355b-0b2e-1039-8359-225b19643884': 'Current Folder (BiologicsAssayTest Project)',
+            'ce3fb429-92f9-1038-8523-225b19648208': 'Shared Folder',
         },
-        "providers" : [ {
-            "name" : "General",
-            "description" : "Imports data from simple Excel or TSV files.",
-            "fileTypes" : [ ".tsv", ".csv", ".xls", ".xlsx", ".txt", ".fna", ".fasta" ]
-        } ],
-        "defaultLocation" : "ea7c355b-0b2e-1039-8359-225b19643884"
+        providers: [
+            {
+                name: 'General',
+                description: 'Imports data from simple Excel or TSV files.',
+                fileTypes: ['.tsv', '.csv', '.xls', '.xlsx', '.txt', '.fna', '.fasta'],
+            },
+        ],
+        defaultLocation: 'ea7c355b-0b2e-1039-8359-225b19643884',
     });
 };
 

--- a/packages/components/src/internal/components/assay/AssayPicker.test.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.test.tsx
@@ -14,6 +14,21 @@ const load = (): Promise<any> => {
     return Promise.resolve(getAssayDesignSectionOptions);
 };
 
+const loadGeneralOnly = (): Promise<any> => {
+    return Promise.resolve({
+        "locations" : {
+            "ea7c355b-0b2e-1039-8359-225b19643884" : "Current Folder (BiologicsAssayTest Project)",
+            "ce3fb429-92f9-1038-8523-225b19648208" : "Shared Folder"
+        },
+        "providers" : [ {
+            "name" : "General",
+            "description" : "Imports data from simple Excel or TSV files.",
+            "fileTypes" : [ ".tsv", ".csv", ".xls", ".xlsx", ".txt", ".fna", ".fasta" ]
+        } ],
+        "defaultLocation" : "ea7c355b-0b2e-1039-8359-225b19643884"
+    });
+};
+
 describe('AssayPicker', () => {
     test('AssayPicker', async () => {
         renderWithAppContext(
@@ -42,6 +57,31 @@ describe('AssayPicker', () => {
                 defaultTab={AssayPickerTabs.SPECIALTY_ASSAY_TAB}
                 hasPremium={false}
                 loadOptions={load}
+                onChange={jest.fn()}
+                showContainerSelect={false}
+                showImport={false}
+            />
+        );
+
+        await waitFor(() => {
+            expect(document.querySelectorAll('.nav-tabs li')).toHaveLength(2);
+        });
+
+        // Verify only two tabs and specialty tab selected
+        expect(document.querySelectorAll('.nav-tabs li')).toHaveLength(2);
+        expect(document.querySelectorAll('.nav-tabs li')[0].textContent).toEqual('Standard Assay');
+        expect(document.querySelectorAll('.nav-tabs li')[1].textContent).toEqual('Specialty Assays');
+        expect(document.querySelectorAll('.nav-tabs li')[1].getAttribute('class')).toEqual('active');
+        expect(document.querySelectorAll('#assay-type-select-container')).toHaveLength(0);
+        expect(document.querySelectorAll('.alert-info')).toHaveLength(1);
+    });
+
+    test('AssayPicker General provider only', async () => {
+        renderWithAppContext(
+            <AssayPicker
+                defaultTab={AssayPickerTabs.SPECIALTY_ASSAY_TAB}
+                hasPremium={false}
+                loadOptions={loadGeneralOnly}
                 onChange={jest.fn()}
                 showContainerSelect={false}
                 showImport={false}

--- a/packages/components/src/internal/components/assay/AssayPicker.tsx
+++ b/packages/components/src/internal/components/assay/AssayPicker.tsx
@@ -140,7 +140,7 @@ export const AssayPicker: FC<AssayPickerProps> = memo(props => {
             if (tab_ === AssayPickerTabs.STANDARD_ASSAY_TAB) {
                 selectProvider(GENERAL_ASSAY_PROVIDER_NAME);
             } else if (tab_ === AssayPickerTabs.SPECIALTY_ASSAY_TAB) {
-                if (providers.length > 0 && (!provider || provider.name === GENERAL_ASSAY_PROVIDER_NAME)) {
+                if (providers.length > 1 && (!provider || provider.name === GENERAL_ASSAY_PROVIDER_NAME)) {
                     selectProvider(providers.filter(p => p.name !== GENERAL_ASSAY_PROVIDER_NAME)?.[0].name);
                 }
             }


### PR DESCRIPTION
#### Rationale
Issue [53164](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53164): LKS new assay design page gives JS error if no specialty assay providers available for server

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1802
- https://github.com/LabKey/platform/pull/6702
- https://github.com/LabKey/limsModules/pull/1432

#### Changes
- AssayPicker.tsx to check for available providers before trying to select one in specialty assay tab
