### PR TITLE
Issue 53326: Don't filter `QuerySelect` in `PrintLabelsModal`

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.0",
+  "version": "6.52.1-miscIssues257seh.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.0",
+      "version": "6.52.1-miscIssues257seh.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.0",
+  "version": "6.51.1-miscIssues257seh.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.51.0",
+      "version": "6.51.1-miscIssues257seh.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.2-miscIssues257seh.0",
+  "version": "6.52.2-miscIssues257seh.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.2-miscIssues257seh.0",
+      "version": "6.52.2-miscIssues257seh.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.2-miscIssues257seh.4",
+  "version": "6.52.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.2-miscIssues257seh.4",
+      "version": "6.52.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.2-miscIssues257seh.4",
+  "version": "6.52.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.2-miscIssues257seh.0",
+  "version": "6.52.2-miscIssues257seh.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.51.0",
+  "version": "6.51.1-miscIssues257seh.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 53326: Don't filter `QuerySelect` in `PrintLabelsModal`
+- Issue 53213: Defensive check for view `sorts` array
+
 ### version 6.51.0
 *Released*: 23 June 2025
 - SampleAliquotViewSelector, GridAliquotViewSelector: Fix props types

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.52.2
+*Released*: 27 June 2025
 - Issue 53326: Don't filter `QuerySelect` in `PrintLabelsModal`
 - Issue 53213: Defensive check for view `sorts` array
 

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -113,13 +113,13 @@ export class ViewInfo {
         const name_ = isDefault || name === undefined || name === '' ? ViewInfo.DEFAULT_NAME : name;
 
         return new ViewInfo({
+            ...rest,
             columns: columns !== undefined ? [...columns] : [],
             filters: getFiltersFromView(filter),
             isDefault,
             label: label_,
             name: name_,
             sorts: getSortsFromView(sort),
-            ...rest,
         });
     }
 

--- a/packages/components/src/internal/components/labelPrinting/PrintLabelsModal.tsx
+++ b/packages/components/src/internal/components/labelPrinting/PrintLabelsModal.tsx
@@ -1,5 +1,4 @@
 import React, { PureComponent, ReactNode } from 'react';
-import { List } from 'immutable';
 
 import { Modal } from '../../Modal';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
@@ -223,7 +222,7 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                 <>
                     <div className="bottom-padding">{message}</div>
                     <div>
-                        <strong>Number of copies</strong>
+                        <label>Number of copies</label>
                         <input
                             className="form-control label-printing--copies"
                             min={1}
@@ -234,7 +233,7 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                         />
                         {showSelection && (
                             <div className="top-padding">
-                                <strong>Selected samples to print</strong>
+                                <label>Selected samples to print</label>
                                 <QuerySelect
                                     formsy={false}
                                     fireQSChangeOnInit={true}
@@ -254,7 +253,7 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                             </div>
                         )}
                         <div className="top-padding">
-                            <strong>Label template</strong>
+                            <label>Label template</label>
                             <QuerySelect
                                 formsy={false}
                                 fireQSChangeOnInit

--- a/packages/components/src/internal/components/labelPrinting/PrintLabelsModal.tsx
+++ b/packages/components/src/internal/components/labelPrinting/PrintLabelsModal.tsx
@@ -247,7 +247,6 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                                     placeholder="Select or type to search..."
                                     required={false}
                                     schemaQuery={model.schemaQuery}
-                                    queryFilters={List(model.filters)}
                                     displayColumn={displayColumn}
                                     valueColumn={valueColumn}
                                     value={this.props.sampleIds?.join(',')}

--- a/packages/components/src/internal/components/labelPrinting/models.ts
+++ b/packages/components/src/internal/components/labelPrinting/models.ts
@@ -20,7 +20,7 @@ export class BarTenderConfiguration implements BarTenderConfigurationModel {
     static create(config?: { defaultLabel: string; serviceURL: string }): BarTenderConfiguration {
         return new BarTenderConfiguration({
             serviceURL: config.serviceURL,
-            defaultLabel: parseInt(config.defaultLabel, 10),
+            defaultLabel: config.defaultLabel ? parseInt(config.defaultLabel, 10) : undefined,
         });
     }
 

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -446,7 +446,7 @@ export class QueryInfo {
             const viewInfo = this.getView(view);
 
             if (viewInfo) {
-                return viewInfo.sorts;
+                return viewInfo.sorts ?? []; // Issue 53212
             }
 
             console.warn('Unable to find view:', view, '(' + this.schemaName + '.' + this.name + ')');

--- a/packages/components/src/public/QueryInfo.ts
+++ b/packages/components/src/public/QueryInfo.ts
@@ -446,7 +446,7 @@ export class QueryInfo {
             const viewInfo = this.getView(view);
 
             if (viewInfo) {
-                return viewInfo.sorts ?? []; // Issue 53212
+                return viewInfo.sorts;
             }
 
             console.warn('Unable to find view:', view, '(' + this.schemaName + '.' + this.name + ')');


### PR DESCRIPTION
#### Rationale
Issue [53326](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53326): The QuerySelect input for the Print Labels modal does not need or want to be filtered based on the grid it is associated with. If filtered, some of the selected samples may not be available since we don't retrieve all columns for that QuerySelect.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1492

#### Changes
- Remove `queryFilter` parameter from `QuerySelect` in `PrintLabelsModal`
- Add a defensive check that assures the `sorts` value for `QueryInfo` is defined. 
