### PR TITLE
Add audit logging for file fields and renaming of files

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.4-fileNameAudit.4",
+  "version": "6.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.4-fileNameAudit.4",
+      "version": "6.57.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.4-fileNameAudit.3",
+  "version": "6.56.4-fileNameAudit.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.4-fileNameAudit.3",
+      "version": "6.56.4-fileNameAudit.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-fileNameAudit.2",
+  "version": "6.56.3-fileNameAudit.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.3-fileNameAudit.2",
+      "version": "6.56.3-fileNameAudit.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-fileNameAudit.1",
+  "version": "6.56.3-fileNameAudit.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.3-fileNameAudit.1",
+      "version": "6.56.3-fileNameAudit.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.0",
+  "version": "6.56.1-fileNameAudit.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.0",
+      "version": "6.56.1-fileNameAudit.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.1-fileNameAudit.0",
+  "version": "6.56.1-fileNameAudit.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.1-fileNameAudit.0",
+      "version": "6.56.1-fileNameAudit.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-fileNameAudit.2",
+  "version": "6.56.3-fileNameAudit.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.4-fileNameAudit.3",
+  "version": "6.56.4-fileNameAudit.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.1-fileNameAudit.0",
+  "version": "6.56.1-fileNameAudit.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.4-fileNameAudit.4",
+  "version": "6.57.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.0",
+  "version": "6.56.1-fileNameAudit.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-fileNameAudit.1",
+  "version": "6.56.3-fileNameAudit.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.57.0
+*Released*: 30 July 2025
 - Add file system audit events for apps
 - Add `TransactionAuditIdRenderer` for displaying link to page of audit records associated with a transaction id
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Add file system audit events for apps
+- Add `TransactionAuditIdRenderer` for displaying link to page of audit records associated with a transaction id
+
 ### version 6.56.0
 *Released*: 11 July 2025
 - Package updates

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -286,6 +286,7 @@ import { ANCESTOR_LOOKUP_CONCEPT_URI, AncestorRenderer } from './internal/render
 import { StorageStatusRenderer } from './internal/renderers/StorageStatusRenderer';
 import { StoredAmountRenderer } from './internal/renderers/StoredAmountRenderer';
 import { SampleStatusRenderer } from './internal/renderers/SampleStatusRenderer';
+import { TransactionAuditIdRenderer } from './internal/renderers/TransactionAuditIdRenderer';
 import { ExpirationDateColumnRenderer } from './internal/renderers/ExpirationDateColumnRenderer';
 import { FolderColumnRenderer } from './internal/renderers/FolderColumnRenderer';
 import { AppendUnits } from './internal/renderers/AppendUnits';
