### PR TITLE
Workflow: Change Required Template Fields to be Required at the start of a Job

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3-fb-requiredJobFields.1",
+  "version": "6.62.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.3-fb-requiredJobFields.1",
+      "version": "6.62.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.2-fb-requiredJobFields.1",
+  "version": "6.62.2-fb-requiredJobFields.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.2-fb-requiredJobFields.1",
+      "version": "6.62.2-fb-requiredJobFields.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.2",
+  "version": "6.62.3-fb-requiredJobFields.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.2",
+      "version": "6.62.3-fb-requiredJobFields.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.1",
+  "version": "6.62.2-fb-requiredJobFields.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.1",
+      "version": "6.62.2-fb-requiredJobFields.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.2-fb-requiredJobFields.1",
+  "version": "6.62.2-fb-requiredJobFields.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3-fb-requiredJobFields.1",
+  "version": "6.62.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.0",
+  "version": "6.62.1-fb-requiredJobFields.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -6,6 +6,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 - Workflow: Change Required Template Fields to be Required at the start of a Job
   - Update required field label display to show overlay before asterisk
   - Fix CheckBoxInput required field display on Formsy forms
+  - Add optional `colFieldKeyMap` param to `flattenValuesFromRow` to convert field names to field keys
 
 ### version 6.62.1
 *Released*: 16 September 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X September 2025
+### version 6.62.3
+*Released*: 18 September 2025
 - Workflow: Change Required Template Fields to be Required at the start of a Job
   - Update required field label display to show overlay before asterisk
   - Fix CheckBoxInput required field display on Formsy forms

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X September 2025
+- Workflow: Change Required Template Fields to be Required at the start of a Job
+  - Update required field label display to show overlay before asterisk
+  - Fix CheckBoxInput required field display on Formsy forms
+
 ### version 6.62.0
 *Released*: 15 September 2025
 - Sample Type Amounts and Units updates for Quantity

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -5,9 +5,9 @@ import {
     formatDate,
     getColDateFormat,
     getDateFNSDateFormat,
-    getJsonDateTimeFormatString,
-    getJsonDateFormatString,
     getDateTimeDisplayValueFromStr,
+    getJsonDateFormatString,
+    getJsonDateTimeFormatString,
 } from '../util/Date';
 import { Key, useEnterEscape } from '../../public/useEnterEscape';
 
