### PR TITLE
Reduce logging for SQL exceptions from queries with calculated columns

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.2",
+  "version": "6.58.2-calcColExceptionLogging.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.2",
+      "version": "6.58.2-calcColExceptionLogging.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.4-calcColExceptionLogging.0",
+  "version": "6.58.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.4-calcColExceptionLogging.0",
+      "version": "6.58.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3",
+  "version": "6.58.3-calcColExceptionLogging.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.3",
+      "version": "6.58.3-calcColExceptionLogging.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.4",
+  "version": "6.58.4-calcColExceptionLogging.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.4",
+      "version": "6.58.4-calcColExceptionLogging.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3-calcColExceptionLogging.0",
+  "version": "6.58.3-calcColExceptionLogging.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.3-calcColExceptionLogging.0",
+      "version": "6.58.3-calcColExceptionLogging.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3-calcColExceptionLogging.0",
+  "version": "6.58.3-calcColExceptionLogging.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3",
+  "version": "6.58.3-calcColExceptionLogging.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.4",
+  "version": "6.58.4-calcColExceptionLogging.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.2",
+  "version": "6.58.2-calcColExceptionLogging.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.4-calcColExceptionLogging.0",
+  "version": "6.58.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD August 2025
+### version 6.58.5
+*Released*: 14 August 2025
 - Issue 52026 and 51862: Reduce the logging for calculated expression column SQL errors
   - add comment tag to executeSql query to indicate it is from a calculated column validation
   - use string value compatible with CAST to NUMERIC for parseCalculatedColumn() temp data

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: TBD August 2025
 - Issue 52026 and 51862: Reduce the logging for calculated expression column SQL errors
   - add comment tag to executeSql query to indicate it is from a calculated column validation
+  - use string value compatible with CAST to NUMERIC for parseCalculatedColumn() temp data
 
 ### version 6.58.3
 *Released*: 7 August 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD August 2025
+- Issue 52026 and 51862: Reduce the logging for calculated expression column SQL errors
+  - add comment tag to executeSql query to indicate it is from a calculated column validation
+
 ### version 6.58.2
 *Released*: 6 August 2025
 - GitHub Issue 788: LKSM Default sample lookup for assay design should default to lookupIsValid

--- a/packages/components/src/internal/components/domainproperties/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.test.ts
@@ -867,17 +867,17 @@ describe('domain properties actions', () => {
         expect(getCastStatement('key', 'VISITDATE')).toBe('CAST(CURDATE() AS TIMESTAMP) AS "key"');
         expect(getCastStatement('key', 'DATE')).toBe('CAST(CURDATE() AS DATE) AS "key"');
         expect(getCastStatement('key', 'TIME')).toBe('CAST(\'13:00\' AS TIME) AS "key"');
-        expect(getCastStatement('key', 'TEXT')).toBe('CAST(\'Testing\' AS VARCHAR) AS "key"');
-        expect(getCastStatement('key', 'OTHER')).toBe('CAST(\'Testing\' AS VARCHAR) AS "key"');
+        expect(getCastStatement('key', 'TEXT')).toBe('CAST(\'1\' AS VARCHAR) AS "key"');
+        expect(getCastStatement('key', 'OTHER')).toBe('CAST(\'1\' AS VARCHAR) AS "key"');
     });
 
     // Issue 52608
     test('getCastStatement for special char field', () => {
         expect(getCastStatement('a"key" with quotes', 'TEXT')).toBe(
-            'CAST(\'Testing\' AS VARCHAR) AS "a""key"" with quotes"'
+            'CAST(\'1\' AS VARCHAR) AS "a""key"" with quotes"'
         );
         expect(getCastStatement('a,./key with!@#$specCHARS', 'TEXT')).toBe(
-            'CAST(\'Testing\' AS VARCHAR) AS "a,./key with!@#$specCHARS"'
+            'CAST(\'1\' AS VARCHAR) AS "a,./key with!@#$specCHARS"'
         );
     });
 

--- a/packages/components/src/internal/components/domainproperties/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.test.ts
@@ -873,9 +873,7 @@ describe('domain properties actions', () => {
 
     // Issue 52608
     test('getCastStatement for special char field', () => {
-        expect(getCastStatement('a"key" with quotes', 'TEXT')).toBe(
-            'CAST(\'1\' AS VARCHAR) AS "a""key"" with quotes"'
-        );
+        expect(getCastStatement('a"key" with quotes', 'TEXT')).toBe('CAST(\'1\' AS VARCHAR) AS "a""key"" with quotes"');
         expect(getCastStatement('a,./key with!@#$specCHARS', 'TEXT')).toBe(
             'CAST(\'1\' AS VARCHAR) AS "a,./key with!@#$specCHARS"'
         );

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -49,6 +49,7 @@ import { IImportAlias } from '../entities/models';
 import { DATA_CLASS_IMPORT_PREFIX, SAMPLE_SET_IMPORT_PREFIX } from '../entities/constants';
 
 import {
+    CALCULATED_COLUMN_SQL_TAG,
     DOMAIN_ERROR_ID,
     DOMAIN_FIELD_CLIENT_SIDE_ERROR,
     DOMAIN_FIELD_LOOKUP_CONTAINER,
@@ -465,7 +466,8 @@ export async function parseCalculatedColumn(
                 .map(key => getCastStatement(key, columnMap[key]))
                 .join(',\n') +
             ') AS x' +
-            ' WHERE 1=0';
+            ' WHERE 1=0' +
+            CALCULATED_COLUMN_SQL_TAG; // Issue 52026 and 51862
 
         await executeSql({
             schemaName: 'core',

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -443,7 +443,7 @@ export function getCastStatement(key: string, type: string): string {
         case 'TIME':
             return `CAST('13:00' AS TIME) AS "${quotedKey}"`;
         default:
-            return `CAST('Testing' AS VARCHAR) AS "${quotedKey}"`;
+            return `CAST('1' AS VARCHAR) AS "${quotedKey}"`;
     }
 }
 

--- a/packages/components/src/internal/components/domainproperties/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/constants.ts
@@ -230,3 +230,5 @@ export const MAX_VALID_TEXT_CHOICES = 200;
 export const LOOKUP_VALIDATOR_VALUES = { type: 'Lookup', name: 'Lookup Validator' };
 
 export const DOMAIN_ERROR_ID = 'domain-error';
+
+export const CALCULATED_COLUMN_SQL_TAG = '/* CALCULATED-EXPRESSION-COLUMN-QUERY */';


### PR DESCRIPTION
#### Rationale
We have a few open issues related to the logging for calculated column errors / exceptions:
Issue [52026](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52026): Calculated column validation incorrectly flags expressions containing CAST
Issue [51862](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51862): Invalid calculated columns on DataClass breaks indexing and viewing in LKS grid

This PR looks to reduce that logging by adding a CALCULATED_COLUMN_SQL_TAG to the SQL query for the validation API check and the inclusion of the calc columns in the table. We then look for that tag in the handleSqlException() method.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6908

#### Changes
- add comment tag to executeSql query to indicate it is from a calculated column validation
