### PR TITLE
Improve ExecuteSql endpoint wrapper

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.1-fb-execute-sql.0",
+  "version": "6.51.1-fb-execute-sql.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.51.1-fb-execute-sql.0",
+      "version": "6.51.1-fb-execute-sql.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.0",
+  "version": "6.51.1-fb-execute-sql.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.51.0",
+      "version": "6.51.1-fb-execute-sql.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.41.3-fb-execute-sql.0",
+        "@labkey/api": "1.42.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.41.3-fb-execute-sql.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.41.3-fb-execute-sql.0.tgz",
-      "integrity": "sha512-RGGPZPY+Xge+qaxvF6BvDxNZ72RVb9n4kGPH5YqYig2zRJN8zE551xMF/FEQ3Qvs99RoXW1uvuZxQFJMwDIpOQ==",
+      "version": "1.42.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.42.0.tgz",
+      "integrity": "sha512-fh65cogl+8HNe9+3OHzI6ygkaa+ARJbKyUopguy3NqtOWIAXAA21GNxayRoeVf9m1n2Kpubqk4QS2z/+WCzf8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.41.2",
+        "@labkey/api": "1.41.3-fb-execute-sql.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.41.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.41.2.tgz",
-      "integrity": "sha512-ninfc/+Sj5+8Zla9bY2j/4fSy41OS27YAHKtDFPnu52QkC8WsOYh3JFI5PkU6Rn+xIp0In4P6d5Qn/yluJRC/w==",
+      "version": "1.41.3-fb-execute-sql.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.41.3-fb-execute-sql.0.tgz",
+      "integrity": "sha512-RGGPZPY+Xge+qaxvF6BvDxNZ72RVb9n4kGPH5YqYig2zRJN8zE551xMF/FEQ3Qvs99RoXW1uvuZxQFJMwDIpOQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.1-fb-execute-sql.1",
+  "version": "6.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.51.1-fb-execute-sql.1",
+      "version": "6.52.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.41.2",
+    "@labkey/api": "1.41.3-fb-execute-sql.0",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.1-fb-execute-sql.1",
+  "version": "6.52.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.1-fb-execute-sql.0",
+  "version": "6.51.1-fb-execute-sql.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.0",
+  "version": "6.51.1-fb-execute-sql.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.41.3-fb-execute-sql.0",
+    "@labkey/api": "1.42.0",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.3.0",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.52.0
+*Released*: 24 June 2025
+- Improve ExecuteSql endpoint wrapper. See #1813.
+
 ### version 6.51.0
 *Released*: 23 June 2025
 - SampleAliquotViewSelector, GridAliquotViewSelector: Fix props types

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -245,6 +245,7 @@ import {
     NOT_IN_EXP_DESCENDANTS_OF_FILTER_TYPE,
     registerFilterType,
 } from './internal/query/filter';
