### PR TITLE
Add `StoragePositionNumber` to storage fields so it is not warned about

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3-storageErrors.0",
+  "version": "6.58.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.3-storageErrors.0",
+      "version": "6.58.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0",
+  "version": "6.57.1-storageErrors.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.57.0",
+      "version": "6.57.1-storageErrors.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.57.0",
+  "version": "6.57.1-storageErrors.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3-storageErrors.0",
+  "version": "6.58.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.58.2
+*Released*: 7 August 2025
 - Add `StoragePositionNumber` as a sample storage column
 
 ### version 6.58.2

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Add `StoragePositionNumber` as a sample storage column
+
 ### version 6.57.0
 *Released*: 30 July 2025
 - Add file system audit events for apps

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -172,6 +172,7 @@ export const AMOUNT_AND_UNITS_COLUMNS_LC = AMOUNT_AND_UNITS_COLUMNS.map(col => c
 
 export const SAMPLE_STORAGE_COLUMNS = [
     'StorageLocation',
+    'StoragePositionNumber',
     'StorageRow',
     'StorageCol',
     'StorageUnit',


### PR DESCRIPTION
#### Rationale
`StoragePositionNumber` is not always used, so exclusion from the download template may have been intentional, but the exclusion from the `SAMPLE_STORAGE_COLUMNS` means we show a warning about this being a system field that will not be updated. After talking with @labkey-hannah, we have decided it is OK to include this in the template file, so I'm adding to this constant and making no special compensation in the template generation.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1567

#### Changes
- Update `SAMPLE_STORAGE_COLUMNS`
