### PR TITLE
Misc domain designer fixes for 25.9

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0-assayDesignerFixes258.1",
+  "version": "6.57.0-assayDesignerFixes258.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.57.0-assayDesignerFixes258.1",
+      "version": "6.57.0-assayDesignerFixes258.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0-assayDesignerFixes258.2",
+  "version": "6.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.57.0-assayDesignerFixes258.2",
+      "version": "6.58.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3",
+  "version": "6.56.3-assayDesignerFixes258.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.3",
+      "version": "6.56.3-assayDesignerFixes258.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0-assayDesignerFixes258.0",
+  "version": "6.57.0-assayDesignerFixes258.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.57.0-assayDesignerFixes258.0",
+      "version": "6.57.0-assayDesignerFixes258.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.2",
+  "version": "6.56.2-assayDesignerFixes258.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.2",
+      "version": "6.56.2-assayDesignerFixes258.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0",
+  "version": "6.57.0-assayDesignerFixes258.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.57.0",
+      "version": "6.57.0-assayDesignerFixes258.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-assayDesignerFixes258.0",
+  "version": "6.56.3-assayDesignerFixes258.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.56.3-assayDesignerFixes258.0",
+      "version": "6.56.3-assayDesignerFixes258.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.2",
+  "version": "6.56.2-assayDesignerFixes258.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0-assayDesignerFixes258.0",
+  "version": "6.57.0-assayDesignerFixes258.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0-assayDesignerFixes258.2",
+  "version": "6.58.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3-assayDesignerFixes258.0",
+  "version": "6.56.3-assayDesignerFixes258.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0",
+  "version": "6.57.0-assayDesignerFixes258.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0-assayDesignerFixes258.1",
+  "version": "6.57.0-assayDesignerFixes258.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.56.3",
+  "version": "6.56.3-assayDesignerFixes258.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.58.0
+*Released*: 4 August 2025
 - GitHub Issue 783: Hide domain designer field Advanced Settings that are not currently implemented in app
 - GitHub Issue 788: Domain Designer better handling of invalid lookup query value for Sample data type
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -4,6 +4,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 ### version TBD
 *Released*: TBD
 - GitHub Issue 783: Hide domain designer field Advanced Settings that are not currently implemented in app
+- GitHub Issue 788: Domain Designer better handling of invalid lookup query value for Sample data type
 
 ### version 6.56.2
 *Released*: 21 July 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue 783: Hide domain designer field Advanced Settings that are not currently implemented in app
