### PR TITLE
Retain grid sort on update and lineage-update pages

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.3",
+  "version": "6.53.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.53.3",
+      "version": "6.53.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.53.3",
+  "version": "6.53.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 5.53.4
-*Released*: ? August 2025
+### version 6.53.4
+*Released*: 21 August 2025
 - SamplesAPIWrapper: add sort arg to getSelectionLineageData
   - Issue 53702: Selection order is not retained when editing multiple samples in grid
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 5.53.4
+*Released*: ? August 2025
+- SamplesAPIWrapper: add sort arg to getSelectionLineageData
+  - Issue 53702: Selection order is not retained when editing multiple samples in grid
+
 ### version 6.53.3
 *Released*: 7 July 2025
 - Issue 53394: FileInput revert removal of the "-fileUpload" suffix from inputId

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -79,7 +79,8 @@ export interface SamplesAPIWrapper {
         schema: string,
         query: string,
         viewName: string,
-        columns?: string[]
+        columns: string[] | undefined,
+        sort: string | undefined
     ) => Promise<ISelectRowsResult>;
 
     getTimelineEvents: (sampleId: number, timezone?: string) => Promise<TimelineEventModel[]>;

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -201,20 +201,22 @@ export function getSelectionLineageData(
     schema: string,
     query: string,
     viewName: string,
-    extraColumns: string[] = []
+    extraColumns: string[] = [],
+    sort: string | undefined
 ): Promise<ISelectRowsResult> {
     if (selections?.size === 0) return Promise.reject('No data is selected.');
     const rowIds = Array.from(selections).map(s => parseInt(s, 10));
 
     return selectRowsDeprecated({
-        schemaName: schema,
-        queryName: query,
-        viewName,
         columns: List.of('RowId', 'Name', 'LSID', 'Folder')
             .concat(ParentEntityLineageColumns)
             .toArray()
             .concat(extraColumns),
         filterArray: [Filter.create('RowId', rowIds, Filter.Types.IN)],
+        queryName: query,
+        schemaName: schema,
+        sort,
+        viewName,
     });
 }
 


### PR DESCRIPTION
#### Rationale
This PR fixes [Issue 53702](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53702)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1843
- https://github.com/LabKey/labkey-ui-premium/pull/807
- https://github.com/LabKey/limsModules/pull/1615

#### Changes
- SamplesAPIWrapper: add sort arg to getSelectionLineageData
