### PR TITLE
Issue 53153: Accept rowId value for "AliquotedFrom"

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.0",
+  "version": "6.51.1-fb-alias-merge.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.51.0",
+      "version": "6.51.1-fb-alias-merge.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.0",
+  "version": "6.51.1-fb-alias-merge.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -338,8 +338,8 @@ export class EditorModel
             if (renderer?.getEditableRawValue) {
                 row = row.set(col.name, renderer.getEditableRawValue(values));
             } else if (col.isLookup()) {
-                if (col.isExpInput() || col.isAliquotParent()) {
-                    // We have to use display values for ExpInput and AliquotParent because of name expressions
+                if (col.isExpInput()) {
+                    // We have to use display values for ExpInput because of name expressions
                     row = row.set(
                         col.name,
                         values


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53153](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53153) by updating the server-side to accept sample rowIds as the value for the `AliquotedFrom` field. Formerly, it would only accept the name of a sample due to limitations around name expression parsing. However, our applications, and the query metadata for the `AliquotedFrom` column annotate the value of the column to be the rowId -- not the name. This results in difficult behaviors where we always need to resolve the name of sample even if we have the rowId.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1815
- https://github.com/LabKey/platform/pull/6788
- https://github.com/LabKey/limsModules/pull/1487

#### Changes
- No longer special case aliquot column in editable grid
