### PR TITLE
EditableColumnMetadata cleanup of unused getFilteredLookupKeys and linkedColInd props

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.0-cleanupEditableColumnMetadata.0",
+  "version": "6.62.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.0-cleanupEditableColumnMetadata.0",
+      "version": "6.62.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.0",
+  "version": "6.62.0-cleanupEditableColumnMetadata.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.0",
+      "version": "6.62.0-cleanupEditableColumnMetadata.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.0",
+  "version": "6.62.0-cleanupEditableColumnMetadata.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.0-cleanupEditableColumnMetadata.0",
+  "version": "6.62.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.62.1
+*Released*: 16 September 2025
 - EditableColumnMetadata cleanup of unused getFilteredLookupKeys and linkedColInd props
 
 ### version 6.62.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- EditableColumnMetadata cleanup of unused getFilteredLookupKeys and linkedColInd props
+
 ### version 6.62.0
 *Released*: 15 September 2025
 - Sample Type Amounts and Units updates for Quantity

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -178,7 +178,6 @@ export interface CellProps extends SharedProps {
     containerPath?: string;
     focused?: boolean;
     forUpdate: boolean;
-    linkedValues?: any[];
     name?: string;
     readOnly?: boolean;
     renderDragHandle?: boolean;
@@ -187,11 +186,7 @@ export interface CellProps extends SharedProps {
     values?: List<ValueDescriptor>;
 }
 
-interface State {
-    filteredLookupKeys?: List<any>;
-}
-
-export class Cell extends React.PureComponent<CellProps, State> {
+export class Cell extends React.PureComponent<CellProps, undefined> {
     private changeTO: number;
     private displayEl: React.RefObject<HTMLDivElement>;
     // This is used to record the dimensions of the cell before focusing so that the
@@ -216,7 +211,6 @@ export class Cell extends React.PureComponent<CellProps, State> {
 
     constructor(props: CellProps) {
         super(props);
-        this.state = { filteredLookupKeys: props.columnMetadata?.filteredLookupKeys };
         this.displayEl = React.createRef();
         this.preFocusDOMRect = React.createRef();
     }
@@ -246,25 +240,12 @@ export class Cell extends React.PureComponent<CellProps, State> {
             if (prevProps.focused) {
                 this.preFocusDOMRect.current = null;
             }
-            if (!prevProps.selected) {
-                this.loadFilteredLookupKeys();
-            }
         }
     }
 
     focusCell = (colIdx: number, rowIdx: number, clearValue?: boolean): void => {
         this.preFocusDOMRect.current = this.displayEl?.current?.getBoundingClientRect();
         this.props.cellActions.focusCell(colIdx, rowIdx, clearValue);
-    };
-
-    loadFilteredLookupKeys = async (): Promise<void> => {
-        const { columnMetadata, linkedValues, readOnly } = this.props;
-
-        if (!columnMetadata?.getFilteredLookupKeys || readOnly) return;
-
-        const linkedFilteredLookupKeys = await columnMetadata.getFilteredLookupKeys(linkedValues);
-
-        this.setState({ filteredLookupKeys: linkedFilteredLookupKeys });
     };
 
     handleSelectionBlur = (): void => {
@@ -613,7 +594,7 @@ export class Cell extends React.PureComponent<CellProps, State> {
                     defaultInputValue={this.recordedKeys}
                     disabled={this.isReadOnly}
                     lookupValueFilters={columnMetadata?.lookupValueFilters}
-                    filteredLookupKeys={this.state.filteredLookupKeys}
+                    filteredLookupKeys={columnMetadata?.filteredLookupKeys}
                     filteredLookupValues={columnMetadata?.filteredLookupValues}
                     forUpdate={forUpdate}
                     modifyCell={cellActions.modifyCell}

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -20,7 +20,7 @@ import { Query } from '@labkey/api';
 
 import { createPortal } from 'react-dom';
 
-import { cancelEvent, isFillDown, isCtrlOrMetaKey, isSelectAll } from '../../events';
+import { cancelEvent, isCtrlOrMetaKey, isFillDown, isSelectAll } from '../../events';
 
 import { CELL_SELECTION_HANDLE_CLASSNAME, KEYS } from '../../constants';
 import { Key } from '../../../public/useEnterEscape';
@@ -593,10 +593,10 @@ export class Cell extends React.PureComponent<CellProps, undefined> {
                     containerPath={containerPath}
                     defaultInputValue={this.recordedKeys}
                     disabled={this.isReadOnly}
-                    lookupValueFilters={columnMetadata?.lookupValueFilters}
                     filteredLookupKeys={columnMetadata?.filteredLookupKeys}
                     filteredLookupValues={columnMetadata?.filteredLookupValues}
                     forUpdate={forUpdate}
+                    lookupValueFilters={columnMetadata?.lookupValueFilters}
                     modifyCell={cellActions.modifyCell}
                     onBlur={this.handleSelectionBlur}
                     onKeyDown={this.handleFocusedDropdownKeys}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -154,7 +154,7 @@ const COUNT_COL = new GridColumn({
     ),
 });
 
-type GridMouseEvent = React.MouseEvent<HTMLDivElement> | MouseEvent;
+type GridMouseEvent = MouseEvent | React.MouseEvent<HTMLDivElement>;
 
 // the column index for cell values and cell messages does not include either the selection
 // column or the row number column, so we adjust the value passed to <Cell> to accommodate.
@@ -227,27 +227,27 @@ function inputCellFactory(
         return (
             <td className={className} key={inputCellKey(c.raw, row)} style={style}>
                 <Cell
-                    borderMaskTop={borderMask[0]}
-                    borderMaskRight={borderMask[1]}
                     borderMaskBottom={borderMask[2]}
                     borderMaskLeft={borderMask[3]}
+                    borderMaskRight={borderMask[1]}
+                    borderMaskTop={borderMask[0]}
                     cellActions={cellActions}
                     col={c.raw}
                     colIdx={colIdx}
                     columnMetadata={columnMetadata}
-                    row={focused ? editorModel.getRowValue(rowIdx) : undefined}
                     containerFilter={containerFilter}
-                    placeholder={columnMetadata?.placeholder}
-                    readOnly={isReadonlyRow || isReadonlyCell}
-                    rowIdx={rowIdx}
+                    containerPath={containerPath}
                     focused={focused}
                     forUpdate={forUpdate}
                     message={editorModel.getMessage(fieldKey, rowIdx)}
+                    placeholder={columnMetadata?.placeholder}
+                    readOnly={isReadonlyRow || isReadonlyCell}
+                    renderDragHandle={renderDragHandle}
+                    row={focused ? editorModel.getRowValue(rowIdx) : undefined}
+                    rowIdx={rowIdx}
                     selected={editorModel.isSelected(colIdx, rowIdx)}
                     selection={inSelection}
-                    renderDragHandle={renderDragHandle}
                     values={editorModel.getValue(fieldKey, rowIdx)}
-                    containerPath={containerPath}
                 />
             </td>
         );
@@ -837,10 +837,10 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 title: '&nbsp;',
                 cell: (selected: boolean, row) => (
                     <input
-                        className="grid-panel__checkbox"
                         checked={this.state.selected.contains(row.get(GRID_EDIT_INDEX))}
-                        type="checkbox"
+                        className="grid-panel__checkbox"
                         onChange={this.select.bind(this, row)}
+                        type="checkbox"
                     />
                 ),
             });
@@ -910,7 +910,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                     </>
                 )}
                 {showOverlayFromMetadata && (
-                    <LabelHelpTip title={label} popoverClassName={metadata?.popoverClassName} placement="bottom">
+                    <LabelHelpTip placement="bottom" popoverClassName={metadata?.popoverClassName} title={label}>
                         <>{metadata?.toolTip}</>
                     </LabelHelpTip>
                 )}
@@ -921,8 +921,8 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                     <DropdownMenu
                         asAnchor={false}
                         className="grid-panel__menu-toggle pull-right"
-                        title={<i className="fa fa-chevron-circle-down" />}
                         pullRight
+                        title={<i className="fa fa-chevron-circle-down" />}
                     >
                         <RemoveColumnMenuItem column={qColumn} onClick={metadata.onRemoveColumn} />
                     </DropdownMenu>
@@ -1456,26 +1456,26 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const maxToAdd = maxRows && amountLeft < MAX_EDITABLE_GRID_ROWS ? amountLeft : MAX_EDITABLE_GRID_ROWS;
         return (
             <QueryInfoForm
-                onSubmitForEdit={this.bulkAdd}
                 asModal
                 checkRequiredFields={false}
-                showLabelAsterisk
-                submitForEditText={`Add ${capitalizeFirstChar(addControlProps?.nounPlural)} to Grid`}
-                maxCount={maxToAdd}
-                onHide={this.toggleBulkAdd}
-                operation={forUpdate ? Operation.update : Operation.insert}
-                onSuccess={this.toggleBulkAdd}
-                queryInfo={queryInfo.getInsertQueryInfo()}
-                queryFilters={bulkAddProps?.queryFilters}
+                columnFilter={bulkAddProps?.columnFilter}
+                containerPath={containerPath}
+                countText={bulkAddProps?.countText}
+                creationTypeOptions={bulkAddProps?.creationTypeOptions}
+                fieldValues={bulkAddProps?.fieldValues}
                 header={
                     !!bulkAddProps?.header && <div className="editable-grid__bulk-header">{bulkAddProps.header}</div>
                 }
-                fieldValues={bulkAddProps?.fieldValues}
-                columnFilter={bulkAddProps?.columnFilter}
+                maxCount={maxToAdd}
+                onHide={this.toggleBulkAdd}
+                onSubmitForEdit={this.bulkAdd}
+                onSuccess={this.toggleBulkAdd}
+                operation={forUpdate ? Operation.update : Operation.insert}
+                queryFilters={bulkAddProps?.queryFilters}
+                queryInfo={queryInfo.getInsertQueryInfo()}
+                showLabelAsterisk
+                submitForEditText={`Add ${capitalizeFirstChar(addControlProps?.nounPlural)} to Grid`}
                 title={bulkAddProps?.title}
-                countText={bulkAddProps?.countText}
-                creationTypeOptions={bulkAddProps?.creationTypeOptions}
-                containerPath={containerPath}
             />
         );
     };

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -190,15 +190,6 @@ function inputCellFactory(
         // If we're updating then we want to use the container path from each row if present
         if (forUpdate && rowContainer) containerPath = rowContainer;
 
-        let linkedValues;
-        if (columnMetadata?.getFilteredLookupKeys) {
-            const linkedFieldKey = editorModel.getFieldKeyByIndex(columnMetadata.linkedColInd);
-            linkedValues = editorModel
-                .getValue(linkedFieldKey, rowIdx)
-                .map(vd => vd.raw)
-                .toArray();
-        }
-
         const { isSparseSelection, selectionCells } = editorModel;
         const renderDragHandle = !isSparseSelection && editorModel.lastSelection(fieldKey, rowIdx);
         let inSelection = editorModel.inSelection(fieldKey, rowIdx);
@@ -256,7 +247,6 @@ function inputCellFactory(
                     selection={inSelection}
                     renderDragHandle={renderDragHandle}
                     values={editorModel.getValue(fieldKey, rowIdx)}
-                    linkedValues={linkedValues}
                     containerPath={containerPath}
                 />
             </td>

--- a/packages/components/src/internal/components/editable/models.ts
+++ b/packages/components/src/internal/components/editable/models.ts
@@ -43,10 +43,8 @@ export interface EditableColumnMetadata {
     containerFilter?: Query.ContainerFilter;
     filteredLookupKeys?: List<any>;
     filteredLookupValues?: List<string>;
-    getFilteredLookupKeys?: (linkedValues: any[]) => Promise<List<any>>; // TODO can this be removed? I don't see any usages (if so, also remove linkedColInd)
     hideTitleTooltip?: boolean;
     isReadOnlyCell?: (rowKey: string) => boolean;
-    linkedColInd?: number; // TODO: change to linkedColFieldKey
     lookupValueFilters?: Filter.IFilter[];
     minWidth?: number;
     onRemoveColumn?: (col: QueryColumn) => void;


### PR DESCRIPTION
#### Rationale
The related PR had updates for amounts/units. During the code review, it was discovered that there are a few props of EditableColumnMetadata that are no longer used and can be removed (along with the related code).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1850
- https://github.com/LabKey/labkey-ui-components/pull/1852
- https://github.com/LabKey/labkey-ui-premium/pull/815
- https://github.com/LabKey/limsModules/pull/1669

#### Changes
- remove unused getFilteredLookupKeys and linkedColInd props and related code
