### PR TITLE
GitHub #788: Sample default field for LKSM assay results shouldn't show invalid type detail message

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.1-assaySample53500.0",
+  "version": "6.58.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.1-assaySample53500.0",
+      "version": "6.58.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.1",
+  "version": "6.58.1-assaySample53500.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.1",
+      "version": "6.58.1-assaySample53500.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.1",
+  "version": "6.58.1-assaySample53500.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.1-assaySample53500.0",
+  "version": "6.58.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD August 2025
+- GitHub Issue 788: LKSM Default sample lookup for assay design should default to lookupIsValid
+
 ### version 6.58.1
 *Released*: 5 August 2025
 - File handling - File path related issue bundle

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD August 2025
+### version 6.58.2
+*Released*: 6 August 2025
 - GitHub Issue 788: LKSM Default sample lookup for assay design should default to lookupIsValid
 
 ### version 6.58.1

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -883,6 +883,7 @@ export interface IDomainField {
     lockExistingField?: boolean;
     lockType: string;
     lookupContainer?: string;
+    lookupIsValid?: boolean;
     lookupQuery?: string;
     lookupQueryValue: string;
     lookupSchema?: string;

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -158,6 +158,7 @@ export const DEFAULT_SAMPLE_FIELD_CONFIG = {
     lookupQuery: 'Materials',
     lookupType: { ...SAMPLE_TYPE },
     lookupValidator: LOOKUP_VALIDATOR,
+    lookupIsValid: true,
     propertyValidators: List([LOOKUP_VALIDATOR]),
     name: 'SampleID',
     label: 'Sample ID',


### PR DESCRIPTION
#### Rationale
Related PR fixed an issue so that we started showing an invalid sample type message for invalid Sample Lookups. However, I didn't account for the default sample lookup field that gets added to LKSM assay result fields.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1837
- https://github.com/LabKey/limsModules/pull/1574

#### Changes
- DEFAULT_SAMPLE_FIELD_CONFIG to set lookupIsValid true
