### PR TITLE
Issue 53366: Do not put undefined into value descriptors

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-fb-aliquot-53153.0",
+  "version": "6.56.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.3-fb-aliquot-53153.0",
+      "version": "6.56.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.42.0",
+        "@labkey/api": "1.42.1-fb-aliquot-53153.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.42.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.42.0.tgz",
-      "integrity": "sha512-fh65cogl+8HNe9+3OHzI6ygkaa+ARJbKyUopguy3NqtOWIAXAA21GNxayRoeVf9m1n2Kpubqk4QS2z/+WCzf8A==",
+      "version": "1.42.1-fb-aliquot-53153.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.42.1-fb-aliquot-53153.0.tgz",
+      "integrity": "sha512-Zn4umVK5K7p2IV4bKo9QyxBVWpc+lNno5wCp1L8nkW/EVKKoMhdDw7V9E9EqsRlyXwxoJFPf76lknmJiFx48rg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.42.1-fb-aliquot-53153.0",
+        "@labkey/api": "1.42.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.42.1-fb-aliquot-53153.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.42.1-fb-aliquot-53153.0.tgz",
-      "integrity": "sha512-Zn4umVK5K7p2IV4bKo9QyxBVWpc+lNno5wCp1L8nkW/EVKKoMhdDw7V9E9EqsRlyXwxoJFPf76lknmJiFx48rg==",
+      "version": "1.42.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.42.1.tgz",
+      "integrity": "sha512-rT+Q/ZM6bE6bU8HDj/7f3DIFuq538e+LZAvBw8P3qJjuAnyO+O+ItZz/YukAKCXXiN2GdedOXDJbt1Ms0bgLsg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.2",
+  "version": "6.56.3-fb-aliquot-53153.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.2",
+      "version": "6.56.3-fb-aliquot-53153.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.2",
+  "version": "6.56.3-fb-aliquot-53153.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.42.0",
+    "@labkey/api": "1.42.1-fb-aliquot-53153.0",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-fb-aliquot-53153.0",
+  "version": "6.56.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.42.1-fb-aliquot-53153.0",
+    "@labkey/api": "1.42.1",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.3.0",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.56.3
+*Released*: 24 July 2025
+- Address Issue 53366 by not putting `undefined` into `List<ValueDescriptor>`
+- Address Issue 53443 by fixing where we check for optional prop
+- Export `ValueDescriptor` for external usage
+- Update `NameIdSettings`, `BarTenderSettingsForm` and `ManageSampleStatusesPanel` to use app context for api
+
 ### version 6.56.2
 *Released*: 21 July 2025
 - Issue 53451: JS error when deleting numeric filter values with Between operator

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1889,6 +1889,7 @@ export type {
     GridResponse,
     UpdatedRow,
     UpdatedRowValue,
+    ValueDescriptor,
 } from './internal/components/editable/models';
 export type { GetParentTypeDataForLineage } from './internal/components/entities/actions';
 export type {

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -139,7 +139,7 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
         }
     };
     handleDrop = (e): void => {
-        var source = e.dataTransfer.getData('dragIndex');
+        const source = e.dataTransfer.getData('dragIndex');
         const target = this.state.dragTarget;
         if (source && target && source !== target) {
             this.props.onColumnDrop?.(source, target); // Issue 53443
@@ -200,24 +200,24 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
 
                                 return (
                                     <th
+                                        className={className}
+                                        data-fieldkey={column.raw?.fieldKeyPath}
+                                        draggable={draggable}
                                         id={index}
                                         key={index}
-                                        className={className}
+                                        onClick={this.handleHeaderClick}
+                                        onDragEnd={this.handleDragEnd}
+                                        onDragEnter={this.handleDragEnter}
+                                        onDragOver={this.handleDragOver}
+                                        onDragStart={this.handleDragStart}
+                                        onDrop={this.handleDrop}
                                         style={style}
                                         title={hideTooltip ? undefined : description}
-                                        draggable={draggable}
-                                        onDragStart={this.handleDragStart}
-                                        onDragOver={this.handleDragOver}
-                                        onDrop={this.handleDrop}
-                                        onDragEnter={this.handleDragEnter}
-                                        onDragEnd={this.handleDragEnd}
-                                        onClick={this.handleHeaderClick}
-                                        data-fieldkey={column.raw?.fieldKeyPath}
                                     >
                                         {headerCell ? headerCell(column, i, columns.size) : title}
                                         {/* headerCell will render the helpTip, so only render here if not using headerCell() */}
                                         {!headerCell && column.helpTipRenderer && (
-                                            <LabelHelpTip title={title} popoverClassName="label-help-arrow-top">
+                                            <LabelHelpTip popoverClassName="label-help-arrow-top" title={title}>
                                                 <HelpTipRenderer type={column.helpTipRenderer} />
                                             </LabelHelpTip>
                                         )}
@@ -242,7 +242,6 @@ const GridMessages: FC<GridMessagesProps> = memo(({ messages }) => (
         {messages
             .map((message: Map<string, string>, i) => {
                 return (
-                    // eslint-disable-next-line react/no-array-index-key
                     <div className={classNames('grid-message', message.get('type'))} key={i}>
                         {message.get('content')}
                     </div>
@@ -297,7 +296,7 @@ interface EmptyGridRowProps {
 }
 
 const EmptyGridRow: FC<EmptyGridRowProps> = memo(({ colSpan, emptyText, isLoading, loadingText }) => (
-    <tr key="grid-default-row" className={isLoading ? 'grid-loading' : 'grid-empty'}>
+    <tr className={isLoading ? 'grid-loading' : 'grid-empty'} key="grid-default-row">
         <td colSpan={colSpan}>{isLoading ? loadingText : emptyText}</td>
     </tr>
 ));
@@ -339,7 +338,7 @@ const GridBody: FC<GridBodyProps> = memo(props => {
 });
 GridBody.displayName = 'GridBody';
 
-export type GridData = Array<Record<string, any>> | List<Map<string, any>>;
+export type GridData = List<Map<string, any>> | Record<string, any>[];
 
 export interface GridProps {
     bordered?: boolean;

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -142,7 +142,7 @@ export class GridHeader extends PureComponent<GridHeaderProps, State> {
         var source = e.dataTransfer.getData('dragIndex');
         const target = this.state.dragTarget;
         if (source && target && source !== target) {
-            this.props?.onColumnDrop(source, target);
+            this.props.onColumnDrop?.(source, target); // Issue 53443
         }
     };
 

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -191,7 +191,7 @@ interface MessageAndValue {
     valueDescriptor: ValueDescriptor;
 }
 
-type MessageAndValueMap = { [colKey: string]: MessageAndValue[] };
+type MessageAndValueMap = Record<string, MessageAndValue[]>;
 
 function resolveValueDescriptors(
     col: QueryColumn,
@@ -442,7 +442,7 @@ interface CellData {
 }
 
 async function convertRowToEditorModelData(
-    data: string | number | boolean,
+    data: boolean | number | string,
     col: QueryColumn,
     containerPath: string
 ): Promise<CellData> {
@@ -513,7 +513,6 @@ async function addBulkRowsToEditorModel(
     const rowCount = editorModel.rowCount + numToAdd;
 
     for (let rowIdx = editorModel.rowCount; rowIdx < rowCount; rowIdx++) {
-        // eslint-disable-next-line no-loop-func
         rowData.forEach((value, colIdx) => {
             const fieldKey = editorModel.getFieldKeyByIndex(colIdx);
             const cellKey = genCellKey(fieldKey, rowIdx);
@@ -597,7 +596,6 @@ export function addColumns(
     let newCellValues = editorModel.cellValues;
 
     for (let rowIdx = 0; rowIdx < editorModel.rowCount; rowIdx++) {
-        // eslint-disable-next-line no-loop-func
         queryColumns.forEach((value: QueryColumn) => {
             newCellValues = newCellValues.set(genCellKey(value.fieldKey, rowIdx), List<ValueDescriptor>());
         });
@@ -748,7 +746,7 @@ export async function updateGridFromBulkForm(
     lockedOrReadonlyRows?: number[],
     isIncludedColumn?: (col: QueryColumn) => boolean,
     containerPath?: string,
-    useEditorModelCols: boolean = false
+    useEditorModelCols = false
 ): Promise<Partial<EditorModel>> {
     let cellMessages = editorModel.cellMessages;
     let cellValues = editorModel.cellValues;
@@ -823,7 +821,7 @@ type PrefixAndNumber = [string | undefined, string | undefined];
  * number the number suffix is undefined. If the entire string is a number the prefix will be undefined. This method
  * intentionally does not parse the numbers.
  */
-export function splitPrefixedNumber(value: string | number): PrefixAndNumber {
+export function splitPrefixedNumber(value: number | string): PrefixAndNumber {
     if (value === undefined || value === null || value === '') return [undefined, undefined];
     const text = value.toString();
     const matches = text?.toString().match(POSTFIX_REGEX);
@@ -874,7 +872,7 @@ interface SelectionIncrement {
     direction: IncrementDirection;
     increment?: number;
     incrementType: IncrementType;
-    initialSelectionValues: Array<List<ValueDescriptor>>; // yes this is a very odd type, but we can clean it up when we rip out Immutable
+    initialSelectionValues: List<ValueDescriptor>[]; // yes this is a very odd type, but we can clean it up when we rip out Immutable
     padLength?: number;
     prefix?: string;
     startingValue: number | string;
@@ -1044,7 +1042,7 @@ export function generateFillCellKeys(
 export function parsePastedLookup(
     column: QueryColumn,
     descriptors: ValueDescriptor[],
-    value: string[] | string
+    value: string | string[]
 ): CellData {
     const originalValues = List([{ display: value, raw: value }]);
 
@@ -1105,7 +1103,7 @@ async function getParsedLookup(
     column: QueryColumn,
     lookupValueCache: LookupValueCache,
     display: any[],
-    value: string[] | string,
+    value: string | string[],
     cellKey: string,
     forUpdate: boolean,
     targetContainerPath: string,

--- a/packages/components/src/internal/components/editable/actions.ts
+++ b/packages/components/src/internal/components/editable/actions.ts
@@ -447,7 +447,7 @@ async function convertRowToEditorModelData(
     containerPath: string
 ): Promise<CellData> {
     let message: CellMessage;
-    let valueDescriptors = List<ValueDescriptor>();
+    const valueDescriptors: ValueDescriptor[] = [];
 
     if (data && col?.isPublicLookup()) {
         // value had better be the rowId here, but it may be several in a comma-separated list.
@@ -456,18 +456,21 @@ async function convertRowToEditorModelData(
 
         for (const val of values) {
             const messageAndValue = await getLookupDisplayValue(col, parseIntIfNumber(val), containerPath);
-            valueDescriptors = valueDescriptors.push(messageAndValue.valueDescriptor);
             message = messageAndValue.message;
+
+            if (messageAndValue.valueDescriptor) {
+                valueDescriptors.push(messageAndValue.valueDescriptor);
+            }
         }
     } else {
         let display = data;
         if (col?.isTimeOrDateTimeColumn && typeof data === 'string') {
             display = getDateTimeDisplayValueFromStr(data, col);
         }
-        valueDescriptors = valueDescriptors.push({ display, raw: data });
+        valueDescriptors.push({ display, raw: data });
     }
 
-    return { message, valueDescriptors };
+    return { message, valueDescriptors: List(valueDescriptors) };
 }
 
 async function prepareInsertRowDataFromBulkForm(

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fromJS, List, Map, OrderedMap, Record as ImmutableRecord } from 'immutable';
+import { fromJS, Record as ImmutableRecord, List, Map, OrderedMap } from 'immutable';
 import { Filter, Query } from '@labkey/api';
 
 import { QueryInfo } from '../../../public/QueryInfo';
@@ -38,6 +38,8 @@ import { SelectInputOption } from './input/SelectInput';
 import { DELIMITER } from './constants';
 import { QuerySelectOwnProps } from './QuerySelect';
 import { resolveDetailFieldLabel, resolveDetailFieldValue } from './utils';
+import { ALIQUOTED_FROM_COL } from '../samples/constants';
+import { SCHEMAS } from '../../schemas';
 
 function formatOption(model: QuerySelectModel, result: any): SelectInputOption {
     const { displayColumn, valueColumn } = model;
@@ -391,6 +393,13 @@ function validValue(value: any): boolean {
     return value !== undefined && value !== null && value !== '';
 }
 
+function isAliquotedFromColumn(props: QuerySelectOwnProps): boolean {
+    return (
+        props.name?.toLowerCase() === ALIQUOTED_FROM_COL.toLowerCase() &&
+        props.schemaQuery.schemaName === SCHEMAS.SAMPLE_SETS.SCHEMA
+    );
+}
+
 function initSelectedItems(
     props: QuerySelectOwnProps,
     queryInfo: QueryInfo,
@@ -423,7 +432,12 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
     let selectedItems: ISelectRowsResult;
 
     if (validValue(value)) {
-        const { expectedValueCount, filter } = buildValueFilter(value, valueColumn, multiple, delimiter);
+        // HACK: Issue 53153: This is a workaround for the AliquotedFrom column to allow for filtering the value
+        // by the display column. The reason for this is the value given is a name of sample rather than a rowId
+        // even though the value column is "RowId".
+        const valueFilterColumn = isAliquotedFromColumn(props) ? displayColumn : valueColumn;
+
+        const { expectedValueCount, filter } = buildValueFilter(value, valueFilterColumn, multiple, delimiter);
         selectedItems = await initSelectedItems(props, queryInfo, valueColumn, displayColumn, groupByColumn, filter);
         const selectedRows = selectedItems.models[selectedItems.key];
 

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -38,8 +38,6 @@ import { SelectInputOption } from './input/SelectInput';
 import { DELIMITER } from './constants';
 import { QuerySelectOwnProps } from './QuerySelect';
 import { resolveDetailFieldLabel, resolveDetailFieldValue } from './utils';
-import { ALIQUOTED_FROM_COL } from '../samples/constants';
-import { SCHEMAS } from '../../schemas';
 
 function formatOption(model: QuerySelectModel, result: any): SelectInputOption {
     const { displayColumn, valueColumn } = model;
@@ -393,13 +391,6 @@ function validValue(value: any): boolean {
     return value !== undefined && value !== null && value !== '';
 }
 
-function isAliquotedFromColumn(props: QuerySelectOwnProps): boolean {
-    return (
-        props.name?.toLowerCase() === ALIQUOTED_FROM_COL.toLowerCase() &&
-        props.schemaQuery.schemaName === SCHEMAS.SAMPLE_SETS.SCHEMA
-    );
-}
-
 function initSelectedItems(
     props: QuerySelectOwnProps,
     queryInfo: QueryInfo,
@@ -432,12 +423,7 @@ export async function initSelect(props: QuerySelectOwnProps): Promise<Partial<Qu
     let selectedItems: ISelectRowsResult;
 
     if (validValue(value)) {
-        // HACK: Issue 53153: This is a workaround for the AliquotedFrom column to allow for filtering the value
-        // by the display column. The reason for this is the value given is a name of sample rather than a rowId
-        // even though the value column is "RowId".
-        const valueFilterColumn = isAliquotedFromColumn(props) ? displayColumn : valueColumn;
-
-        const { expectedValueCount, filter } = buildValueFilter(value, valueFilterColumn, multiple, delimiter);
+        const { expectedValueCount, filter } = buildValueFilter(value, valueColumn, multiple, delimiter);
         selectedItems = await initSelectedItems(props, queryInfo, valueColumn, displayColumn, groupByColumn, filter);
         const selectedRows = selectedItems.models[selectedItems.key];
 

--- a/packages/components/src/internal/components/labelPrinting/BarTenderSettingsForm.test.tsx
+++ b/packages/components/src/internal/components/labelPrinting/BarTenderSettingsForm.test.tsx
@@ -5,25 +5,34 @@ import { Container } from '../base/models/Container';
 
 import { getLabelPrintingTestAPIWrapper } from './APIWrapper';
 
-import { BarTenderSettingsForm } from './BarTenderSettingsForm';
+import { BarTenderSettingsForm, BarTenderSettingsFormProps } from './BarTenderSettingsForm';
 import { BarTenderConfiguration } from './models';
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 import { waitFor } from '@testing-library/dom';
 import { userEvent } from '@testing-library/user-event';
+import { AppContextTestProviderProps } from '../../test/testHelpers';
+import { TEST_FOLDER_CONTAINER } from '../../containerFixtures';
 
 describe('BarTenderSettingsForm', () => {
-    const DEFAULT_PROPS = {
-        api: getTestAPIWrapper(jest.fn, {
-            labelprinting: getLabelPrintingTestAPIWrapper(jest.fn),
-        }),
-        canPrintLabels: false,
-        printServiceUrl: '',
-        onChange: jest.fn(),
-        onSuccess: jest.fn(),
-        getIsDirty: jest.fn(),
-        setIsDirty: jest.fn(),
-        defaultLabel: 1,
-    };
+    function defaultContext(): AppContextTestProviderProps {
+        return {
+            appContext: {
+                api: getTestAPIWrapper(jest.fn, {
+                    labelprinting: getLabelPrintingTestAPIWrapper(jest.fn),
+                }),
+            },
+        };
+    }
+
+    function defaultProps(): BarTenderSettingsFormProps {
+        return {
+            container: TEST_FOLDER_CONTAINER,
+            getIsDirty: jest.fn(),
+            onChange: jest.fn(),
+            onSuccess: jest.fn(),
+            setIsDirty: jest.fn(),
+        };
+    }
 
     function validate(withHeading = true): void {
         expect(document.querySelectorAll('.panel-heading')).toHaveLength(withHeading ? 1 : 0);
@@ -36,22 +45,23 @@ describe('BarTenderSettingsForm', () => {
         expect(buttons).toHaveLength(1);
         const button = buttons.item(0);
         if (canTest) {
-            expect(button.textContent).toBe('Test Connection');
-            expect(button.getAttribute('disabled')).toBeNull();
+            expect(button).toHaveTextContent('Test Connection');
+            expect(button).not.toBeDisabled();
         } else {
-            expect(button.textContent).toBe('Save');
+            expect(button).toHaveTextContent('Save');
 
             if (canSave) {
-                expect(button.getAttribute('disabled')).toBeNull();
+                expect(button).not.toBeDisabled();
             } else {
-                expect(button.getAttribute('disabled')).toBeDefined();
+                expect(button).toBeDisabled();
             }
         }
     }
 
     test('default props, home project', async () => {
         renderWithAppContext(
-            <BarTenderSettingsForm {...DEFAULT_PROPS} container={new Container({ path: '/Test' })} />
+            <BarTenderSettingsForm {...defaultProps()} container={new Container({ path: '/Test' })} />,
+            defaultContext()
         );
         await waitFor(() => {
             expect(document.querySelectorAll('.label-templates-container')).toHaveLength(1);
@@ -61,17 +71,12 @@ describe('BarTenderSettingsForm', () => {
     });
 
     test('default props, product folder', async () => {
-        renderWithAppContext(
-            <BarTenderSettingsForm
-                {...DEFAULT_PROPS}
-                container={new Container({ path: '/Test/Folder', type: 'folder' })}
-            />,
-            {
-                serverContext: {
-                    moduleContext: { query: { isProductFoldersEnabled: true } },
-                },
-            }
-        );
+        renderWithAppContext(<BarTenderSettingsForm {...defaultProps()} />, {
+            ...defaultContext(),
+            serverContext: {
+                moduleContext: { query: { isProductFoldersEnabled: true } },
+            },
+        });
 
         await waitFor(() => {
             expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
@@ -84,19 +89,14 @@ describe('BarTenderSettingsForm', () => {
     });
 
     test('default props, subfolder without folders', async () => {
-        renderWithAppContext(
-            <BarTenderSettingsForm
-                {...DEFAULT_PROPS}
-                container={new Container({ path: '/Test/Folder', type: 'folder' })}
-            />,
-            {
-                serverContext: {
-                    moduleContext: {
-                        query: { isProductFoldersEnabled: false },
-                    },
+        renderWithAppContext(<BarTenderSettingsForm {...defaultProps()} />, {
+            ...defaultContext(),
+            serverContext: {
+                moduleContext: {
+                    query: { isProductFoldersEnabled: false },
                 },
-            }
-        );
+            },
+        });
 
         await waitFor(() => {
             expect(document.querySelectorAll('.label-templates-container')).toHaveLength(1);
@@ -107,19 +107,17 @@ describe('BarTenderSettingsForm', () => {
     });
 
     test('with initial form values', async () => {
-        renderWithAppContext(
-            <BarTenderSettingsForm
-                {...DEFAULT_PROPS}
-                container={new Container({ path: '/Test' })}
-                api={getTestAPIWrapper(jest.fn, {
+        renderWithAppContext(<BarTenderSettingsForm {...defaultProps()} />, {
+            appContext: {
+                api: getTestAPIWrapper(jest.fn, {
                     labelprinting: getLabelPrintingTestAPIWrapper(jest.fn, {
                         fetchBarTenderConfiguration: jest
                             .fn()
                             .mockResolvedValue(new BarTenderConfiguration({ serviceURL: 'testServerURL' })),
                     }),
-                })}
-            />
-        );
+                }),
+            },
+        });
         await waitFor(() => {
             expect(document.querySelectorAll('.label-templates-container')).toHaveLength(1);
         });
@@ -129,8 +127,7 @@ describe('BarTenderSettingsForm', () => {
         const urlInput = document.querySelector('input');
         expect(urlInput.getAttribute('value')).toBe('testServerURL');
         await userEvent.click(urlInput);
-        const newUrl = 'changeURL';
-        await userEvent.paste(newUrl);
+        await userEvent.paste('changeURL');
         validateButtons(false, true);
     });
 });

--- a/packages/components/src/internal/components/labelPrinting/BarTenderSettingsForm.tsx
+++ b/packages/components/src/internal/components/labelPrinting/BarTenderSettingsForm.tsx
@@ -6,8 +6,6 @@ import { HelpLink } from '../../util/helpLinks';
 
 import { LabelHelpTip } from '../base/LabelHelpTip';
 
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-
 import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 
 import { LoadingSpinner } from '../base/LoadingSpinner';
@@ -23,14 +21,7 @@ import { resolveErrorMessage } from '../../util/messaging';
 import { BarTenderConfiguration } from './models';
 import { BAR_TENDER_TOPIC, BARTENDER_CONFIGURATION_TITLE } from './constants';
 import { LabelsConfigurationPanel } from './LabelsConfigurationPanel';
-
-interface Props extends InjectedRouteLeaveProps {
-    api?: ComponentsAPIWrapper;
-    container: Container;
-    onChange: () => void;
-    onSuccess: () => void;
-    title?: string;
-}
+import { useAppContext } from '../../AppContext';
 
 const SUCCESSFUL_NOTIFICATION_MESSAGE = 'Successfully connected to BarTender web service.';
 const FAILED_NOTIFICATION_MESSAGE = 'Failed to connect to BarTender web service.';
@@ -68,12 +59,12 @@ const SettingsInput: FC<SettingsInputProps> = memo(({ children, description, lab
             <div>
                 <input
                     className="form-control"
-                    type={type}
                     id={name}
                     name={name}
-                    value={value}
                     onChange={onChange_}
                     placeholder="BarTender Web Service URL"
+                    type={type}
+                    value={value}
                 />
             </div>
         </div>
@@ -90,15 +81,16 @@ const btTestConnectionTemplate = (): string => {
         </XMLScript>`;
 };
 
-// exported for jest testing
-export const BarTenderSettingsForm: FC<Props> = memo(props => {
-    const {
-        api = getDefaultAPIWrapper(),
-        container,
-        title = BARTENDER_CONFIGURATION_TITLE,
-        onChange,
-        onSuccess,
-    } = props;
+export interface BarTenderSettingsFormProps extends InjectedRouteLeaveProps {
+    container: Container;
+    onChange: () => void;
+    onSuccess: () => void;
+    title?: string;
+}
+
+export const BarTenderSettingsForm: FC<BarTenderSettingsFormProps> = memo(props => {
+    const { container, onChange, onSuccess, title = BARTENDER_CONFIGURATION_TITLE } = props;
+    const { api } = useAppContext();
     const [btServiceURL, setBtServiceURL] = useState<string>();
     const [error, setError] = useState<string>();
     const [defaultLabel, setDefaultLabel] = useState<number>();
@@ -211,7 +203,7 @@ export const BarTenderSettingsForm: FC<Props> = memo(props => {
                             value={btServiceURL}
                         >
                             <div className="pull-right">
-                                <HelpLink topic={BAR_TENDER_TOPIC} className="label-printing--help-link">
+                                <HelpLink className="label-printing--help-link" topic={BAR_TENDER_TOPIC}>
                                     Learn more about BarTender
                                 </HelpLink>
                             </div>
@@ -232,8 +224,8 @@ export const BarTenderSettingsForm: FC<Props> = memo(props => {
                             {isTestable && (
                                 <button
                                     className="button-right-margin pull-right btn btn-success"
-                                    onClick={onVerifyBarTenderConfiguration}
                                     disabled={testing}
+                                    onClick={onVerifyBarTenderConfiguration}
                                     type="button"
                                 >
                                     Test Connection
@@ -245,8 +237,8 @@ export const BarTenderSettingsForm: FC<Props> = memo(props => {
                                 <LabelsConfigurationPanel
                                     {...props}
                                     api={api}
-                                    defaultLabel={defaultLabel}
                                     container={container}
+                                    defaultLabel={defaultLabel}
                                 />
                             </div>
                         )}

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.test.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.test.tsx
@@ -1,4 +1,5 @@
 import React, { act } from 'react';
+import { render, waitFor } from '@testing-library/react';
 
 import { getTestAPIWrapper } from '../../APIWrapper';
 
@@ -8,23 +9,35 @@ import { SampleState, SampleStateType } from './models';
 import { ManageSampleStatusesPanel, SampleStatusDetail, SampleStatusesList } from './ManageSampleStatusesPanel';
 
 import { getSamplesTestAPIWrapper } from './APIWrapper';
-import { render } from '@testing-library/react';
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
+import { AppContextTestProviderProps } from '../../test/testHelpers';
 
 describe('ManageSampleStatusesPanel', () => {
-    const DEFAULT_PROPS = {
-        api: getTestAPIWrapper(jest.fn, {
-            samples: getSamplesTestAPIWrapper(jest.fn, {
-                getSampleStatuses: jest.fn().mockResolvedValue([new SampleState({ isLocal: true, rowId: 1 })]),
-            }),
-        }),
-        getIsDirty: jest.fn(),
-        setIsDirty: jest.fn(),
-    };
+    function defaultContext(states = [new SampleState({ isLocal: true, rowId: 1 })]): AppContextTestProviderProps {
+        return {
+            appContext: {
+                api: getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
+                        getSampleStatuses: jest.fn().mockResolvedValue(states),
+                    }),
+                }),
+            },
+        };
+    }
 
-    function validate(hasError = false): void {
-        expect(document.querySelector('.fa-spinner')).toBeNull();
-        expect(document.querySelectorAll('.alert')).toHaveLength(hasError ? 1 : 0);
+    function defaultProps() {
+        return {
+            getIsDirty: jest.fn(),
+            homeContainer: TEST_PROJECT_CONTAINER,
+            setIsDirty: jest.fn(),
+        };
+    }
+
+    async function validate(hasError = false): Promise<void> {
+        await waitFor(() => {
+            expect(document.querySelector('.fa-spinner')).toBeNull();
+            expect(document.querySelectorAll('.alert')).toHaveLength(hasError ? 1 : 0);
+        });
 
         expect(document.querySelectorAll('.panel')).toHaveLength(1);
         expect(document.querySelectorAll('.panel-heading')).toHaveLength(1);
@@ -34,45 +47,26 @@ describe('ManageSampleStatusesPanel', () => {
     }
 
     test('initial state', async () => {
-        await act(async () => {
-            renderWithAppContext(<ManageSampleStatusesPanel {...DEFAULT_PROPS} homeContainer={TEST_PROJECT_CONTAINER} />);
-        });
-        validate();
+        renderWithAppContext(<ManageSampleStatusesPanel {...defaultProps()} />, defaultContext());
+        await validate();
     });
 
     test('no states', async () => {
-        await act(async () => {
-            renderWithAppContext(
-                <ManageSampleStatusesPanel
-                    {...DEFAULT_PROPS}
-                    homeContainer={TEST_PROJECT_CONTAINER}
-                    api={getTestAPIWrapper(jest.fn, {
-                        samples: getSamplesTestAPIWrapper(jest.fn, {
-                            getSampleStatuses: jest.fn().mockResolvedValue([]),
-                        }),
-                    })}
-                />
-            );
-        });
-
-        validate();
+        renderWithAppContext(<ManageSampleStatusesPanel {...defaultProps()} />, defaultContext([]));
+        await validate();
     });
 
     test('error retrieving states', async () => {
-        await act(async () => {
-            renderWithAppContext(
-                <ManageSampleStatusesPanel
-                    {...DEFAULT_PROPS}
-                    homeContainer={TEST_PROJECT_CONTAINER}
-                    api={getTestAPIWrapper(jest.fn, {
-                        samples: getSamplesTestAPIWrapper(jest.fn, {
-                            getSampleStatuses: () => Promise.reject({ exception: 'Failure' }),
-                        }),
-                    })}
-                />
-            );
+        renderWithAppContext(<ManageSampleStatusesPanel {...defaultProps()} />, {
+            appContext: {
+                api: getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
+                        getSampleStatuses: jest.fn().mockRejectedValue({ exception: 'Failure' }),
+                    }),
+                }),
+            },
         });
-        validate(true);
+        await validate(true);
     });
 });
 
@@ -90,7 +84,7 @@ describe('SampleStatusesList', () => {
         const listGroups = document.querySelectorAll('.list-group');
         if (groupCount === 0) {
             expect(listGroups).toHaveLength(1);
-            expect(listGroups.item(0).textContent).toBe('No sample statuses defined.');
+            expect(listGroups.item(0)).toHaveTextContent('No sample statuses defined.');
         } else {
             expect(listGroups).toHaveLength(groupCount);
             const stateLists = Object.values(statesByType);
@@ -111,9 +105,7 @@ describe('SampleStatusesList', () => {
                 new SampleState({ label: 'First', isLocal: true, rowId: 1 }),
                 new SampleState({ label: 'Second', isLocal: true, rowId: 2 }),
             ],
-            [SampleStateType.Consumed]: [
-                new SampleState({ label: 'Third', isLocal: true, rowId: 3 }),
-            ]
+            [SampleStateType.Consumed]: [new SampleState({ label: 'Third', isLocal: true, rowId: 3 })],
         };
         renderWithAppContext(<SampleStatusesList {...DEFAULT_PROPS} statesByType={states} />);
         validate(states);
@@ -130,9 +122,9 @@ describe('SampleStatusesList', () => {
         renderWithAppContext(
             <SampleStatusesList
                 {...DEFAULT_PROPS}
-                statesByType={states}
                 selected={1}
                 selectedGroup={SampleStateType.Available}
+                statesByType={states}
             />
         );
         validate(states);
@@ -166,9 +158,9 @@ describe('SampleStatusesList', () => {
         renderWithAppContext(
             <SampleStatusesList
                 {...DEFAULT_PROPS}
-                statesByType={unsortedStates}
                 selected={1}
                 selectedGroup={SampleStateType.Consumed}
+                statesByType={unsortedStates}
             />
         );
         validate(states);
@@ -269,13 +261,13 @@ describe('SampleStatusDetail', () => {
         expect(document.querySelector('textarea').value).toBe(STATE.description);
         expect(document.querySelector('textarea').getAttribute('disabled')).toBeFalsy();
         const selectInput = document.querySelector('.select-input__single-value');
-        expect(selectInput.textContent).toBe(STATE.stateType);
+        expect(selectInput).toHaveTextContent(STATE.stateType);
         expect(selectInput.getAttribute('class')).not.toContain('select-input__single-value--is-disabled');
         const buttons = document.querySelectorAll('button');
         expect(buttons).toHaveLength(3);
         expect(buttons.item(1).textContent).toContain('Delete');
         expect(buttons.item(1).getAttribute('disabled')).toBeFalsy();
-        expect(buttons.item(2).textContent).toBe('Save');
+        expect(buttons.item(2)).toHaveTextContent('Save');
         expect(buttons.item(2).getAttribute('disabled')).not.toBeNull(); // save initially disabled
     });
 
@@ -306,7 +298,7 @@ describe('SampleStatusDetail', () => {
         expect(buttons).toHaveLength(3);
         expect(buttons.item(1).textContent).toContain('Delete');
         expect(buttons.item(1).getAttribute('disabled')).not.toBeNull(); // delete disabled
-        expect(buttons.item(2).textContent).toBe('Save');
+        expect(buttons.item(2)).toHaveTextContent('Save');
         expect(buttons.item(2).getAttribute('disabled')).not.toBeNull(); // save initially disabled
     });
 

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -15,8 +15,6 @@ import { caseInsensitive } from '../../util/utils';
 import { SCHEMAS } from '../../schemas';
 import { resolveErrorMessage } from '../../util/messaging';
 
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-
 import { DisableableButton } from '../buttons/DisableableButton';
 
 import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
@@ -396,16 +394,16 @@ SampleStatusesList.displayName = 'SampleStatusesList';
 
 interface ManageSampleStatusesPanelProps extends InjectedRouteLeaveProps {
     addFromHomeOnly?: boolean;
-    api?: ComponentsAPIWrapper;
     homeContainer?: Container;
 }
 
 export const ManageSampleStatusesPanel: FC<ManageSampleStatusesPanelProps> = memo(props => {
-    const { api = getDefaultAPIWrapper(), setIsDirty, homeContainer, addFromHomeOnly } = props;
+    const { setIsDirty, homeContainer, addFromHomeOnly } = props;
     const [states, setStates] = useState<Record<string, SampleState[]>>();
     const [error, setError] = useState<string>();
     const [selected, setSelected] = useState<number>();
     const [selectedGroup, setSelectedGroup] = useState<string>();
+    const { api } = useAppContext();
     const { container, moduleContext } = useServerContext();
     const showAdd = !addFromHomeOnly || isAppHomeFolder(container, moduleContext);
     const addNew = useMemo(() => selected === NEW_STATUS_INDEX, [selected]);

--- a/packages/components/src/internal/components/settings/NameIdSettings.test.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.test.tsx
@@ -5,69 +5,65 @@ import { waitFor } from '@testing-library/dom';
 
 import { BIOLOGICS_APP_PROPERTIES, SAMPLE_MANAGER_APP_PROPERTIES } from '../../app/constants';
 
-import { getTestAPIWrapper } from '../../APIWrapper';
+import { ComponentsAPIWrapper, getTestAPIWrapper } from '../../APIWrapper';
 import { getSamplesTestAPIWrapper } from '../samples/APIWrapper';
 
 import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 
-import { NameIdSettingsForm } from './NameIdSettings';
+import { NameIdSettingsForm, NameIdSettingsFormProps } from './NameIdSettings';
+import { TEST_FOLDER_CONTAINER } from '../../containerFixtures';
+import { AppContextTestProviderProps } from '../../test/testHelpers';
+import { ModuleContext } from '../base/ServerContext';
 
 describe('NameIdSettings', () => {
-    const apiWithSamples = getTestAPIWrapper(jest.fn, {
-        samples: getSamplesTestAPIWrapper(jest.fn, {
-            getSampleCounter: jest.fn().mockResolvedValue(5),
-            hasExistingSamples: jest.fn().mockResolvedValue(true),
-        }),
-    });
-    const apiWithCounterWithoutSamples = getTestAPIWrapper(jest.fn, {
-        samples: getSamplesTestAPIWrapper(jest.fn, {
-            getSampleCounter: jest.fn().mockResolvedValue(5),
-            hasExistingSamples: jest.fn().mockResolvedValue(false),
-        }),
-    });
-    const apiWithNoSamples = getTestAPIWrapper(jest.fn, {
-        samples: getSamplesTestAPIWrapper(jest.fn, {
-            getSampleCounter: jest.fn().mockResolvedValue(0),
-        }),
-    });
-
-    let DEFAULT_PROPS;
-    beforeEach(() => {
-        LABKEY.moduleContext = {
-            biologics: {
-                productId: BIOLOGICS_APP_PROPERTIES.productId,
+    function defaultContext(api?: ComponentsAPIWrapper, moduleContext?: ModuleContext): AppContextTestProviderProps {
+        return {
+            appContext: {
+                api:
+                    api ??
+                    getTestAPIWrapper(jest.fn, {
+                        samples: getSamplesTestAPIWrapper(jest.fn, {
+                            getSampleCounter: jest.fn().mockResolvedValue(0),
+                        }),
+                    }),
+            },
+            serverContext: {
+                moduleContext: moduleContext ?? {
+                    biologics: {
+                        productId: BIOLOGICS_APP_PROPERTIES.productId,
+                    },
+                },
             },
         };
+    }
 
-        const container = {
-            id: 'testContainerId',
-            title: 'TestContainer',
-            path: '/testContainer',
-        };
-
-        DEFAULT_PROPS = {
+    function defaultProps(): NameIdSettingsFormProps {
+        return {
+            container: TEST_FOLDER_CONTAINER,
+            getIsDirty: jest.fn(),
+            isAppHome: true,
             loadNameExpressionOptions: jest.fn(async () => {
                 return { prefix: 'ABC-', allowUserSpecifiedNames: false };
             }),
             saveNameExpressionOptions: jest.fn(async () => {
                 return [];
             }),
-            api: apiWithNoSamples,
-            getIsDirty: jest.fn(),
             setIsDirty: jest.fn(),
-            container,
-            isAppHome: true,
         };
-    });
+    }
 
     test('on init', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} />);
-        expect(document.querySelectorAll('.fa-spinner').length).toEqual(3);
+        const loadNameExpressionOptions = jest.fn();
+        renderWithAppContext(
+            <NameIdSettingsForm {...defaultProps()} loadNameExpressionOptions={loadNameExpressionOptions} />,
+            defaultContext()
+        );
+        expect(document.querySelectorAll('.fa-spinner')).toHaveLength(3);
         expect(document.querySelectorAll('.name-id-setting__prefix-field')).toHaveLength(0);
         expect(document.querySelectorAll('.checkbox')).toHaveLength(0);
 
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
         expect(document.querySelectorAll('.name-id-setting__setting-section')).toHaveLength(2);
         expect(document.querySelectorAll('.name-id-setting__prefix-field')).toHaveLength(1);
@@ -76,27 +72,35 @@ describe('NameIdSettings', () => {
         expect(document.querySelectorAll('.checkbox')).toHaveLength(1);
         expect(document.querySelectorAll('.form-control')).toHaveLength(3);
         expect(document.querySelectorAll('button')).toHaveLength(3);
-        expect(DEFAULT_PROPS.loadNameExpressionOptions).toHaveBeenCalled();
+        expect(loadNameExpressionOptions).toHaveBeenCalled();
 
         const counterLabel = document.querySelectorAll('div.sample-counter__prefix-label');
-        expect(counterLabel.length).toEqual(2);
-        expect(counterLabel[0].textContent).toBe('sampleCount');
-        expect(counterLabel[1].textContent).toBe('rootSampleCount');
+        expect(counterLabel).toHaveLength(2);
+        expect(counterLabel[0]).toHaveTextContent('sampleCount');
+        expect(counterLabel[1]).toHaveTextContent('rootSampleCount');
 
         const counterInputs = document.querySelectorAll('input.update-samplecount-input');
-        expect(counterInputs.length).toEqual(2);
+        expect(counterInputs).toHaveLength(2);
         expect(counterInputs[0].getAttribute('value')).toBe('0');
         expect(counterInputs[1].getAttribute('value')).toBe('0');
     });
 
     test('not app home', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} isAppHome={false} />);
-        expect(document.querySelectorAll('.fa-spinner').length).toEqual(2);
+        const loadNameExpressionOptions = jest.fn();
+        renderWithAppContext(
+            <NameIdSettingsForm
+                {...defaultProps()}
+                isAppHome={false}
+                loadNameExpressionOptions={loadNameExpressionOptions}
+            />,
+            defaultContext()
+        );
+        expect(document.querySelectorAll('.fa-spinner')).toHaveLength(2);
         expect(document.querySelectorAll('.name-id-setting__prefix-field')).toHaveLength(0);
         expect(document.querySelectorAll('.checkbox')).toHaveLength(0);
 
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
         expect(document.querySelectorAll('.name-id-setting__setting-section')).toHaveLength(2);
         expect(document.querySelectorAll('.name-id-setting__prefix-field')).toHaveLength(1);
@@ -105,38 +109,42 @@ describe('NameIdSettings', () => {
         expect(document.querySelectorAll('.checkbox')).toHaveLength(1);
         expect(document.querySelectorAll('.form-control')).toHaveLength(1);
         expect(document.querySelectorAll('button')).toHaveLength(1);
-        expect(DEFAULT_PROPS.loadNameExpressionOptions).toHaveBeenCalled();
+        expect(loadNameExpressionOptions).toHaveBeenCalled();
 
         const counterLabel = document.querySelectorAll('div.sample-counter__prefix-label');
-        expect(counterLabel.length).toEqual(0);
+        expect(counterLabel).toHaveLength(0);
 
         const counterInputs = document.querySelectorAll('input.update-samplecount-input');
-        expect(counterInputs.length).toEqual(0);
+        expect(counterInputs).toHaveLength(0);
     });
 
     test('allowUserSpecifiedNames checkbox', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} />);
+        const saveNameExpressionOptions = jest.fn();
+        renderWithAppContext(
+            <NameIdSettingsForm {...defaultProps()} saveNameExpressionOptions={saveNameExpressionOptions} />,
+            defaultContext()
+        );
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
 
         await userEvent.click(document.querySelectorAll('input')[0]); // check
-        expect(DEFAULT_PROPS.saveNameExpressionOptions).toHaveBeenCalled();
+        expect(saveNameExpressionOptions).toHaveBeenCalled();
     });
 
     test('prefix preview', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} />);
+        renderWithAppContext(<NameIdSettingsForm {...defaultProps()} />, defaultContext());
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
 
         expect(document.querySelector('.name-id-setting__prefix-example').textContent).toContain('ABC-Blood-${GenId}');
     });
 
     test('apply prefix confirm modal -- cancel', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} />);
+        renderWithAppContext(<NameIdSettingsForm {...defaultProps()} />, defaultContext());
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
 
         expect(document.querySelectorAll('.modal')).toHaveLength(0);
@@ -148,9 +156,13 @@ describe('NameIdSettings', () => {
     });
 
     test('apply prefix confirm modal -- save', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} />);
+        const saveNameExpressionOptions = jest.fn();
+        renderWithAppContext(
+            <NameIdSettingsForm {...defaultProps()} saveNameExpressionOptions={saveNameExpressionOptions} />,
+            defaultContext()
+        );
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
 
         expect(document.querySelectorAll('.modal')).toHaveLength(0);
@@ -160,19 +172,20 @@ describe('NameIdSettings', () => {
 
         // Click on 'Yes, Save and Apply Prefix' button
         await userEvent.click(document.querySelector('.modal').querySelectorAll('button')[2]);
-        expect(DEFAULT_PROPS.saveNameExpressionOptions).toHaveBeenCalled();
+        expect(saveNameExpressionOptions).toHaveBeenCalled();
     });
 
     test('LKSM - not showing prefix', async () => {
-        LABKEY.moduleContext = {
-            samplemanagement: {
-                productId: SAMPLE_MANAGER_APP_PROPERTIES.productId,
-            },
-        };
-
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} />);
+        renderWithAppContext(
+            <NameIdSettingsForm {...defaultProps()} />,
+            defaultContext(undefined, {
+                samplemanagement: {
+                    productId: SAMPLE_MANAGER_APP_PROPERTIES.productId,
+                },
+            })
+        );
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
 
         expect(document.querySelectorAll('.name-id-setting__setting-section')).toHaveLength(1);
@@ -182,45 +195,65 @@ describe('NameIdSettings', () => {
     });
 
     test('With counter, with existing sample', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} api={apiWithSamples} />);
+        renderWithAppContext(
+            <NameIdSettingsForm {...defaultProps()} />,
+            defaultContext(
+                getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
+                        getSampleCounter: jest.fn().mockResolvedValue(5),
+                        hasExistingSamples: jest.fn().mockResolvedValue(true),
+                    }),
+                })
+            )
+        );
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
 
         expect(document.querySelectorAll('.sample-counter__setting-section')).toHaveLength(1);
         expect(document.querySelectorAll('.sample-counter__prefix-label')).toHaveLength(2);
         expect(document.querySelectorAll('.form-control')).toHaveLength(3);
         const buttons = document.querySelectorAll('button');
-        expect(buttons.length).toEqual(3);
+        expect(buttons).toHaveLength(3);
 
-        expect(buttons[1].textContent).toBe('Apply New sampleCount');
-        expect(buttons[2].textContent).toBe('Apply New rootSampleCount');
+        expect(buttons[1]).toHaveTextContent('Apply New sampleCount');
+        expect(buttons[2]).toHaveTextContent('Apply New rootSampleCount');
 
         const counterInputs = document.querySelectorAll('input.update-samplecount-input');
-        expect(counterInputs.length).toEqual(2);
+        expect(counterInputs).toHaveLength(2);
         expect(counterInputs[0].getAttribute('value')).toBe('5');
         expect(counterInputs[1].getAttribute('value')).toBe('5');
     });
 
     test('With counter, with no existing sample', async () => {
-        renderWithAppContext(<NameIdSettingsForm {...DEFAULT_PROPS} api={apiWithCounterWithoutSamples} />);
+        renderWithAppContext(
+            <NameIdSettingsForm {...defaultProps()} />,
+            defaultContext(
+                getTestAPIWrapper(jest.fn, {
+                    samples: getSamplesTestAPIWrapper(jest.fn, {
+                        getSampleCounter: jest.fn().mockResolvedValue(5),
+                        hasExistingSamples: jest.fn().mockResolvedValue(false),
+                    }),
+                })
+            )
+        );
         await waitFor(() => {
-            expect(document.querySelectorAll('.fa-spinner').length).toEqual(0);
+            expect(document.querySelectorAll('.fa-spinner')).toHaveLength(0);
         });
 
         expect(document.querySelectorAll('.sample-counter__setting-section')).toHaveLength(1);
         expect(document.querySelectorAll('.sample-counter__prefix-label')).toHaveLength(2);
         expect(document.querySelectorAll('.form-control')).toHaveLength(3);
         const buttons = document.querySelectorAll('button');
-        expect(buttons.length).toEqual(5);
+        expect(buttons).toHaveLength(5);
 
-        expect(buttons[1].textContent).toBe('Apply New sampleCount');
-        expect(buttons[2].textContent).toBe('Reset sampleCount');
-        expect(buttons[3].textContent).toBe('Apply New rootSampleCount');
-        expect(buttons[4].textContent).toBe('Reset rootSampleCount');
+        expect(buttons[1]).toHaveTextContent('Apply New sampleCount');
+        expect(buttons[2]).toHaveTextContent('Reset sampleCount');
+        expect(buttons[3]).toHaveTextContent('Apply New rootSampleCount');
+        expect(buttons[4]).toHaveTextContent('Reset rootSampleCount');
 
         const counterInputs = document.querySelectorAll('input.update-samplecount-input');
-        expect(counterInputs.length).toEqual(2);
+        expect(counterInputs).toHaveLength(2);
         expect(counterInputs[0].getAttribute('value')).toBe('5');
         expect(counterInputs[1].getAttribute('value')).toBe('5');
     });

--- a/packages/components/src/internal/components/settings/NameIdSettings.test.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.test.tsx
@@ -17,15 +17,23 @@ import { ModuleContext } from '../base/ServerContext';
 
 describe('NameIdSettings', () => {
     function defaultContext(api?: ComponentsAPIWrapper, moduleContext?: ModuleContext): AppContextTestProviderProps {
+        const testApi = getTestAPIWrapper(jest.fn);
+
         return {
             appContext: {
-                api:
-                    api ??
-                    getTestAPIWrapper(jest.fn, {
-                        samples: getSamplesTestAPIWrapper(jest.fn, {
-                            getSampleCounter: jest.fn().mockResolvedValue(0),
-                        }),
-                    }),
+                api: api ?? {
+                    ...testApi,
+                    entity: {
+                        ...testApi.entity,
+                        loadNameExpressionOptions: jest
+                            .fn()
+                            .mockResolvedValue({ allowUserSpecifiedNames: false, prefix: 'ABC-' }),
+                    },
+                    samples: {
+                        ...testApi.samples,
+                        getSampleCounter: jest.fn().mockResolvedValue(0),
+                    },
+                },
             },
             serverContext: {
                 moduleContext: moduleContext ?? {
@@ -42,22 +50,14 @@ describe('NameIdSettings', () => {
             container: TEST_FOLDER_CONTAINER,
             getIsDirty: jest.fn(),
             isAppHome: true,
-            loadNameExpressionOptions: jest.fn(async () => {
-                return { prefix: 'ABC-', allowUserSpecifiedNames: false };
-            }),
-            saveNameExpressionOptions: jest.fn(async () => {
-                return [];
-            }),
+            saveNameExpressionOptions: jest.fn().mockResolvedValue([]),
             setIsDirty: jest.fn(),
         };
     }
 
     test('on init', async () => {
-        const loadNameExpressionOptions = jest.fn();
-        renderWithAppContext(
-            <NameIdSettingsForm {...defaultProps()} loadNameExpressionOptions={loadNameExpressionOptions} />,
-            defaultContext()
-        );
+        const context = defaultContext();
+        renderWithAppContext(<NameIdSettingsForm {...defaultProps()} />, context);
         expect(document.querySelectorAll('.fa-spinner')).toHaveLength(3);
         expect(document.querySelectorAll('.name-id-setting__prefix-field')).toHaveLength(0);
         expect(document.querySelectorAll('.checkbox')).toHaveLength(0);
@@ -72,7 +72,7 @@ describe('NameIdSettings', () => {
         expect(document.querySelectorAll('.checkbox')).toHaveLength(1);
         expect(document.querySelectorAll('.form-control')).toHaveLength(3);
         expect(document.querySelectorAll('button')).toHaveLength(3);
-        expect(loadNameExpressionOptions).toHaveBeenCalled();
+        expect(context.appContext.api.entity.loadNameExpressionOptions).toHaveBeenCalled();
 
         const counterLabel = document.querySelectorAll('div.sample-counter__prefix-label');
         expect(counterLabel).toHaveLength(2);
@@ -86,15 +86,8 @@ describe('NameIdSettings', () => {
     });
 
     test('not app home', async () => {
-        const loadNameExpressionOptions = jest.fn();
-        renderWithAppContext(
-            <NameIdSettingsForm
-                {...defaultProps()}
-                isAppHome={false}
-                loadNameExpressionOptions={loadNameExpressionOptions}
-            />,
-            defaultContext()
-        );
+        const context = defaultContext();
+        renderWithAppContext(<NameIdSettingsForm {...defaultProps()} isAppHome={false} />, context);
         expect(document.querySelectorAll('.fa-spinner')).toHaveLength(2);
         expect(document.querySelectorAll('.name-id-setting__prefix-field')).toHaveLength(0);
         expect(document.querySelectorAll('.checkbox')).toHaveLength(0);
@@ -109,7 +102,7 @@ describe('NameIdSettings', () => {
         expect(document.querySelectorAll('.checkbox')).toHaveLength(1);
         expect(document.querySelectorAll('.form-control')).toHaveLength(1);
         expect(document.querySelectorAll('button')).toHaveLength(1);
-        expect(loadNameExpressionOptions).toHaveBeenCalled();
+        expect(context.appContext.api.entity.loadNameExpressionOptions).toHaveBeenCalled();
 
         const counterLabel = document.querySelectorAll('div.sample-counter__prefix-label');
         expect(counterLabel).toHaveLength(0);

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -2,7 +2,7 @@ import React, { FC, memo, useCallback, useEffect, useReducer } from 'react';
 
 import { PermissionTypes } from '@labkey/api';
 
-import { isNamingPrefixEnabled, isRegistryEnabled } from '../../app/utils';
+import { isNamingPrefixEnabled } from '../../app/utils';
 
 import { invalidateFullQueryDetailsCache } from '../../query/api';
 
@@ -16,8 +16,6 @@ import { useServerContext } from '../base/ServerContext';
 
 import { InjectedRouteLeaveProps } from '../../util/RouteLeave';
 
-import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-
 import { HelpLink } from '../../util/helpLinks';
 import { SAMPLE_TYPE_NAME_EXPRESSION_TOPIC } from '../samples/constants';
 
@@ -26,28 +24,26 @@ import { Container } from '../base/models/Container';
 import { CheckboxLK } from '../../Checkbox';
 
 import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
+import { useAppContext } from '../../AppContext';
 
 const TITLE = 'ID/Name Settings';
 
-interface NameIdSettingsFormProps extends InjectedRouteLeaveProps {
-    api?: ComponentsAPIWrapper;
+export interface NameIdSettingsFormProps extends InjectedRouteLeaveProps {
     container: Container;
     isAppHome?: boolean;
     loadNameExpressionOptions: (
         containerPath?: string
     ) => Promise<{ allowUserSpecifiedNames: boolean; prefix: string }>;
-    saveNameExpressionOptions: (key: string, value: string | boolean, containerPath?: string) => Promise<string[]>;
+    saveNameExpressionOptions: (key: string, value: boolean | string, containerPath?: string) => Promise<string[]>;
 }
 
 interface NameIdSettingsProps extends InjectedRouteLeaveProps {
-    api?: ComponentsAPIWrapper;
     container: Container;
     isAppHome?: boolean;
 }
 
 interface State {
     allowUserSpecifiedNames: boolean;
-    api?: ComponentsAPIWrapper;
     confirmCounterModalOpen?: boolean;
     confirmModalOpen: boolean;
     error: string;
@@ -87,18 +83,12 @@ const initialState: State = {
 };
 
 export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
-    const {
-        api = getDefaultAPIWrapper(),
-        loadNameExpressionOptions,
-        saveNameExpressionOptions,
-        setIsDirty,
-        isAppHome,
-        container,
-    } = props;
+    const { loadNameExpressionOptions, saveNameExpressionOptions, setIsDirty, isAppHome, container } = props;
     const [state, setState] = useReducer(
         (currentState: State, newState: Partial<State>): State => ({ ...currentState, ...newState }),
         initialState
     );
+    const { api } = useAppContext();
     const { moduleContext } = useServerContext();
 
     const {
@@ -168,12 +158,12 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
         initialize();
     }, [isAppHome, container]);
 
-    const displayError = (err): void => {
+    const displayError = useCallback(err => {
         setState({
             error: err.exception ?? 'Error saving setting',
             savingAllowUserSpecifiedNames: false,
         });
-    };
+    }, []);
 
     const saveAllowUserSpecifiedNames = useCallback(async () => {
         setState({ savingAllowUserSpecifiedNames: true });
@@ -193,7 +183,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
         } catch (err) {
             displayError(err);
         }
-    }, [allowUserSpecifiedNames, saveNameExpressionOptions, container.path]);
+    }, [allowUserSpecifiedNames, displayError, saveNameExpressionOptions, container.path]);
 
     const savePrefix = useCallback(async () => {
         setState({ savingPrefix: true });
@@ -211,7 +201,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
             prefixIneligibleSampleTypeNames: response ?? [],
         });
         setIsDirty(false);
-    }, [prefix, saveNameExpressionOptions, setIsDirty, container.path]);
+    }, [displayError, prefix, saveNameExpressionOptions, setIsDirty, container.path]);
 
     const prefixOnChange = useCallback(
         (evt: any) => {
@@ -254,7 +244,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
         const newCount = isReset ? 0 : isRoot ? newRootSampleCount : newSampleCount;
         try {
             await api.samples.saveSampleCounter(newCount, isRoot ? 'rootSampleCount' : 'sampleCount');
-            if (isRoot)
+            if (isRoot) {
                 setState({
                     rootSampleCount: newCount,
                     confirmCounterModalOpen: false,
@@ -263,7 +253,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                     prefixIneligibleSampleTypeNames: [],
                     hasRootSampleCountChange: false,
                 });
-            else
+            } else {
                 setState({
                     sampleCount: newCount,
                     confirmCounterModalOpen: false,
@@ -272,6 +262,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                     prefixIneligibleSampleTypeNames: [],
                     hasSampleCountChange: false,
                 });
+            }
             setIsDirty(false);
         } catch (error) {
             if (isRoot) {
@@ -288,7 +279,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                 });
             }
         }
-    }, [isRoot, isReset, newRootSampleCount, newSampleCount, setIsDirty, rootSampleCount, sampleCount]);
+    }, [isReset, isRoot, newRootSampleCount, newSampleCount, api.samples, setIsDirty, rootSampleCount, sampleCount]);
 
     return (
         <div className="name-id-settings-panel panel panel-default">
@@ -312,10 +303,10 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                     {!loadingNamingOptions && (
                         <form>
                             <CheckboxLK
+                                checked={allowUserSpecifiedNames}
+                                disabled={savingAllowUserSpecifiedNames}
                                 name="allowUserSpecifiedNames"
                                 onChange={saveAllowUserSpecifiedNames}
-                                disabled={savingAllowUserSpecifiedNames}
-                                checked={allowUserSpecifiedNames}
                             >
                                 Allow users to create/import their own IDs/Names in this folder
                                 <LabelHelpTip title="User Defined ID/Names">
@@ -352,17 +343,17 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         <input
                                             className="form-control"
                                             name="prefix"
-                                            type="text"
-                                            placeholder="Enter Prefix"
                                             onChange={prefixOnChange}
+                                            placeholder="Enter Prefix"
+                                            type="text"
                                             value={prefix}
                                         />
                                     </div>
 
                                     <button
                                         className="btn btn-success"
-                                        onClick={openConfirmModal}
                                         disabled={savingPrefix || !hasPrefixChange}
+                                        onClick={openConfirmModal}
                                         type="button"
                                     >
                                         Apply Prefix
@@ -375,17 +366,17 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                 {confirmModalOpen && (
                                     <Modal
                                         confirmClass="btn-danger"
-                                        title="Apply Prefix?"
+                                        confirmText="Yes, Save and Apply Prefix"
                                         onCancel={closeConfirmModal}
                                         onConfirm={savePrefix}
-                                        confirmText="Yes, Save and Apply Prefix"
+                                        title="Apply Prefix?"
                                     >
                                         <div>
                                             <p>
                                                 This action will change the Naming Pattern for all new and existing
-                                                Sample Types and Source Types. No
-                                                existing IDs/Names will be affected but any new IDs/Names will have the
-                                                prefix applied. Are you sure you want to apply the prefix?
+                                                Sample Types and Source Types. No existing IDs/Names will be affected
+                                                but any new IDs/Names will have the prefix applied. Are you sure you
+                                                want to apply the prefix?
                                             </p>
                                         </div>
                                     </Modal>
@@ -400,9 +391,9 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                         <div className="list__bold-text margin-bottom">Naming Pattern Elements/Tokens</div>
                         <div>
                             The following tokens/counters are utilized in naming patterns for the application and all
-                            folders. To modify a counter, simply enter a number greater than the current value and
-                            click "Apply". Please be aware that once a counter is changed, the action cannot be
-                            reversed. For additional information regarding these tokens, you can refer to this{' '}
+                            folders. To modify a counter, simply enter a number greater than the current value and click
+                            "Apply". Please be aware that once a counter is changed, the action cannot be reversed. For
+                            additional information regarding these tokens, you can refer to this{' '}
                             <HelpLink topic={SAMPLE_TYPE_NAME_EXPRESSION_TOPIC}>link</HelpLink>.
                         </div>
 
@@ -417,21 +408,21 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         <input
                                             className="form-control update-samplecount-input"
                                             min={sampleCount}
-                                            step={1}
                                             name="newSampleCount"
                                             onChange={(event: any) => setNewSampleCount(event?.target?.value, false)}
+                                            placeholder="Enter new sampleCount..."
+                                            step={1}
                                             type="number"
                                             value={newSampleCount}
-                                            placeholder="Enter new sampleCount..."
                                         />
                                     </div>
                                     <div className="col-sm-8">
                                         <button
                                             className="btn btn-success sample-counter-btn"
+                                            disabled={updatingCounter || !hasSampleCountChange}
                                             onClick={() => {
                                                 openSetCounterConfirmModal(false, false);
                                             }}
-                                            disabled={updatingCounter || !hasSampleCountChange}
                                             type="button"
                                         >
                                             Apply New sampleCount
@@ -439,10 +430,10 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         {!hasSamples && sampleCount > 0 && (
                                             <button
                                                 className="btn btn-success sample-counter-btn"
+                                                disabled={updatingCounter}
                                                 onClick={() => {
                                                     openSetCounterConfirmModal(false, true);
                                                 }}
-                                                disabled={updatingCounter}
                                                 type="button"
                                             >
                                                 Reset sampleCount
@@ -458,21 +449,21 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         <input
                                             className="form-control update-samplecount-input"
                                             min={rootSampleCount}
-                                            step={1}
                                             name="newRootSampleCount"
                                             onChange={(event: any) => setNewSampleCount(event?.target?.value, true)}
+                                            placeholder="Enter new rootSampleCount..."
+                                            step={1}
                                             type="number"
                                             value={newRootSampleCount}
-                                            placeholder="Enter new rootSampleCount..."
                                         />
                                     </div>
                                     <div className="col-sm-8">
                                         <button
                                             className="btn btn-success sample-counter-btn"
+                                            disabled={updatingCounter || !hasRootSampleCountChange}
                                             onClick={() => {
                                                 openSetCounterConfirmModal(true, false);
                                             }}
-                                            disabled={updatingCounter || !hasRootSampleCountChange}
                                             type="button"
                                         >
                                             Apply New rootSampleCount
@@ -480,10 +471,10 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                         {!hasRootSamples && rootSampleCount > 0 && (
                                             <button
                                                 className="btn btn-success sample-counter-btn"
+                                                disabled={updatingCounter}
                                                 onClick={() => {
                                                     openSetCounterConfirmModal(true, true);
                                                 }}
-                                                disabled={updatingCounter}
                                                 type="button"
                                             >
                                                 Reset rootSampleCount
@@ -494,13 +485,13 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
                                 {confirmCounterModalOpen && (
                                     <Modal
                                         confirmClass="btn-danger"
+                                        confirmText={'Yes, ' + (isReset ? 'Reset' : 'Update')}
+                                        onCancel={closeCounterConfirmModal}
+                                        onConfirm={saveSampleCounter}
                                         title={
                                             (isReset ? 'Reset ' : 'Update ') +
                                             (isRoot ? 'rootSampleCount' : 'sampleCount')
                                         }
-                                        onCancel={closeCounterConfirmModal}
-                                        onConfirm={saveSampleCounter}
-                                        confirmText={'Yes, ' + (isReset ? 'Reset' : 'Update')}
                                     >
                                         <div>
                                             <p>
@@ -529,8 +520,8 @@ export const NameIdSettings: FC<NameIdSettingsProps> = memo(props => {
         <RequiresPermission perms={PermissionTypes.Admin}>
             <NameIdSettingsForm
                 {...props}
-                saveNameExpressionOptions={saveNameExpressionOptions}
                 loadNameExpressionOptions={loadNameExpressionOptions}
+                saveNameExpressionOptions={saveNameExpressionOptions}
             />
         </RequiresPermission>
     );

--- a/packages/components/src/internal/components/settings/NameIdSettings.tsx
+++ b/packages/components/src/internal/components/settings/NameIdSettings.tsx
@@ -23,7 +23,7 @@ import { Container } from '../base/models/Container';
 
 import { CheckboxLK } from '../../Checkbox';
 
-import { loadNameExpressionOptions, saveNameExpressionOptions } from './actions';
+import { saveNameExpressionOptions } from './actions';
 import { useAppContext } from '../../AppContext';
 
 const TITLE = 'ID/Name Settings';
@@ -31,9 +31,6 @@ const TITLE = 'ID/Name Settings';
 export interface NameIdSettingsFormProps extends InjectedRouteLeaveProps {
     container: Container;
     isAppHome?: boolean;
-    loadNameExpressionOptions: (
-        containerPath?: string
-    ) => Promise<{ allowUserSpecifiedNames: boolean; prefix: string }>;
     saveNameExpressionOptions: (key: string, value: boolean | string, containerPath?: string) => Promise<string[]>;
 }
 
@@ -83,7 +80,7 @@ const initialState: State = {
 };
 
 export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
-    const { loadNameExpressionOptions, saveNameExpressionOptions, setIsDirty, isAppHome, container } = props;
+    const { saveNameExpressionOptions, setIsDirty, isAppHome, container } = props;
     const [state, setState] = useReducer(
         (currentState: State, newState: Partial<State>): State => ({ ...currentState, ...newState }),
         initialState
@@ -118,7 +115,7 @@ export const NameIdSettingsForm: FC<NameIdSettingsFormProps> = props => {
 
     const initializeNamingPattern = async (): Promise<void> => {
         try {
-            const payload = await loadNameExpressionOptions(container.path);
+            const payload = await api.entity.loadNameExpressionOptions(container.path);
             setState({
                 prefix: payload.prefix ?? '',
                 allowUserSpecifiedNames: payload.allowUserSpecifiedNames,
@@ -518,11 +515,7 @@ NameIdSettingsForm.displayName = 'NameIdSettingsForm';
 export const NameIdSettings: FC<NameIdSettingsProps> = memo(props => {
     return (
         <RequiresPermission perms={PermissionTypes.Admin}>
-            <NameIdSettingsForm
-                {...props}
-                loadNameExpressionOptions={loadNameExpressionOptions}
-                saveNameExpressionOptions={saveNameExpressionOptions}
-            />
+            <NameIdSettingsForm {...props} saveNameExpressionOptions={saveNameExpressionOptions} />
         </RequiresPermission>
     );
 });


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53366](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53366) by fixing logic that was inadvertently putting `undefined` into the `List<ValueDescriptor>`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1835
- https://github.com/LabKey/labkey-ui-premium/pull/793
- https://github.com/LabKey/limsModules/pull/1537

#### Changes
- Address [Issue 53366](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53366) by not putting `undefined` into `List<ValueDescriptor>`
- Address [Issue 53443](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53443) by fixing where we check for optional prop
- Export `ValueDescriptor` for external usage
- Update `NameIdSettings`, `BarTenderSettingsForm` and `ManageSampleStatusesPanel` to use app context for api
