### PR TITLE
Issue 53022: Fix bulk update from sample-only and aliquot-only selections in succession

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.5-bulkUpdateFormReload.0",
+  "version": "6.52.6-bulkUpdateFormReload.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.5-bulkUpdateFormReload.0",
+      "version": "6.52.6-bulkUpdateFormReload.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.4",
+  "version": "6.52.5-bulkUpdateFormReload.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.52.4",
+      "version": "6.52.5-bulkUpdateFormReload.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.52.4",
+  "version": "6.52.5-bulkUpdateFormReload.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-- Issue 53022: Reload data in `BulkdUpdateForm` when columns change because of aliquot or sample selections
+- Issue 53022: Reload data in `BulkUpdateForm` when columns change because of aliquot or sample selections
 
 ### version 6.52.4
 *Released*: 30 June 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 53022: Reload data in `BulkdUpdateForm` when columns change because of aliquot or sample selections
+
 ### version 6.52.4
 *Released*: 30 June 2025
 - Issue 53118: Filter modal change to multiValue type to account for numeric value when parsing

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -82,15 +82,29 @@ export class BulkUpdateForm extends PureComponent<BulkUpdateFormProps, State> {
         };
     }
 
-    componentDidMount = async (): Promise<void> => {
-        const { onCancel, pluralNoun, queryInfo, selectedIds, sortString, viewName, requiredColumns } = this.props;
-        const { schemaName, name } = queryInfo;
-
-        const columns = queryInfo
+    getQueryColumns(queryInfo: QueryInfo): string[] {
+        const { requiredColumns } = this.props;
+        return queryInfo
             .getPkCols()
             .concat(queryInfo.getUpdateColumns())
             .map(c => c.fieldKey)
             .concat(requiredColumns);
+    }
+
+    componentDidUpdate = async (prevProps: BulkUpdateFormProps, prevState: State): Promise<void> => {
+        if (this.getQueryColumns(prevProps.queryInfo).sort().join(",") != this.getQueryColumns(this.props.queryInfo).sort().join(",")) {
+            this.initData();
+        }
+    };
+
+    componentDidMount = async (): Promise<void> => {
+       this.initData();
+    };
+
+    initData = async (): Promise<void> => {
+        const { onCancel, pluralNoun, queryInfo, selectedIds, sortString, viewName } = this.props;
+        const { schemaName, name } = queryInfo;
+        const columns = this.getQueryColumns(queryInfo);
 
         try {
             const { data, dataIds } = await getSelectedDataDeprecated(

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -92,13 +92,19 @@ export class BulkUpdateForm extends PureComponent<BulkUpdateFormProps, State> {
     }
 
     componentDidUpdate = async (prevProps: BulkUpdateFormProps, prevState: State): Promise<void> => {
-        if (this.getQueryColumns(prevProps.queryInfo).sort().join(",") != this.getQueryColumns(this.props.queryInfo).sort().join(",")) {
-            this.initData();
+        if (
+            prevProps.viewName != this.props.viewName ||
+            prevProps.selectedIds.join(',') != this.props.selectedIds.join(',') ||
+            prevProps.sortString != this.props.sortString ||
+            this.getQueryColumns(prevProps.queryInfo).sort().join(',') !=
+                this.getQueryColumns(this.props.queryInfo).sort().join(',')
+        ) {
+            await this.initData();
         }
     };
 
     componentDidMount = async (): Promise<void> => {
-       this.initData();
+        await this.initData();
     };
 
     initData = async (): Promise<void> => {

--- a/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkUpdateForm.tsx
@@ -91,7 +91,7 @@ export class BulkUpdateForm extends PureComponent<BulkUpdateFormProps, State> {
             .concat(requiredColumns);
     }
 
-    componentDidUpdate = async (prevProps: BulkUpdateFormProps, prevState: State): Promise<void> => {
+    componentDidUpdate = async (prevProps: BulkUpdateFormProps): Promise<void> => {
         if (
             prevProps.viewName != this.props.viewName ||
             prevProps.selectedIds.join(',') != this.props.selectedIds.join(',') ||


### PR DESCRIPTION
#### Rationale
Issue [53022](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53022): Because we modify the `queryInfo.columns` for the `BulkUpdateForm` depending on whether there are aliquots in the selection or not, we need to be sure to reload the data in the form when the columns change. This PR does this by adding a `componentDidUpdate` method to that component.

The `BulkUpdateForm` component is ripe for conversion to a functional component and if anyone feels strongly that that's the less risky/better approach here, I can do that instead, but given proximity to branching for the release this fairly minimal change seemed a good path to take.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1498

#### Changes
- Add `componentDidUpdate` method to `BulkUpdateForm`
