### PR TITLE
Issue 53394: FileInput revert removal of the "-fileUpload" suffix from inputId

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.2",
+  "version": "6.53.2-fileInputId53394.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.53.2",
+      "version": "6.53.2-fileInputId53394.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.0",
+  "version": "6.53.0-fileInputId53394.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.53.0",
+      "version": "6.53.0-fileInputId53394.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.2-fileInputId53394.0",
+  "version": "6.53.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.53.2-fileInputId53394.0",
+      "version": "6.53.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.0",
+  "version": "6.53.0-fileInputId53394.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.2",
+  "version": "6.53.2-fileInputId53394.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.2-fileInputId53394.0",
+  "version": "6.53.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.53.TBD
-*Released*: TBD July 2025
+### version 6.53.3
+*Released*: 7 July 2025
 - Issue 53394: FileInput revert removal of the "-fileUpload" suffix from inputId
 
 ### version 6.53.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.53.TBD
+*Released*: TBD July 2025
+- Issue 53394: FileInput revert removal of the "-fileUpload" suffix from inputId
+
 ### version 6.53.0
 *Released*: 1 July 2025
 - Remove AssayResultsForSamplesButton, AssayResultsForSamplesMenuItem

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -199,7 +199,8 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
         } = this.props;
         const { data, file, isDisabled, isHover } = this.state;
 
-        const inputId = this.getInputName();
+        const name = this.getInputName();
+        const inputId = `${name}-fileUpload`; // Issue 53394: needs to be a distinct input id so it doesn't collide with other elements on the page for this fieldKey
         let body;
 
         if (file) {
@@ -235,7 +236,7 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
                         disabled={this.state.isDisabled}
                         type="file"
                         className="file-upload__input" // This class makes the file input hidden
-                        name={inputId}
+                        name={name}
                         id={inputId}
                         multiple={false}
                         onChange={this.onChange}

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -210,10 +210,10 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
             body = (
                 <div
                     className={attachedFileClass}
-                    onDrop={this.onDrop}
                     onDragEnter={this.onDrag}
-                    onDragOver={this.onDrag}
                     onDragLeave={this.onDragLeave}
+                    onDragOver={this.onDrag}
+                    onDrop={this.onDrop}
                 >
                     <span className="fa fa-times-circle attached-file__remove-icon" onClick={this.onRemove} />
                     <span className="fa fa-file-text attached-file--icon" />
@@ -224,8 +224,8 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
         } else if (data?.get('value')) {
             body = (
                 <FileColumnRenderer
-                    isFileLink={queryColumn?.rangeURI === FILELINK_RANGE_URI}
                     data={data}
+                    isFileLink={queryColumn?.rangeURI === FILELINK_RANGE_URI}
                     onRemove={isDisabled ? undefined : this.onRemove}
                 />
             );
@@ -233,14 +233,14 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
             body = (
                 <>
                     <input
-                        disabled={this.state.isDisabled}
-                        type="file"
                         className="file-upload__input" // This class makes the file input hidden
-                        name={name}
+                        disabled={this.state.isDisabled}
                         id={inputId}
                         multiple={false}
+                        name={name}
                         onChange={this.onChange}
                         ref={this.fileInput}
+                        type="file"
                     />
 
                     {/* We render a label here so click and drag events propagate to the input above */}
@@ -250,12 +250,12 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
                             'file-upload__is-hover': isHover && !isDisabled,
                         })}
                         htmlFor={inputId}
-                        onDrop={this.onDrop}
                         onDragEnter={this.onDrag}
-                        onDragOver={this.onDrag}
                         onDragLeave={this.onDragLeave}
+                        onDragOver={this.onDrag}
+                        onDrop={this.onDrop}
                     >
-                        <i className="fa fa-cloud-upload" aria-hidden="true" />
+                        <i aria-hidden="true" className="fa fa-cloud-upload" />
                         &nbsp;
                         <span>Select file or drag and drop here.</span>
                         <div className="file-upload__error-message">{this.state.error}</div>
@@ -279,11 +279,11 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
                     renderFieldLabel(queryColumn)
                 ) : (
                     <FieldLabel
+                        column={queryColumn}
+                        isDisabled={isDisabled}
                         labelOverlayProps={labelOverlayProps}
                         showLabel={showLabel}
                         showToggle={allowDisable}
-                        column={queryColumn}
-                        isDisabled={isDisabled}
                         toggleProps={{
                             onClick: toggleDisabledTooltip ? undefined : this.toggleDisabled,
                             toolTip: toggleDisabledTooltip,


### PR DESCRIPTION
#### Rationale
Issue [53394](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53394): LKSM: Selection of file doesn't work on develop

Revert changes from https://github.com/LabKey/labkey-ui-components/pull/1800 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1825
- https://github.com/LabKey/testAutomation/pull/2532
- https://github.com/LabKey/limsModules/pull/1506

#### Changes
- FileInput revert removal of the "-fileUpload" suffix from inputId
