### PR TITLE
Misc assay issues fixes for 25.7

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.49.0",
+  "version": "6.49.0-cory257fixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.49.0",
+      "version": "6.49.0-cory257fixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.49.1",
+  "version": "6.49.1-cory257fixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.49.1",
+      "version": "6.49.1-cory257fixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.49.1-cory257fixes.0",
+  "version": "6.49.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.49.1-cory257fixes.0",
+      "version": "6.49.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.49.1",
+  "version": "6.49.1-cory257fixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.49.1-cory257fixes.0",
+  "version": "6.49.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.49.0",
+  "version": "6.49.0-cory257fixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.49.2
+*Released*: 17 June 2025
 - GitHub Issue 748: "View Assay Results for Selected" gives error when no rows have sample IDs
 
 ### version 6.49.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue 748: "View Assay Results for Selected" gives error when no rows have sample IDs
+
 ### version 6.49.0
 *Released*: 11 June 2025
 - Remove SOURCE_TYPE_KEY constant

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -445,6 +445,12 @@ export async function createSessionAssayRunSummaryQuery(sampleIds: number[]): Pr
         assayRunsQuery = 'AssayRunsPerSampleChildFolder';
     }
 
+    // GitHub Issue 748: need to account for the case with no sampleIds
+    let whereClause = 'WHERE RowId IN (' + sampleIds.join(',') + ')\n';
+    if (sampleIds.length === 0) {
+        whereClause = 'WHERE 1 = 0\n'; // add where clause that will always result in zero rows
+    }
+
     return await selectRowsDeprecated({
         saveInSession: true,
         schemaName: 'exp',
@@ -453,9 +459,7 @@ export async function createSessionAssayRunSummaryQuery(sampleIds: number[]): Pr
             "FROM (SELECT RowId, SampleID, SampleType, Assay || ' Run Count' AS Assay FROM " +
             assayRunsQuery +
             ') X\n' +
-            'WHERE RowId IN (' +
-            sampleIds.join(',') +
-            ')\n' +
+            whereClause +
             'GROUP BY RowId, SampleID, SampleType, Assay\n' +
             'PIVOT RunCount BY Assay',
         maxRows: 0, // we don't need any data back here, we just need to get the temp session schema/query


### PR DESCRIPTION
#### Rationale
#[748](https://github.com/LabKey/internal-issues/issues/643): Samples->View Assay Results for Selected gives error when no rows have sample IDs

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1810
- https://github.com/LabKey/labkey-ui-premium/pull/774
- https://github.com/LabKey/limsModules/pull/1470
- https://github.com/LabKey/platform/pull/6760
- https://github.com/LabKey/testAutomation/pull/2497

#### Changes
- "View Assay Results for Selected" to account for no sampleIds in query filter
