### PR TITLE
Selenium tests : Required Lineage Relationships

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.2",
+  "version": "6.58.3-fb-requiredLineageTest.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.2",
+      "version": "6.58.3-fb-requiredLineageTest.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3-fb-requiredLineageTest.1",
+  "version": "6.58.4-fb-requiredLineageTest.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.3-fb-requiredLineageTest.1",
+      "version": "6.58.4-fb-requiredLineageTest.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.4-fb-requiredLineageTest.2",
+  "version": "6.58.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.58.4-fb-requiredLineageTest.2",
+      "version": "6.58.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.4-fb-requiredLineageTest.2",
+  "version": "6.58.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.3-fb-requiredLineageTest.1",
+  "version": "6.58.4-fb-requiredLineageTest.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.58.2",
+  "version": "6.58.3-fb-requiredLineageTest.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,7 +5,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: X August 2025
 - Adding new parent alias on designer doesn't always add the bottom of the list
 
-### version 6.58.2
+### version 6.58.3
 *Released*: 7 August 2025
 - Add `StoragePositionNumber` as a sample storage column
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X August 2025
+### version 6.58.4
+*Released*: 12 August 2025
 - Adding new parent alias on designer doesn't always add to the bottom of the list
 
 ### version 6.58.3

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 6.X
 *Released*: X August 2025
-- Adding new parent alias on designer doesn't always add the bottom of the list
+- Adding new parent alias on designer doesn't always add to the bottom of the list
 
 ### version 6.58.3
 *Released*: 7 August 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X August 2025
+- Adding new parent alias on designer doesn't always add the bottom of the list
+
 ### version 6.58.2
 *Released*: 6 August 2025
 - GitHub Issue 788: LKSM Default sample lookup for assay design should default to lookupIsValid

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1,5 +1,5 @@
 import { ActionURL, Ajax, Filter, getServerContext, PermissionTypes, Query, Security, Utils } from '@labkey/api';
-import { List, Map } from 'immutable';
+import { List, Map, OrderedMap } from 'immutable';
 
 import { getSelected, getSelectedDataDeprecated, setSnapshotSelections } from '../../actions';
 
@@ -1032,7 +1032,7 @@ export const initParentOptionsSelects = (
     idPrefix?: string,
     formatLabel?: (name: string, prefix: string, isDataClass?: boolean, containerPath?: string) => string
 ): Promise<{
-    parentAliases: Map<string, IParentAlias>;
+    parentAliases: OrderedMap<string, IParentAlias>;
     parentOptions: IParentOption[];
 }> => {
     const promises: Promise<SelectRowsResponse>[] = [];
@@ -1097,7 +1097,8 @@ export const initParentOptionsSelects = (
 
                 const parentOptions = allOptions.sort(naturalSortByProperty('label'));
 
-                let parentAliases = Map<string, IParentAlias>();
+                // used ordered map so new import aliases are added after existing aliases on the UI
+                let parentAliases = OrderedMap<string, IParentAlias>();
 
                 if (importAliases) {
                     Object.keys(importAliases).forEach(key => {

--- a/packages/components/src/internal/components/samples/constants.ts
+++ b/packages/components/src/internal/components/samples/constants.ts
@@ -173,6 +173,7 @@ export const AMOUNT_AND_UNITS_COLUMNS_LC = AMOUNT_AND_UNITS_COLUMNS.map(col => c
 
 export const SAMPLE_STORAGE_COLUMNS = [
     'StorageLocation',
+    'StoragePositionNumber',
     'StorageRow',
     'StorageCol',
     'StorageUnit',


### PR DESCRIPTION
#### Rationale
Adding new parent alias on designer doesn't always add to the bottom of the list due to use or unordered map to hold list of import aliases.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1842
- https://github.com/LabKey/labkey-ui-premium/pull/804
- https://github.com/LabKey/platform/pull/6915
- https://github.com/LabKey/limsModules/pull/1594
- https://github.com/LabKey/testAutomation/pull/2617

#### Changes
- Switch to use orderedMap for aliases.
