### PR TITLE
Issue 52657: LKSM: We shouldn't allow creating sample names that differ only in case

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.54.1",
+  "version": "6.54.2-fb-sampleNameCase.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.54.1",
+      "version": "6.54.2-fb-sampleNameCase.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.54.0",
+  "version": "6.54.1-fb-sampleNameCase.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.54.0",
+      "version": "6.54.1-fb-sampleNameCase.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.54.3-fb-sampleNameCase.1",
+  "version": "6.54.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.54.3-fb-sampleNameCase.1",
+      "version": "6.54.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.54.2",
+  "version": "6.54.3-fb-sampleNameCase.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.54.2",
+      "version": "6.54.3-fb-sampleNameCase.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.54.0",
+  "version": "6.54.1-fb-sampleNameCase.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.54.3-fb-sampleNameCase.1",
+  "version": "6.54.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X July 2025
+- Issue 52657: LKSM: We shouldn't allow creating sample names that differ only in case
+  - Use original case in duplicate name error message
+
 ### version 6.54.0
 *Released*: 3 July 2025
 - ProductMenu shows 'Dashboard' instead of 'Storage' as subtitle in FM /home route

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X July 2025
+### version 6.54.3
+*Released*: 10 July 2025
 - Issue 52657: LKSM: We shouldn't allow creating sample names that differ only in case
   - Use original case in duplicate name error message
 

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -930,7 +930,7 @@ describe('EditorModel', () => {
             });
 
             test('with original multi values, multiple same values, but ordering is changed', () => {
-                let updatedRows = emMultipleComplexInputs.getUpdatedData(
+                const updatedRows = emMultipleComplexInputs.getUpdatedData(
                     fromJS({
                         0: {
                             [expInputCol.fieldKey]: [
@@ -941,7 +941,7 @@ describe('EditorModel', () => {
                                 {
                                     value: 123,
                                     displayValue: 'Value 123',
-                                }
+                                },
                             ],
                         },
                         1: {

--- a/packages/components/src/internal/components/editable/models.test.ts
+++ b/packages/components/src/internal/components/editable/models.test.ts
@@ -252,15 +252,16 @@ describe('EditorModel', () => {
             expect(uniqueKeyViolations.get(colOneCaption).size).toBe(3);
             expect(uniqueKeyViolations.get(colOneCaption).has('a')).toBe(true);
             expect(uniqueKeyViolations.get(colOneCaption).get('a')).toEqual(List<number>([1, 2]));
-            expect(uniqueKeyViolations.get(colOneCaption).has('caseinsensitive')).toBe(true);
-            expect(uniqueKeyViolations.get(colOneCaption).get('caseinsensitive')).toEqual(List<number>([3, 4]));
-            expect(uniqueKeyViolations.get(colOneCaption).has('spacedupe')).toBe(true);
-            expect(uniqueKeyViolations.get(colOneCaption).get('spacedupe')).toEqual(List<number>([5, 6]));
+            expect(uniqueKeyViolations.get(colOneCaption).has('caseinsensitive')).toBe(false);
+            expect(uniqueKeyViolations.get(colOneCaption).has('caseInSenSiTive')).toBe(true);
+            expect(uniqueKeyViolations.get(colOneCaption).get('caseInSenSiTive')).toEqual(List<number>([3, 4]));
+            expect(uniqueKeyViolations.get(colOneCaption).has('spaceDupe')).toBe(true);
+            expect(uniqueKeyViolations.get(colOneCaption).get('spaceDupe')).toEqual(List<number>([5, 6]));
             const errors = editorModel.getValidationErrors(colOneFk);
             expect(errors.errors).toEqual([
                 `Duplicate value (a) for ${colOneCaption} on rows 1, 2.`,
-                `Duplicate value (caseinsensitive) for ${colOneCaption} on rows 3, 4.`,
-                `Duplicate value (spacedupe) for ${colOneCaption} on rows 5, 6.`,
+                `Duplicate value (caseInSenSiTive) for ${colOneCaption} on rows 3, 4.`,
+                `Duplicate value (spaceDupe) for ${colOneCaption} on rows 5, 6.`,
             ]);
         });
 
@@ -290,11 +291,11 @@ describe('EditorModel', () => {
             expect(uniqueKeyViolations.size).toBe(1);
             expect(uniqueKeyViolations.has(colOneCaption)).toBe(true);
             expect(uniqueKeyViolations.get(colOneCaption).size).toBe(1);
-            expect(uniqueKeyViolations.get(colOneCaption).has('caseinsensitive')).toBe(true);
-            expect(uniqueKeyViolations.get(colOneCaption).get('caseinsensitive')).toEqual(List<number>([3, 4]));
+            expect(uniqueKeyViolations.get(colOneCaption).has('caseInSenSiTive')).toBe(true);
+            expect(uniqueKeyViolations.get(colOneCaption).get('caseInSenSiTive')).toEqual(List<number>([3, 4]));
             const errors = editorModel.getValidationErrors(colOneFk);
             expect(errors.errors).toEqual([
-                `Duplicate value (caseinsensitive) for ${colOneCaption} on rows 3, 4.`,
+                `Duplicate value (caseInSenSiTive) for ${colOneCaption} on rows 3, 4.`,
                 `${colOneCaption} is missing from row 1.`,
             ]);
             expect(errors.cellMessages.toJS()).toStrictEqual({

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -426,6 +426,7 @@ export class EditorModel
         let keyValues = Map<number, List<string>>(); // map from row number to list of key values on that row
         let uniqueKeyMap = Map<string, List<number>>(); // map from value to rows with that value
         let missingRequired = Map<string, List<number>>(); // map from column caption to list of rows missing a value for that column
+        const originalUniqueValMap = {}
         for (let rn = 0; rn < this.rowCount; rn++) {
             columns.forEach(col => {
                 const fieldKey = col.fieldKey;
@@ -476,11 +477,13 @@ export class EditorModel
                     // there better be only one of these
                     const valueDescriptor = values.get(0);
                     if (valueDescriptor && this.hasRawValue(valueDescriptor)) {
-                        const stringVal = valueDescriptor.raw.toString().trim().toLowerCase();
-                        if (uniqueKeyMap.has(stringVal)) {
-                            uniqueKeyMap = uniqueKeyMap.set(stringVal, uniqueKeyMap.get(stringVal).push(rn + 1));
+                        const rawStringVal = valueDescriptor.raw.toString().trim();
+                        const stringValLc = rawStringVal.toLowerCase();
+                        if (uniqueKeyMap.has(stringValLc)) {
+                            uniqueKeyMap = uniqueKeyMap.set(stringValLc, uniqueKeyMap.get(stringValLc).push(rn + 1));
                         } else {
-                            uniqueKeyMap = uniqueKeyMap.set(stringVal, List<number>([rn + 1]));
+                            originalUniqueValMap[stringValLc] = rawStringVal;
+                            uniqueKeyMap = uniqueKeyMap.set(stringValLc, List<number>([rn + 1]));
                         }
                     }
                 }
@@ -488,7 +491,14 @@ export class EditorModel
         }
 
         let uniqueKeyViolations = Map<string, Map<string, List<number>>>();
-        const duplicates = uniqueKeyMap.filter(rowNumbers => rowNumbers.size > 1).toMap();
+        const duplicates = uniqueKeyMap
+            .filter(rowNumbers => rowNumbers.size > 1)
+            .reduce((keyMap, values, uniqueValueLc) => {
+                const uniqueValueOriginal = originalUniqueValMap[uniqueValueLc];
+                if (uniqueValueOriginal) return keyMap.set(uniqueValueOriginal, values);
+                else return keyMap.set(uniqueValueLc, values);
+            }, Map<string, List<number>>())
+            .toMap();
         if (duplicates.size > 0 && uniqueFieldCol) {
             uniqueKeyViolations = uniqueKeyViolations.set(uniqueFieldCol.caption, duplicates);
         }

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -426,7 +426,7 @@ export class EditorModel
         let keyValues = Map<number, List<string>>(); // map from row number to list of key values on that row
         let uniqueKeyMap = Map<string, List<number>>(); // map from value to rows with that value
         let missingRequired = Map<string, List<number>>(); // map from column caption to list of rows missing a value for that column
-        const originalUniqueValMap = {}
+        const originalUniqueValMap = {};
         for (let rn = 0; rn < this.rowCount; rn++) {
             columns.forEach(col => {
                 const fieldKey = col.fieldKey;


### PR DESCRIPTION
#### Rationale
In order to compute the list of names that are duplicate for the editable grid, `toLowerCase` is called on the raw name to build a map. This altered key is then used in the duplicate error message, which is confusing since it might not match user provided name.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1828
- https://github.com/LabKey/platform/pull/6820
- https://github.com/LabKey/limsModules/pull/1510
- https://github.com/LabKey/testAutomation/pull/2541

#### Changes
- Use original case in duplicate name error message