### PR TITLE
Add defensive null check in `FindByIdsModal`

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.0",
+  "version": "6.56.1-misc258seh2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.0",
+      "version": "6.56.1-misc258seh2.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.1-misc258seh2.0",
+  "version": "6.56.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.1-misc258seh2.0",
+      "version": "6.56.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.1-misc258seh2.0",
+  "version": "6.56.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.0",
+  "version": "6.56.1-misc258seh2.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.56.1
+*Released*: 18 July 1015
 - null checks for exceptions reported to Mothership
 
 ### version 6.56.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- null checks for exceptions reported to Mothership
+
 ### version 6.56.0
 *Released*: 11 July 2025
 - Package updates

--- a/packages/components/src/internal/components/search/FindByIdsModal.tsx
+++ b/packages/components/src/internal/components/search/FindByIdsModal.tsx
@@ -71,6 +71,8 @@ export const FindByIdsModal: FC<Props> = memo(props => {
     }, []);
 
     const _onFind = useCallback(async () => {
+        if (!idString) return;
+
         const ids = idString
             .split('\n')
             .map(id => id.trim())


### PR DESCRIPTION
#### Rationale
[Issue 53470](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53470)

#### Related Pull Requests

- https://github.com/LabKey/limsModules/pull/1529
- https://github.com/LabKey/labkey-ui-premium/pull/791

#### Changes
- Check for an empty `idString` (though I'm not sure how it can get this far and be empty).