@@ -100,7 +100,7 @@ export const EditInlineField: FC<Props> = memo(props => {
         // Issue 48196: if the domain column has been setup with a "url" prop, use it in the EditInlineField value display
         if (value_ !== undefined && value?.url) {
             value_ = (
-                <a href={value.url} target="_blank" rel="noopener noreferrer">
+                <a href={value.url} rel="noopener noreferrer" target="_blank">
                     {value_}
                 </a>
             );
@@ -220,38 +220,38 @@ export const EditInlineField: FC<Props> = memo(props => {
             {state.editing && isDateOrTime && !!column && (
                 <DatePickerInput
                     autoFocus
-                    name={name}
                     formsy={false}
+                    inlineEdit
+                    inputWrapperClassName="form-control"
+                    name={name}
+                    onBlur={onBlur}
+                    onChange={onDateChange}
+                    onKeyDown={onKeyDown}
+                    placeholderText={placeholder}
                     queryColumn={column}
                     showLabel={false}
                     value={isDate ? dateValue : _value}
-                    inputWrapperClassName="form-control"
-                    onBlur={onBlur}
-                    onKeyDown={onKeyDown}
-                    onChange={onDateChange}
-                    placeholderText={placeholder}
-                    inlineEdit
                 />
             )}
             {state.editing && isDateOrTime && !column && (
                 <DateInput
                     autoFocus
                     container={container}
+                    dateFormat={dateInputDateFormat}
                     endDate={endDate}
-                    minDate={startDate}
                     maxDate={endDate}
+                    minDate={startDate}
                     name={name}
                     onBlur={onBlur}
-                    onKeyDown={onKeyDown}
                     onChange={onDateChange}
+                    onKeyDown={onKeyDown}
                     onMonthChange={onDateChange}
                     placeholderText={placeholder}
                     selected={dateValue}
                     selectsEnd={startDate !== undefined}
                     selectsStart={endDate !== undefined}
-                    startDate={startDate}
                     showTimeSelect={!!column}
-                    dateFormat={dateInputDateFormat}
+                    startDate={startDate}
                 />
             )}
             {state.editing && isTextArea && (
@@ -261,10 +261,10 @@ export const EditInlineField: FC<Props> = memo(props => {
                         className="form-control"
                         cols={100}
                         defaultValue={_value}
+                        name={name}
                         onBlur={onBlur}
                         onFocus={onTextAreaFocus}
                         onKeyDown={onKeyDown}
-                        name={name}
                         placeholder={placeholder}
                         ref={inputRef}
                         rows={5}
@@ -284,14 +284,14 @@ export const EditInlineField: FC<Props> = memo(props => {
                         autoFocus
                         className="form-control"
                         defaultValue={_value}
-                        onBlur={onBlur}
-                        onKeyDown={onKeyDown}
                         name={name}
+                        onBlur={onBlur}
+                        onInput={onInputChange}
+                        onKeyDown={onKeyDown}
                         placeholder={placeholder}
                         ref={inputRef}
-                        type={inputType}
                         size={Math.max(_value?.length ?? 0, 20)}
-                        onInput={onInputChange}
+                        type={inputType}
                     />
                 </span>
             )}
@@ -300,13 +300,13 @@ export const EditInlineField: FC<Props> = memo(props => {
                     {label && (
                         <span
                             className="edit-inline-field__label"
-                            unselectable="on"
                             title={allowEdit ? tooltip : undefined}
+                            unselectable="on"
                         >
                             {label}
                         </span>
                     )}
-                    {isUser && <UserLink userId={value?.value} userDisplayValue={value?.displayValue} />}
+                    {isUser && <UserLink userDisplayValue={value?.displayValue} userId={value?.value} />}
                     <span
                         className={classNames({ 'edit-inline-field__toggle': allowEdit, 'ws-pre-wrap': isTextArea })}
                         onClick={toggleEdit}

--- a/packages/components/src/internal/components/EditInlineField.tsx
+++ b/packages/components/src/internal/components/EditInlineField.tsx
@@ -20,6 +20,7 @@ import { useServerContext } from './base/ServerContext';
 import { resolveDetailEditRenderer } from './forms/detail/DetailDisplay';
 import { UserLink } from './user/UserLink';
 import { DatePickerInput } from './forms/input/DatePickerInput';
+import { isBlankValue } from '../util/utils';
 
 interface Props {
     allowBlank?: boolean;
@@ -128,7 +129,7 @@ export const EditInlineField: FC<Props> = memo(props => {
     const saveEdit = useCallback(() => {
         const inputValue = getInputValue();
 
-        if (allowBlank === false && !isDate && inputValue.trim() === '') {
+        if (allowBlank === false && !isDate && isBlankValue(inputValue)) {
             return;
         }
 
@@ -140,7 +141,7 @@ export const EditInlineField: FC<Props> = memo(props => {
 
     const onBlur = useCallback((): void => {
         if (!state.ignoreBlur) {
-            if (allowBlank === false && !isDate && getInputValue().trim() === '') {
+            if (allowBlank === false && !isDate && isBlankValue(getInputValue())) {
                 onCancel();
             } else {
                 saveEdit();
@@ -154,6 +155,11 @@ export const EditInlineField: FC<Props> = memo(props => {
             if (date instanceof Array) throw new Error('Unsupported date/time type');
 
             if (!date) {
+                if (allowBlank === false) {
+                    onCancel();
+                    return;
+                }
+
                 if (isDate) setDateValue(undefined);
                 else setTimeJsonValue(undefined);
             } else if (typeof date === 'string') {
@@ -162,7 +168,7 @@ export const EditInlineField: FC<Props> = memo(props => {
                 if (isDate) setDateValue(date);
             }
         },
-        [isDate]
+        [isDate, allowBlank]
     );
 
     const onFormsyColumnChange = useCallback(

--- a/packages/components/src/internal/components/forms/LabelOverlay.test.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LabelOverlay } from './LabelOverlay';
+
+describe('LabelOverlay', () => {
+
+    it('renders label with overlay, not formsy', () => {
+        render(<LabelOverlay label="Test Label" isFormsy={false} />);
+        expect(document.querySelector('label')?.textContent).toBe('Test Label ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
+    });
+
+    it('renders label with overlay and required symbol when required, not formsy', () => {
+        render(<LabelOverlay label="Test Label" required={true}  isFormsy={false}/>);
+        expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
+    });
+
+    it('renders label with overlay and required, but addLabelAsterisk = false, not formsy', () => {
+        render(<LabelOverlay label="Test Label" required={true} addLabelAsterisk={false}  isFormsy={false} />);
+        expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
+    });
+
+    it('renders label with overlay, required = false, and addLabelAsterisk = true, , not formsy', () => {
+        render(<LabelOverlay label="Test Label" required={false} addLabelAsterisk={true}  isFormsy={false} />);
+        expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
+    });
+
+    it('renders label with no overlay and required symbol when required, not formsy', () => {
+        render(<LabelOverlay label="Test Label" required={true} helpTipRenderer='NONE' isFormsy={false} />);
+        expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(0);
+    });
+
+    it('renders label with overlay, isFormsy = true (default)', () => {
+        render(<LabelOverlay label="Test Label" />);
+        expect(document.querySelector('label')).toBeNull();
+        expect(document.querySelector('span')?.textContent).toBe('Test Label ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
+    });
+
+    it('renders label with overlay and required', () => {
+        render(<LabelOverlay label="Test Label" isFormsy={true} required={true} />);
+        expect(document.querySelector('label')).toBeNull();
+        expect(document.querySelector('span')?.textContent).toBe('Test Label * ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
+    });
+
+    it('renders label with overlay and addLabelAsterisk', () => {
+        render(<LabelOverlay label="Test Label" isFormsy={true} addLabelAsterisk={true} />);
+        expect(document.querySelector('label')).toBeNull();
+        expect(document.querySelector('span')?.textContent).toBe('Test Label * ');
+        expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
+    });
+
+});

--- a/packages/components/src/internal/components/forms/LabelOverlay.test.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.test.tsx
@@ -3,33 +3,32 @@ import { render } from '@testing-library/react';
 import { LabelOverlay } from './LabelOverlay';
 
 describe('LabelOverlay', () => {
-
     it('renders label with overlay, not formsy', () => {
-        render(<LabelOverlay label="Test Label" isFormsy={false} />);
+        render(<LabelOverlay isFormsy={false} label="Test Label" />);
         expect(document.querySelector('label')?.textContent).toBe('Test Label ');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay and required symbol when required, not formsy', () => {
-        render(<LabelOverlay label="Test Label" required={true}  isFormsy={false}/>);
+        render(<LabelOverlay isFormsy={false} label="Test Label" required={true} />);
         expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay and required, but addLabelAsterisk = false, not formsy', () => {
-        render(<LabelOverlay label="Test Label" required={true} addLabelAsterisk={false}  isFormsy={false} />);
+        render(<LabelOverlay addLabelAsterisk={false} isFormsy={false} label="Test Label" required={true} />);
         expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay, required = false, and addLabelAsterisk = true, , not formsy', () => {
-        render(<LabelOverlay label="Test Label" required={false} addLabelAsterisk={true}  isFormsy={false} />);
+        render(<LabelOverlay addLabelAsterisk={true} isFormsy={false} label="Test Label" required={false} />);
         expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with no overlay and required symbol when required, not formsy', () => {
-        render(<LabelOverlay label="Test Label" required={true} helpTipRenderer='NONE' isFormsy={false} />);
+        render(<LabelOverlay helpTipRenderer="NONE" isFormsy={false} label="Test Label" required={true} />);
         expect(document.querySelector('label')?.textContent).toBe('Test Label * ');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(0);
     });
@@ -42,17 +41,16 @@ describe('LabelOverlay', () => {
     });
 
     it('renders label with overlay and required', () => {
-        render(<LabelOverlay label="Test Label" isFormsy={true} required={true} />);
+        render(<LabelOverlay isFormsy={true} label="Test Label" required={true} />);
         expect(document.querySelector('label')).toBeNull();
         expect(document.querySelector('span')?.textContent).toBe('Test Label * ');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay and addLabelAsterisk', () => {
-        render(<LabelOverlay label="Test Label" isFormsy={true} addLabelAsterisk={true} />);
+        render(<LabelOverlay addLabelAsterisk={true} isFormsy={true} label="Test Label" />);
         expect(document.querySelector('label')).toBeNull();
         expect(document.querySelector('span')?.textContent).toBe('Test Label * ');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
-
 });

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -111,6 +111,7 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
         if (isFormsy) {
             // when being used as a label for a formsy component directly this will use just a span without the
             // classes applied as well as not needing to handle 'required' display
+            // TODO: remove space for required-symbol after *
             return (
                 <span>
                     {label}&nbsp;
@@ -120,6 +121,7 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
             );
         }
 
+        // TODO: remove space for required-symbol after *
         return (
             <label className={(labelClass ? labelClass + ' ' : '') + 'text__truncate-and-wrap'} htmlFor={inputId}>
                 <span>{label}</span>&nbsp;

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -114,8 +114,8 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
             return (
                 <span>
                     {label}&nbsp;
-                    {required || addLabelAsterisk ? <span className="required-symbol">* </span> : null}
                     {overlay}
+                    {required || addLabelAsterisk ? <span className="required-symbol">* </span> : null}
                 </span>
             );
         }
@@ -123,8 +123,8 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
         return (
             <label className={(labelClass ? labelClass + ' ' : '') + 'text__truncate-and-wrap'} htmlFor={inputId}>
                 <span>{label}</span>&nbsp;
-                {required || addLabelAsterisk ? <span className="required-symbol">* </span> : null}
                 {overlay}
+                {required || addLabelAsterisk ? <span className="required-symbol">* </span> : null}
             </label>
         );
     }

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -61,14 +61,14 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
 
         if (column?.helpTipRenderer || helpTipRenderer) {
             return (
-                <HelpTipRenderer type={column?.helpTipRenderer || helpTipRenderer} column={column}>
+                <HelpTipRenderer column={column} type={column?.helpTipRenderer || helpTipRenderer}>
                     {children}
                 </HelpTipRenderer>
             );
         }
 
         return (
-            <DomainFieldHelpTipContents column={column} required={required} description={description} type={type}>
+            <DomainFieldHelpTipContents column={column} description={description} required={required} type={type}>
                 {children}
             </DomainFieldHelpTipContents>
         );
@@ -84,7 +84,7 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
                 : undefined;
         const body = this.overlayBody();
         return (
-            <Popover id={this._popoverId} title={label} placement={placement} className={popoverClassName}>
+            <Popover className={popoverClassName} id={this._popoverId} placement={placement} title={label}>
                 {body}
             </Popover>
         );

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.test.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { List, fromJS } from 'immutable';
+import { fromJS, List } from 'immutable';
 import React from 'react';
 import { render } from '@testing-library/react';
 
@@ -11,7 +11,7 @@ import { AssayRunReferenceRenderer } from '../../../renderers/AssayRunReferenceR
 import { LabelColorRenderer } from '../../../renderers/LabelColorRenderer';
 import { FileColumnRenderer } from '../../../renderers/FileColumnRenderer';
 
-import { DetailDisplay, resolveDetailRenderer, defaultTitleRenderer, Renderer } from './DetailDisplay';
+import { defaultTitleRenderer, DetailDisplay, Renderer, resolveDetailRenderer } from './DetailDisplay';
 
 describe('DetailDisplay', () => {
     const namePatternCol = new QueryColumn({
@@ -132,9 +132,9 @@ describe('DetailDisplay', () => {
         render(
             <DetailDisplay
                 asPanel={true}
-                editingMode={false}
                 data={data}
                 displayColumns={cols}
+                editingMode={false}
                 fieldHelpTexts={fieldHelpText}
             />
         );

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -119,6 +119,7 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputImplProps, Checkbo
                         labelOverlayProps={{
                             isFormsy: false,
                             inputId: queryColumn.fieldKey,
+                            required: queryColumn?.required,
                             addLabelAsterisk,
                         }}
                         showLabel={showLabel}

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -115,6 +115,8 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputImplProps, Checkbo
                     </label>
                 ) : (
                     <FieldLabel
+                        column={queryColumn}
+                        isDisabled={isDisabled}
                         label={label}
                         labelOverlayProps={{
                             isFormsy: false,
@@ -124,8 +126,6 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputImplProps, Checkbo
                         }}
                         showLabel={showLabel}
                         showToggle={allowDisable}
-                        column={queryColumn}
-                        isDisabled={isDisabled}
                         toggleProps={{
                             onClick: this.toggleDisabled,
                         }}
@@ -133,16 +133,16 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputImplProps, Checkbo
                 )}
                 <div className={wrapperClassName}>
                     <input
+                        checked={checked}
                         disabled={isDisabled}
                         id={queryColumn.fieldKey}
                         name={queryColumn.fieldKey}
+                        onChange={this.onChange}
                         // Issue 43299: Ignore "required" property for boolean columns as this will
                         // cause any false value (i.e. unchecked) to prevent submission.
                         // required={queryColumn.required}
                         type="checkbox"
                         value={formsy ? value : checked}
-                        checked={checked}
-                        onChange={this.onChange}
                     />
                 </div>
             </div>

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -236,7 +236,7 @@ export function getPermissionRestrictionMessage(
 }
 
 export function lookupValidationErrorMessage(
-    value: string | number | boolean,
+    value: boolean | number | string,
     fromPaste?: boolean,
     displayValue?: any
 ): string {

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -197,6 +197,8 @@ export function resolveErrorMessage(
         } else if (errorMsg.indexOf('null value in column "name"') > -1) {
             const noun = errorMsg.indexOf('material') > -1 ? 'Sample ID' : 'ID';
             return noun + ' cannot be blank.';
+        } else if (noun === 'job' && errorMsg.indexOf('when it contains rows with blank values') > -1) {
+            return errorMsg.replace('it contains rows with blank values', 'there are already jobs using this template');
         }
     }
     return errorMsg;

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -1692,4 +1692,3 @@ describe('isBlankValue', () => {
         expect(isBlankValue(new Date())).toBe(false);
     });
 });
-

--- a/packages/components/src/internal/util/utils.test.ts
+++ b/packages/components/src/internal/util/utils.test.ts
@@ -35,6 +35,7 @@ import {
     getValueFromRow,
     getValuesSummary,
     hasAmountOrUnitChanged,
+    isBlankValue,
     isBoolean,
     isImage,
     isInteger,
@@ -1671,3 +1672,24 @@ describe('isSameWithStringCompare', () => {
         expect(isSameWithStringCompare(123, 123.1)).toBe(false);
     });
 });
+
+describe('isBlankValue', () => {
+    it('blank', () => {
+        expect(isBlankValue(undefined)).toBe(true);
+        expect(isBlankValue(null)).toBe(true);
+        expect(isBlankValue('')).toBe(true);
+        expect(isBlankValue('   ')).toBe(true);
+    });
+
+    it('not blank', () => {
+        expect(isBlankValue('value')).toBe(false);
+        expect(isBlankValue(' value ')).toBe(false);
+        expect(isBlankValue(0)).toBe(false);
+        expect(isBlankValue({})).toBe(false);
+        expect(isBlankValue([])).toBe(false);
+        expect(isBlankValue(true)).toBe(false);
+        expect(isBlankValue(false)).toBe(false);
+        expect(isBlankValue(new Date())).toBe(false);
+    });
+});
+

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -842,6 +842,12 @@ export function isSetEqual<T = any>(a: Collection<T>, b: Collection<T>): boolean
     return toJsonSet(a) === toJsonSet(b);
 }
 
+export function isBlankValue(val: any): boolean {
+    if (val === undefined || val === null) return true;
+    if (typeof val !== 'string') return false;
+    return val.toString().trim() === '';
+}
+
 /**
  * When this package is exported this environment variable reference is inline rewritten as
  * `const IS_NODE_TEST_ENV = "production" === 'test';`

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -149,8 +149,8 @@ export function generateId(prefix?: string): string {
 export function debounce(func, wait, immediate?: boolean): () => void {
     let timeout: number;
     return function () {
-        const context = this,
-            args = arguments;
+        const args = arguments,
+            context = this;
         const later = function (): void {
             timeout = null;
             if (!immediate) func.apply(context, args);
@@ -764,7 +764,7 @@ export function getValuesSummary<T>(values: T[], nounSingular: string, nounPlura
  * fields in that row. If no column is provided, the data is expected to be a single field's data.
  * @param data either a row of data or a single field's data
  */
-export function getDataStyling(data: Map<string, any> | any): CSSProperties {
+export function getDataStyling(data: any | Map<string, any>): CSSProperties {
     if (!data) {
         return undefined;
     }

--- a/packages/components/src/public/QueryModel/QueryModel.test.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.test.ts
@@ -342,12 +342,51 @@ describe('flattenValuesFromRow', () => {
             test4: undefined,
         };
 
-        expect(flattenValuesFromRow(data, Object.keys(data)).test0).toBe(undefined);
+        expect(flattenValuesFromRow(data, Object.keys(data))).toEqual({
+            test1: 123,
+            test2: 456,
+            test3: null
+        });
         expect(flattenValuesFromRow(data, Object.keys(data)).test1).toBe(123);
         expect(flattenValuesFromRow(data, Object.keys(data)).test2).toBe(456);
         expect(flattenValuesFromRow(data, Object.keys(data)).test3).toBe(null);
         expect(flattenValuesFromRow(data, Object.keys(data)).test4).toBe(undefined);
+        expect(flattenValuesFromRow(data, Object.keys(data)).test0).toBe(undefined);
     });
+
+    test('with values and colFieldKeyMap', () => {
+        const data = {
+            "test/1": { value: 123, displayValue: 'TEST123' },
+            "test$2": { value: 456 },
+            "test.3": { value: 789 },
+            "test4": { value: 101 },
+        };
+
+        expect(flattenValuesFromRow(data, Object.keys(data))).toEqual(
+            { 'test/1': 123, 'test$2': 456, 'test.3': 789, test4: 101 }
+        );
+
+        const colFieldKeyMap = {
+            'test/1': 'test$S1',
+            'test$2': 'test$D2',
+            'test.3': 'test$P3',
+            test4: 'test4',
+        };
+
+        expect(flattenValuesFromRow(data, Object.keys(data), colFieldKeyMap)).toEqual(
+            { 'test$S1': 123, 'test$D2': 456, 'test$P3': 789, test4: 101 }
+        );
+
+        const colFieldKeyMapPartial = {
+            'test/1': 'test$S1',
+            test4: null,
+        };
+
+        expect(flattenValuesFromRow(data, Object.keys(data), colFieldKeyMapPartial)).toEqual(
+            { 'test$S1': 123, 'test$2': 456, 'test.3': 789, test4: 101 }
+        );
+    });
+
 });
 
 describe('locationHasQueryParamSettings', () => {

--- a/packages/components/src/public/QueryModel/QueryModel.test.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.test.ts
@@ -319,11 +319,11 @@ describe('QueryModel', () => {
 
 describe('createQueryModelId', () => {
     test('with/without special characters in schema/query', () => {
-        expect(createQueryModelId(new SchemaQuery("samples", "Blood"))).toBe('samples.Blood');
-        expect(createQueryModelId(new SchemaQuery("exp.data", "participant"))).toBe('exp$Pdata.participant');
-        expect(createQueryModelId(new SchemaQuery("samples", "Blood Plasma"))).toBe('samples.Blood Plasma');
-        expect(createQueryModelId(new SchemaQuery("samples", "Blood/Plasma"))).toBe('samples.Blood$SPlasma');
-        expect(createQueryModelId(new SchemaQuery("exp.data", "Blood/Plasma"))).toBe('exp$Pdata.Blood$SPlasma');
+        expect(createQueryModelId(new SchemaQuery('samples', 'Blood'))).toBe('samples.Blood');
+        expect(createQueryModelId(new SchemaQuery('exp.data', 'participant'))).toBe('exp$Pdata.participant');
+        expect(createQueryModelId(new SchemaQuery('samples', 'Blood Plasma'))).toBe('samples.Blood Plasma');
+        expect(createQueryModelId(new SchemaQuery('samples', 'Blood/Plasma'))).toBe('samples.Blood$SPlasma');
+        expect(createQueryModelId(new SchemaQuery('exp.data', 'Blood/Plasma'))).toBe('exp$Pdata.Blood$SPlasma');
     });
 });
 
@@ -345,7 +345,7 @@ describe('flattenValuesFromRow', () => {
         expect(flattenValuesFromRow(data, Object.keys(data))).toEqual({
             test1: 123,
             test2: 456,
-            test3: null
+            test3: null,
         });
         expect(flattenValuesFromRow(data, Object.keys(data)).test1).toBe(123);
         expect(flattenValuesFromRow(data, Object.keys(data)).test2).toBe(456);
@@ -356,37 +356,45 @@ describe('flattenValuesFromRow', () => {
 
     test('with values and colFieldKeyMap', () => {
         const data = {
-            "test/1": { value: 123, displayValue: 'TEST123' },
-            "test$2": { value: 456 },
-            "test.3": { value: 789 },
-            "test4": { value: 101 },
+            'test/1': { value: 123, displayValue: 'TEST123' },
+            test$2: { value: 456 },
+            'test.3': { value: 789 },
+            test4: { value: 101 },
         };
 
-        expect(flattenValuesFromRow(data, Object.keys(data))).toEqual(
-            { 'test/1': 123, 'test$2': 456, 'test.3': 789, test4: 101 }
-        );
+        expect(flattenValuesFromRow(data, Object.keys(data))).toEqual({
+            'test/1': 123,
+            test$2: 456,
+            'test.3': 789,
+            test4: 101,
+        });
 
         const colFieldKeyMap = {
             'test/1': 'test$S1',
-            'test$2': 'test$D2',
+            test$2: 'test$D2',
             'test.3': 'test$P3',
             test4: 'test4',
         };
 
-        expect(flattenValuesFromRow(data, Object.keys(data), colFieldKeyMap)).toEqual(
-            { 'test$S1': 123, 'test$D2': 456, 'test$P3': 789, test4: 101 }
-        );
+        expect(flattenValuesFromRow(data, Object.keys(data), colFieldKeyMap)).toEqual({
+            test$S1: 123,
+            test$D2: 456,
+            test$P3: 789,
+            test4: 101,
+        });
 
         const colFieldKeyMapPartial = {
             'test/1': 'test$S1',
             test4: null,
         };
 
-        expect(flattenValuesFromRow(data, Object.keys(data), colFieldKeyMapPartial)).toEqual(
-            { 'test$S1': 123, 'test$2': 456, 'test.3': 789, test4: 101 }
-        );
+        expect(flattenValuesFromRow(data, Object.keys(data), colFieldKeyMapPartial)).toEqual({
+            test$S1: 123,
+            test$2: 456,
+            'test.3': 789,
+            test4: 101,
+        });
     });
-
 });
 
 describe('locationHasQueryParamSettings', () => {

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -17,7 +17,11 @@ import { naturalSortByProperty } from '../sort';
 import { PaginationData } from '../../internal/components/pagination/Pagination';
 import { SelectRowsOptions } from '../../internal/query/selectRows';
 
-export function flattenValuesFromRow(row: any, columns: string[], colFieldKeyMap?: Record<string, string>): Record<string, any> {
+export function flattenValuesFromRow(
+    row: any,
+    columns: string[],
+    colFieldKeyMap?: Record<string, string>
+): Record<string, any> {
     const values = {};
     if (row && columns) {
         columns.forEach((col: string) => {

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -17,12 +17,23 @@ import { naturalSortByProperty } from '../sort';
 import { PaginationData } from '../../internal/components/pagination/Pagination';
 import { SelectRowsOptions } from '../../internal/query/selectRows';
 
-export function flattenValuesFromRow(row: any, keys: string[]): Record<string, any> {
+export function flattenValuesFromRow(row: any, columns: string[], colFieldKeyMap?: Record<string, string>): Record<string, any> {
     const values = {};
-    if (row && keys) {
-        keys.forEach((key: string) => {
-            if (row[key]) {
-                values[key] = row[key].value;
+    if (row && columns) {
+        columns.forEach((col: string) => {
+            if (row[col]) {
+                values[col] = row[col].value;
+            }
+        });
+    }
+
+    // convert values[key] to values[fieldKey] if fieldKeyMap provided
+    if (colFieldKeyMap) {
+        Object.keys(colFieldKeyMap).forEach(col => {
+            const fieldKey = colFieldKeyMap[col];
+            if (fieldKey && fieldKey !== col && values[col] !== undefined) {
+                values[fieldKey] = values[col];
+                delete values[col];
             }
         });
     }


### PR DESCRIPTION
#### Rationale
Required field labels have been inconsistent depending on its render context. For formsy forms, FormsyReactComponent.Label adds a required sign (* asterisk) at the end of the rendered label, resulting in "FieldLabel ?helpIcon *" display. Outside of Formsy forms, the label is rendered as "FieldLabel * helpIcon" by LabelOverlay. This PR changes the label rendering behavior so that "FieldLabel ?helpIcon *" is consistently used.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1854
- https://github.com/LabKey/labkey-ui-premium/pull/819
- https://github.com/LabKey/limsModules/pull/1674

#### Changes
- Update required field label display to show overlay before asterisk
- Fix CheckBoxInput required field display on Formsy forms