+import { executeSql } from './internal/query/executeSql';
 import { getSelectedRows, selectRows } from './internal/query/selectRows';
 import { flattenBrowseDataTreeResponse, loadReports } from './internal/query/reports';
 import {
@@ -1304,6 +1305,7 @@ export {
     EntityMoveModal,
     EntityParentType,
     EntityTypeOption,
+    executeSql,
     ExpandableContainer,
     ExpandableFilterToggle,
     EXPERIMENT_AUDIT_EVENT,
@@ -1967,6 +1969,13 @@ export type { UseTimeout } from './internal/hooks';
 export type { ModalProps } from './internal/Modal';
 export type { TriggerType } from './internal/OverlayTrigger';
 export type { IImportData, ISelectRowsResult } from './internal/query/api';
+export type {
+    ExecuteSqlOptions,
+    ExecuteSqlResponse,
+    ExecuteSqlResponseBase,
+    ExecuteSqlResponseWithoutSession,
+    ExecuteSqlResponseWithSession,
+} from './internal/query/executeSql';
 export type { Row, RowValue, SelectRowsOptions, SelectRowsResponse } from './internal/query/selectRows';
 export type { IAttachment } from './internal/renderers/AttachmentCard';
 export type { RequestHandler, RequestOptions } from './internal/request';

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -38,7 +38,7 @@ import { handleRequestFailure } from '../../request';
 
 import { getExcludedDataTypeNames } from '../entities/actions';
 
-import { getQueryDetails, selectRowsDeprecated } from '../../query/api';
+import { getQueryDetails } from '../../query/api';
 
 import { selectRows } from '../../query/selectRows';
 
@@ -104,6 +104,7 @@ import {
 } from './models';
 import { createFormInputId, createFormInputName, getIndexFromId, getNameFromId } from './utils';
 import { DomainPropertiesAPIWrapper } from './APIWrapper';
+import { executeSql } from '../../query/executeSql';
 
 let sharedCache = Map<string, Promise<any>>();
 
@@ -248,8 +249,8 @@ export function getRequiredParentTypes(
             success: response => {
                 const domainDetails: DomainDetails = DomainDetails.create(Map(response));
                 const importAliases: Record<string, IImportAlias> = domainDetails.options?.get('importAliases');
-                const sampleTypes = [],
-                    dataClasses = [];
+                const dataClasses = [],
+                    sampleTypes = [];
                 if (importAliases && Object.keys(importAliases).length > 0) {
                     Object.values(importAliases).forEach(alias => {
                         if (alias.required) {
@@ -317,11 +318,11 @@ export function getExcludedSchemaQueryNames(schemaName: string, queryContainerPa
     switch (schemaName) {
         case 'assay':
             return getExcludedDataTypeNames(SCHEMAS.ASSAY_TABLES.ASSAY_LIST, 'AssayDesign', queryContainerPath);
-        case 'samples':
-        case 'exp.materials':
-            return getExcludedDataTypeNames(SCHEMAS.EXP_TABLES.SAMPLE_SETS, 'SampleType', queryContainerPath);
         case 'exp.data':
             return getExcludedDataTypeNames(SCHEMAS.EXP_TABLES.DATA_CLASSES, 'DataClass', queryContainerPath);
+        case 'exp.materials':
+        case 'samples':
+            return getExcludedDataTypeNames(SCHEMAS.EXP_TABLES.SAMPLE_SETS, 'SampleType', queryContainerPath);
     }
     return new Promise(resolve => {
         resolve([]);
@@ -423,21 +424,21 @@ export function getMaxPhiLevel(containerPath?: string): Promise<string> {
 export function getCastStatement(key: string, type: string): string {
     const quotedKey = key.replace(/"/g, '""'); // Issue 52608: escape double quotes in key
     switch (type) {
+        case 'BOOLEAN':
+            return `CAST(TRUE AS BOOLEAN) AS "${quotedKey}"`;
+        case 'DATE':
+            return `CAST(CURDATE() AS DATE) AS "${quotedKey}"`;
+        case 'DATETIME':
+        case 'VISITDATE':
+            return `CAST(CURDATE() AS TIMESTAMP) AS "${quotedKey}"`;
+        case 'DECIMAL (FLOATING POINT)':
+        case 'DOUBLE':
+        case 'VISITID':
+            return `CAST(1.1 AS DOUBLE) AS "${quotedKey}"`;
         case 'INTEGER':
         case 'SAMPLE':
         case 'USERS':
             return `CAST(1 AS INTEGER) AS "${quotedKey}"`;
-        case 'DOUBLE':
-        case 'DECIMAL (FLOATING POINT)':
-        case 'VISITID':
-            return `CAST(1.1 AS DOUBLE) AS "${quotedKey}"`;
-        case 'BOOLEAN':
-            return `CAST(TRUE AS BOOLEAN) AS "${quotedKey}"`;
-        case 'DATETIME':
-        case 'VISITDATE':
-            return `CAST(CURDATE() AS TIMESTAMP) AS "${quotedKey}"`;
-        case 'DATE':
-            return `CAST(CURDATE() AS DATE) AS "${quotedKey}"`;
         case 'TIME':
             return `CAST('13:00' AS TIME) AS "${quotedKey}"`;
         default:
@@ -461,14 +462,12 @@ export async function parseCalculatedColumn(
             expression +
             '\nFROM (SELECT ' +
             Object.keys(columnMap)
-                .map(key => {
-                    return getCastStatement(key, columnMap[key]);
-                })
+                .map(key => getCastStatement(key, columnMap[key]))
                 .join(',\n') +
             ') AS x' +
             ' WHERE 1=0';
 
-        await selectRowsDeprecated({
+        await executeSql({
             schemaName: 'core',
             sql,
             includeTotalCount: false,
@@ -811,17 +810,8 @@ export function updateDomainField(domain: DomainDesign, change: IFieldChange): D
         let newField = isSelection ? field : (field.set('updatedField', true) as DomainField);
 
         switch (type) {
-            case DOMAIN_FIELD_TYPE:
-                newField = updateDataType(newField, change.value);
-                break;
             case DOMAIN_FIELD_LOOKUP_CONTAINER:
                 newField = updateLookup(newField, change.value);
-                break;
-            case DOMAIN_FIELD_LOOKUP_SCHEMA:
-                newField = updateLookup(newField, newField.lookupContainer, change.value);
-                break;
-            case DOMAIN_FIELD_SAMPLE_TYPE:
-                newField = updateSampleField(newField, change.value);
                 break;
             case DOMAIN_FIELD_LOOKUP_QUERY:
                 const { queryName, rangeURI } = decodeLookup(change.value);
@@ -833,15 +823,23 @@ export function updateDomainField(domain: DomainDesign, change: IFieldChange): D
                     lookupIsValid: true,
                 }) as DomainField;
                 break;
+            case DOMAIN_FIELD_LOOKUP_SCHEMA:
+                newField = updateLookup(newField, newField.lookupContainer, change.value);
+                break;
             case DOMAIN_FIELD_ONTOLOGY_PRINCIPAL_CONCEPT:
                 const concept = change.value as ConceptModel;
                 newField = newField.merge({ principalConceptCode: concept?.code }) as DomainField;
+                break;
+            case DOMAIN_FIELD_SAMPLE_TYPE:
+                newField = updateSampleField(newField, change.value);
+                break;
+            case DOMAIN_FIELD_TYPE:
+                newField = updateDataType(newField, change.value);
                 break;
             case DOMAIN_FIELD_NAME:
                 // Note: it's important to update filter criteria names, because if the field we're updating is new
                 // we rely on the name when saving. For existing fields we can rely on propertyId.
                 newField = updateFilterCriteriaNames(newField, change.value);
-            // eslint-disable-next-line no-fallthrough -- Intentionally falling through here
             default:
                 newField = newField.set(type, change.value) as DomainField;
                 break;
@@ -1357,12 +1355,14 @@ export function getDomainNamePreviews(
     });
 }
 
+type TextChoiceInUseValues = Record<string, { count: number; locked: boolean }>;
+
 export async function getTextChoiceInUseValues(
     field: DomainField,
     schemaName: string,
     queryName: string,
     lockedSqlFragment: string
-): Promise<Record<string, any>> {
+): Promise<TextChoiceInUseValues> {
     const containerFilter = Query.ContainerFilter.allInProjectPlusShared; // to account for a shared domain at project or /Shared
     const fieldName = field.original?.name ?? field.name;
 
@@ -1376,7 +1376,7 @@ export async function getTextChoiceInUseValues(
             schemaQuery: new SchemaQuery(schemaName, queryName),
         });
 
-        const values = {};
+        const values: TextChoiceInUseValues = {};
         result.rows.forEach(row => {
             const value = row[fieldName]?.value;
             if (isValidTextChoiceValue(value)) {
@@ -1391,33 +1391,25 @@ export async function getTextChoiceInUseValues(
         return values;
     }
 
-    return new Promise((resolve, reject) => {
-        Query.executeSql({
-            containerFilter,
-            schemaName,
-            sql: `SELECT "${fieldName}", ${lockedSqlFragment} AS IsLocked, COUNT(*) AS RowCount FROM "${queryName}" WHERE "${fieldName}" IS NOT NULL GROUP BY "${fieldName}"`,
-            success: response => {
-                const values = response.rows
-                    .filter(row => isValidTextChoiceValue(row[fieldName]))
-                    .reduce((prev, current) => {
-                        prev[current[fieldName]] = {
-                            count: current['RowCount'],
-                            locked: current['IsLocked'] === 1,
-                        };
-                        return prev;
-                    }, {});
-
-                resolve(values);
-            },
-            failure: error => {
-                console.error('Error fetching distinct values for the text field: ', error);
-                reject(error);
-            },
-        });
+    const response = await executeSql({
+        containerFilter,
+        schemaName,
+        sql: `SELECT "${fieldName}", ${lockedSqlFragment} AS IsLocked, COUNT(*) AS RowCount FROM "${queryName}" WHERE "${fieldName}" IS NOT NULL GROUP BY "${fieldName}"`,
     });
+
+    return response.rows
+        .filter(row => isValidTextChoiceValue(row[fieldName].value))
+        .reduce<TextChoiceInUseValues>((prev, row) => {
+            const value = row[fieldName].value;
+            prev[value] = {
+                count: row.RowCount.value,
+                locked: row.IsLocked.value === 1,
+            };
+            return prev;
+        }, {});
 }
 
-export function getGenId(rowId: number, kindName: 'SampleSet' | 'DataClass', containerPath?: string): Promise<number> {
+export function getGenId(rowId: number, kindName: 'DataClass' | 'SampleSet', containerPath?: string): Promise<number> {
     return new Promise((resolve, reject) => {
         Experiment.getEntitySequence({
             containerPath,
@@ -1440,7 +1432,7 @@ export function getGenId(rowId: number, kindName: 'SampleSet' | 'DataClass', con
 
 export function setGenId(
     rowId: number,
-    kindName: 'SampleSet' | 'DataClass',
+    kindName: 'DataClass' | 'SampleSet',
     genId: number,
     containerPath?: string
 ): Promise<any> {

--- a/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataclasses/actions.ts
@@ -103,6 +103,6 @@ function fetchDataClassProperties(rowId: number, containerPath?: string): Promis
     });
 }
 
-export function deleteDataClass(rowId: number, containerPath?: string, auditUserComment?: string): Promise<any> {
+export function deleteDataClass(rowId: number, containerPath?: string, auditUserComment?: string): Promise<void> {
     return deleteEntityType('deleteDataClass', rowId, containerPath, auditUserComment);
 }

--- a/packages/components/src/internal/components/domainproperties/dataset/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/actions.ts
@@ -36,38 +36,28 @@ import {
 } from './constants';
 import { DatasetModel } from './models';
 import { StudyProperties } from './utils';
+import { executeSql } from '../../../query/executeSql';
 
-export function fetchCategories(): Promise<SelectInputOption[]> {
-    return new Promise((resolve, reject) => {
-        selectRowsDeprecated({
-            saveInSession: true,
-            schemaName: 'study',
-            sql: 'SELECT DISTINCT CategoryId.Label, CategoryId.RowId FROM DataSets',
-        })
-            .then(data => {
-                const models = fromJS(data.models[data.key]);
-                const categories = [];
-
-                data.orderedModels[data.key].forEach(modelKey => {
-                    const row = models.get(modelKey);
-                    const value = row.getIn(['Label', 'value']);
-                    const label = row.getIn(['Label', 'value']);
-
-                    categories.push({ value, label });
-                });
-
-                resolve(categories);
-            })
-            .catch(response => {
-                reject(response.message);
-            });
+export async function fetchCategories(): Promise<SelectInputOption[]> {
+    // TODO: Does this need to be using executeSql? Would selectRows be able to accomplish the same thing?
+    const result = await executeSql({
+        saveInSession: true,
+        schemaName: 'study',
+        sql: 'SELECT DISTINCT CategoryId.Label, CategoryId.RowId FROM DataSets',
     });
+
+    return result.rows.reduce<SelectInputOption[]>((option, row) => {
+        const label = row.Label.value;
+        // TODO: Seems odd that we are fetching the rowId but not using it as the value
+        option.push({ label, value: label });
+        return option;
+    }, []);
 }
 
 export function getVisitDateColumns(domain: DomainDesign): List<SelectInputOption> {
     let visitDateColumns = List<SelectInputOption>();
 
-    // date field is a built in field for a dataset for a date based study
+    // date field is a built-in field for a dataset for a date based study
     visitDateColumns = visitDateColumns.push({ value: 'date', label: 'date' });
 
     domain.fields.map(field => {
@@ -127,26 +117,20 @@ export function getHelpTip(fieldName: string, studyProperties: StudyProperties):
     let helpTip = '';
 
     switch (fieldName) {
-        case 'name':
-            helpTip = DATASET_NAME_TIP;
-            break;
-        case 'label':
-            helpTip = DATASET_LABEL_TIP;
-            break;
         case 'category':
             helpTip = DATASET_CATEGORY_TIP;
-            break;
-        case 'datasetId':
-            helpTip = DATASET_ID_TIP;
-            break;
-        case 'visitDateColumn':
-            helpTip = VISIT_DATE_TIP;
             break;
         case 'cohort':
             helpTip = COHORT_TIP;
             break;
-        case 'tag':
-            helpTip = TAG_TIP;
+        case 'dataRowUniqueness':
+            helpTip =
+                'Choose criteria for how ' +
+                studyProperties.SubjectNounPlural.toLowerCase() +
+                ' and visits/timepoints are paired with, or without, an additional data column.';
+            break;
+        case 'datasetId':
+            helpTip = DATASET_ID_TIP;
             break;
         case 'dataspace':
             helpTip =
@@ -159,11 +143,17 @@ export function getHelpTip(fieldName: string, studyProperties: StudyProperties):
                 studyProperties.SubjectNounPlural.toLowerCase() +
                 ' that are part of that study.';
             break;
-        case 'dataRowUniqueness':
-            helpTip =
-                'Choose criteria for how ' +
-                studyProperties.SubjectNounPlural.toLowerCase() +
-                ' and visits/timepoints are paired with, or without, an additional data column.';
+        case 'label':
+            helpTip = DATASET_LABEL_TIP;
+            break;
+        case 'name':
+            helpTip = DATASET_NAME_TIP;
+            break;
+        case 'tag':
+            helpTip = TAG_TIP;
+            break;
+        case 'visitDateColumn':
+            helpTip = VISIT_DATE_TIP;
             break;
     }
     return helpTip;
@@ -173,7 +163,6 @@ function getDatasetProperties(datasetId?: number): Promise<DatasetModel> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL('study', 'getDataset.api'),
-            method: 'GET',
             params: { datasetId },
             success: Utils.getCallbackWrapper(data => {
                 resolve(DatasetModel.create(data, undefined));

--- a/packages/components/src/internal/components/domainproperties/dataset/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/actions.ts
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ActionURL, Domain } from '@labkey/api';
 
-import { ActionURL, Ajax, Domain, Utils } from '@labkey/api';
-
-import { fromJS, List } from 'immutable';
+import { List } from 'immutable';
 
 import { SelectInputOption } from '../../forms/input/SelectInput';
-import { selectRowsDeprecated } from '../../../query/api';
 import { DomainDesign } from '../models';
 
 import {
@@ -37,12 +35,14 @@ import {
 import { DatasetModel } from './models';
 import { StudyProperties } from './utils';
 import { executeSql } from '../../../query/executeSql';
+import { SCHEMAS } from '../../../schemas';
+import { selectRows } from '../../../query/selectRows';
+import { caseInsensitive } from '../../../util/utils';
+import { request } from '../../../request';
 
 export async function fetchCategories(): Promise<SelectInputOption[]> {
-    // TODO: Does this need to be using executeSql? Would selectRows be able to accomplish the same thing?
     const result = await executeSql({
-        saveInSession: true,
-        schemaName: 'study',
+        schemaName: SCHEMAS.STUDY_TABLES.SCHEMA,
         sql: 'SELECT DISTINCT CategoryId.Label, CategoryId.RowId FROM DataSets',
     });
 
@@ -87,30 +87,16 @@ export function getAdditionalKeyFields(domain: DomainDesign, timepointType: stri
     return additionalKeyFields;
 }
 
-export function fetchCohorts(): Promise<SelectInputOption[]> {
-    return new Promise((resolve, reject) => {
-        selectRowsDeprecated({
-            schemaName: 'study',
-            queryName: 'Cohort',
-        })
-            .then(data => {
-                const models = fromJS(data.models[data.key]);
-                const cohorts = [];
-
-                data.orderedModels[data.key].forEach(modelKey => {
-                    const row = models.get(modelKey);
-                    const value = row.getIn(['rowid', 'value']);
-                    const label = row.getIn(['label', 'value']);
-
-                    cohorts.push({ value, label });
-                });
-
-                resolve(cohorts);
-            })
-            .catch(response => {
-                reject(response.message);
-            });
+export async function fetchCohorts(): Promise<SelectInputOption[]> {
+    const results = await selectRows({
+        columns: ['Label', 'RowId'],
+        schemaQuery: SCHEMAS.STUDY_TABLES.COHORT,
     });
+
+    return results.rows.map(row => ({
+        label: caseInsensitive(row, 'Label').value,
+        value: caseInsensitive(row, 'RowId').value,
+    }));
 }
 
 export function getHelpTip(fieldName: string, studyProperties: StudyProperties): string {
@@ -159,19 +145,14 @@ export function getHelpTip(fieldName: string, studyProperties: StudyProperties):
     return helpTip;
 }
 
-function getDatasetProperties(datasetId?: number): Promise<DatasetModel> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: ActionURL.buildURL('study', 'getDataset.api'),
-            params: { datasetId },
-            success: Utils.getCallbackWrapper(data => {
-                resolve(DatasetModel.create(data, undefined));
-            }),
-            failure: Utils.getCallbackWrapper(error => {
-                reject(error);
-            }),
-        });
+async function getDatasetProperties(datasetId?: number): Promise<DatasetModel> {
+    const result = await request({
+        url: ActionURL.buildURL('study', 'getDataset.api'),
+        params: { datasetId },
+        errorLogMsg: 'Failed to load dataset properties',
     });
+
+    return DatasetModel.create(result);
 }
 
 export function fetchDatasetDesign(datasetId?: number): Promise<DatasetModel> {

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -3,13 +3,12 @@ import { List, Map } from 'immutable';
 
 import { getSelected, getSelectedDataDeprecated, setSnapshotSelections } from '../../actions';
 
-import { buildURL } from '../../url/AppURL';
 import { SampleOperation } from '../samples/constants';
 import { SchemaQuery } from '../../../public/SchemaQuery';
 import { getFilterForSampleOperation, isSamplesSchema } from '../samples/utils';
 import { importData, InsertOptions } from '../../query/api';
 import { caseInsensitive, generateId } from '../../util/utils';
-import { handleRequestFailure } from '../../request';
+import { request } from '../../request';
 import { EntityCreationType } from '../samples/models';
 
 import { SHARED_CONTAINER_PATH } from '../../constants';
@@ -69,10 +68,11 @@ import {
     OperationConfirmationData,
     RemappedKeyValues,
 } from './models';
+import { executeSql } from '../../query/executeSql';
 
 export async function getOperationConfirmationData(
     dataType: EntityDataType,
-    rowIds: string[] | number[],
+    rowIds: number[] | string[],
     selectionKey?: string,
     useSnapshotSelection?: boolean,
     extraParams?: Record<string, any>,
@@ -152,7 +152,7 @@ export function getContainersForPermission(permission: PermissionTypes): Promise
 export type GetDeleteConfirmationDataOptions = {
     containerPath?: string;
     dataType: EntityDataType;
-    rowIds: string[] | number[];
+    rowIds: number[] | string[];
     schemaQuery?: SchemaQuery;
     selectionKey?: string;
     useSnapshotSelection?: boolean;
@@ -195,7 +195,7 @@ export function getDeleteConfirmationData(
 }
 
 async function getAssayResultOperationConfirmationData(
-    rowIds: string[] | number[],
+    rowIds: number[] | string[],
     schemaQuery: SchemaQuery,
     containerPath?: string
 ): Promise<OperationConfirmationData> {
@@ -219,7 +219,7 @@ async function getAssayResultOperationConfirmationData(
 
 export function getSampleOperationConfirmationData(
     operation: SampleOperation,
-    rowIds?: string[] | number[],
+    rowIds?: number[] | string[],
     selectionKey?: string,
     useSnapshotSelection?: boolean,
     containerPath?: string
@@ -278,7 +278,7 @@ function resolveSampleParentTypes(
     isAliquotParent?: boolean,
     orderedRowIds?: string[]
 ): List<EntityParentType> {
-    const groups: { [key: string]: any[] } = {};
+    const groups: Record<string, any[]> = {};
     const results = [];
 
     // The transformation done here makes the entities compatible with the editable grid
@@ -493,9 +493,9 @@ export async function getChosenParentData(
         );
 
         // if we have an initial parent, we want to start with a row in the grid (entityCount = 1) otherwise we start with none
-        let totalParentValueCount = 0,
-            isParentTypeOnly = false,
-            parentEntityDataType;
+        let isParentTypeOnly = false,
+            parentEntityDataType,
+            totalParentValueCount = 0;
         chosenParents.forEach(chosenParent => {
             if (chosenParent.value !== undefined && parentSchemaNames.contains(chosenParent.schema)) {
                 totalParentValueCount += chosenParent.value.size;
@@ -530,7 +530,7 @@ export async function getChosenParentData(
 
 export async function getEntityTypeOptionsWithExclusions(
     entityDataType: EntityDataType,
-    dataTypeExclusions?: { [key: string]: number[] },
+    dataTypeExclusions?: Record<string, number[]>,
     containerPath?: string
 ): Promise<Map<string, List<IEntityTypeOption>>> {
     return getEntityTypeOptions(entityDataType, containerPath, undefined, undefined, undefined, dataTypeExclusions);
@@ -544,7 +544,7 @@ export async function getEntityTypeOptions(
     containerFilter?: Query.ContainerFilter,
     skipFolderDataExclusion?: boolean,
     requiredParentTypes?: string[],
-    dataTypeExclusions?: { [key: string]: number[] }
+    dataTypeExclusions?: Record<string, number[]>
 ): Promise<Map<string, List<IEntityTypeOption>>> {
     const { typeListingSchemaQuery, filterArray, instanceSchemaName } = entityDataType;
 
@@ -631,7 +631,7 @@ export function getEntityTypeData(
     isItemSamples: boolean
 ): Promise<Partial<EntityIdCreationModel>> {
     return new Promise((resolve, reject) => {
-        const promises: Array<Promise<any>> = [
+        const promises: Promise<any>[] = [
             getEntityTypeOptions(entityDataType),
             // get all the parent schemaQuery data
             getChosenParentData(model, parentSchemaQueries, allowParents, isItemSamples, targetQueryName),
@@ -681,20 +681,15 @@ export function deleteEntityType(
     containerPath?: string,
     auditUserComment?: string
 ): Promise<any> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL('experiment', deleteActionName + '.api', undefined, { container: containerPath }),
-            method: 'POST',
-            params: {
-                singleObjectRowId: rowId,
-                forceDelete: true,
-                userComment: auditUserComment,
-            },
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to delete entity type.'),
-        });
+    return request({
+        url: ActionURL.buildURL('experiment', deleteActionName + '.api', containerPath),
+        method: 'POST',
+        jsonData: {
+            singleObjectRowId: rowId,
+            forceDelete: true,
+            userComment: auditUserComment,
+        },
+        errorLogMsg: 'Failed to delete entity type.',
     });
 }
 
@@ -739,7 +734,7 @@ export function handleEntityFileImport(
 }
 
 export function getDataDeleteConfirmationData(
-    rowIds: string[] | number[],
+    rowIds: number[] | string[],
     selectionKey?: string,
     useSnapshotSelection?: boolean
 ): Promise<OperationConfirmationData> {
@@ -748,7 +743,7 @@ export function getDataDeleteConfirmationData(
 
 export function getDataOperationConfirmationData(
     operation: DataOperation,
-    rowIds: string[] | number[],
+    rowIds: number[] | string[],
     selectionKey?: string,
     useSnapshotSelection?: boolean
 ): Promise<OperationConfirmationData> {
@@ -768,7 +763,7 @@ export function getCrossFolderSelectionResult(
     dataRegionSelectionKey: string,
     dataType: string, // 'samples' | 'exp.data' | 'assay',
     useSnapshotSelection?: boolean,
-    rowIds?: string[] | number[],
+    rowIds?: number[] | string[],
     picklistName?: string
 ): Promise<CrossFolderSelectionResult> {
     if (!dataRegionSelectionKey && !rowIds?.length) {
@@ -777,7 +772,7 @@ export function getCrossFolderSelectionResult(
 
     return new Promise((resolve, reject) => {
         return Ajax.request({
-            url: buildURL('experiment', 'getCrossFolderDataSelection.api'),
+            url: ActionURL.buildURL('experiment', 'getCrossFolderDataSelection.api'),
             method: 'POST',
             jsonData: {
                 dataRegionSelectionKey,
@@ -806,7 +801,7 @@ export function getCrossFolderSelectionResult(
 }
 
 export type ParentIdData = {
-    parentId: string | number;
+    parentId: number | string;
     rowId: number;
 };
 
@@ -823,7 +818,7 @@ async function getParentRowIdAndDataType(
         filterArray: [Filter.create('LSID', parentIDs, Filter.Types.IN)],
     });
 
-    const filteredParentItems = {};
+    const filteredParentItems: Record<string, ParentIdData> = {};
     response.rows.forEach(row => {
         const lsid = caseInsensitive(row, 'LSID').value;
         filteredParentItems[lsid] = {
@@ -968,7 +963,7 @@ export const getOriginalParentsFromLineage = async (
 
 export function getMoveConfirmationData(
     dataType: EntityDataType,
-    rowIds: string[] | number[],
+    rowIds: number[] | string[],
     selectionKey?: string,
     useSnapshotSelection?: boolean
 ): Promise<OperationConfirmationData> {
@@ -992,7 +987,7 @@ export function getMoveConfirmationData(
     );
 }
 
-export interface MoveEntitiesOptions extends Omit<Query.MoveRowsOptions, 'rows' | 'success' | 'failure' | 'scope'> {
+export interface MoveEntitiesOptions extends Omit<Query.MoveRowsOptions, 'failure' | 'rows' | 'scope' | 'success'> {
     entityDataType: EntityDataType;
     rowIds?: number[];
 }
@@ -1039,9 +1034,7 @@ export const initParentOptionsSelects = (
     parentAliases: Map<string, IParentAlias>;
     parentOptions: IParentOption[];
 }> => {
-    const promises: Array<Promise<SelectRowsResponse>> = [];
-
-    const dataTypeExclusions = getFolderDataExclusion();
+    const promises: Promise<SelectRowsResponse>[] = [];
 
     // Get Sample Types
     if (includeSampleTypes) {
@@ -1106,7 +1099,6 @@ export const initParentOptionsSelects = (
                 let parentAliases = Map<string, IParentAlias>();
 
                 if (importAliases) {
-                    const initialAlias = importAliases;
                     Object.keys(importAliases).forEach(key => {
                         const val = importAliases[key];
                         const newId = generateId(idPrefix);
@@ -1137,12 +1129,12 @@ export const initParentOptionsSelects = (
     });
 };
 
-export const getFolderDataTypeExclusions = (
+export const getFolderDataTypeExclusions = async (
     excludedContainer?: string,
     reload?: boolean
-): Promise<{ [key: string]: number[] }> => {
+): Promise<Record<string, number[]>> => {
     if (!hasModule(SAMPLE_MANAGER_APP_PROPERTIES.moduleName)) {
-        return Promise.resolve(undefined);
+        return undefined;
     }
 
     let isCurrentContainer = true;
@@ -1153,22 +1145,16 @@ export const getFolderDataTypeExclusions = (
     }
 
     if (isCurrentContainer && !reload) {
-        return new Promise(resolve => resolve(getFolderDataExclusion()));
+        return getFolderDataExclusion();
     }
 
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: ActionURL.buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getDataTypeExclusion.api'),
-            method: 'GET',
-            params: {
-                excludedContainer,
-            },
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response['excludedDataTypes']);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to get excluded data types'),
-        });
+    const response = await request<{ excludedDataTypes: Record<string, number[]> }>({
+        url: ActionURL.buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getDataTypeExclusion.api'),
+        params: { excludedContainer },
+        errorLogMsg: 'Failed to get excluded data types',
     });
+
+    return response.excludedDataTypes;
 };
 
 export const getFolderExcludedDataTypes = (dataType: string, excludedContainer?: string): Promise<number[]> => {
@@ -1319,27 +1305,20 @@ function getDataTypeDataExistSql(dataType: FolderConfigurableDataType, lsid?: st
     return `SELECT count(*) as HasData FROM (SELECT 1 FROM ${from} ${where} limit 1)`;
 }
 
-export function isDataTypeEmpty(
+export async function isDataTypeEmpty(
     dataType: FolderConfigurableDataType,
     lsid?: string,
     rowId?: number,
     containerPath?: string
 ): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-        Query.executeSql({
-            containerPath,
-            containerFilter: Query.ContainerFilter.allInProject,
-            schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
-            sql: getDataTypeDataExistSql(dataType, lsid, rowId),
-            success: result => {
-                resolve(caseInsensitive(result.rows[0], 'HasData') === 0);
-            },
-            failure: error => {
-                console.error(error);
-                reject(error);
-            },
-        });
+    const result = await executeSql({
+        containerPath,
+        containerFilter: Query.ContainerFilter.allInProject,
+        schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
+        sql: getDataTypeDataExistSql(dataType, lsid, rowId),
     });
+
+    return caseInsensitive(result.rows[0], 'HasData')?.value === 0;
 }
 
 export function getDataTypesWithRequiredLineage(
@@ -1347,16 +1326,10 @@ export function getDataTypesWithRequiredLineage(
     sampleParent?: boolean,
     containerPath?: string
 ): Promise<{ dataClasses: string[]; sampleTypes: string[] }> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: ActionURL.buildURL('experiment', 'getDataTypesWithRequiredLineage.api', containerPath),
-            params: { parentDataTypeRowId, sampleParent },
-            scope: this,
-            success: Utils.getCallbackWrapper(data => {
-                resolve(data);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to get data types with required lineage.'),
-        });
+    return request({
+        url: ActionURL.buildURL('experiment', 'getDataTypesWithRequiredLineage.api', containerPath),
+        params: { parentDataTypeRowId, sampleParent },
+        errorLogMsg: 'Failed to get data types with required lineage.',
     });
 }
 
@@ -1419,7 +1392,7 @@ export function updateCellValuesForSampleIds(
     samplesQueryInfo?: QueryInfo,
     sampleFieldKeyPrefix?: string
 ): Promise<{
-    cellKeyChanges: { toAddOrUpdate: { [key: string]: number }; toRemove: string[] };
+    cellKeyChanges: { toAddOrUpdate: Record<string, number>; toRemove: string[] };
     editorModelChanges: Partial<EditorModel>;
 }> {
     return new Promise((resolve, reject) => {

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -675,20 +675,21 @@ export function getEntityTypeData(
     });
 }
 
-export function deleteEntityType(
+export async function deleteEntityType(
     deleteActionName: string,
     rowId: number,
     containerPath?: string,
     auditUserComment?: string
-): Promise<any> {
-    return request({
-        url: ActionURL.buildURL('experiment', deleteActionName + '.api', containerPath),
-        method: 'POST',
-        jsonData: {
+): Promise<void> {
+    // This is only currently used to POST against HTML-based actions (e.g. experiment-deleteDataClass) which are
+    // expecting parameters on the URL rather than in the request payload.
+    await request({
+        url: ActionURL.buildURL('experiment', deleteActionName + '.api', containerPath, {
             singleObjectRowId: rowId,
             forceDelete: true,
             userComment: auditUserComment,
-        },
+        }),
+        method: 'POST',
         errorLogMsg: 'Failed to delete entity type.',
     });
 }

--- a/packages/components/src/internal/components/folder/actions.ts
+++ b/packages/components/src/internal/components/folder/actions.ts
@@ -5,6 +5,7 @@ import { DataTypeEntity, EntityDataType, FolderConfigurableDataType } from '../e
 import { getContainerFilterForFolder } from '../../query/api';
 import { SCHEMAS } from '../../schemas';
 import { isAllProductFoldersFilteringEnabled, isProductFoldersDataListingScopedToFolder } from '../../app/utils';
+import { executeSql } from '../../query/executeSql';
 
 export function getFolderDataTypeDataCountSql(dataType: FolderConfigurableDataType): string {
     if (!dataType) return null;
@@ -29,54 +30,49 @@ export function getFolderDataTypeDataCountSql(dataType: FolderConfigurableDataTy
     return select + 'FROM ' + from + where + groupBy;
 }
 
-export function getFolderDataTypeDataCount(
+export async function getFolderDataTypeDataCount(
     dataType: FolderConfigurableDataType,
     containerPath?: string,
     allDataTypes?: DataTypeEntity[],
     isNewFolder?: boolean
 ): Promise<Record<string, number>> {
-    return new Promise((resolve, reject) => {
-        if (isProductFoldersDataListingScopedToFolder() && isNewFolder) {
-            resolve({});
-            return;
-        }
+    if (isProductFoldersDataListingScopedToFolder() && isNewFolder) {
+        return {};
+    }
 
-        // samples and assay runs reference their data type by lsid, but dataclass data reference by rowid
-        const byLsid = dataType === 'SampleType' || dataType === 'AssayDesign';
-        const lookup = {};
-        if (byLsid && allDataTypes) {
-            allDataTypes.forEach(type => {
-                lookup[type.lsid] = type.rowId;
-            });
-        }
-        let cf = getContainerFilterForFolder(containerPath);
-        if (isNewFolder) {
-            cf = isAllProductFoldersFilteringEnabled()
-                ? Query.ContainerFilter.allInProjectPlusShared
-                : Query.ContainerFilter.currentPlusProjectAndShared;
-        }
-
-        Query.executeSql({
-            containerPath,
-            containerFilter: cf,
-            schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
-            sql: getFolderDataTypeDataCountSql(dataType),
-            success: result => {
-                const typeCounts = {};
-                result.rows?.forEach(row => {
-                    const type = caseInsensitive(row, 'Type');
-                    const count = caseInsensitive(row, 'DataCount');
-                    if (byLsid && allDataTypes) typeCounts[lookup[type] + ''] = count;
-                    else typeCounts[type] = count;
-                });
-                resolve(typeCounts);
-            },
-            failure: error => {
-                console.error(error);
-                reject(error);
-            },
+    // samples and assay runs reference their data type by lsid, but dataclass data reference by rowid
+    const byLsid = dataType === 'SampleType' || dataType === 'AssayDesign';
+    const lookup = {};
+    if (byLsid && allDataTypes) {
+        allDataTypes.forEach(type => {
+            lookup[type.lsid] = type.rowId;
         });
+    }
+    let cf: Query.ContainerFilter;
+    if (isNewFolder) {
+        cf = isAllProductFoldersFilteringEnabled()
+            ? Query.ContainerFilter.allInProjectPlusShared
+            : Query.ContainerFilter.currentPlusProjectAndShared;
+    } else {
+        cf = getContainerFilterForFolder(containerPath);
+    }
+
+    const result = await executeSql({
+        containerPath,
+        containerFilter: cf,
+        schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
+        sql: getFolderDataTypeDataCountSql(dataType),
     });
+
+    const typeCounts: Record<string, number> = {};
+    result.rows?.forEach(row => {
+        const type = caseInsensitive(row, 'Type').value;
+        const count = caseInsensitive(row, 'DataCount').value;
+        if (byLsid && allDataTypes) typeCounts[lookup[type] + ''] = count;
+        else typeCounts[type] = count;
+    });
+
+    return typeCounts;
 }
 
 // exported for jest testing
@@ -88,49 +84,36 @@ export function getDataTypeFolderDataCountSql(
     const isAssay = entityDataType.folderConfigurableDataType === 'AssayDesign';
     const isStorage = entityDataType.folderConfigurableDataType === 'StorageLocation';
     const queryName = isAssay || isStorage ? entityDataType.listingSchemaQuery.queryName : dataTypeName;
-    const whereClause = isAssay ? 'WHERE Protocol.RowId = ' + dataTypeRowId : '';
+    const whereClause = isAssay ? `WHERE Protocol.RowId = ${dataTypeRowId}` : '';
     if (!queryName) return null;
 
-    return (
-        'SELECT Folder, COUNT(*) as DataCount FROM "' + queryName + '" ' + whereClause + ' GROUP BY Folder'
-    );
+    return `SELECT Folder, COUNT(*) as DataCount FROM "${queryName}" ${whereClause} GROUP BY Folder`;
 }
 
-export function getDataTypeFolderDataCount(
+export async function getDataTypeFolderDataCount(
     entityDataType: EntityDataType,
     dataTypeRowId: number,
     dataTypeName: string
 ): Promise<Record<string, number>> {
-    return new Promise((resolve, reject) => {
-        const isAssay = entityDataType.folderConfigurableDataType === 'AssayDesign';
-        const isStorage = entityDataType.folderConfigurableDataType === 'StorageLocation';
-        const schemaName =
-            isAssay || isStorage ? entityDataType.listingSchemaQuery.schemaName : entityDataType.instanceSchemaName;
-        const parameters = isStorage ? { ParentId: dataTypeRowId } : undefined;
+    const isAssay = entityDataType.folderConfigurableDataType === 'AssayDesign';
+    const isStorage = entityDataType.folderConfigurableDataType === 'StorageLocation';
+    const schemaName =
+        isAssay || isStorage ? entityDataType.listingSchemaQuery.schemaName : entityDataType.instanceSchemaName;
+    const sql = getDataTypeFolderDataCountSql(entityDataType, dataTypeRowId, dataTypeName);
+    if (!sql) {
+        return {};
+    }
 
-        const sql = getDataTypeFolderDataCountSql(entityDataType, dataTypeRowId, dataTypeName);
-        if (!sql) {
-            resolve({});
-            return;
-        }
-
-        Query.executeSql({
-            containerFilter: Query.ContainerFilter.allInProject, // use AllInProject for all cases
-            schemaName,
-            sql,
-            parameters,
-            success: result => {
-                const counts = {};
-                result.rows?.forEach(row => {
-                    const container = caseInsensitive(row, 'Folder');
-                    counts[container] = caseInsensitive(row, 'DataCount');
-                });
-                resolve(counts);
-            },
-            failure: error => {
-                console.error(error);
-                reject(error);
-            },
-        });
+    const result = await executeSql({
+        containerFilter: Query.ContainerFilter.allInProject, // use AllInProject for all cases
+        schemaName,
+        sql,
+        parameters: isStorage ? { ParentId: dataTypeRowId } : undefined,
     });
+
+    return result.rows.reduce<Record<string, number>>((counts, row) => {
+        const container = caseInsensitive(row, 'Folder').value;
+        counts[container] = caseInsensitive(row, 'DataCount').value;
+        return counts;
+    }, {});
 }

--- a/packages/components/src/internal/components/permissions/actions.ts
+++ b/packages/components/src/internal/components/permissions/actions.ts
@@ -11,9 +11,10 @@ import { ISelectRowsResult, selectRowsDeprecated } from '../../query/api';
 import { Container } from '../base/models/Container';
 import { FetchContainerOptions } from '../security/APIWrapper';
 
-import { APPLICATION_ROLES_LABELS, APPLICATION_ROLES_DESCRIPTIONS } from '../administration/constants';
+import { APPLICATION_ROLES_DESCRIPTIONS, APPLICATION_ROLES_LABELS } from '../administration/constants';
 
 import { Principal, SecurityPolicy, SecurityRole } from './models';
+import { executeSql } from '../../query/executeSql';
 
 export function processGetRolesResponse(rawRoles: any): List<SecurityRole> {
     let roles = List<SecurityRole>();
@@ -35,35 +36,15 @@ export function getRolesByUniqueName(roles: List<SecurityRole>): Map<string, Sec
     return rolesByUniqueName;
 }
 
-function processPrincipalsResponse(data: ISelectRowsResult, resolve) {
-    const models = fromJS(data.models[data.key]);
-    let principals = List<Principal>();
-
-    data.orderedModels[data.key].forEach(modelKey => {
-        const row = models.get(modelKey);
-        const principal = Principal.createFromSelectRow(row);
-        principals = principals.push(principal);
+export async function getPrincipals(): Promise<List<Principal>> {
+    const result = await executeSql({
+        saveInSession: true, // needed so that we can call getQueryDetails
+        schemaName: 'core',
+        // Issue 17704: add displayName for users
+        sql: "SELECT p.*, u.DisplayName FROM Principals p LEFT JOIN Users u ON p.type='u' AND p.UserId=u.UserId",
     });
 
-    resolve(principals);
-}
-
-export function getPrincipals(): Promise<List<Principal>> {
-    return new Promise((resolve, reject) => {
-        selectRowsDeprecated({
-            saveInSession: true, // needed so that we can call getQueryDetails
-            schemaName: 'core',
-            // issue 17704, add displayName for users
-            sql: "SELECT p.*, u.DisplayName FROM Principals p LEFT JOIN Users u ON p.type='u' AND p.UserId=u.UserId",
-        })
-            .then((data: ISelectRowsResult) => {
-                processPrincipalsResponse(data, resolve);
-            })
-            .catch(response => {
-                console.error(response);
-                reject(response.message);
-            });
-    });
+    return result.rows.reduce<List<Principal>>((p, row) => p.push(Principal.createFromSelectRow(fromJS(row))), List());
 }
 
 export function getInactiveUsers(): Promise<List<Principal>> {

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -21,6 +21,7 @@ import { getOrderedSelectedMappedKeys } from '../entities/actions';
 
 import { Picklist, PICKLIST_KEY_COLUMN, PICKLIST_SAMPLE_ID_COLUMN } from './models';
 import { PRIVATE_PICKLIST_CATEGORY, PUBLIC_PICKLIST_CATEGORY } from './constants';
+import { executeSql } from '../../query/executeSql';
 
 export function getPicklistsForInsert(): Promise<Picklist[]> {
     return new Promise((resolve, reject) => {
@@ -147,38 +148,28 @@ export interface SampleTypeCount {
     SampleType: string;
 }
 
-export function getPicklistCountsBySampleType(listName: string): Promise<SampleTypeCount[]> {
-    return new Promise(async (resolve, reject) => {
-        try {
-            const { key, models, orderedModels } = await selectRowsDeprecated({
-                schemaName: SCHEMAS.PICKLIST_TABLES.SCHEMA,
-                queryName: listName,
-                sql: [
-                    'SELECT COUNT(*) as ItemCount,',
-                    'SampleId.SampleSet.Name AS SampleType,',
-                    'SampleId.LabelColor',
-                    `FROM ${SCHEMAS.PICKLIST_TABLES.SCHEMA}."${listName}"`,
-                    'WHERE SampleId.Name IS NOT NULL',
-                    'GROUP BY SampleId.SampleSet.Name, SampleId.LabelColor',
-                    'ORDER BY SampleId.SampleSet.Name',
-                ].join('\n'),
-            });
-
-            const counts = orderedModels[key]
-                .map(idx => models[key][idx])
-                .map(row => ({
-                    ItemCount: row.ItemCount.value,
-                    LabelColor: row.LabelColor.value,
-                    SampleType: row.SampleType.value,
-                }))
-                .toArray();
-
-            resolve(counts);
-        } catch (e) {
-            console.error('Failed to get picklist counts by sample type', e);
-            reject(e);
-        }
+export async function getPicklistCountsBySampleType(listName: string): Promise<SampleTypeCount[]> {
+    const result = await executeSql({
+        schemaName: SCHEMAS.PICKLIST_TABLES.SCHEMA,
+        sql: [
+            'SELECT COUNT(*) as ItemCount,',
+            'SampleId.SampleSet.Name AS SampleType,',
+            'SampleId.LabelColor',
+            `FROM ${SCHEMAS.PICKLIST_TABLES.SCHEMA}."${listName}"`,
+            'WHERE SampleId.Name IS NOT NULL',
+            'GROUP BY SampleId.SampleSet.Name, SampleId.LabelColor',
+            'ORDER BY SampleId.SampleSet.Name',
+        ].join('\n'),
     });
+
+    return result.rows.reduce<SampleTypeCount[]>((counts, row) => {
+        counts.push({
+            ItemCount: row.ItemCount.value,
+            LabelColor: row.LabelColor.value,
+            SampleType: row.SampleType.value,
+        });
+        return counts;
+    }, []);
 }
 
 export function getPicklistSamples(listName: string): Promise<Set<number>> {
@@ -402,20 +393,16 @@ export const getPicklistFromId = async (listId: number, loadSampleTypes = true):
     let picklist = Picklist.create(listRow);
 
     if (loadSampleTypes) {
-        const listSampleTypeData = await selectRowsDeprecated({
+        const result = await executeSql({
             schemaName: SCHEMAS.PICKLIST_TABLES.SCHEMA,
             sql: `SELECT DISTINCT SampleID.SampleSet, SampleID.SampleSet.Category FROM "${picklist.name}" WHERE SampleID.SampleSet IS NOT NULL`,
         });
 
         picklist = picklist.mutate({
-            sampleTypes: Object.values(listSampleTypeData.models[listSampleTypeData.key])
+            hasMedia: !!result.rows.find(row => caseInsensitive(row, 'Category')?.value === 'media'),
+            sampleTypes: result.rows
                 .map(row => caseInsensitive(row, 'SampleSet')?.displayValue)
                 .filter(value => !!value),
-        });
-        picklist = picklist.mutate({
-            hasMedia: !!Object.values(listSampleTypeData.models[listSampleTypeData.key]).find(
-                row => caseInsensitive(row, 'Category')?.value === 'media'
-            ),
         });
     }
 

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -385,7 +385,6 @@ export const getPicklistFromId = async (listId: number, loadSampleTypes = true):
         containerFilter: getPicklistListingContainerFilter(),
         schemaName: SCHEMAS.LIST_METADATA_TABLES.PICKLISTS.schemaName,
         queryName: SCHEMAS.LIST_METADATA_TABLES.PICKLISTS.queryName,
-        requiredColumns: ['Category'],
         filterArray: [Filter.create('listId', listId)],
     });
     const listRow = listData.models[listData.key][listId];

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -14,8 +14,8 @@ import {
     createSessionAssayRunSummaryQuery,
     getDefaultDiscardStatus,
     getDistinctAssaysPerSample,
-    getLookupRowIdsFromSelection,
     getGroupedSampleDomainFields,
+    getLookupRowIdsFromSelection,
     getSampleAliquotRows,
     getSampleAssayResultViewConfigs,
     getSampleCounter,
@@ -30,13 +30,17 @@ import {
 } from './actions';
 import { GroupedSampleFields, SampleState } from './models';
 import { SampleOperation } from './constants';
+import { ExecuteSqlResponseWithSession } from '../../query/executeSql';
+import { Row } from '../../query/selectRows';
 
 export interface SamplesAPIWrapper {
-    createSessionAssayRunSummaryQuery: (sampleIds: number[]) => Promise<ISelectRowsResult>;
+    createSessionAssayRunSummaryQuery: (sampleIds: number[]) => Promise<ExecuteSqlResponseWithSession>;
 
     getDefaultDiscardStatus: (containerPath?: string) => Promise<number>;
 
     getDistinctAssaysPerSample: (sampleIds: number[]) => Promise<string[]>;
+
+    getGroupedSampleDomainFields: (sampleType: string) => Promise<GroupedSampleFields>;
 
     getLookupRowIdsFromSelection: (
         schemaName: string,
@@ -45,9 +49,7 @@ export interface SamplesAPIWrapper {
         fieldKey: string
     ) => Promise<number[]>;
 
-    getGroupedSampleDomainFields: (sampleType: string) => Promise<GroupedSampleFields>;
-
-    getSampleAliquotRows: (sampleId: number | string) => Promise<Array<Record<string, any>>>;
+    getSampleAliquotRows: (sampleId: number | string) => Promise<Row[]>;
 
     getSampleAssayResultViewConfigs: () => Promise<SampleAssayResultViewConfig[]>;
 

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -94,7 +94,7 @@ export function getSampleTypeDetails(
     });
 }
 
-export function deleteSampleSet(rowId: number, containerPath?: string, auditUserComment?: string): Promise<any> {
+export function deleteSampleSet(rowId: number, containerPath?: string, auditUserComment?: string): Promise<void> {
     return deleteEntityType('deleteSampleTypes', rowId, containerPath, auditUserComment);
 }
 

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -22,7 +22,7 @@ import { deleteEntityType, getSelectedItemSamples } from '../entities/actions';
 import { getSelectedDataDeprecated, getSelection, getSnapshotSelections } from '../../actions';
 
 import { caseInsensitive } from '../../util/utils';
-import { handleRequestFailure } from '../../request';
+import { request } from '../../request';
 
 import { ParentEntityLineageColumns } from '../entities/constants';
 
@@ -34,7 +34,6 @@ import { SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 import { SCHEMAS } from '../../schemas';
 
 import {
-    getContainerFilter,
     getQueryDetails,
     invalidateFullQueryDetailsCache,
     ISelectRowsResult,
@@ -48,9 +47,7 @@ import { getSelectedPicklistSamples } from '../picklist/actions';
 import { resolveErrorMessage } from '../../util/messaging';
 import { TimelineEventModel } from '../auditlog/models';
 
-import { buildURL } from '../../url/AppURL';
-
-import { selectRows } from '../../query/selectRows';
+import { Row, selectRows } from '../../query/selectRows';
 
 import { QueryInfo } from '../../../public/QueryInfo';
 
@@ -61,18 +58,16 @@ import {
     STORED_AMOUNT_FIELDS,
 } from './constants';
 import { FindField, GroupedSampleFields, SampleState, SampleStateType } from './models';
+import { executeSql, ExecuteSqlResponseWithSession } from '../../query/executeSql';
 
-export function getSampleSet(config: IEntityTypeDetails): Promise<any> {
-    return new Promise<any>((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL('experiment', 'getSampleTypeApi.api'),
-            params: config,
-            success: Utils.getCallbackWrapper(response => {
-                resolve(Map(response));
-            }),
-            failure: handleRequestFailure(reject, 'Failed to fetch sample type'),
-        });
+export async function getSampleSet(config: IEntityTypeDetails): Promise<any> {
+    const response = await request({
+        url: ActionURL.buildURL('experiment', 'getSampleType.api'),
+        params: config,
+        errorLogMsg: 'Failed to fetch sample type',
     });
+
+    return Map(response);
 }
 
 // TODO: This should share implementation with api.domain.fetchDomainDetails / api.domain.getDataClassDetails
@@ -391,22 +386,13 @@ export function saveIdsToFind(fieldType: FindField, ids: string[], sessionKey: s
     });
 }
 
-export function getSampleAliquotRows(sampleId: number | string): Promise<Record<string, any>[]> {
-    return new Promise((resolve, reject) => {
-        Query.executeSql({
-            containerFilter: getContainerFilter(),
-            sql: `SELECT RowId, Name FROM materials WHERE RowId <> RootMaterialRowId AND RootMaterialRowId = ${sampleId}`,
-            schemaName: SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
-            requiredVersion: 17.1,
-            success: result => {
-                resolve(result.rows);
-            },
-            failure: reason => {
-                console.error(reason);
-                reject(reason);
-            },
-        });
+export async function getSampleAliquotRows(sampleId: number | string): Promise<Row[]> {
+    const result = await executeSql({
+        schemaName: SCHEMAS.EXP_TABLES.MATERIALS.schemaName,
+        sql: `SELECT RowId, Name FROM materials WHERE RowId <> RootMaterialRowId AND RootMaterialRowId = ${sampleId}`,
     });
+
+    return result.rows;
 }
 
 export type SampleAssayResultViewConfig = {
@@ -420,22 +406,16 @@ export type SampleAssayResultViewConfig = {
     viewName?: string;
 };
 
-export function getSampleAssayResultViewConfigs(): Promise<SampleAssayResultViewConfig[]> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getSampleAssayResultsViewConfigs.api'),
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response.configs ?? []);
-            }),
-            failure: Utils.getCallbackWrapper(response => {
-                console.error(response);
-                reject(response);
-            }),
-        });
+export async function getSampleAssayResultViewConfigs(): Promise<SampleAssayResultViewConfig[]> {
+    const response = await request<{ configs: SampleAssayResultViewConfig[] }>({
+        url: ActionURL.buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getSampleAssayResultsViewConfigs.api'),
+        errorLogMsg: 'Failed to load sample assay result view configuration',
     });
+
+    return response.configs ?? [];
 }
 
-export async function createSessionAssayRunSummaryQuery(sampleIds: number[]): Promise<ISelectRowsResult> {
+export function createSessionAssayRunSummaryQuery(sampleIds: number[]): Promise<ExecuteSqlResponseWithSession> {
     // issue with temp table re-use of queryName, invalidate cache to clear any queryDetails for old temp table
     invalidateFullQueryDetailsCache();
 
@@ -450,9 +430,9 @@ export async function createSessionAssayRunSummaryQuery(sampleIds: number[]): Pr
         whereClause = 'WHERE 1 = 0\n'; // add where clause that will always result in zero rows
     }
 
-    return await selectRowsDeprecated({
+    return executeSql({
         saveInSession: true,
-        schemaName: 'exp',
+        schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
         sql:
             'SELECT RowId, SampleID, SampleType, Assay, COUNT(*) AS RunCount\n' +
             "FROM (SELECT RowId, SampleID, SampleType, Assay || ' Run Count' AS Assay FROM " +
@@ -621,7 +601,7 @@ export function updateSampleStorageData(
 
     return new Promise<any>((resolve, reject) => {
         return Ajax.request({
-            url: buildURL('inventory', 'updateSampleStorageData.api', undefined, { container: containerPath }),
+            url: ActionURL.buildURL('inventory', 'updateSampleStorageData.api', containerPath),
             jsonData: {
                 sampleRows: sampleStorageData,
                 [STORED_AMOUNT_FIELDS.AUDIT_COMMENT]: userComment,
@@ -685,7 +665,7 @@ export function saveSampleCounter(
     });
 }
 
-export function hasExistingSamples(isRoot?: boolean, containerPath?: string): Promise<boolean> {
+export async function hasExistingSamples(isRoot?: boolean, containerPath?: string): Promise<boolean> {
     let dataCountSql =
         'SELECT m.Name As SampleName ' +
         '\n' +
@@ -695,18 +675,12 @@ export function hasExistingSamples(isRoot?: boolean, containerPath?: string): Pr
     if (isRoot) dataCountSql += ' AND mi.RootMaterialRowId = mi.RowId';
     dataCountSql += ')';
 
-    return new Promise((resolve, reject) => {
-        Query.executeSql({
-            containerPath,
-            containerFilter: Query.ContainerFilter.allInProject,
-            schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
-            sql: dataCountSql,
-            success: async data => {
-                resolve(!!data.rows[0]?.SampleName);
-            },
-            failure: error => {
-                reject(error);
-            },
-        });
+    const result = await executeSql({
+        containerPath,
+        containerFilter: Query.ContainerFilter.allInProject,
+        schemaName: SCHEMAS.EXP_TABLES.SCHEMA,
+        sql: dataCountSql,
     });
+
+    return !!result.rows[0]?.SampleName?.value;
 }

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -1,29 +1,29 @@
 import { List, Map } from 'immutable';
-import { ActionURL, Ajax, Filter, Query, Security, Utils, User } from '@labkey/api';
+import { ActionURL, Filter, Query, Security, User, Utils } from '@labkey/api';
 
 import { Container } from '../base/models/Container';
 import {
+    fetchContainers,
     fetchContainerSecurityPolicy,
-    UserLimitSettings,
     getUserLimitSettings,
     processGetRolesResponse,
-    fetchContainers,
+    UserLimitSettings,
 } from '../permissions/actions';
 import { Principal, SecurityPolicy, SecurityRole } from '../permissions/models';
 import { selectRows } from '../../query/selectRows';
 import { SCHEMAS } from '../../schemas';
 import { naturalSortByProperty } from '../../../public/sort';
 import { caseInsensitive } from '../../util/utils';
-import { handleRequestFailure } from '../../request';
+import { request } from '../../request';
 import { getUserProperties } from '../user/actions';
 import { flattenValuesFromRow } from '../../../public/QueryModel/QueryModel';
 import { SchemaQuery } from '../../../public/SchemaQuery';
-import { deleteRows, processRequest, QueryCommandResponse } from '../../query/api';
+import { deleteRows, QueryCommandResponse } from '../../query/api';
 import { GroupMembership } from '../administration/models';
 import { getUsersWithPermissions } from '../forms/actions';
 import { checkPermissions } from '../base/models/User';
 
-type NonRequestCallback<T extends Utils.RequestCallbackOptions> = Omit<T, 'success' | 'failure' | 'scope'>;
+type NonRequestCallback<T extends Utils.RequestCallbackOptions> = Omit<T, 'failure' | 'scope' | 'success'>;
 export type DeleteContainerOptions = NonRequestCallback<Security.DeleteContainerOptions>;
 export type FetchContainerOptions = NonRequestCallback<Security.GetContainersOptions>;
 export type GetUserPermissionsOptions = NonRequestCallback<Security.GetUserPermissionsOptions>;
@@ -64,7 +64,7 @@ export interface SecurityAPIWrapper {
         projectPath: string,
         permissions?: string | string[],
         checkIsAdmin?: boolean,
-        permissionCheck?: 'any' | 'all'
+        permissionCheck?: 'all' | 'any'
     ) => Promise<FetchedGroup[]>;
     fetchPolicy: (
         containerId: string,
@@ -72,7 +72,7 @@ export interface SecurityAPIWrapper {
         inactiveUsersById?: Map<number, Principal>
     ) => Promise<SecurityPolicy>;
     fetchRoles: () => Promise<List<SecurityRole>>;
-    getAuditLogDate: (filterCol: string, filterVal: string | number) => Promise<string>;
+    getAuditLogDate: (filterCol: string, filterVal: number | string) => Promise<string>;
     getDeletionSummaries: (containerPath?: string) => Promise<Summary[]>;
     getGroupMemberships: () => Promise<GroupMembership[]>;
     getInheritedContainers: (container: Container) => Promise<string[]>;
@@ -116,18 +116,15 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         });
     };
 
-    createApiKey = (type = 'apikey', description?: string): Promise<string> => {
-        return new Promise((resolve, reject) => {
-            Ajax.request({
-                url: ActionURL.buildURL('security', 'createApiKey.api'),
-                method: 'POST',
-                jsonData: { type, description },
-                success: Utils.getCallbackWrapper(response => {
-                    resolve(response.apikey);
-                }),
-                failure: handleRequestFailure(reject, 'Problem generating the apiKey for this user.'),
-            });
+    createApiKey = async (type = 'apikey', description?: string): Promise<string> => {
+        const response = await request<{ apikey: string }>({
+            url: ActionURL.buildURL('security', 'createApiKey.api'),
+            method: 'POST',
+            jsonData: { type, description },
+            errorLogMsg: 'Problem generating the apiKey for this user.',
         });
+
+        return response.apikey;
     };
 
     deleteApiKeys(selections: Set<string>): Promise<QueryCommandResponse> {
@@ -241,7 +238,7 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         });
     };
 
-    getAuditLogDate = async (filterCol: string, filterVal: string | number): Promise<string> => {
+    getAuditLogDate = async (filterCol: string, filterVal: number | string): Promise<string> => {
         const result = await selectRows({
             columns: ['Date'],
             containerFilter: Query.ContainerFilter.allFolders,
@@ -259,18 +256,13 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         return dateRow.formattedValue ?? dateRow.value;
     };
 
-    getDeletionSummaries = (containerPath?: string): Promise<Summary[]> => {
-        return new Promise((resolve, reject) => {
-            Ajax.request({
-                url: ActionURL.buildURL('core', 'getModuleSummary.api', containerPath),
-                success: Utils.getCallbackWrapper(response => {
-                    const { moduleSummary } = response;
-                    moduleSummary.sort(naturalSortByProperty('noun'));
-                    resolve(moduleSummary);
-                }),
-                failure: handleRequestFailure(reject, 'Failed to retrieve deletion summary.'),
-            });
+    getDeletionSummaries = async (containerPath?: string): Promise<Summary[]> => {
+        const { moduleSummary } = await request<{ moduleSummary: Summary[] }>({
+            url: ActionURL.buildURL('core', 'getModuleSummary.api', containerPath),
+            errorLogMsg: 'Failed to retrieve deletion summary.',
         });
+        moduleSummary.sort(naturalSortByProperty('noun'));
+        return moduleSummary;
     };
 
     getGroupMemberships = async (): Promise<GroupMembership[]> => {
@@ -360,43 +352,34 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         });
     };
 
-    updateUserDetails = (data: FormData): Promise<any> => {
-        return new Promise((resolve, reject) => {
-            Ajax.request({
-                url: ActionURL.buildURL('user', 'updateUserDetails.api'),
-                method: 'POST',
-                form: data,
-                success: Utils.getCallbackWrapper((response, request) => {
-                    if (processRequest(response, request, reject)) return;
-                    resolve(response);
-                }),
-                failure: handleRequestFailure(reject, 'Failed to update user details'),
-            });
+    updateUserDetails = (form: FormData): Promise<any> => {
+        return request({
+            url: ActionURL.buildURL('user', 'updateUserDetails.api'),
+            method: 'POST',
+            form,
+            errorLogMsg: 'Failed to update user details',
         });
     };
 
-    getInheritedContainers = (container: Container): Promise<string[]> => {
-        return new Promise((resolve, reject) => {
-            Ajax.request({
-                url: ActionURL.buildURL('core', 'getExtSecurityContainerTree.api', container.path),
-                params: {
-                    requiredPermission: Security.PermissionTypes.Admin,
-                    nodeId: container.id,
-                },
-                success: Utils.getCallbackWrapper(containers => {
-                    const inherited = [];
-                    containers.forEach(proj => {
-                        if (proj.inherit) {
-                            const name = proj.text.substring(0, proj.text.length - 1); // remove trailing *
-                            inherited.push(name);
-                        }
-                    });
-
-                    resolve(inherited);
-                }),
-                failure: handleRequestFailure(reject, 'Failed to get folders'),
-            });
+    getInheritedContainers = async (container: Container): Promise<string[]> => {
+        const containers = await request<{ inherit: boolean; text: string }[]>({
+            url: ActionURL.buildURL('core', 'getExtSecurityContainerTree.api', container.path),
+            params: {
+                requiredPermission: Security.PermissionTypes.Admin,
+                nodeId: container.id,
+            },
+            errorLogMsg: 'Failed to get folders',
         });
+
+        const inherited: string[] = [];
+        containers.forEach(c => {
+            if (c.inherit) {
+                const name = c.text.substring(0, c.text.length - 1); // remove trailing *
+                inherited.push(name);
+            }
+        });
+
+        return inherited;
     };
 
     savePolicy = (policy: any, containerPath?: string): Promise<any> => {

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -65,6 +65,7 @@ import {
     updateRowsByContainer,
     UpdateRowsOptions,
 } from './api';
+import { executeSql, ExecuteSqlOptions, ExecuteSqlResponse } from './executeSql';
 import { selectRows, SelectRowsOptions, SelectRowsResponse } from './selectRows';
 
 export interface QueryAPIWrapper {
@@ -74,6 +75,7 @@ export interface QueryAPIWrapper {
     deleteRows: (options: DeleteRowsOptions) => Promise<QueryCommandResponse>;
     deleteRowsByContainer: (options: DeleteRowsOptions, containerField: string) => Promise<QueryCommandResponse>;
     deleteView: (schemaQuery: SchemaQuery, containerPath: string, viewName?: string, revert?: boolean) => Promise<void>;
+    executeSql: <T extends ExecuteSqlOptions>(options: T) => Promise<ExecuteSqlResponse<T>>;
     getDataTypeFolderDataCount: (
         entityDataType: EntityDataType,
         dataTypeRowId: number,
@@ -175,6 +177,7 @@ export class QueryServerAPIWrapper implements QueryAPIWrapper {
     deleteRows = deleteRows;
     deleteRowsByContainer = deleteRowsByContainer;
     deleteView = deleteView;
+    executeSql = executeSql;
     getDataTypeFolderDataCount = getDataTypeFolderDataCount;
     getEntityTypeOptions = getEntityTypeOptionsWithExclusions;
     getGridViews = getGridViews;
@@ -215,6 +218,7 @@ export function getQueryTestAPIWrapper(
         deleteRows: mockFn(),
         deleteRowsByContainer: mockFn(),
         deleteView: mockFn(),
+        executeSql: mockFn(),
         getDataTypeFolderDataCount: mockFn(),
         getEntityTypeOptions: mockFn(),
         getGridViews: mockFn(),

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -84,7 +84,7 @@ export interface QueryAPIWrapper {
     getDefaultVisibleColumns: (options: GetQueryDetailsOptions) => Promise<QueryColumn[]>;
     getEntityTypeOptions: (
         entityDataType: EntityDataType,
-        dataTypeExclusions?: { [key: string]: number[] },
+        dataTypeExclusions?: Record<string, number[]>,
         containerPath?: string
     ) => Promise<Map<string, List<IEntityTypeOption>>>;
     getFolderConfigurableEntityTypeOptions: (
@@ -147,7 +147,7 @@ export interface QueryAPIWrapper {
     setSelected: (
         key: string,
         checked: boolean,
-        ids: string[] | string,
+        ids: string | string[],
         containerPath?: string,
         validateIds?: boolean,
         schemaName?: string,
@@ -157,7 +157,7 @@ export interface QueryAPIWrapper {
     ) => Promise<SelectResponse>;
     setSnapshotSelections: (
         key: string,
-        ids: string[] | string | number[],
+        ids: number[] | string | string[],
         containerPath?: string
     ) => Promise<SelectResponse>; // deprecated
     updateRows: (options: UpdateRowsOptions) => Promise<QueryCommandResponse>;

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -453,7 +453,6 @@ export function isSelectRowMetadataRequired(includeMetadata?: boolean, columns?:
 }
 
 export interface ISelectRowsResult {
-    caller?: any;
     key: string;
     messages?: List<Map<string, string>>;
     models: any;
@@ -462,16 +461,26 @@ export interface ISelectRowsResult {
     rowCount: number;
 }
 
+export type SelectRowsDeprecatedOptions = Omit<
+    Query.SelectRowsOptions,
+    'failure' | 'method' | 'requiredVersion' | 'success'
+>;
+
 /**
  * @deprecated use selectRows() or executeSql() instead.
  * Fetches an API response and normalizes the result JSON according to schema.
  * This makes every API response have the same shape, regardless of how nested it was.
  */
-export function selectRowsDeprecated(userConfig, caller?): Promise<ISelectRowsResult> {
+export function selectRowsDeprecated(options: SelectRowsDeprecatedOptions): Promise<ISelectRowsResult> {
+    if (options.hasOwnProperty('sql')) {
+        throw new Error('selectRowsDeprecated() no longer supports the "sql" property. Use executeSql() instead.');
+    }
+
     return new Promise((resolve, reject) => {
-        let key, schemaQuery;
-        if (userConfig.queryName) {
-            schemaQuery = new SchemaQuery(userConfig.schemaName, userConfig.queryName, userConfig.viewName);
+        let key: string;
+        let schemaQuery: SchemaQuery;
+        if (options.queryName) {
+            schemaQuery = new SchemaQuery(options.schemaName, options.queryName, options.viewName);
             key = schemaQuery.getKey();
         }
 
@@ -483,132 +492,68 @@ export function selectRowsDeprecated(userConfig, caller?): Promise<ISelectRowsRe
         function doResolve() {
             if (hasDetails && hasResults) {
                 result = handleSelectRowsResponse(result, details);
-
                 if (key !== result.key) {
                     key = result.key; // default to model key
                 }
-                resolve(
-                    Object.assign(
-                        {},
-                        {
-                            key,
-                            models: result.models,
-                            orderedModels: result.orderedModels,
-                            queries: {
-                                [key]: details,
-                            },
-                            rowCount: result.rowCount,
-                            messages: result.messages,
-                            caller,
-                        }
-                    )
-                );
+
+                resolve({
+                    key,
+                    models: result.models,
+                    orderedModels: result.orderedModels,
+                    queries: {
+                        [key]: details,
+                    },
+                    rowCount: result.rowCount,
+                    messages: result.messages,
+                });
             }
         }
 
-        if (userConfig.hasOwnProperty('sql')) {
-            const saveInSession = userConfig.saveInSession === true;
-            Query.executeSql(
-                Object.assign({}, userConfig, {
-                    method: 'POST',
-                    requiredVersion: 17.1,
-                    sql: userConfig.sql,
-                    saveInSession,
-                    containerFilter: userConfig.containerFilter ?? getContainerFilter(userConfig.containerPath),
-                    success: json => {
-                        result = json;
-                        hasResults = true;
-                        let resultSchemaQuery: SchemaQuery;
+        const columns = options.columns ? options.columns : '*';
+        Query.selectRows({
+            ...options,
+            requiredVersion: 17.1,
+            filterArray: options.filterArray,
+            method: 'POST',
+            // put on this another parameter!
+            columns,
+            containerFilter: options.containerFilter ?? getContainerFilter(options.containerPath),
+            includeMetadata: isSelectRowMetadataRequired(options.includeMetadata, columns),
+            includeTotalCount: options.includeTotalCount ?? false, // default to false to improve performance
+            success: json => {
+                result = json;
+                hasResults = true;
+                doResolve();
+            },
+            failure: (data, request) => {
+                // If we hit a communication failure, try to get better error messaging from the request.responseText (Issues 51232 and 51204)
+                if (
+                    data.exception?.toLowerCase().indexOf('communication failure') === 0 &&
+                    processRequest(undefined, request, reject)
+                ) {
+                    return;
+                }
 
-                        if (saveInSession) {
-                            resultSchemaQuery = new SchemaQuery(userConfig.schemaName, json.queryName);
-                            key = resultSchemaQuery.getKey();
-                        } else {
-                            resultSchemaQuery = schemaQuery;
-                        }
-
-                        // We're not guaranteed to have a schemaQuery provided. When executing with SQL
-                        // the user only needs to supply a schemaName. If they do not saveInSession then
-                        // a queryName is not generated and getQueryDetails() is unable to fetch details.
-                        if (resultSchemaQuery) {
-                            getQueryDetails(resultSchemaQuery)
-                                .then(d => {
-                                    hasDetails = true;
-                                    details = d;
-                                    doResolve();
-                                })
-                                .catch(error => reject(error));
-                        } else {
-                            hasDetails = true;
-                            doResolve();
-                        }
-                    },
-                    failure: (data, request) => {
-                        // If we hit a communication failure, try to get better error messaging from the request.responseText (Issues 51232 and 51204)
-                        if (
-                            data.exception?.toLowerCase().indexOf('communication failure') === 0 &&
-                            processRequest(undefined, request, reject)
-                        ) {
-                            return;
-                        }
-
-                        console.error('There was a problem retrieving the data', data);
-                        reject({
-                            exceptionClass: data.exceptionClass,
-                            message: data.exception,
-                            status: request.status,
-                        });
-                    },
-                })
-            );
-        } else {
-            const columns = userConfig.columns ? userConfig.columns : '*';
-            Query.selectRows(
-                Object.assign({}, userConfig, {
-                    requiredVersion: 17.1,
-                    filterArray: userConfig.filterArray,
-                    method: 'POST',
-                    // put on this another parameter!
-                    columns,
-                    containerFilter: userConfig.containerFilter ?? getContainerFilter(userConfig.containerPath),
-                    includeMetadata: isSelectRowMetadataRequired(userConfig.includeMetadata, columns),
-                    includeTotalCount: userConfig.includeTotalCount ?? false, // default to false to improve performance
-                    success: json => {
-                        result = json;
-                        hasResults = true;
-                        doResolve();
-                    },
-                    failure: (data, request) => {
-                        // If we hit a communication failure, try to get better error messaging from the request.responseText (Issues 51232 and 51204)
-                        if (
-                            data.exception?.toLowerCase().indexOf('communication failure') === 0 &&
-                            processRequest(undefined, request, reject)
-                        ) {
-                            return;
-                        }
-
-                        console.error('There was a problem retrieving the data', data);
-                        reject({
-                            exceptionClass: data.exceptionClass,
-                            message: data.exception,
-                            schemaQuery,
-                            status: request.status,
-                        });
-                    },
-                })
-            );
-
-            getQueryDetails(userConfig)
-                .then(d => {
-                    hasDetails = true;
-                    details = d;
-                    doResolve();
-                })
-                .catch(error => {
-                    console.error('There was a problem retrieving the data', error);
-                    reject(error);
+                console.error('There was a problem retrieving the data', data);
+                reject({
+                    exceptionClass: data.exceptionClass,
+                    message: data.exception,
+                    schemaQuery,
+                    status: request.status,
                 });
-        }
+            },
+        });
+
+        getQueryDetails(options)
+            .then(d => {
+                hasDetails = true;
+                details = d;
+                doResolve();
+            })
+            .catch(error => {
+                console.error('There was a problem retrieving the data', error);
+                reject(error);
+            });
     });
 }
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -463,7 +463,7 @@ export interface ISelectRowsResult {
 
 export type SelectRowsDeprecatedOptions = Omit<
     Query.SelectRowsOptions,
-    'failure' | 'method' | 'requiredVersion' | 'success'
+    'failure' | 'method' | 'requiredVersion' | 'scope' | 'success'
 >;
 
 /**

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1015,7 +1015,7 @@ export function updateRowsByContainer(
             schemaQuery,
         });
     } else {
-        const commands = [];
+        const commands: Query.Command[] = [];
         commands.push({
             command: 'update',
             schemaName: schemaQuery.schemaName,
@@ -1093,7 +1093,7 @@ export function saveRowsByContainer(
     options: SaveRowsOptions,
     containerField = 'Folder'
 ): Promise<Query.SaveRowsResponse> {
-    const commands = []; // TODO type as Query.Command
+    const commands: Query.Command[] = [];
 
     // for each original command, split it into multiple commands for each container in the rows
     options.commands.forEach(command => {
@@ -1120,7 +1120,7 @@ export function deleteRowsByContainer(
     options: DeleteRowsOptions,
     containerField = 'ContainerPath'
 ): Promise<QueryCommandResponse> {
-    const commands = [];
+    const commands: Query.Command[] = [];
 
     const allRows = options.rows;
     if (

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -471,90 +471,61 @@ export type SelectRowsDeprecatedOptions = Omit<
  * Fetches an API response and normalizes the result JSON according to schema.
  * This makes every API response have the same shape, regardless of how nested it was.
  */
-export function selectRowsDeprecated(options: SelectRowsDeprecatedOptions): Promise<ISelectRowsResult> {
-    if (options.hasOwnProperty('sql')) {
-        throw new Error('selectRowsDeprecated() no longer supports the "sql" property. Use executeSql() instead.');
+export async function selectRowsDeprecated(options: SelectRowsDeprecatedOptions): Promise<ISelectRowsResult> {
+    const schemaQuery = new SchemaQuery(options.schemaName, options.queryName, options.viewName);
+
+    const columns = options.columns ? options.columns : '*';
+    const [queryInfo, response] = await Promise.all([
+        getQueryDetails(options),
+        new Promise<Query.Response>((resolve, reject) => {
+            Query.selectRows({
+                ...options,
+                requiredVersion: 17.1,
+                method: 'POST',
+                // put on this another parameter!
+                columns,
+                containerFilter: options.containerFilter ?? getContainerFilter(options.containerPath),
+                includeMetadata: isSelectRowMetadataRequired(options.includeMetadata, columns),
+                includeTotalCount: options.includeTotalCount ?? false, // default to false to improve performance
+                success: response_ => {
+                    resolve(response_);
+                },
+                failure: (data, request) => {
+                    // If we hit a communication failure, try to get better error messaging from the request.responseText (Issues 51232 and 51204)
+                    if (
+                        data.exception?.toLowerCase().indexOf('communication failure') === 0 &&
+                        processRequest(undefined, request, reject)
+                    ) {
+                        return;
+                    }
+
+                    console.error('There was a problem retrieving the data', data);
+                    reject({
+                        exceptionClass: data.exceptionClass,
+                        message: data.exception,
+                        schemaQuery,
+                        status: request.status,
+                    });
+                },
+            });
+        }),
+    ]);
+
+    const result = handleSelectRowsResponse(response, queryInfo);
+
+    let key = schemaQuery.getKey();
+    if (key !== result.key) {
+        key = result.key; // default to model key
     }
 
-    return new Promise((resolve, reject) => {
-        let key: string;
-        let schemaQuery: SchemaQuery;
-        if (options.queryName) {
-            schemaQuery = new SchemaQuery(options.schemaName, options.queryName, options.viewName);
-            key = schemaQuery.getKey();
-        }
-
-        let hasDetails = false;
-        let details: QueryInfo;
-        let hasResults = false;
-        let result;
-
-        function doResolve() {
-            if (hasDetails && hasResults) {
-                result = handleSelectRowsResponse(result, details);
-                if (key !== result.key) {
-                    key = result.key; // default to model key
-                }
-
-                resolve({
-                    key,
-                    models: result.models,
-                    orderedModels: result.orderedModels,
-                    queries: {
-                        [key]: details,
-                    },
-                    rowCount: result.rowCount,
-                    messages: result.messages,
-                });
-            }
-        }
-
-        const columns = options.columns ? options.columns : '*';
-        Query.selectRows({
-            ...options,
-            requiredVersion: 17.1,
-            filterArray: options.filterArray,
-            method: 'POST',
-            // put on this another parameter!
-            columns,
-            containerFilter: options.containerFilter ?? getContainerFilter(options.containerPath),
-            includeMetadata: isSelectRowMetadataRequired(options.includeMetadata, columns),
-            includeTotalCount: options.includeTotalCount ?? false, // default to false to improve performance
-            success: json => {
-                result = json;
-                hasResults = true;
-                doResolve();
-            },
-            failure: (data, request) => {
-                // If we hit a communication failure, try to get better error messaging from the request.responseText (Issues 51232 and 51204)
-                if (
-                    data.exception?.toLowerCase().indexOf('communication failure') === 0 &&
-                    processRequest(undefined, request, reject)
-                ) {
-                    return;
-                }
-
-                console.error('There was a problem retrieving the data', data);
-                reject({
-                    exceptionClass: data.exceptionClass,
-                    message: data.exception,
-                    schemaQuery,
-                    status: request.status,
-                });
-            },
-        });
-
-        getQueryDetails(options)
-            .then(d => {
-                hasDetails = true;
-                details = d;
-                doResolve();
-            })
-            .catch(error => {
-                console.error('There was a problem retrieving the data', error);
-                reject(error);
-            });
-    });
+    return {
+        key,
+        models: result.models,
+        orderedModels: result.orderedModels,
+        queries: { [key]: queryInfo },
+        rowCount: result.rowCount,
+        messages: result.messages,
+    };
 }
 
 export function handleSelectRowsResponse(response: Query.Response, queryInfo: QueryInfo): any {

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fromJS, List, Map, Record as ImmutableRecord, Set as ImmutableSet } from 'immutable';
+import { fromJS, Record as ImmutableRecord, Set as ImmutableSet, List, Map } from 'immutable';
 import { immerable } from 'immer';
 import { normalize, schema } from 'normalizr';
 import { ActionURL, Ajax, AuditBehaviorTypes, Filter, Query, QueryDOM, Utils } from '@labkey/api';
@@ -93,7 +93,7 @@ export function invalidateQueryDetailsCache(
 }
 
 interface GetQueryDetailsBasic
-    extends Omit<Query.GetQueryDetailsOptions, 'method' | 'schemaName' | 'queryName' | 'viewName'> {
+    extends Omit<Query.GetQueryDetailsOptions, 'method' | 'queryName' | 'schemaName' | 'viewName'> {
     lookup?: QueryLookup;
 }
 
@@ -458,20 +458,18 @@ export interface ISelectRowsResult {
     messages?: List<Map<string, string>>;
     models: any;
     orderedModels: List<any>;
-    queries: {
-        [key: string]: QueryInfo;
-    };
+    queries: Record<string, QueryInfo>;
     rowCount: number;
 }
 
 /**
- * @deprecated use selectRows() instead.
+ * @deprecated use selectRows() or executeSql() instead.
  * Fetches an API response and normalizes the result JSON according to schema.
  * This makes every API response have the same shape, regardless of how nested it was.
  */
 export function selectRowsDeprecated(userConfig, caller?): Promise<ISelectRowsResult> {
     return new Promise((resolve, reject) => {
-        let schemaQuery, key;
+        let key, schemaQuery;
         if (userConfig.queryName) {
             schemaQuery = new SchemaQuery(userConfig.schemaName, userConfig.queryName, userConfig.viewName);
             key = schemaQuery.getKey();
@@ -624,7 +622,7 @@ export function handleSelectRowsResponse(response: Query.Response, queryInfo: Qu
         qsKey = 'queries',
         rowCount = response.rowCount || 0;
 
-    let metadataKey: string, metadataAltKey: string;
+    let metadataAltKey: string, metadataKey: string;
     if (resolved.metaData) {
         // If metaData is present, then use its "id" value regardless of presence of a queryInfo
         metadataKey = resolved.metaData.id;
@@ -836,7 +834,7 @@ export class InsertRowsErrorResponse extends ImmutableRecord({
 }
 
 export interface InsertRowsOptions
-    extends Omit<Query.QueryRequestOptions, 'apiVersion' | 'schemaName' | 'queryName' | 'rows'> {
+    extends Omit<Query.QueryRequestOptions, 'apiVersion' | 'queryName' | 'rows' | 'schemaName'> {
     fillEmptyFields?: boolean;
     rows: List<any>; // TODO: convert to Array<Record<string, any>>
     schemaQuery: SchemaQuery;
@@ -956,7 +954,7 @@ function ensureNullForUndefined(row: Map<string, any>): Map<string, any> {
     return row.reduce((map, v, k) => map.set(k, v === undefined ? null : v), Map<string, any>());
 }
 
-export interface UpdateRowsOptions extends Omit<Query.QueryRequestOptions, 'schemaName' | 'queryName'> {
+export interface UpdateRowsOptions extends Omit<Query.QueryRequestOptions, 'queryName' | 'schemaName'> {
     schemaQuery: SchemaQuery;
 }
 
@@ -1005,7 +1003,7 @@ export function updateRowsByContainer(
     rows: any[],
     containerPaths: string[],
     auditUserComment: string,
-    containerField: string = 'Folder'
+    containerField = 'Folder'
 ): Promise<Query.SaveRowsResponse | QueryCommandResponse> {
     // if all rows are in the same container, we can use updateRows (which supports file/attachments)
     if (containerPaths.length < 2) {
@@ -1031,7 +1029,7 @@ export function updateRowsByContainer(
     }
 }
 
-export interface DeleteRowsOptions extends Omit<Query.QueryRequestOptions, 'schemaName' | 'queryName'> {
+export interface DeleteRowsOptions extends Omit<Query.QueryRequestOptions, 'queryName' | 'schemaName'> {
     schemaQuery: SchemaQuery;
 }
 
@@ -1093,7 +1091,7 @@ export function splitRowsByContainer(rows: any[], containerField: string): Recor
 
 export function saveRowsByContainer(
     options: SaveRowsOptions,
-    containerField: string = 'Folder'
+    containerField = 'Folder'
 ): Promise<Query.SaveRowsResponse> {
     const commands = []; // TODO type as Query.Command
 
@@ -1120,7 +1118,7 @@ export function saveRowsByContainer(
 
 export function deleteRowsByContainer(
     options: DeleteRowsOptions,
-    containerField: string = 'ContainerPath'
+    containerField = 'ContainerPath'
 ): Promise<QueryCommandResponse> {
     const commands = [];
 
@@ -1187,7 +1185,7 @@ export enum InsertOptions {
     CREATE, // synonymous with Import for server-side; used for better messaging client-side
 }
 
-export function getVerbForInsertOption(option: string, defaultVerb: string = 'imported'): string {
+export function getVerbForInsertOption(option: string, defaultVerb = 'imported'): string {
     if (option === InsertOptions.MERGE.toString()) {
         return defaultVerb + ' or updated';
     } else if (option === InsertOptions.UPDATE.toString()) {
@@ -1340,7 +1338,7 @@ export function getContainerFilterForLookups(moduleContext?: ModuleContext): Que
     return Query.ContainerFilter.currentPlusProjectAndShared;
 }
 
-export interface SelectDistinctOptions extends Omit<Query.SelectDistinctOptions, 'success' | 'failure'> {
+export interface SelectDistinctOptions extends Omit<Query.SelectDistinctOptions, 'failure' | 'success'> {
     requestHandler?: RequestHandler;
 }
 

--- a/packages/components/src/internal/query/executeSql.ts
+++ b/packages/components/src/internal/query/executeSql.ts
@@ -7,7 +7,8 @@ import { QueryInfo } from '../../public/QueryInfo';
 import { URLResolver } from '../url/URLResolver';
 import { RequestHandler } from '../request';
 
-export interface ExecuteSqlOptions extends Omit<Query.ExecuteSqlOptions, 'requiredVersion' | 'scope'> {
+export interface ExecuteSqlOptions
+    extends Omit<Query.ExecuteSqlOptions, 'failure' | 'requiredVersion' | 'scope' | 'success'> {
     requestHandler?: RequestHandler;
 }
 

--- a/packages/components/src/internal/query/executeSql.ts
+++ b/packages/components/src/internal/query/executeSql.ts
@@ -1,0 +1,90 @@
+import { Query } from '@labkey/api';
+
+import { Row } from './selectRows';
+import { getContainerFilter, getQueryDetails } from './api';
+import { SchemaQuery } from '../../public/SchemaQuery';
+import { QueryInfo } from '../../public/QueryInfo';
+import { URLResolver } from '../url/URLResolver';
+import { RequestHandler } from '../request';
+
+export interface ExecuteSqlOptions extends Omit<Query.ExecuteSqlOptions, 'requiredVersion' | 'scope'> {
+    requestHandler?: RequestHandler;
+}
+
+export interface ExecuteSqlResponseBase {
+    messages: Record<string, string>[];
+    rowCount: number;
+    rows: Row[];
+}
+
+export interface ExecuteSqlResponseWithSession extends ExecuteSqlResponseBase {
+    queryInfo: QueryInfo;
+    schemaQuery: SchemaQuery;
+}
+
+export type ExecuteSqlResponseWithoutSession = ExecuteSqlResponseBase;
+
+export type ExecuteSqlResponse<T extends ExecuteSqlOptions> = T['saveInSession'] extends true
+    ? ExecuteSqlResponseWithSession
+    : ExecuteSqlResponseWithoutSession;
+
+export async function executeSql<T extends ExecuteSqlOptions>(options: T): Promise<ExecuteSqlResponse<T>> {
+    const {
+        containerFilter = getContainerFilter(options.containerPath),
+        requestHandler,
+        ...executeSqlOptions
+    } = options;
+    const saveInSession = executeSqlOptions.saveInSession === true;
+
+    return new Promise((resolve, reject) => {
+        const request_ = Query.executeSql({
+            ...executeSqlOptions,
+            containerFilter,
+            requiredVersion: 17.1,
+            success: async response => {
+                let queryInfo: QueryInfo;
+                let schemaQuery: SchemaQuery;
+
+                if (saveInSession) {
+                    schemaQuery = new SchemaQuery(options.schemaName, response.queryName);
+
+                    try {
+                        queryInfo = await getQueryDetails({ containerPath: options.containerPath, schemaQuery });
+                    } catch (e) {
+                        reject(e);
+                        return;
+                    }
+                }
+
+                const { messages, rows, rowCount } = new URLResolver().resolveSelectRows(response, queryInfo);
+
+                if (saveInSession) {
+                    // For saveInSession=true case
+                    resolve({
+                        messages,
+                        queryInfo,
+                        rows,
+                        rowCount,
+                        schemaQuery,
+                    } as ExecuteSqlResponseWithSession);
+                } else {
+                    // For saveInSession=false case
+                    resolve({
+                        messages,
+                        rows,
+                        rowCount,
+                    } as ExecuteSqlResponse<T>);
+                }
+            },
+            failure: (data, request) => {
+                console.error('There was a problem retrieving the data', data);
+                reject({
+                    exceptionClass: data.exceptionClass,
+                    message: data.exception,
+                    status: request.status,
+                });
+            },
+        });
+        requestHandler?.(request_);
+    });
+}

--- a/packages/components/src/internal/query/selectRows.ts
+++ b/packages/components/src/internal/query/selectRows.ts
@@ -7,7 +7,10 @@ import { URLResolver } from '../url/URLResolver';
 import { getContainerFilter, getQueryDetails, isSelectRowMetadataRequired } from './api';
 
 export interface SelectRowsOptions
-    extends Omit<Query.SelectRowsOptions, 'queryName' | 'requiredVersion' | 'schemaName' | 'scope'> {
+    extends Omit<
+        Query.SelectRowsOptions,
+        'failure' | 'queryName' | 'requiredVersion' | 'schemaName' | 'scope' | 'success'
+    > {
     schemaQuery: SchemaQuery;
 }
 
@@ -20,7 +23,7 @@ export interface RowValue {
 export type Row = Record<string, RowValue>;
 
 export interface SelectRowsResponse {
-    messages: Array<Record<string, string>>;
+    messages: Record<string, string>[];
     queryInfo: QueryInfo;
     rowCount: number;
     rows: Row[];

--- a/packages/components/src/internal/query/selectRows.ts
+++ b/packages/components/src/internal/query/selectRows.ts
@@ -42,7 +42,7 @@ export async function selectRows(options: SelectRowsOptions): Promise<SelectRows
 
     const [queryInfo, response] = await Promise.all([
         getQueryDetails({ containerPath: options.containerPath, schemaQuery }),
-        new Promise<any>((resolve, reject) => {
+        new Promise<Query.Response>((resolve, reject) => {
             Query.selectRows({
                 ...selectRowsOptions,
                 columns,

--- a/packages/components/src/internal/request.ts
+++ b/packages/components/src/internal/request.ts
@@ -11,7 +11,7 @@ import { Ajax, Utils } from '@labkey/api';
  *
  * new Promise((resolve, reject) => {
  *     return Ajax.request({
- *         // ... url, success handler, etc
+ *         // ... url, success handler, etc.
  *         failure: handleRequestFailure(reject, 'This optional message is logged to console.error'),
  *     });
  * });

--- a/packages/components/src/public/InferDomainResponse.ts
+++ b/packages/components/src/public/InferDomainResponse.ts
@@ -1,9 +1,6 @@
 import { fromJS, List, Record } from 'immutable';
 
-import { Ajax, Utils } from '@labkey/api';
-
-import { buildURL } from '../internal/url/AppURL';
-import { processRequest } from '../internal/query/api';
+import { ActionURL, Ajax, Utils } from '@labkey/api';
 
 import { QueryColumn } from './QueryColumn';
 
@@ -61,11 +58,10 @@ export function inferDomainFromFile(
         }
 
         Ajax.request({
-            url: buildURL('property', 'inferDomain'),
+            url: ActionURL.buildURL('property', 'inferDomain.api'),
             method: 'POST',
             form,
-            success: Utils.getCallbackWrapper((response, request) => {
-                if (processRequest(response, request, reject)) return;
+            success: Utils.getCallbackWrapper(response => {
                 resolve(InferDomainResponse.create(response));
             }),
             failure: Utils.getCallbackWrapper(error => {


### PR DESCRIPTION
#### Rationale
Introduce a standalone `executeSql()` that is akin to `selectRows()`. We have a number of usages of `Query.executeSql()` that are not going through our wrappers (namely `selectRowsDeprecated()`). This streamlines all of the executeSql calls, gets rid of the awkward patterns in `selectRowsDeprecated()`, and allows for reduction of a lot of boilerplate.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/197
- https://github.com/LabKey/labkey-ui-components/pull/1813
- https://github.com/LabKey/labkey-ui-premium/pull/777
- https://github.com/LabKey/limsModules/pull/1480
- https://github.com/LabKey/platform/pull/6779

#### Changes
- Introduces `executeSql()` and adds it to our `QueryAPIWrapper`.
- Refactors all usages of `Query.executeSql()` in our apps to use the new `executeSql()`.
- Refactors all usages of `selectRowsDeprecated()` that are using the sql parameter to use `executeSql()`.
- Removes supports for calling `Query.executeSql()` from `selectRowsDeprecated()`.
- Add typings to `selectRowsDeprecated()` (better late then never).
- Update usages of `Query.Command` interface
