### PR TITLE
Issue 53118: Filter modal change to multiValue type to account for numeric value when parsing

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.3",
+  "version": "6.52.3-filterModal53118.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.3",
+      "version": "6.52.3-filterModal53118.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.3-filterModal53118.0",
+  "version": "6.52.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.3-filterModal53118.0",
+      "version": "6.52.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.3-filterModal53118.0",
+  "version": "6.52.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.3",
+  "version": "6.52.3-filterModal53118.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 53118: Filter modal change to multiValue type to account for numeric value when parsing
+
 ### version 6.52.3
 *Released*: 27 June 2025
 - GitHub Issue 787: DomainField JSON file import should respect required boolean for SampleId field

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.52.4
+*Released*: 30 June 2025
 - Issue 53118: Filter modal change to multiValue type to account for numeric value when parsing
 
 ### version 6.52.3

--- a/packages/components/src/internal/components/search/FilterExpressionView.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.tsx
@@ -285,8 +285,10 @@ export const FilterExpressionView: FC<Props> = memo(props => {
             }
 
             if (filterType.multiValue && !filterType.betweenOperator) {
-                // Issue 52068: if the valueRaw is an array, just join it by new lines (not replacing semicolons)
-                const value = Array.isArray(valueRaw) ? valueRaw.join('\n') : (valueRaw?.replaceAll(';', '\n') ?? '');
+                // Issue 52068/53118: if the valueRaw is an array, just join it by new lines (not replacing semicolons)
+                const value = Array.isArray(valueRaw)
+                    ? valueRaw.join('\n')
+                    : (valueRaw?.toString().replaceAll(';', '\n') ?? '');
 
                 return (
                     <textarea

--- a/packages/components/src/internal/components/search/FilterExpressionView.tsx
+++ b/packages/components/src/internal/components/search/FilterExpressionView.tsx
@@ -13,9 +13,9 @@ import { DatePickerInput } from '../forms/input/DatePickerInput';
 import { OntologyBrowserFilterPanel } from '../ontology/OntologyBrowserFilterPanel';
 
 import {
+    getFilterOptionsForType,
     getFilterSelections,
     getFilterTypePlaceHolder,
-    getFilterOptionsForType,
     getUpdatedFilters,
     getUpdatedFilterSelection,
 } from './utils';
@@ -229,16 +229,12 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                 return (
                     <DatePickerInput
                         allowRelativeInput={allowRelativeDateFilter}
-                        formsy={false}
-                        inputClassName="form-control filter-expression__input"
-                        wrapperClassName="form-group col-sm-12 filter-expression__input-wrapper"
-                        queryColumn={field}
-                        name={'field-value-date' + suffix}
-                        value={valueRaw}
-                        showLabel={false}
-                        isClearable
-                        hideTime={!isTimeOnly} // filter date and datetime by date only, without timepicker
                         disabled={disabled}
+                        formsy={false}
+                        hideTime={!isTimeOnly} // filter date and datetime by date only, without timepicker
+                        inputClassName="form-control filter-expression__input"
+                        isClearable
+                        name={'field-value-date' + suffix}
                         onChange={newDate => {
                             let dateStr = newDate;
                             if (typeof newDate !== 'string')
@@ -247,6 +243,10 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                                     : getJsonDateFormatString(newDate);
                             updateDateFilterFieldValue(filterIndex, dateStr, isSecondInput);
                         }}
+                        queryColumn={field}
+                        showLabel={false}
+                        value={valueRaw}
+                        wrapperClassName="form-group col-sm-12 filter-expression__input-wrapper"
                     />
                 );
             } else if (jsonType === 'boolean') {
@@ -257,11 +257,11 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                                 <input
                                     checked={valueRaw == 'true'}
                                     className=""
-                                    type="radio"
-                                    name={'field-value-bool' + suffix}
-                                    value="true"
                                     disabled={disabled}
+                                    name={'field-value-bool' + suffix}
                                     onChange={event => updateBooleanFilterFieldValue(filterIndex, event)}
+                                    type="radio"
+                                    value="true"
                                 />{' '}
                                 TRUE
                             </label>
@@ -271,11 +271,11 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                                 <input
                                     checked={valueRaw && valueRaw != 'true'}
                                     className=""
-                                    type="radio"
-                                    name={'field-value-bool' + suffix}
-                                    value="false"
                                     disabled={disabled}
+                                    name={'field-value-bool' + suffix}
                                     onChange={event => updateBooleanFilterFieldValue(filterIndex, event)}
+                                    type="radio"
+                                    value="false"
                                 />{' '}
                                 FALSE
                             </label>
@@ -293,12 +293,12 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                 return (
                     <textarea
                         className="form-control filter-expression__textarea"
+                        defaultValue={value}
                         name={'field-value-text' + suffix}
                         onChange={event => updateTextFilterFieldValue(filterIndex, event)}
-                        defaultValue={value}
-                        rows={3}
-                        required
                         placeholder={placeholder}
+                        required
+                        rows={3}
                     />
                 );
             }
@@ -307,15 +307,15 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                 return (
                     <input
                         className="form-control filter-expression__input"
-                        step={jsonType === 'int' ? 1 : undefined}
+                        disabled={disabled}
                         name={'field-value-text' + suffix}
                         onChange={event => updateTextFilterFieldValue(filterIndex, event, true)}
                         pattern={jsonType === 'int' ? '-?[0-9]*' : undefined}
-                        type="number"
-                        value={valueRaw ?? ''}
                         placeholder={placeholder}
                         required
-                        disabled={disabled}
+                        step={jsonType === 'int' ? 1 : undefined}
+                        type="number"
+                        value={valueRaw ?? ''}
                     />
                 );
             }
@@ -323,13 +323,13 @@ export const FilterExpressionView: FC<Props> = memo(props => {
             const textInput = (
                 <input
                     className="form-control filter-expression__input"
+                    disabled={disabled}
                     name={'field-value-text' + suffix}
-                    type="text"
-                    value={valueRaw ?? ''}
                     onChange={event => updateTextFilterFieldValue(filterIndex, event)}
                     placeholder={placeholder}
                     required
-                    disabled={disabled}
+                    type="text"
+                    value={valueRaw ?? ''}
                 />
             );
 
@@ -351,13 +351,13 @@ export const FilterExpressionView: FC<Props> = memo(props => {
                             </a>
                             {expanded && (
                                 <OntologyBrowserFilterPanel
-                                    ontologyId={field.sourceOntology}
                                     conceptSubtree={field.conceptSubtree}
-                                    filterValue={valueRaw}
                                     filterType={Filter.getFilterTypeForURLSuffix(filterType.value)}
+                                    filterValue={valueRaw}
                                     onFilterChange={filterValue =>
                                         updateOntologyFieldValue(filterIndex, filterValue, isSecondInput)
                                     }
+                                    ontologyId={field.sourceOntology}
                                 />
                             )}
                         </div>
@@ -411,31 +411,31 @@ export const FilterExpressionView: FC<Props> = memo(props => {
     return (
         <div className="filter-expression__panel">
             <SelectInput
+                containerClass="form-group filter-expression__input-wrapper"
+                disabled={disabled}
+                inputClass="filter-expression__input-select"
                 key={'filter-expression-field-filter-type-' + removeFilterCount} // we need to recreate this component when a filter is removed
                 name="filter-expression-field-filter-type"
-                containerClass="form-group filter-expression__input-wrapper"
-                inputClass="filter-expression__input-select"
-                placeholder="Select a filter type..."
-                value={activeFilters[0]?.filterType?.value}
                 onChange={onUpdateFirstField}
                 options={unusedFilterOptions(0)}
-                disabled={disabled}
+                placeholder="Select a filter type..."
+                value={activeFilters[0]?.filterType?.value}
             />
             {renderFilterTypeInputs(0)}
             {shouldShowSecondFilter && (
                 <>
                     <div className="field-modal__col-sub-title">and</div>
                     <SelectInput
-                        key="filter-expression-field-filter-type"
-                        name="filter-expression-field-filter-type"
                         containerClass="form-group filter-expression__input-wrapper"
+                        disabled={disabled}
                         inputClass="filter-expression__input-select"
-                        placeholder="Select a filter type..."
-                        value={activeFilters[1]?.filterType?.value}
+                        key="filter-expression-field-filter-type"
+                        menuPosition="fixed"
+                        name="filter-expression-field-filter-type"
                         onChange={onUpdateSecondField}
                         options={unusedFilterOptions(1)}
-                        menuPosition="fixed"
-                        disabled={disabled}
+                        placeholder="Select a filter type..."
+                        value={activeFilters[1]?.filterType?.value}
                     />
                     {renderFilterTypeInputs(1)}
                 </>

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -16,6 +16,7 @@ import {
     ALL_VALUE_DISPLAY,
     decodeErrorMessage,
     EMPTY_VALUE_DISPLAY,
+    escapeSearchQuery,
     getCheckedFilterValues,
     getFieldFiltersValidationResult,
     getFilterSelections,
@@ -27,7 +28,6 @@ import {
     getUpdatedFilterSelection,
     getUpdateFilterExpressionFilter,
     isValidFilterField,
-    escapeSearchQuery,
 } from './utils';
 import { SearchCategory } from './constants';
 import { FieldFilter } from './models';

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -467,6 +467,12 @@ describe('getUpdateFilterExpressionFilter', () => {
     });
 
     test('in filter type with value string', () => {
+        expect(getUpdateFilterExpressionFilter(oneOfOption, stringField, null, null, '123')).toStrictEqual(
+            Filter.create(fieldKey, ['123'], Filter.Types.IN)
+        );
+        expect(getUpdateFilterExpressionFilter(oneOfOption, stringField, null, null, 123)).toStrictEqual(
+            Filter.create(fieldKey, ['123'], Filter.Types.IN)
+        );
         expect(getUpdateFilterExpressionFilter(oneOfOption, stringField, null, null, 'a;b;c')).toStrictEqual(
             Filter.create(fieldKey, ['a', 'b', 'c'], Filter.Types.IN)
         );

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -127,8 +127,8 @@ export function getFilterValuesAsArray(filter: Filter.IFilter, blankValue?: stri
 }
 
 export function getFieldFiltersValidationResult(
-    dataTypeFilters: { [key: string]: FieldFilter[] },
-    queryLabels?: { [key: string]: string },
+    dataTypeFilters: Record<string, FieldFilter[]>,
+    queryLabels?: Record<string, string>,
     maxMultiValuedValues: number = MAX_MULTI_VALUE_FILTER_VALUES
 ): string {
     const missingValueFields = {};
@@ -302,6 +302,9 @@ export function getCheckedFilterValues(filter: Filter.IFilter, allValues: string
         case '':
         case 'any':
             return allValues;
+        case 'eq':
+        case 'in':
+            return filterValues;
         case 'isblank':
             return [EMPTY_VALUE_DISPLAY];
         case 'isnonblank':
@@ -311,9 +314,6 @@ export function getCheckedFilterValues(filter: Filter.IFilter, allValues: string
         case 'neq':
         case 'neqornull':
             return allValues.filter(value => value !== filterValues[0] && value !== ALL_VALUE_DISPLAY);
-        case 'eq':
-        case 'in':
-            return filterValues;
         case 'notin':
             return allValues?.filter(value => filterValues.indexOf(value) === -1 && value !== ALL_VALUE_DISPLAY);
         default:

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -265,6 +265,9 @@ export function getUpdateFilterExpressionFilter(
         } else if (!value && field.getDisplayFieldJsonType() === 'boolean') {
             value = 'false';
         } else if (value && filterType.isMultiValued()) {
+            // Issue 53118: if the value is not an array, convert it to a string
+            if (!Array.isArray(value) && !Utils.isString(value)) value = value.toString();
+
             // Issue 52068: for multivalued filter types, split on new line to get an array of values
             value = value.indexOf('\n') > -1 ? value.split('\n') : filterType.parseValue(value);
         }


### PR DESCRIPTION
#### Rationale
Issue [53118](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53118): LKSM/LKB: Between or Equals One Of Filter type created without an array results in Uncaught Error from Object.parseValue ()

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1819
- https://github.com/LabKey/limsModules/pull/1495

#### Changes
- Filter modal change to multiValue type to account for numeric value when parsing
