### PR TITLE
Issue 53153: Disable value validation for expInput, aliquotParent columns

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.1-fb-aa-53153.0",
+  "version": "6.53.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.53.1-fb-aa-53153.0",
+      "version": "6.53.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.0",
+  "version": "6.53.1-fb-aa-53153.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.53.0",
+      "version": "6.53.1-fb-aa-53153.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.1-fb-aa-53153.0",
+  "version": "6.53.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.0",
+  "version": "6.53.1-fb-aa-53153.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.53.1
+*Released*: 3 July 2025
+- Issue 53153: Disable value validation for expInput, aliquotParent columns
+
 ### version 6.53.0
 *Released*: 1 July 2025
 - Remove AssayResultsForSamplesButton, AssayResultsForSamplesMenuItem

--- a/packages/components/src/internal/components/forms/BulkAddUpdateForm.tsx
+++ b/packages/components/src/internal/components/forms/BulkAddUpdateForm.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useMemo } from 'react';
-import { List, Map } from 'immutable';
+import { List } from 'immutable';
 
 import { Operation } from '../../../public/QueryColumn';
 
@@ -18,9 +18,9 @@ type BaseProps = Omit<
     | 'hideButtons'
     | 'includeCountField'
     | 'initiallyDisableFields'
+    | 'queryInfo'
     | 'showLabelAsterisk'
     | 'title'
-    | 'queryInfo'
 >;
 
 interface BulkAddUpdateFormProps extends BaseProps {

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -282,6 +282,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                         maxRows={10}
                                         multiple={multiple}
                                         name={fieldKey}
+                                        notFoundValuesEnabled={!(col.isExpInput() || col.isAliquotParent())} // Issue 53153
                                         onQSChange={this.onSelectChange}
                                         onToggleDisable={this.onToggleDisable}
                                         placeholder="Select or type to search..."

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -270,7 +270,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                             getContainerFilterForLookups()
                                         }
                                         containerPath={col.lookup.containerPath ?? containerPath}
-                                        toggleDisabledTooltip={toggleDisabledTooltip}
                                         description={col.description}
                                         displayColumn={col.lookup.displayColumn}
                                         fireQSChangeOnInit={fireQSChangeOnInit}
@@ -291,6 +290,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                         required={col.required}
                                         schemaQuery={col.lookup.schemaQuery}
                                         showLabel
+                                        toggleDisabledTooltip={toggleDisabledTooltip}
                                         value={value}
                                         valueColumn={col.lookup.keyColumn}
                                     />
@@ -304,6 +304,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                             <TextChoiceInput
                                 addLabelAsterisk={showAsteriskSymbol}
                                 allowDisable={allowFieldDisable}
+                                description={col.description}
                                 formsy
                                 initiallyDisabled={shouldDisableField}
                                 key={fieldKey}
@@ -312,7 +313,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 placeholder="Select or type to search..."
                                 queryColumn={col}
                                 renderFieldLabel={renderFieldLabel}
-                                description={col.description}
                                 value={value}
                             />
                         );
