### PR TITLE
Issue 53120: remove processRequest, use getCallbackWrapper

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.0",
+  "version": "6.52.1-fb-request-53120.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.0",
+      "version": "6.52.1-fb-request-53120.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.1-fb-request-53120.0",
+  "version": "6.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.1-fb-request-53120.0",
+      "version": "6.52.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.1-fb-request-53120.0",
+  "version": "6.52.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.0",
+  "version": "6.52.1-fb-request-53120.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.52.1
+*Released*: 25 June 2025
+- Issue 53120: remove processRequest, use getCallbackWrapper
+
 ### version 6.52.0
 *Released*: 24 June 2025
 - Improve ExecuteSql endpoint wrapper. See #1813.

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -1151,12 +1151,20 @@ export function importData(config: IImportData): Promise<any> {
     });
 }
 
-export function processRequest(response: any, request: any, reject: (reason?: any) => void): boolean {
+export function processRequest(response: any, request: XMLHttpRequest, reject: (reason?: any) => void): boolean {
     if (!response && request?.responseText) {
-        const resp = JSON.parse(request.responseText);
-        if (!resp?.success) {
-            console.error(resp);
-            reject(resp);
+        let json: any;
+        try {
+            json = JSON.parse(request.responseText);
+        } catch (e) {
+            // Issue 53120: Unable to parse JSON. Do not attempt to process this request any further.
+            console.error(`Failed to parse response as JSON. ResponseURL: ${request.responseURL}`, e);
+            return false;
+        }
+
+        if (!json?.success) {
+            console.error(json);
+            reject(json);
             return true;
         }
     }

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -491,14 +491,6 @@ export async function selectRowsDeprecated(options: SelectRowsDeprecatedOptions)
                     resolve(response_);
                 },
                 failure: (data, request) => {
-                    // If we hit a communication failure, try to get better error messaging from the request.responseText (Issues 51232 and 51204)
-                    if (
-                        data.exception?.toLowerCase().indexOf('communication failure') === 0 &&
-                        processRequest(undefined, request, reject)
-                    ) {
-                        return;
-                    }
-
                     console.error('There was a problem retrieving the data', data);
                     reject({
                         exceptionClass: data.exceptionClass,
@@ -803,9 +795,7 @@ export function insertRows(options: InsertRowsOptions): Promise<QueryCommandResp
                     ? true
                     : options.skipReselectRows,
             apiVersion: 13.2,
-            success: (response, request) => {
-                if (processRequest(response, request, reject)) return;
-
+            success: response => {
                 resolve(
                     new QueryCommandResponse({
                         schemaQuery,
@@ -886,9 +876,7 @@ export function updateRows(options: UpdateRowsOptions): Promise<QueryCommandResp
                 options.skipReselectRows === null || options.skipReselectRows === undefined
                     ? true
                     : options.skipReselectRows,
-            success: (response, request) => {
-                if (processRequest(response, request, reject)) return;
-
+            success: response => {
                 resolve(
                     new QueryCommandResponse({
                         schemaQuery,
@@ -1149,27 +1137,6 @@ export function importData(config: IImportData): Promise<any> {
             })
         );
     });
-}
-
-export function processRequest(response: any, request: XMLHttpRequest, reject: (reason?: any) => void): boolean {
-    if (!response && request?.responseText) {
-        let json: any;
-        try {
-            json = JSON.parse(request.responseText);
-        } catch (e) {
-            // Issue 53120: Unable to parse JSON. Do not attempt to process this request any further.
-            console.error(`Failed to parse response as JSON. ResponseURL: ${request.responseURL}`, e);
-            return false;
-        }
-
-        if (!json?.success) {
-            console.error(json);
-            reject(json);
-            return true;
-        }
-    }
-
-    return false;
 }
 
 /**

--- a/packages/components/src/internal/query/reports.ts
+++ b/packages/components/src/internal/query/reports.ts
@@ -1,7 +1,8 @@
-import { Ajax, Utils } from '@labkey/api';
+import { ActionURL } from '@labkey/api';
 
 import { IDataViewInfo } from '../DataViewInfo';
-import { AppURL, buildURL } from '../url/AppURL';
+import { AppURL } from '../url/AppURL';
+import { request } from '../request';
 
 export type ReportURLMapper = (report: IDataViewInfo) => AppURL;
 
@@ -9,8 +10,8 @@ export type ReportURLMapper = (report: IDataViewInfo) => AppURL;
  * FlattenResponse converts the response body (a nested tree structure) from browseDataTree into a flat list of
  * ReportItem objects. This method purposely ignores categories and their nested structures.
  *
- * @param response: the body from the browseDataTree API Action
- * @param urlMapper: ReportURLMapper
+ * @param response the body from the browseDataTree API Action
+ * @param urlMapper ReportURLMapper
  */
 export function flattenBrowseDataTreeResponse(response: any, urlMapper?: ReportURLMapper): IDataViewInfo[] {
     function _flattenBrowseDataTreeResponse(all, item): IDataViewInfo[] {
@@ -32,22 +33,11 @@ export function flattenBrowseDataTreeResponse(response: any, urlMapper?: ReportU
     return _flattenBrowseDataTreeResponse([], response);
 }
 
-export function loadReports(urlMapper?: ReportURLMapper): Promise<IDataViewInfo[]> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            method: 'GET',
-            url: buildURL('reports', 'browseDataTree.api'),
-            success: request => {
-                const reports = flattenBrowseDataTreeResponse(JSON.parse(request.responseText), urlMapper);
-                resolve(reports);
-            },
-            failure: Utils.getCallbackWrapper(
-                error => {
-                    reject(error);
-                },
-                this,
-                true
-            ),
-        });
+export async function loadReports(urlMapper?: ReportURLMapper): Promise<IDataViewInfo[]> {
+    const result = await request({
+        url: ActionURL.buildURL('reports', 'browseDataTree.api'),
+        errorLogMsg: 'Failed to load reports',
     });
+
+    return flattenBrowseDataTreeResponse(result, urlMapper);
 }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53120](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53120) by removing the client-side redundant processing of request payloads and deferring to the commonly used `Utils.getCallbackWrapper()`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1814
- https://github.com/LabKey/labkey-ui-premium/pull/778
- https://github.com/LabKey/limsModules/pull/1482
- https://github.com/LabKey/platform/pull/6780

#### Changes
- Remove the post-processing `processRequest()` that was handling the scenario where the content did not match the content type (e.g. a JSON payload where the content-type header is html or something else).
- Update `reports-browseDataTree.api` endpoint wrapper to not perform its own JSON parsing and use `getCallbackWrapper()` instead.
