### PR TITLE
Issue 53360: User comments for domain changes are not being saved when there are naming pattern warnings.

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.3-domainCommentWithWarning.0",
+  "version": "6.52.3-domainCommentWithWarning.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.3-domainCommentWithWarning.0",
+      "version": "6.52.3-domainCommentWithWarning.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.4",
+  "version": "6.52.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.4",
+      "version": "6.52.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.2",
+  "version": "6.52.3-domainCommentWithWarning.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.2",
+      "version": "6.52.3-domainCommentWithWarning.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.4-domainCommentWithWarning.1",
+  "version": "6.52.4-domainCommentWithWarning.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.4-domainCommentWithWarning.1",
+      "version": "6.52.4-domainCommentWithWarning.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.4-domainCommentWithWarning.1",
+  "version": "6.52.4-domainCommentWithWarning.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.2",
+  "version": "6.52.3-domainCommentWithWarning.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.5-domainCommentWithWarning.2",
+  "version": "6.52.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.3-domainCommentWithWarning.0",
+  "version": "6.52.3-domainCommentWithWarning.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 53360: Pass user comment through after naming pattern warning
+
 ### version 6.52.2
 *Released*: 27 June 2025
 - Issue 53326: Don't filter `QuerySelect` in `PrintLabelsModal`

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -357,14 +357,14 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         });
     };
 
-    onFinish = (auditUserComment?: string): void => {
+    onFinish = (comment?: string): void => {
         const { defaultSampleFieldConfig, setSubmitting, metricUnitProps } = this.props;
-        const { model, uniqueIdsConfirmed } = this.state;
+        const { model, uniqueIdsConfirmed, auditUserComment } = this.state;
 
         if (!model.isNew() && this.getNumNewUniqueIdFields() > 0 && !uniqueIdsConfirmed) {
             this.setState({
                 showUniqueIdConfirmation: true,
-                auditUserComment
+                auditUserComment: comment,
             });
             return;
         }
@@ -397,7 +397,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
             this.setState(
                 {
                     model: updatedModel,
-                    auditUserComment,
+                    auditUserComment: comment,
                 },
                 () => {
                     scrollDomainErrorIntoView();

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -475,6 +475,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                                 nameExpressionWarnings: response.warnings,
                                 namePreviews: response.previews,
                                 showUniqueIdConfirmation: false,
+                                auditUserComment: comment,
                             }),
                             () => {
                                 scrollDomainErrorIntoView();

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -372,7 +372,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         const metricUnitRequired = metricUnitProps?.metricUnitRequired;
         const isValid = model.isValid(defaultSampleFieldConfig, metricUnitRequired);
 
-        this.props.onFinish(isValid, () => this.saveDomain(false, auditUserComment));
+        this.props.onFinish(isValid, () => this.saveDomain(false, comment ?? auditUserComment));
 
         if (isValid) return;
 


### PR DESCRIPTION
#### Rationale
Issue [53360](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53360)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1494

#### Changes
- Save the user comment, if any, before showing naming pattern warnings.