@@ -321,80 +321,80 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (col.inputType === 'textarea') {
                         return (
                             <TextAreaInput
-                                key={fieldKey}
-                                queryColumn={col}
-                                value={value}
+                                addLabelAsterisk={showAsteriskSymbol}
                                 allowDisable={allowFieldDisable}
                                 initiallyDisabled={shouldDisableField}
+                                key={fieldKey}
                                 onToggleDisable={this.onToggleDisable}
-                                addLabelAsterisk={showAsteriskSymbol}
+                                queryColumn={col}
                                 renderFieldLabel={renderFieldLabel}
+                                value={value}
                             />
                         );
                     } else if (col.inputType === 'file' && renderFileInputs) {
                         return (
                             <FileInput
-                                formsy
-                                key={fieldKey}
-                                queryColumn={col}
-                                initialValue={value}
-                                name={fieldKey}
-                                allowDisable={allowFieldDisable}
-                                initiallyDisabled={shouldDisableField}
-                                onToggleDisable={this.onToggleDisable}
                                 addLabelAsterisk={showAsteriskSymbol}
+                                allowDisable={allowFieldDisable}
+                                formsy
+                                initiallyDisabled={shouldDisableField}
+                                initialValue={value}
+                                key={fieldKey}
+                                name={fieldKey}
+                                onToggleDisable={this.onToggleDisable}
+                                queryColumn={col}
                                 renderFieldLabel={renderFieldLabel}
                                 showLabel
                             />
                         );
                     }
                     switch (col.jsonType) {
+                        case 'boolean':
+                            return (
+                                <CheckboxInput
+                                    addLabelAsterisk={showAsteriskSymbol}
+                                    allowDisable={allowFieldDisable}
+                                    initiallyDisabled={shouldDisableField}
+                                    key={fieldKey}
+                                    onToggleDisable={this.onToggleDisable}
+                                    queryColumn={col}
+                                    renderFieldLabel={renderFieldLabel}
+                                    value={value}
+                                />
+                            );
                         case 'date':
                         case 'time':
                             return (
                                 <DatePickerInput
-                                    key={fieldKey}
-                                    queryColumn={col}
-                                    value={value}
+                                    addLabelAsterisk={showAsteriskSymbol}
                                     allowDisable={allowFieldDisable}
                                     initiallyDisabled={shouldDisableField}
-                                    onToggleDisable={this.onToggleDisable}
-                                    addLabelAsterisk={showAsteriskSymbol}
-                                    renderFieldLabel={renderFieldLabel}
-                                />
-                            );
-                        case 'boolean':
-                            return (
-                                <CheckboxInput
                                     key={fieldKey}
-                                    queryColumn={col}
-                                    value={value}
-                                    allowDisable={allowFieldDisable}
-                                    initiallyDisabled={shouldDisableField}
                                     onToggleDisable={this.onToggleDisable}
-                                    addLabelAsterisk={showAsteriskSymbol}
+                                    queryColumn={col}
                                     renderFieldLabel={renderFieldLabel}
+                                    value={value}
                                 />
                             );
                         default:
                             return (
                                 <React.Fragment key={fieldKey}>
                                     <TextInput
-                                        queryColumn={col}
-                                        value={value ? String(value) : value}
+                                        addLabelAsterisk={showAsteriskSymbol}
                                         allowDisable={allowFieldDisable}
                                         initiallyDisabled={shouldDisableField}
                                         onToggleDisable={this.onToggleDisable}
-                                        addLabelAsterisk={showAsteriskSymbol}
+                                        queryColumn={col}
                                         renderFieldLabel={renderFieldLabel}
+                                        value={value ? String(value) : value}
                                     />
                                     {internalSpacesWarningFieldKeys?.indexOf(fieldKey.toLowerCase()) > -1 && (
                                         <div className="row shift-margin-to-bottom">
                                             <div className="col-sm-3 col-xs-12" />
                                             <div className="col-sm-9 col-xs-12 text-danger">
                                                 <InternalSpacesWarning
-                                                    value={value}
                                                     fieldName={col.caption?.toLowerCase() ?? col.name.toLowerCase()}
+                                                    value={value}
                                                 />
                                             </div>
                                         </div>

--- a/packages/components/src/internal/components/forms/QueryInfoForm.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.tsx
@@ -27,7 +27,6 @@ import { FormButtons } from '../../FormButtons';
 
 import { EntityCreationTypeModel } from '../samples/models';
 import { QueryInfo } from '../../../public/QueryInfo';
-import { formatDate, formatDateTime, formatTime } from '../../util/Date';
 import { Alert } from '../base/Alert';
 import { LoadingSpinner } from '../base/LoadingSpinner';
 
@@ -56,7 +55,7 @@ export const getUpdatedFields = (
     for (const key in data) {
         if (data.hasOwnProperty(key)) {
             if (fieldsToUpdate.has(key.toLowerCase()) || (additionalFields && additionalFields?.indexOf(key) !== -1)) {
-                const col = queryInfo?.getColumn(key);
+                const col = queryInfo.getColumn(key);
                 if (col?.jsonType === 'string' && typeof data[key] === 'string') {
                     filteredData = filteredData.set(key, data[key]?.trim());
                 } else {

--- a/packages/components/src/internal/components/forms/QueryInfoForm.tsx
+++ b/packages/components/src/internal/components/forms/QueryInfoForm.tsx
@@ -71,8 +71,8 @@ export const getUpdatedFields = (
 export interface QueryInfoFormProps extends Omit<QueryFormInputsProps, 'onFieldsEnabledChange'> {
     api?: ComponentsAPIWrapper;
     asModal?: boolean;
-    canSubmitNotDirty?: boolean;
     cancelText?: string;
+    canSubmitNotDirty?: boolean;
     countText?: string;
     creationTypeOptions?: EntityCreationTypeModel[];
     disabled?: boolean;
@@ -346,9 +346,9 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
                     <CommentTextArea
                         actionName="Update"
                         containerClassName="inline-comment"
+                        inline
                         onChange={this.onCommentChange}
                         requiresUserComment={requiresUserComment}
-                        inline
                     />
                 )}
 
@@ -433,17 +433,17 @@ export class QueryInfoForm extends PureComponent<QueryInfoFormProps, State> {
                     {!showErrorsAtBottom && this.renderError()}
                     <Formsy
                         className="form-horizontal"
-                        onValidSubmit={this.handleValidSubmit}
-                        onValid={this.enableSubmitButton}
                         onChange={this.handleChange}
                         onInvalid={this.disableSubmitButton}
+                        onValid={this.enableSubmitButton}
+                        onValidSubmit={this.handleValidSubmit}
                         ref={this.formRef}
                     >
                         <QueryInfoQuantity
+                            countText={countText}
                             creationTypeOptions={creationTypeOptions}
                             includeCountField={includeCountField}
                             maxCount={maxCount}
-                            countText={countText}
                             onCountChange={this.onCountChange}
                         />
                         {(header || showQuantityHeader) && <hr />}

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -341,6 +341,7 @@ export function resolveDetailEditRenderer(
                         maxRows={10}
                         multiple={multiple}
                         name={col.fieldKey}
+                        notFoundValuesEnabled={!(col.isExpInput() || col.isAliquotParent())} // Issue 53153
                         onBlur={options?.onBlur}
                         onQSChange={options?.onSelectChange}
                         placeholder={options?.placeholder ?? 'Select or type to search...'}

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -359,15 +359,15 @@ export function resolveDetailEditRenderer(
         if (col.validValues) {
             return (
                 <TextChoiceInput
+                    autoFocus={options?.autoFocus}
                     formsy
                     inputClass={DETAIL_INPUT_WRAPPER_CLASS_NAME}
-                    queryColumn={col}
-                    value={value}
-                    autoFocus={options?.autoFocus}
                     onBlur={options?.onBlur}
                     onChange={options?.onSelectChange}
                     placeholder={options?.placeholder ?? 'Select or type to search...'}
+                    queryColumn={col}
                     showLabel={showLabel}
+                    value={value}
                 />
             );
         }
@@ -426,6 +426,7 @@ export function resolveDetailEditRenderer(
                 return (
                     <TextInput
                         elementWrapperClassName={DETAIL_INPUT_WRAPPER_CLASS_NAME}
+                        includeSpacesWarning={options.includeSpacesWarning}
                         isUpdate={true}
                         queryColumn={col}
                         // Issue 43561: Support name expression fields
@@ -435,7 +436,6 @@ export function resolveDetailEditRenderer(
                         // required if the nameExpression is not defined to force the form to require a value.
                         required={col.required || col.nameExpression !== undefined}
                         showLabel={showLabel}
-                        includeSpacesWarning={options.includeSpacesWarning}
                         validatePristine
                         validationError={validationError}
                         value={value}
@@ -450,20 +450,17 @@ export function resolveDetailRenderer(column: QueryColumn): Renderer {
 
     if (column?.detailRenderer) {
         switch (column.detailRenderer.toLowerCase()) {
-            case 'multivaluedetailrenderer':
-                renderer = d => <MultiValueRenderer data={d} />;
-                break;
             case 'aliasrenderer':
                 renderer = d => <AliasRenderer data={d} view="detail" />;
                 break;
             case 'appendunits':
-                renderer = d => <AppendUnits data={d} col={column} />;
+                renderer = d => <AppendUnits col={column} data={d} />;
                 break;
             case 'assayrunreference':
                 renderer = d => <AssayRunReferenceRenderer data={d} />;
                 break;
-            case 'labelcolorrenderer':
-                renderer = d => <LabelColorRenderer data={d} />;
+            case 'expirationdatecolumnrenderer':
+                renderer = d => <ExpirationDateColumnRenderer col={column} data={d} tableCell={false} />;
                 break;
             case 'filecolumnrenderer':
                 renderer = d => <FileColumnRenderer data={d} isFileLink={column.rangeURI === FILELINK_RANGE_URI} />;
@@ -471,8 +468,17 @@ export function resolveDetailRenderer(column: QueryColumn): Renderer {
             case 'foldercolumnrenderer':
                 renderer = d => <FolderColumnRenderer data={d} />;
                 break;
+            case 'labelcolorrenderer':
+                renderer = d => <LabelColorRenderer data={d} />;
+                break;
+            case 'multivaluedetailrenderer':
+                renderer = d => <MultiValueRenderer data={d} />;
+                break;
             case 'nolinkrenderer':
                 renderer = d => <NoLinkRenderer data={d} />;
+                break;
+            case 'samplestatusrenderer':
+                renderer = (d, r) => <SampleStatusRenderer row={r} />;
                 break;
             case 'sampletypeimportaliasrenderer':
                 renderer = d => <SampleTypeImportAliasRenderer data={d} />;
@@ -480,14 +486,8 @@ export function resolveDetailRenderer(column: QueryColumn): Renderer {
             case 'sourcetypeimportaliasrenderer':
                 renderer = d => <SourceTypeImportAliasRenderer data={d} />;
                 break;
-            case 'samplestatusrenderer':
-                renderer = (d, r) => <SampleStatusRenderer row={r} />;
-                break;
             case 'userdetailsrenderer':
                 renderer = d => <UserDetailsRenderer data={d} />;
-                break;
-            case 'expirationdatecolumnrenderer':
-                renderer = d => <ExpirationDateColumnRenderer data={d} col={column} tableCell={false} />;
                 break;
             default:
                 break;


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53153](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53153) by disabling value validation in dropdowns for columns that self-identify as experiment inputs and aliquot parents. This effectively restores behavior as found in 25.3 and before.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1824
- https://github.com/LabKey/limsModules/pull/1505
- https://github.com/LabKey/testAutomation/pull/2531

#### Changes
- Set `notFoundValuesEnabled={false}` on `QuerySelect` components generated in forms