+
 ### version 6.56.2
 *Released*: 21 July 2025
 - Issue 53451: JS error when deleting numeric filter values with Between operator

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.test.tsx
@@ -27,6 +27,12 @@ import {
 import { AdvancedSettings } from './AdvancedSettings';
 import { DomainField } from './models';
 
+// mock isApp() to return false for this test case, affects MV enabled checkbox and Default Value Type
+jest.mock('../../app/utils', () => ({
+    ...jest.requireActual('../../app/utils'),
+    isApp: () => false,
+}));
+
 describe('AdvancedSettings', () => {
     const _fieldName = 'Marty';
     const _title = 'Advanced Settings and Properties';
@@ -114,9 +120,7 @@ describe('AdvancedSettings', () => {
         // Verify mvEnabled
         id = createFormInputId(DOMAIN_FIELD_MVENABLED, _domainIndex, _index);
         const mvEnabled = document.querySelector('#' + id);
-        expect(mvEnabled).toBeNull();
-        // TODO update this test case for isApp scenario
-        // expect(mvEnabled.getAttribute('checked')).toBeNull();
+        expect(mvEnabled.getAttribute('checked')).toBeNull(); // Note mock of isApp above
 
         // Verify recommendedVariable
         id = createFormInputId(DOMAIN_FIELD_RECOMMENDEDVARIABLE, _domainIndex, _index);
@@ -131,9 +135,7 @@ describe('AdvancedSettings', () => {
         // Verify default type
         id = createFormInputId(DOMAIN_FIELD_DEFAULT_VALUE_TYPE, _domainIndex, _index);
         const defaultType = document.querySelector('#' + id);
-        expect(defaultType).toBeNull();
-        // TODO update this test case for isApp scenario
-        // expect(defaultType.textContent).toEqual('Editable defaultLast enteredFixed value');
+        expect(defaultType.textContent).toEqual('Editable defaultLast enteredFixed value'); // Note mock of isApp above
 
         // Verify buttons
         const btns = document.getElementsByClassName('btn');

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.test.tsx
@@ -114,7 +114,9 @@ describe('AdvancedSettings', () => {
         // Verify mvEnabled
         id = createFormInputId(DOMAIN_FIELD_MVENABLED, _domainIndex, _index);
         const mvEnabled = document.querySelector('#' + id);
-        expect(mvEnabled.getAttribute('checked')).toBeNull();
+        expect(mvEnabled).toBeNull();
+        // TODO update this test case for isApp scenario
+        // expect(mvEnabled.getAttribute('checked')).toBeNull();
 
         // Verify recommendedVariable
         id = createFormInputId(DOMAIN_FIELD_RECOMMENDEDVARIABLE, _domainIndex, _index);
@@ -129,7 +131,9 @@ describe('AdvancedSettings', () => {
         // Verify default type
         id = createFormInputId(DOMAIN_FIELD_DEFAULT_VALUE_TYPE, _domainIndex, _index);
         const defaultType = document.querySelector('#' + id);
-        expect(defaultType.textContent).toEqual('Editable defaultLast enteredFixed value');
+        expect(defaultType).toBeNull();
+        // TODO update this test case for isApp scenario
+        // expect(defaultType.textContent).toEqual('Editable defaultLast enteredFixed value');
 
         // Verify buttons
         const btns = document.getElementsByClassName('btn');

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -60,7 +60,6 @@ interface AdvancedSettingsProps {
 }
 
 interface AdvancedSettingsState {
-    PHI?: string;
     defaultDisplayValue?: string;
     defaultValueType?: string;
     dimension?: boolean;
@@ -68,7 +67,8 @@ interface AdvancedSettingsState {
     hidden?: boolean;
     measure?: boolean;
     mvEnabled?: boolean;
-    phiLevels?: Array<{ label: string; value: string; }>;
+    PHI?: string;
+    phiLevels?: { label: string; value: string }[];
     recommendedVariable?: boolean;
     shownInDetailsView?: boolean;
     shownInInsertView?: boolean;
@@ -265,9 +265,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 <div>These options configure how and in which views this field will be visible.</div>
                 <CheckboxLK
                     checked={hidden === false}
-                    onChange={this.handleCheckbox}
-                    name={createFormInputName(DOMAIN_FIELD_HIDDEN)}
                     id={createFormInputId(DOMAIN_FIELD_HIDDEN, domainIndex, index)}
+                    name={createFormInputName(DOMAIN_FIELD_HIDDEN)}
+                    onChange={this.handleCheckbox}
                 >
                     Show field on default view of the grid
                 </CheckboxLK>
@@ -275,17 +275,17 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                     <>
                         <CheckboxLK
                             checked={shownInUpdateView === true}
-                            onChange={this.handleCheckbox}
-                            name={createFormInputName(DOMAIN_FIELD_SHOWNINUPDATESVIEW)}
                             id={createFormInputId(DOMAIN_FIELD_SHOWNINUPDATESVIEW, domainIndex, index)}
+                            name={createFormInputName(DOMAIN_FIELD_SHOWNINUPDATESVIEW)}
+                            onChange={this.handleCheckbox}
                         >
                             Show on update form when updating a single row of data
                         </CheckboxLK>
                         <CheckboxLK
                             checked={shownInInsertView === true}
-                            onChange={this.handleCheckbox}
-                            name={createFormInputName(DOMAIN_FIELD_SHOWNININSERTVIEW)}
                             id={createFormInputId(DOMAIN_FIELD_SHOWNININSERTVIEW, domainIndex, index)}
+                            name={createFormInputName(DOMAIN_FIELD_SHOWNININSERTVIEW)}
+                            onChange={this.handleCheckbox}
                         >
                             Show on insert form when updating a single row of data
                         </CheckboxLK>
@@ -293,9 +293,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 )}
                 <CheckboxLK
                     checked={shownInDetailsView === true}
-                    onChange={this.handleCheckbox}
-                    name={createFormInputName(DOMAIN_FIELD_SHOWNINDETAILSVIEW)}
                     id={createFormInputId(DOMAIN_FIELD_SHOWNINDETAILSVIEW, domainIndex, index)}
+                    name={createFormInputName(DOMAIN_FIELD_SHOWNINDETAILSVIEW)}
+                    onChange={this.handleCheckbox}
                 >
                     Show on details page for a single row
                 </CheckboxLK>
@@ -312,21 +312,23 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 <div className="domain-adv-misc-options">Default Value Options</div>
                 <div className="row domain-adv-thick-row">
                     <div className="col-xs-3">
-                        <DomainFieldLabel label="Default Type" helpTipBody={this.getDefaultTypeHelpText()} />
+                        <DomainFieldLabel helpTipBody={this.getDefaultTypeHelpText()} label="Default Type" />
                     </div>
                     <div className="col-xs-6">
                         <select
                             className="form-control"
-                            name={createFormInputName(DOMAIN_FIELD_DEFAULT_VALUE_TYPE)}
                             id={createFormInputId(DOMAIN_FIELD_DEFAULT_VALUE_TYPE, domainIndex, index)}
+                            name={createFormInputName(DOMAIN_FIELD_DEFAULT_VALUE_TYPE)}
                             onChange={this.handleChange}
                             value={defaultValueType}
                         >
-                            {defaultValueOptions.map(level => (
-                                <option key={level} value={level}>
-                                    {DOMAIN_DEFAULT_TYPES[level]}
-                                </option>
-                            )).toArray()}
+                            {defaultValueOptions
+                                .map(level => (
+                                    <option key={level} value={level}>
+                                        {DOMAIN_DEFAULT_TYPES[level]}
+                                    </option>
+                                ))
+                                .toArray()}
                         </select>
                     </div>
                     <div className="col-xs-3" />
@@ -342,9 +344,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                                 : ''}
                         </span>
                         <a
-                            style={{ marginLeft: '20px' }}
-                            onClick={this.handleSetDefaultValues}
                             className="domain-adv-link"
+                            onClick={this.handleSetDefaultValues}
+                            style={{ marginLeft: '20px' }}
                         >
                             Set Default Values
                         </a>
@@ -378,16 +380,16 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 {!field.isCalculatedField() && (
                     <div className="row">
                         <div className="col-xs-3">
-                            <DomainFieldLabel label="PHI Level" helpTipBody={this.getPhiHelpText()} />
+                            <DomainFieldLabel helpTipBody={this.getPhiHelpText()} label="PHI Level" />
                         </div>
                         <div className="col-xs-6">
                             <select
                                 className="form-control"
-                                name={createFormInputName(DOMAIN_FIELD_PHI)}
+                                disabled={disablePhiSelect}
                                 id={createFormInputId(DOMAIN_FIELD_PHI, domainIndex, index)}
+                                name={createFormInputName(DOMAIN_FIELD_PHI)}
                                 onChange={this.handleChange}
                                 value={PHI}
-                                disabled={disablePhiSelect}
                             >
                                 {!currentValueExists && (
                                     <option key={PHI} value={PHI}>
@@ -407,9 +409,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 {field.dataType === DATETIME_TYPE && (
                     <CheckboxLK
                         checked={excludeFromShifting}
-                        onChange={this.handleCheckbox}
-                        name={createFormInputName(DOMAIN_FIELD_EXCLUDE_FROM_SHIFTING)}
                         id={createFormInputId(DOMAIN_FIELD_EXCLUDE_FROM_SHIFTING, domainIndex, index)}
+                        name={createFormInputName(DOMAIN_FIELD_EXCLUDE_FROM_SHIFTING)}
+                        onChange={this.handleCheckbox}
                     >
                         Exclude from "Participant Date Shifting" on export/publication
                         <LabelHelpTip title="Exclude from Date Shifting">
@@ -421,9 +423,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 {PropDescType.isMeasure(field.dataType.rangeURI) && (
                     <CheckboxLK
                         checked={measure}
-                        onChange={this.handleCheckbox}
-                        name={createFormInputName(DOMAIN_FIELD_MEASURE)}
                         id={createFormInputId(DOMAIN_FIELD_MEASURE, domainIndex, index)}
+                        name={createFormInputName(DOMAIN_FIELD_MEASURE)}
+                        onChange={this.handleCheckbox}
                     >
                         Make this field available as a measure
                         <LabelHelpTip title="Measure">
@@ -446,9 +448,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 {PropDescType.isDimension(field.dataType.rangeURI) && (
                     <CheckboxLK
                         checked={dimension}
-                        onChange={this.handleCheckbox}
-                        name={createFormInputName(DOMAIN_FIELD_DIMENSION)}
                         id={createFormInputId(DOMAIN_FIELD_DIMENSION, domainIndex, index)}
+                        name={createFormInputName(DOMAIN_FIELD_DIMENSION)}
+                        onChange={this.handleCheckbox}
                     >
                         Make this field available as a dimension
                         <LabelHelpTip title="Data Dimension">
@@ -470,9 +472,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 )}
                 <CheckboxLK
                     checked={recommendedVariable}
-                    onChange={this.handleCheckbox}
-                    name={createFormInputName(DOMAIN_FIELD_RECOMMENDEDVARIABLE)}
                     id={createFormInputId(DOMAIN_FIELD_RECOMMENDEDVARIABLE, domainIndex, index)}
+                    name={createFormInputName(DOMAIN_FIELD_RECOMMENDEDVARIABLE)}
+                    onChange={this.handleCheckbox}
                 >
                     Make this field a recommended variable
                     <LabelHelpTip title="Recommended Variable">
@@ -485,10 +487,10 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 {PropDescType.isMvEnableable(field.dataType.rangeURI) && !field.isCalculatedField() && !isApp() && (
                     <CheckboxLK
                         checked={mvEnabled}
-                        onChange={this.handleCheckbox}
-                        name={createFormInputName(DOMAIN_FIELD_MVENABLED)}
-                        id={createFormInputId(DOMAIN_FIELD_MVENABLED, domainIndex, index)}
                         disabled={domainFormDisplayOptions.disableMvEnabled}
+                        id={createFormInputId(DOMAIN_FIELD_MVENABLED, domainIndex, index)}
+                        name={createFormInputName(DOMAIN_FIELD_MVENABLED)}
+                        onChange={this.handleCheckbox}
                     >
                         Track reason for missing data values
                         <LabelHelpTip title="Missing Value Indicators">
@@ -510,9 +512,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                     <CheckboxLK
                         checked={uniqueConstraint || field.isPrimaryKey}
                         disabled={field.isPrimaryKey}
-                        onChange={this.handleCheckbox}
-                        name={createFormInputName(DOMAIN_FIELD_UNIQUECONSTRAINT)}
                         id={createFormInputId(DOMAIN_FIELD_UNIQUECONSTRAINT, domainIndex, index)}
+                        name={createFormInputName(DOMAIN_FIELD_UNIQUECONSTRAINT)}
+                        onChange={this.handleCheckbox}
                     >
                         Require all values to be unique
                         <LabelHelpTip title="Unique Constraint">
@@ -536,7 +538,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 >
                     Cancel
                 </button>
-                <HelpLink topic={ADVANCED_FIELD_EDITOR_TOPIC} className="domain-adv-footer domain-adv-link">
+                <HelpLink className="domain-adv-footer domain-adv-link" topic={ADVANCED_FIELD_EDITOR_TOPIC}>
                     Get help with field designer settings
                 </HelpLink>
                 <button

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -3,7 +3,7 @@ import { List } from 'immutable';
 import { ActionURL } from '@labkey/api';
 
 import { Modal } from '../../Modal';
-import { getSubmitButtonClass } from '../../app/utils';
+import { getSubmitButtonClass, isApp } from '../../app/utils';
 
 import {
     ADVANCED_FIELD_EDITOR_TOPIC,
@@ -243,6 +243,9 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
     showDefaultValues = () => {
         const { field, showDefaultValueSettings } = this.props;
 
+        // GitHub Issue #783: we don't yet support default values in the App
+        if (isApp()) return false;
+
         // some domains just don't support default values
         if (!showDefaultValueSettings) return false;
 
@@ -479,7 +482,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                         </div>
                     </LabelHelpTip>
                 </CheckboxLK>
-                {PropDescType.isMvEnableable(field.dataType.rangeURI) && !field.isCalculatedField() && (
+                {PropDescType.isMvEnableable(field.dataType.rangeURI) && !field.isCalculatedField() && !isApp() && (
                     <CheckboxLK
                         checked={mvEnabled}
                         onChange={this.handleCheckbox}

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -11,7 +11,7 @@ import { LabelHelpTip } from '../base/LabelHelpTip';
 import { isFieldFullyLocked } from './propertiesUtil';
 import { fetchQueries } from './actions';
 import { createFormInputId, createFormInputName } from './utils';
-import { ALL_SAMPLES_DISPLAY_TEXT, DOMAIN_FIELD_SAMPLE_TYPE, DOMAIN_VALIDATOR_LOOKUP } from './constants';
+import { DOMAIN_FIELD_SAMPLE_TYPE, DOMAIN_VALIDATOR_LOOKUP } from './constants';
 import {
     DomainField,
     encodeLookup,
@@ -35,6 +35,7 @@ interface SampleFieldProps extends ITypeDependentProps {
 }
 
 interface State {
+    isValidOptions?: boolean;
     loadingState: LoadingState;
     sampleTypes: List<LookupInfo>;
     validateLookup: boolean;
@@ -48,7 +49,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
     };
 
     componentDidMount = async (): Promise<void> => {
-        const { original, field } = this.props;
+        const { original, field, value } = this.props;
 
         this.setState({ loadingState: LoadingState.LOADING });
 
@@ -60,7 +61,14 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                 .filter(st => st.type.isInteger()) // Remove rowId duplicates
                 .toList();
 
+            let isValidOptions = true;
+            if (value !== SAMPLE_TYPE_OPTION_VALUE && sampleTypes.size > 0) {
+                const optionValues = sampleTypes.map(st => encodeLookup(st.name, st.type));
+                isValidOptions = optionValues.includes(value);
+            }
+
             this.setState({
+                isValidOptions,
                 loadingState: LoadingState.LOADED,
                 sampleTypes,
                 validateLookup: field.isNew() || !!field.lookupValidator,
@@ -73,6 +81,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
 
     onFieldChange = (evt): void => {
         this.props.onChange(evt.target.id, evt.target.value);
+        this.setState({ isValidOptions: true });
     };
 
     addLookupValidator = (evt): void => {
@@ -88,9 +97,8 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
     };
 
     render() {
-        const { index, label, lockType, value, domainIndex } = this.props;
-
-        const { loadingState, sampleTypes, validateLookup } = this.state;
+        const { index, label, lockType, value, domainIndex, field } = this.props;
+        const { loadingState, sampleTypes, validateLookup, isValidOptions } = this.state;
         const isLoaded = !isLoading(loadingState);
 
         const id = createFormInputId(DOMAIN_FIELD_SAMPLE_TYPE, domainIndex, index);
@@ -129,11 +137,23 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                             disabled={isFieldFullyLocked(lockType)}
                             name={createFormInputName(DOMAIN_FIELD_SAMPLE_TYPE)}
                             onChange={this.onFieldChange}
-                            value={value || ALL_SAMPLES_DISPLAY_TEXT}
+                            value={value || SAMPLE_TYPE_OPTION_VALUE}
                         >
                             {!isLoaded && (
                                 <option disabled key="_loading" value={value}>
                                     Loading...
+                                </option>
+                            )}
+                            {!isValidOptions && (
+                                <option
+                                    key={createFormInputId(
+                                        DOMAIN_FIELD_SAMPLE_TYPE + '-empty-' + index,
+                                        domainIndex,
+                                        index
+                                    )}
+                                    value={undefined}
+                                >
+                                    &lt;Invalid sample type: {field?.lookupQuery}&gt;
                                 </option>
                             )}
                             {isLoaded && (

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -35,7 +35,6 @@ interface SampleFieldProps extends ITypeDependentProps {
 }
 
 interface State {
-    isValidOption?: boolean;
     loadingState: LoadingState;
     sampleTypes: List<LookupInfo>;
     validateLookup: boolean;
@@ -49,7 +48,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
     };
 
     componentDidMount = async (): Promise<void> => {
-        const { original, field, value } = this.props;
+        const { original, field } = this.props;
 
         this.setState({ loadingState: LoadingState.LOADING });
 
@@ -61,14 +60,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                 .filter(st => st.type.isInteger()) // Remove rowId duplicates
                 .toList();
 
-            let isValidOption = true;
-            if (value !== SAMPLE_TYPE_ALL_OPTION_VALUE) {
-                const optionValues = sampleTypes.map(st => encodeLookup(st.name, st.type));
-                isValidOption = optionValues.includes(value);
-            }
-
             this.setState({
-                isValidOption,
                 loadingState: LoadingState.LOADED,
                 sampleTypes,
                 validateLookup: field.isNew() || !!field.lookupValidator,
@@ -81,7 +73,6 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
 
     onFieldChange = (evt): void => {
         this.props.onChange(evt.target.id, evt.target.value);
-        this.setState({ isValidOption: true });
     };
 
     addLookupValidator = (evt): void => {
@@ -98,7 +89,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
 
     render() {
         const { index, label, lockType, value, domainIndex, field } = this.props;
-        const { loadingState, sampleTypes, validateLookup, isValidOption } = this.state;
+        const { loadingState, sampleTypes, validateLookup } = this.state;
         const isLoaded = !isLoading(loadingState);
 
         const id = createFormInputId(DOMAIN_FIELD_SAMPLE_TYPE, domainIndex, index);
@@ -144,7 +135,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                                     Loading...
                                 </option>
                             )}
-                            {!isValidOption && (
+                            {field && !field.lookupIsValid && (
                                 <option
                                     key={createFormInputId(
                                         DOMAIN_FIELD_SAMPLE_TYPE + '-empty-' + index,

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -123,9 +123,9 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                         </div>
                         <select
                             className="form-control"
+                            disabled={isFieldFullyLocked(lockType)}
                             id={id}
                             key={id}
-                            disabled={isFieldFullyLocked(lockType)}
                             name={createFormInputName(DOMAIN_FIELD_SAMPLE_TYPE)}
                             onChange={this.onFieldChange}
                             value={value || SAMPLE_TYPE_ALL_OPTION_VALUE}
@@ -175,10 +175,10 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                     <div className="col-xs-6">
                         <div className="domain-field-label">Lookup Validator</div>
                         <DomainDesignerCheckbox
+                            checked={validateLookup}
                             className="domain-field-checkbox-margin"
                             id={createFormInputId(DOMAIN_VALIDATOR_LOOKUP, domainIndex, index)}
                             name={createFormInputName(DOMAIN_VALIDATOR_LOOKUP)}
-                            checked={validateLookup}
                             onChange={this.addLookupValidator}
                         >
                             <span className="domain-lookup-validator-text">Ensure Value Exists in Lookup Target</span>

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -62,7 +62,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                 .toList();
 
             let isValidOptions = true;
-            if (value !== SAMPLE_TYPE_OPTION_VALUE && sampleTypes.size > 0) {
+            if (value !== SAMPLE_TYPE_OPTION_VALUE) {
                 const optionValues = sampleTypes.map(st => encodeLookup(st.name, st.type));
                 isValidOptions = optionValues.includes(value);
             }

--- a/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
+++ b/packages/components/src/internal/components/domainproperties/SampleFieldOptions.tsx
@@ -20,7 +20,7 @@ import {
     ITypeDependentProps,
     LOOKUP_VALIDATOR,
     LookupInfo,
-    SAMPLE_TYPE_OPTION_VALUE,
+    SAMPLE_TYPE_ALL_OPTION_VALUE,
 } from './models';
 
 import { SectionHeading } from './SectionHeading';
@@ -35,7 +35,7 @@ interface SampleFieldProps extends ITypeDependentProps {
 }
 
 interface State {
-    isValidOptions?: boolean;
+    isValidOption?: boolean;
     loadingState: LoadingState;
     sampleTypes: List<LookupInfo>;
     validateLookup: boolean;
@@ -61,14 +61,14 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                 .filter(st => st.type.isInteger()) // Remove rowId duplicates
                 .toList();
 
-            let isValidOptions = true;
-            if (value !== SAMPLE_TYPE_OPTION_VALUE) {
+            let isValidOption = true;
+            if (value !== SAMPLE_TYPE_ALL_OPTION_VALUE) {
                 const optionValues = sampleTypes.map(st => encodeLookup(st.name, st.type));
-                isValidOptions = optionValues.includes(value);
+                isValidOption = optionValues.includes(value);
             }
 
             this.setState({
-                isValidOptions,
+                isValidOption,
                 loadingState: LoadingState.LOADED,
                 sampleTypes,
                 validateLookup: field.isNew() || !!field.lookupValidator,
@@ -81,7 +81,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
 
     onFieldChange = (evt): void => {
         this.props.onChange(evt.target.id, evt.target.value);
-        this.setState({ isValidOptions: true });
+        this.setState({ isValidOption: true });
     };
 
     addLookupValidator = (evt): void => {
@@ -98,7 +98,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
 
     render() {
         const { index, label, lockType, value, domainIndex, field } = this.props;
-        const { loadingState, sampleTypes, validateLookup, isValidOptions } = this.state;
+        const { loadingState, sampleTypes, validateLookup, isValidOption } = this.state;
         const isLoaded = !isLoading(loadingState);
 
         const id = createFormInputId(DOMAIN_FIELD_SAMPLE_TYPE, domainIndex, index);
@@ -137,14 +137,14 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                             disabled={isFieldFullyLocked(lockType)}
                             name={createFormInputName(DOMAIN_FIELD_SAMPLE_TYPE)}
                             onChange={this.onFieldChange}
-                            value={value || SAMPLE_TYPE_OPTION_VALUE}
+                            value={value || SAMPLE_TYPE_ALL_OPTION_VALUE}
                         >
                             {!isLoaded && (
                                 <option disabled key="_loading" value={value}>
                                     Loading...
                                 </option>
                             )}
-                            {!isValidOptions && (
+                            {!isValidOption && (
                                 <option
                                     key={createFormInputId(
                                         DOMAIN_FIELD_SAMPLE_TYPE + '-empty-' + index,
@@ -163,7 +163,7 @@ export class SampleFieldOptions extends PureComponent<SampleFieldProps, State> {
                                         domainIndex,
                                         index
                                     )}
-                                    value={SAMPLE_TYPE_OPTION_VALUE}
+                                    value={SAMPLE_TYPE_ALL_OPTION_VALUE}
                                 >
                                     All Samples
                                 </option>

--- a/packages/components/src/internal/components/domainproperties/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.test.ts
@@ -22,8 +22,8 @@ import { QueryColumn } from '../../../public/QueryColumn';
 import { ConceptModel, OntologyModel } from '../ontology/models';
 
 import {
-    TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
     TEST_LKS_STARTER_MODULE_CONTEXT,
+    TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT,
     TEST_LKSM_STARTER_MODULE_CONTEXT,
 } from '../../productFixtures';
 

--- a/packages/components/src/internal/components/domainproperties/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.test.ts
@@ -821,7 +821,7 @@ describe('domain properties actions', () => {
         expect(field.dataType).toBe(SAMPLE_TYPE);
         expect(field.lookupSchema).toBe('exp');
         expect(field.lookupQuery).toBe('Materials');
-        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|Materials');
+        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|all');
     });
 
     test('updateDataType Sample data type, saved field', () => {
@@ -830,7 +830,7 @@ describe('domain properties actions', () => {
         expect(field.dataType).toBe(SAMPLE_TYPE);
         expect(field.lookupSchema).toBe('exp');
         expect(field.lookupQuery).toBe('Materials');
-        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|Materials');
+        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|all');
     });
 
     test('updateDataType Sample data type, saved lookup field', () => {
@@ -839,7 +839,7 @@ describe('domain properties actions', () => {
         expect(field.dataType).toBe(SAMPLE_TYPE);
         expect(field.lookupSchema).toBe('exp');
         expect(field.lookupQuery).toBe('Materials');
-        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|Materials');
+        expect(field.lookupQueryValue).toBe('http://www.w3.org/2001/XMLSchema#int|all');
     });
 
     test('updateDomainField principalConceptCode', () => {

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -866,6 +866,7 @@ export function updateDataType(field: DomainField, value: any): DomainField {
             rangeURI: dataType.rangeURI,
             lookupSchema: dataType.lookupSchema,
             lookupQuery: dataType.lookupQuery,
+            lookupIsValid: true,
             sourceOntology: undefined,
             conceptSubtree: undefined,
             conceptLabelColumn: undefined,

--- a/packages/components/src/internal/components/domainproperties/models.test.ts
+++ b/packages/components/src/internal/components/domainproperties/models.test.ts
@@ -64,6 +64,7 @@ import {
     isValidTextChoiceValue,
     PropertyValidator,
     PropertyValidatorProperties,
+    resolveLookupQueryValue,
 } from './models';
 import {
     BOOLEAN_RANGE_URI,
@@ -1468,5 +1469,23 @@ describe('resolveBaseProperties', () => {
         expect(DomainField.resolveBaseProperties({ name: 'TEST1' }, List(['test1'])).lockType).toBe(
             DOMAIN_FIELD_PARTIALLY_LOCKED
         );
+    });
+});
+
+describe('resolveLookupQueryValue', () => {
+    test('isSampleType', () => {
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', true)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'query', true)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'Materials', false)).toBe('http://www.w3.org/2001/XMLSchema#string|Materials');
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'Materials', true)).toBe('http://www.w3.org/2001/XMLSchema#int|all');
+    });
+
+    test('lookupType', () => {
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
+        expect(resolveLookupQueryValue(INTEGER_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#int|query');
+        expect(resolveLookupQueryValue(DATETIME_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#dateTime|query');
+        expect(resolveLookupQueryValue(SAMPLE_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#int|query');
     });
 });

--- a/packages/components/src/internal/components/domainproperties/models.test.ts
+++ b/packages/components/src/internal/components/domainproperties/models.test.ts
@@ -1012,7 +1012,20 @@ describe('DomainField', () => {
         field = field.merge({ propertyId: 0, updatedField: true }) as DomainField;
         expect(field.getDetailsArray().join('')).toBe('Updated');
 
-        field = field.merge({ dataType: SAMPLE_TYPE, lookupSchema: 'exp', lookupQuery: 'SampleType1' }) as DomainField;
+        field = field.merge({
+            dataType: SAMPLE_TYPE,
+            lookupSchema: 'exp',
+            lookupQuery: 'SampleType1',
+            lookupIsValid: false,
+        }) as DomainField;
+        expect(field.getDetailsArray().join('')).toBe('Updated. SampleType1[object Object]');
+
+        field = field.merge({
+            dataType: SAMPLE_TYPE,
+            lookupSchema: 'exp',
+            lookupQuery: 'SampleType1',
+            lookupIsValid: true,
+        }) as DomainField;
         expect(field.getDetailsArray().join('')).toBe('Updated. SampleType1');
 
         field = field.merge({ dataType: LOOKUP_TYPE }) as DomainField;
@@ -1474,18 +1487,38 @@ describe('resolveBaseProperties', () => {
 
 describe('resolveLookupQueryValue', () => {
     test('isSampleType', () => {
-        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
-        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', true)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
-        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
-        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'query', true)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
-        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'Materials', false)).toBe('http://www.w3.org/2001/XMLSchema#string|Materials');
-        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'Materials', true)).toBe('http://www.w3.org/2001/XMLSchema#int|all');
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', false)).toBe(
+            'http://www.w3.org/2001/XMLSchema#string|query'
+        );
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', true)).toBe(
+            'http://www.w3.org/2001/XMLSchema#string|query'
+        );
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'query', false)).toBe(
+            'http://www.w3.org/2001/XMLSchema#string|query'
+        );
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'query', true)).toBe(
+            'http://www.w3.org/2001/XMLSchema#string|query'
+        );
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'Materials', false)).toBe(
+            'http://www.w3.org/2001/XMLSchema#string|Materials'
+        );
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'exp', 'Materials', true)).toBe(
+            'http://www.w3.org/2001/XMLSchema#int|all'
+        );
     });
 
     test('lookupType', () => {
-        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#string|query');
-        expect(resolveLookupQueryValue(INTEGER_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#int|query');
-        expect(resolveLookupQueryValue(DATETIME_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#dateTime|query');
-        expect(resolveLookupQueryValue(SAMPLE_TYPE, 'schema', 'query', false)).toBe('http://www.w3.org/2001/XMLSchema#int|query');
+        expect(resolveLookupQueryValue(TEXT_TYPE, 'schema', 'query', false)).toBe(
+            'http://www.w3.org/2001/XMLSchema#string|query'
+        );
+        expect(resolveLookupQueryValue(INTEGER_TYPE, 'schema', 'query', false)).toBe(
+            'http://www.w3.org/2001/XMLSchema#int|query'
+        );
+        expect(resolveLookupQueryValue(DATETIME_TYPE, 'schema', 'query', false)).toBe(
+            'http://www.w3.org/2001/XMLSchema#dateTime|query'
+        );
+        expect(resolveLookupQueryValue(SAMPLE_TYPE, 'schema', 'query', false)).toBe(
+            'http://www.w3.org/2001/XMLSchema#int|query'
+        );
     });
 });

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1422,6 +1422,17 @@ export class DomainField
                     ? ALL_SAMPLES_DISPLAY_TEXT
                     : this.lookupQuery;
             details.push(period + detailsText);
+
+            if (!this.lookupIsValid) {
+                const fieldError = new DomainFieldError({
+                    extraInfo:
+                        'The selected sample type may have been deleted or renamed. Expand the row to select a valid sample lookup.',
+                    message: 'Invalid sample type',
+                    severity: SEVERITY_LEVEL_ERROR,
+                });
+                details.push(<DomainRowWarning fieldError={fieldError} key="domain-row-sample-error" />);
+            }
+
             period = '. ';
         } else if (this.dataType.isLookup() && this.lookupSchema && this.lookupQuery) {
             // only show the query as a link in LKS, for now
@@ -1571,6 +1582,7 @@ export function updateSampleField(field: Partial<DomainField>, sampleQueryValue?
                   lookupQueryValue: sampleQueryValue,
                   lookupType: field.lookupType.set('rangeURI', rangeURI),
                   lookupValidator: LOOKUP_VALIDATOR,
+                  lookupIsValid: true,
                   propertyValidators: List([LOOKUP_VALIDATOR]),
                   rangeURI,
               }
@@ -1581,6 +1593,7 @@ export function updateSampleField(field: Partial<DomainField>, sampleQueryValue?
                   lookupQueryValue: sampleQueryValue,
                   lookupType: lookupType.set('rangeURI', rangeURI),
                   lookupValidator: LOOKUP_VALIDATOR,
+                  lookupIsValid: true,
                   propertyValidators: List([LOOKUP_VALIDATOR]),
                   rangeURI,
               };

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1124,12 +1124,12 @@ export class DomainField
     }
 
     static resolveLookupConfig(rawField: Partial<IDomainField>, dataType: PropDescType): ILookupConfig {
+        const isSampleType = dataType === SAMPLE_TYPE;
         const lookupType = LOOKUP_TYPE.set('rangeURI', rawField.rangeURI) as PropDescType;
         const lookupContainer = rawField.lookupContainer === null ? undefined : rawField.lookupContainer;
         const lookupSchema = resolveLookupSchema(rawField, dataType);
-        const lookupQuery =
-            rawField.lookupQuery || (dataType === SAMPLE_TYPE ? SCHEMAS.EXP_TABLES.MATERIALS.queryName : undefined);
-        const lookupQueryValue = encodeLookup(lookupQuery, lookupType);
+        const lookupQuery = rawField.lookupQuery || (dataType === SAMPLE_TYPE ? SCHEMAS.EXP_TABLES.MATERIALS.queryName : undefined);
+        const lookupQueryValue = resolveLookupQueryValue(lookupType, lookupSchema, lookupQuery, isSampleType);
 
         return {
             lookupContainer,
@@ -1542,6 +1542,23 @@ function resolveLookupSchema(rawField: Partial<IDomainField>, dataType: PropDesc
     return undefined;
 }
 
+// TODO add jest coverage
+function resolveLookupQueryValue(
+    lookupType: PropDescType,
+    lookupSchema: string,
+    lookupQuery: string,
+    isSampleType = false
+): string {
+    if (
+        isSampleType &&
+        lookupSchema === SCHEMAS.EXP_TABLES.SCHEMA &&
+        lookupQuery === SCHEMAS.EXP_TABLES.MATERIALS.queryName
+    ) {
+        return SAMPLE_TYPE_OPTION_VALUE;
+    }
+    return encodeLookup(lookupQuery, lookupType);
+}
+
 export function updateSampleField(field: Partial<DomainField>, sampleQueryValue?: string): DomainField {
     const { queryName, rangeURI = INT_RANGE_URI } = decodeLookup(sampleQueryValue);
     const lookupType = field.lookupType || LOOKUP_TYPE;
@@ -1561,7 +1578,7 @@ export function updateSampleField(field: Partial<DomainField>, sampleQueryValue?
                   // use the samples.<SampleType> table for specific sample types
                   lookupSchema: SCHEMAS.SAMPLE_SETS.SCHEMA,
                   lookupQuery: queryName,
-                  lookupQueryValue: sampleQueryValue || SAMPLE_TYPE_OPTION_VALUE,
+                  lookupQueryValue: sampleQueryValue,
                   lookupType: lookupType.set('rangeURI', rangeURI),
                   lookupValidator: LOOKUP_VALIDATOR,
                   propertyValidators: List([LOOKUP_VALIDATOR]),

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1128,7 +1128,8 @@ export class DomainField
         const lookupType = LOOKUP_TYPE.set('rangeURI', rawField.rangeURI) as PropDescType;
         const lookupContainer = rawField.lookupContainer === null ? undefined : rawField.lookupContainer;
         const lookupSchema = resolveLookupSchema(rawField, dataType);
-        const lookupQuery = rawField.lookupQuery || (dataType === SAMPLE_TYPE ? SCHEMAS.EXP_TABLES.MATERIALS.queryName : undefined);
+        const lookupQuery =
+            rawField.lookupQuery || (dataType === SAMPLE_TYPE ? SCHEMAS.EXP_TABLES.MATERIALS.queryName : undefined);
         const lookupQueryValue = resolveLookupQueryValue(lookupType, lookupSchema, lookupQuery, isSampleType);
 
         return {

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1542,8 +1542,8 @@ function resolveLookupSchema(rawField: Partial<IDomainField>, dataType: PropDesc
     return undefined;
 }
 
-// TODO add jest coverage
-function resolveLookupQueryValue(
+// export for jest testing
+export function resolveLookupQueryValue(
     lookupType: PropDescType,
     lookupSchema: string,
     lookupQuery: string,

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -138,7 +138,7 @@ export interface DomainPropertiesGridColumn {
     sortable: boolean;
 }
 
-export const SAMPLE_TYPE_OPTION_VALUE = `${SAMPLE_TYPE.rangeURI}|all`;
+export const SAMPLE_TYPE_ALL_OPTION_VALUE = `${SAMPLE_TYPE.rangeURI}|all`;
 
 interface IDomainDesign {
     allowAttachmentProperties: boolean;
@@ -1554,7 +1554,7 @@ export function resolveLookupQueryValue(
         lookupSchema === SCHEMAS.EXP_TABLES.SCHEMA &&
         lookupQuery === SCHEMAS.EXP_TABLES.MATERIALS.queryName
     ) {
-        return SAMPLE_TYPE_OPTION_VALUE;
+        return SAMPLE_TYPE_ALL_OPTION_VALUE;
     }
     return encodeLookup(lookupQuery, lookupType);
 }


### PR DESCRIPTION
#### Rationale
#[783](https://github.com/LabKey/internal-issues/issues/654): Enabling missing value indicator on Sample assay result field prevents import 
#[784](https://github.com/LabKey/kanban/issues/784): Error attempting to remove missing value tracking on SampleID assay result field
#[788](https://github.com/LabKey/internal-issues/issues/657): Sample field pointed at invalid sample type quietly degrades to an integer field

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1837
- https://github.com/LabKey/platform/pull/6883
- https://github.com/LabKey/limsModules/pull/1555
- https://github.com/LabKey/testAutomation/pull/2590

#### Changes
- Hide domain designer field Advanced Settings that are not currently implemented in app
- Domain Designer better handling of invalid lookup query value for Sample data type