@@ -1745,6 +1746,7 @@ export {
     StorageAmountInput,
     StorageStatusRenderer,
     StoredAmountRenderer,
+    TransactionAuditIdRenderer,
     SVGIcon,
     Tab,
     TabbedGridPanel,

--- a/packages/components/src/internal/components/auditlog/AuditDetails.test.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.test.tsx
@@ -89,17 +89,37 @@ describe('AuditDetails', () => {
     test('changeDetails', () => {
         renderWithAppContext(
             <AuditDetails
-                rowId={1}
-                user={TEST_USER_APP_ADMIN}
                 changeDetails={AuditDetailsModel.create({
                     oldData: { a: 1 },
                     newData: { a: 2 },
                 })}
+                rowId={1}
+                user={TEST_USER_APP_ADMIN}
             />,
             { serverContext: { user: TEST_USER_APP_ADMIN } }
         );
         expect(document.querySelectorAll('.table-responsive')).toHaveLength(0);
         expect(document.querySelectorAll('.user-link')).toHaveLength(0);
         expect(document.querySelector('.panel-body').textContent).toBe('a12');
+    });
+    test('original data', () => {
+        renderWithAppContext(
+            <AuditDetails
+                changeDetails={AuditDetailsModel.create({
+                    oldData: { a: 'file.txt' },
+                    newData: { a: 'new-1.txt' },
+                    originalValues: {
+                        a: 'new.txt',
+                    },
+                })}
+                rowId={1}
+                user={TEST_USER_APP_ADMIN}
+            />,
+            { serverContext: { user: TEST_USER_APP_ADMIN } }
+        );
+        expect(document.querySelectorAll('.table-responsive')).toHaveLength(0);
+        expect(document.querySelectorAll('.user-link')).toHaveLength(0);
+        expect(document.querySelector('.panel-body').textContent).toBe('afile.txtnew-1.txt');
+        expect(document.querySelector('.original-value-icon')).toBeInTheDocument();
     });
 });

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -14,6 +14,7 @@ import { UserLink } from '../user/UserLink';
 
 import { getEventDataValueDisplay } from './utils';
 import { AuditDetailsModel } from './models';
+import { LabelHelpTip } from '../base/LabelHelpTip';
 
 interface Props extends PropsWithChildren {
     changeDetails?: AuditDetailsModel;
@@ -52,7 +53,7 @@ export class AuditDetails extends Component<Props> {
         return displayVal;
     };
 
-    renderRow(field: string, oldVal: string, newVal: string, isUpdate: boolean, isInsert: boolean): ReactNode {
+    renderRow(field: string, oldVal: string, newVal: string, originalVal: string, isUpdate: boolean, isInsert: boolean): ReactNode {
         const { user } = this.props;
 
         if (!user.isSignedIn && AuditDetails.isUserFieldLabel(field)) return null;
@@ -64,7 +65,17 @@ export class AuditDetails extends Component<Props> {
         return (
             <div className="row margin-bottom" key={field}>
                 <div className="left-padding right-padding">
-                    <span className="audit-detail-row-label right-padding">{capitalizeFirstChar(field)}</span>
+                    <span className="audit-detail-row-label right-padding">
+                        {capitalizeFirstChar(field)}
+                        {originalVal != null && (
+                            <LabelHelpTip
+                                iconComponent={<i className="original-value-icon fa fa-info-circle left-padding" />}
+                                placement="right"
+                            >
+                                <div className="ws-pre-wrap">Original value: {originalVal}</div>
+                            </LabelHelpTip>
+                        )}
+                    </span>
                 </div>
                 <div className="left-padding right-padding">
                     {isInsert && <span className="new-audit-value">{newValue}</span>}
@@ -91,7 +102,7 @@ export class AuditDetails extends Component<Props> {
         const isInsert = changeDetails.isInsert();
         const usedFields = [];
 
-        let oldFields, newFields;
+        let newFields, oldFields;
         if (changeDetails.oldData) {
             oldFields = changeDetails.oldData.entrySeq().map(([field, value]) => {
                 let newValue;
@@ -99,16 +110,23 @@ export class AuditDetails extends Component<Props> {
                     newValue = changeDetails.newData.get(field);
                     usedFields.push(field);
                 }
+                let originalValue;
+                if (changeDetails.originalValues) {
+                    originalValue = changeDetails.originalValues.get(field);
+                }
 
-                return this.renderRow(field, value, newValue, isUpdate, isInsert);
+                return this.renderRow(field, value, newValue, originalValue, isUpdate, isInsert);
             });
         }
 
         if (changeDetails.newData) {
             newFields = changeDetails.newData.entrySeq().map(([field, value]) => {
                 if (usedFields.indexOf(field) >= 0) return null;
-
-                return this.renderRow(field, undefined, value, isUpdate, isInsert);
+                let originalValue;
+                if (changeDetails.originalValues) {
+                    originalValue = changeDetails.originalValues.get(field);
+                }
+                return this.renderRow(field, undefined, value, originalValue, isUpdate, isInsert);
             });
         }
 

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -6,7 +6,7 @@ import React, { Component, PropsWithChildren, ReactNode } from 'react';
 import { List, Map } from 'immutable';
 
 import { User } from '../base/models/User';
-import { capitalizeFirstChar } from '../../util/utils';
+import { capitalizeFirstChar, caseInsensitive } from '../../util/utils';
 import { GridColumn } from '../base/models/GridColumn';
 import { Grid } from '../base/Grid';
 
@@ -110,11 +110,7 @@ export class AuditDetails extends Component<Props> {
                     newValue = changeDetails.newData.get(field);
                     usedFields.push(field);
                 }
-                let originalValue;
-                if (changeDetails.originalValues) {
-                    originalValue = changeDetails.originalValues.get(field);
-                }
-
+                const originalValue = caseInsensitive(changeDetails.originalValues, field);
                 return this.renderRow(field, value, newValue, originalValue, isUpdate, isInsert);
             });
         }
@@ -122,10 +118,7 @@ export class AuditDetails extends Component<Props> {
         if (changeDetails.newData) {
             newFields = changeDetails.newData.entrySeq().map(([field, value]) => {
                 if (usedFields.indexOf(field) >= 0) return null;
-                let originalValue;
-                if (changeDetails.originalValues) {
-                    originalValue = changeDetails.originalValues.get(field);
-                }
+                const originalValue = caseInsensitive(changeDetails.originalValues, field);
                 return this.renderRow(field, undefined, value, originalValue, isUpdate, isInsert);
             });
         }

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -3,6 +3,7 @@ import { Query } from '@labkey/api';
 export type AuditQuery = {
     containerFilter?: Query.ContainerFilter;
     hasDetail?: boolean;
+    hasTransactionId?: boolean;
     label: string;
     value: string;
 };
@@ -21,12 +22,14 @@ export const QUERY_UPDATE_AUDIT_QUERY: AuditQuery = {
 
 export const DATACLASS_DATA_UPDATE_AUDIT_QUERY: AuditQuery = {
     hasDetail: true,
+    hasTransactionId: true,
     label: 'Data Update Events',
     value: 'dataclassdataauditevent',
 };
 
 export const INVENTORY_AUDIT_QUERY: AuditQuery = {
     hasDetail: true,
+    hasTransactionId: true,
     label: 'Storage Management Events',
     value: 'inventoryauditevent',
 };
@@ -41,9 +44,14 @@ export const CONTAINER_AUDIT_QUERY: AuditQuery = {
     label: 'Folder Events',
     value: 'containerauditevent',
 };
-export const SAMPLE_TYPE_AUDIT_QUERY: AuditQuery = { label: 'Sample Type Events', value: 'samplesetauditevent' };
+export const SAMPLE_TYPE_AUDIT_QUERY: AuditQuery = {
+    hasTransactionId: true,
+    label: 'Sample Type Events',
+    value: 'samplesetauditevent',
+};
 export const SAMPLE_TIMELINE_AUDIT_QUERY: AuditQuery = {
     hasDetail: true,
+    hasTransactionId: true,
     label: 'Sample Timeline Events',
     value: 'sampletimelineevent',
 };
@@ -52,13 +60,22 @@ export const USER_AUDIT_QUERY: AuditQuery = {
     label: 'User Events',
     value: 'userauditevent',
 };
-export const ASSAY_AUDIT_QUERY: AuditQuery = { value: 'assayauditevent', label: 'Assay Events' };
+export const ASSAY_AUDIT_QUERY: AuditQuery = {
+    hasTransactionId: true,
+    value: 'assayauditevent',
+    label: 'Assay Events',
+};
 export const WORKFLOW_AUDIT_QUERY: AuditQuery = {
     hasDetail: true,
     label: 'Sample Workflow Events',
     value: 'samplesworkflowauditevent',
 };
-export const SOURCE_AUDIT_QUERY: AuditQuery = { hasDetail: true, label: 'Sources Events', value: 'sourcesauditevent' };
+export const SOURCE_AUDIT_QUERY: AuditQuery = {
+    hasDetail: true,
+    hasTransactionId: true,
+    label: 'Sources Events',
+    value: 'sourcesauditevent',
+};
 
 export const NOTEBOOK_AUDIT_QUERY: AuditQuery = {
     label: 'Notebook Events',
@@ -74,12 +91,19 @@ export const REGISTRY_AUDIT_QUERY: AuditQuery = { label: 'Registry Events', valu
 
 export const REPORT_AUDIT_QUERY: AuditQuery = { label: 'Report Events', value: 'ReportEvent' };
 
+export const FILE_SYSTEM_AUDIT_QUERY: AuditQuery = {
+    hasTransactionId: true,
+    label: 'File Events',
+    value: 'filesystem',
+};
+
 export const AUDIT_EVENT_TYPE_PARAM = 'eventType';
 
 export const COMMON_AUDIT_QUERIES: AuditQuery[] = [
     ATTACHMENT_AUDIT_QUERY,
     DOMAIN_AUDIT_QUERY,
     DOMAIN_PROPERTY_AUDIT_QUERY,
+    FILE_SYSTEM_AUDIT_QUERY,
     QUERY_UPDATE_AUDIT_QUERY,
     INVENTORY_AUDIT_QUERY,
     LIST_AUDIT_QUERY,

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -33,7 +33,7 @@ export const INVENTORY_AUDIT_QUERY: AuditQuery = {
     label: 'Storage Management Events',
     value: 'inventoryauditevent',
 };
-export const LIST_AUDIT_QUERY: AuditQuery = { label: 'List Events', value: 'listauditevent' };
+export const LIST_AUDIT_QUERY: AuditQuery = { hasTransactionId: true, label: 'List Events', value: 'listauditevent' };
 export const GROUP_AUDIT_QUERY: AuditQuery = {
     containerFilter: Query.ContainerFilter.allFolders,
     label: 'Roles and Assignment Events',

--- a/packages/components/src/internal/components/auditlog/models.ts
+++ b/packages/components/src/internal/components/auditlog/models.ts
@@ -13,6 +13,7 @@ export class AuditDetailsModel extends Record({
     eventDateFormatted: undefined,
     oldData: undefined,
     newData: undefined,
+    originalValues: undefined,
     userComment: undefined,
 }) {
     declare rowId?: number;
@@ -21,6 +22,7 @@ export class AuditDetailsModel extends Record({
     declare eventDateFormatted?: string;
     declare oldData?: Map<string, string>;
     declare newData?: Map<string, string>;
+    declare originalValues?: Map<string, string>;
     declare userComment?: string;
 
     static create(raw: any): AuditDetailsModel {
@@ -28,6 +30,7 @@ export class AuditDetailsModel extends Record({
             ...raw,
             oldData: raw.oldData ? fromJS(raw.oldData) : undefined,
             newData: raw.newData ? fromJS(raw.newData) : undefined,
+            originalValues: raw.originalValues ? fromJS(raw.originalValues) : undefined,
         });
     }
 
@@ -65,6 +68,7 @@ export class TimelineEventModel extends Record({
     metadata: undefined,
     oldData: undefined,
     newData: undefined,
+    originalValues: undefined, // map from field name to user-provided values that were converted
     userComment: undefined,
 }) {
     declare rowId?: number;
@@ -80,6 +84,7 @@ export class TimelineEventModel extends Record({
     declare metadata?: List<Map<string, any>>;
     declare oldData?: Map<string, string>;
     declare newData?: Map<string, string>;
+    declare originalValues?: Map<string, string>;
     declare userComment?: string;
 
     constructor(values?: { [key: string]: any }) {
@@ -118,6 +123,7 @@ export class TimelineEventModel extends Record({
 
         if (raw.oldData) fields.oldData = fromJS(raw.oldData);
         if (raw.newData) fields.newData = fromJS(raw.newData);
+        if (raw.originalValues) fields.originalValues = fromJS(raw.originalValues);
 
         return new TimelineEventModel(fields);
     }
@@ -129,6 +135,7 @@ export class TimelineEventModel extends Record({
             rowId: this.rowId,
             oldData: this.oldData,
             newData: this.newData,
+            originalValues: this.originalValues,
             userComment: this.userComment,
         });
     }

--- a/packages/components/src/internal/components/auditlog/models.ts
+++ b/packages/components/src/internal/components/auditlog/models.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-2018 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { fromJS, Map, Record, List } from 'immutable';
+import { fromJS, List, Map, Record } from 'immutable';
 
 import { ASSAYS_KEY, SAMPLES_KEY } from '../../app/constants';
 
@@ -22,7 +22,7 @@ export class AuditDetailsModel extends Record({
     declare eventDateFormatted?: string;
     declare oldData?: Map<string, string>;
     declare newData?: Map<string, string>;
-    declare originalValues?: Map<string, string>;
+    declare originalValues?: Record<string, string>;
     declare userComment?: string;
 
     static create(raw: any): AuditDetailsModel {
@@ -30,7 +30,7 @@ export class AuditDetailsModel extends Record({
             ...raw,
             oldData: raw.oldData ? fromJS(raw.oldData) : undefined,
             newData: raw.newData ? fromJS(raw.newData) : undefined,
-            originalValues: raw.originalValues ? fromJS(raw.originalValues) : undefined,
+            originalValues: raw.originalValues,
         });
     }
 
@@ -123,7 +123,7 @@ export class TimelineEventModel extends Record({
 
         if (raw.oldData) fields.oldData = fromJS(raw.oldData);
         if (raw.newData) fields.newData = fromJS(raw.newData);
-        if (raw.originalValues) fields.originalValues = fromJS(raw.originalValues);
+        if (raw.originalValues) fields.originalValues = raw.originalValues;
 
         return new TimelineEventModel(fields);
     }

--- a/packages/components/src/internal/components/auditlog/utils.test.ts
+++ b/packages/components/src/internal/components/auditlog/utils.test.ts
@@ -28,17 +28,17 @@ import {
 describe('getAuditQueries', () => {
     test('LKS starter', () => {
         const auditQueries = getAuditQueries(TEST_LKS_STARTER_MODULE_CONTEXT);
-        expect(auditQueries.length).toBe(12);
+        expect(auditQueries.length).toBe(13);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(10);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(11);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBe(-1);
         expect(auditQueries.findIndex(entry => entry === SOURCE_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
     });
 
     test('LKSM starter', () => {
         const auditQueries = getAuditQueries(TEST_LKSM_STARTER_MODULE_CONTEXT);
-        expect(auditQueries.length).toBe(11);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(9);
+        expect(auditQueries.length).toBe(12);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(10);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBe(-1);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBe(-1);
         expect(auditQueries.findIndex(entry => entry === SOURCE_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
@@ -46,8 +46,8 @@ describe('getAuditQueries', () => {
 
     test('LKSM professional', () => {
         const auditQueries = getAuditQueries(TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT);
-        expect(auditQueries.length).toBe(15);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(13);
+        expect(auditQueries.length).toBe(16);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(14);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === SOURCE_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
@@ -69,8 +69,8 @@ describe('getAuditQueries', () => {
             },
         };
         const auditQueries = getAuditQueries(moduleContext);
-        expect(auditQueries.length).toBe(16);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(14);
+        expect(auditQueries.length).toBe(17);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(15);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === NOTEBOOK_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);

--- a/packages/components/src/internal/renderers/TransactionAuditIdRenderer.tsx
+++ b/packages/components/src/internal/renderers/TransactionAuditIdRenderer.tsx
@@ -11,10 +11,16 @@ interface Props {
 export class TransactionAuditIdRenderer extends PureComponent<Props> {
     render(): ReactNode {
         const { row } = this.props;
-        const id = caseInsensitive(row.toJS(), 'transactionId')?.value;
+        const _row = row.toJS();
+        const id = caseInsensitive(_row, 'transactionId')?.value;
         if (!id) {
             return null;
         }
-        return <AppLink to={AppURL.create('audit', id)}>{id}</AppLink>;
+        let url = AppURL.create('audit', id);
+        const activeTab = caseInsensitive(_row, 'EventType')?.value.toLowerCase();
+        if (activeTab) {
+            url = url.addParam('tab', activeTab);
+        }
+        return <AppLink to={url}>{id}</AppLink>;
     }
 }

--- a/packages/components/src/internal/renderers/TransactionAuditIdRenderer.tsx
+++ b/packages/components/src/internal/renderers/TransactionAuditIdRenderer.tsx
@@ -17,7 +17,7 @@ export class TransactionAuditIdRenderer extends PureComponent<Props> {
             return null;
         }
         let url = AppURL.create('audit', id);
-        const activeTab = caseInsensitive(_row, 'EventType')?.value.toLowerCase();
+        const activeTab = caseInsensitive(_row, 'EventType')?.value;
         if (activeTab) {
             url = url.addParam('tab', activeTab);
         }

--- a/packages/components/src/internal/renderers/TransactionAuditIdRenderer.tsx
+++ b/packages/components/src/internal/renderers/TransactionAuditIdRenderer.tsx
@@ -1,0 +1,20 @@
+import { Map } from 'immutable';
+import React, { PureComponent, ReactNode } from 'react';
+import { AppLink } from '../url/AppLink';
+import { AppURL } from '../url/AppURL';
+import { caseInsensitive } from '../util/utils';
+
+interface Props {
+    row: Map<any, any>;
+}
+
+export class TransactionAuditIdRenderer extends PureComponent<Props> {
+    render(): ReactNode {
+        const { row } = this.props;
+        const id = caseInsensitive(row.toJS(), 'transactionId')?.value;
+        if (!id) {
+            return null;
+        }
+        return <AppLink to={AppURL.create('audit', id)}>{id}</AppLink>;
+    }
+}

--- a/packages/components/src/theme/timeline.scss
+++ b/packages/components/src/theme/timeline.scss
@@ -125,6 +125,7 @@
 
 }
 
+.original-value-icon,
 .timeline-comments-icon {
     color: $brand-primary;
 }


### PR DESCRIPTION
#### Rationale
When files are uploaded to store on the file system, we need to avoid name collisions and thus must sometimes rename files. We do this by appending counter suffixes to the file name base. For better accountability, we want to now add audit records for these file uploads and renames. See the related PRs for more info.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/795
- https://github.com/LabKey/limsModules/pull/1543
- https://github.com/LabKey/platform/pull/6869

#### Changes
- Add file system audit events for apps
- Add `TransactionAuditIdRenderer` for displaying link to page of audit records associated with a transaction id
- Update `AuditDetails` to show original file name values in tooltip when appropriate