### PR TITLE
Issue 53036: LKSM: Aliquot registration event in timeline polish

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.4-fb-issue53036.1",
+  "version": "6.62.4-fb-issue53036.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.4-fb-issue53036.1",
+      "version": "6.62.4-fb-issue53036.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.4-fb-issue53036.2",
+  "version": "6.62.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.4-fb-issue53036.2",
+      "version": "6.62.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3",
+  "version": "6.62.4-fb-issue53036.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.3",
+      "version": "6.62.4-fb-issue53036.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.4-fb-issue53036.1",
+  "version": "6.62.4-fb-issue53036.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3",
+  "version": "6.62.4-fb-issue53036.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.4-fb-issue53036.2",
+  "version": "6.62.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X September 2025
+- Issue 53036: LKSM: Aliquot registration event in timeline polish
+  - Display "inherited" instead of NA for aliquot's parent fields in timeline view
+
 ### version 6.62.3
 *Released*: 18 September 2025
 - Workflow: Change Required Template Fields to be Required at the start of a Job

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X September 2025
+### version 6.62.4
+*Released*: 26 September 2025
 - Issue 53036: LKSM: Aliquot registration event in timeline polish
   - Display "inherited" instead of NA for aliquot's parent fields in timeline view
 

--- a/packages/components/src/internal/components/auditlog/AuditDetails.test.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.test.tsx
@@ -166,7 +166,7 @@ describe('AuditDetails', () => {
             <AuditDetails
                 changeDetails={AuditDetailsModel.create({
                     newData: { a: AUDIT_DETAIL_FIELD_VALUE_INHERITED },
-                    oldData: {}
+                    oldData: {},
                 })}
                 inheritedFieldMsg="This value is inherited from a parent folder."
                 rowId={1}
@@ -183,7 +183,7 @@ describe('AuditDetails', () => {
             <AuditDetails
                 changeDetails={AuditDetailsModel.create({
                     newData: { a: AUDIT_DETAIL_FIELD_VALUE_INHERITED },
-                    oldData: {}
+                    oldData: {},
                 })}
                 rowId={1}
                 user={TEST_USER_APP_ADMIN}
@@ -227,5 +227,4 @@ describe('AuditDetails', () => {
         expect(document.querySelector('.panel-body').textContent).toBe('aInherited1');
         expect(document.querySelectorAll('.fa-info-circle')).toHaveLength(0);
     });
-
 });

--- a/packages/components/src/internal/components/auditlog/AuditDetails.test.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.test.tsx
@@ -9,6 +9,7 @@ import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 import { AuditDetails } from './AuditDetails';
 
 import { AuditDetailsModel } from './models';
+import { AUDIT_DETAIL_FIELD_VALUE_INHERITED } from './constants';
 
 describe('AuditDetails', () => {
     test('default props, empty', () => {
@@ -142,4 +143,89 @@ describe('AuditDetails', () => {
         expect(document.querySelector('.panel-body').textContent).toBe('afile.txtnew-1.txt');
         expect(document.querySelector('.original-value-icon')).toBeInTheDocument();
     });
+
+    test('with inheritedFieldMsg, without inherited value', () => {
+        renderWithAppContext(
+            <AuditDetails
+                changeDetails={AuditDetailsModel.create({
+                    oldData: { a: 1 },
+                    newData: { a: 2 },
+                })}
+                inheritedFieldMsg="This value is inherited from a parent folder."
+                rowId={1}
+                user={TEST_USER_APP_ADMIN}
+            />,
+            { serverContext: { user: TEST_USER_APP_ADMIN } }
+        );
+        expect(document.querySelector('.panel-body').textContent).toBe('a12');
+        expect(document.querySelectorAll('.fa-info-circle')).toHaveLength(0);
+    });
+
+    test('with inherited value', () => {
+        renderWithAppContext(
+            <AuditDetails
+                changeDetails={AuditDetailsModel.create({
+                    newData: { a: AUDIT_DETAIL_FIELD_VALUE_INHERITED },
+                    oldData: {}
+                })}
+                inheritedFieldMsg="This value is inherited from a parent folder."
+                rowId={1}
+                user={TEST_USER_APP_ADMIN}
+            />,
+            { serverContext: { user: TEST_USER_APP_ADMIN } }
+        );
+        expect(document.querySelector('.panel-body').textContent).toBe('aInherited');
+        expect(document.querySelectorAll('.fa-info-circle')).toHaveLength(1);
+    });
+
+    test('with inherited value, no inheritedFieldMsg', () => {
+        renderWithAppContext(
+            <AuditDetails
+                changeDetails={AuditDetailsModel.create({
+                    newData: { a: AUDIT_DETAIL_FIELD_VALUE_INHERITED },
+                    oldData: {}
+                })}
+                rowId={1}
+                user={TEST_USER_APP_ADMIN}
+            />,
+            { serverContext: { user: TEST_USER_APP_ADMIN } }
+        );
+        expect(document.querySelector('.panel-body').textContent).toBe('aInherited');
+        expect(document.querySelectorAll('.fa-info-circle')).toHaveLength(0);
+    });
+
+    test('with inherited value, with oldData', () => {
+        renderWithAppContext(
+            <AuditDetails
+                changeDetails={AuditDetailsModel.create({
+                    oldData: { a: 1 },
+                    newData: { a: AUDIT_DETAIL_FIELD_VALUE_INHERITED },
+                })}
+                inheritedFieldMsg="This value is inherited from a parent folder."
+                rowId={1}
+                user={TEST_USER_APP_ADMIN}
+            />,
+            { serverContext: { user: TEST_USER_APP_ADMIN } }
+        );
+        expect(document.querySelector('.panel-body').textContent).toBe('a1Inherited');
+        expect(document.querySelectorAll('.fa-info-circle')).toHaveLength(1);
+    });
+
+    test('with inherited value, with oldData inherited', () => {
+        renderWithAppContext(
+            <AuditDetails
+                changeDetails={AuditDetailsModel.create({
+                    oldData: { a: AUDIT_DETAIL_FIELD_VALUE_INHERITED },
+                    newData: { a: 1 },
+                })}
+                inheritedFieldMsg="This value is inherited from a parent folder."
+                rowId={1}
+                user={TEST_USER_APP_ADMIN}
+            />,
+            { serverContext: { user: TEST_USER_APP_ADMIN } }
+        );
+        expect(document.querySelector('.panel-body').textContent).toBe('aInherited1');
+        expect(document.querySelectorAll('.fa-info-circle')).toHaveLength(0);
+    });
+
 });

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -23,11 +23,11 @@ interface Props extends PropsWithChildren {
     fieldValueRenderer?: (label, value, displayValue, hasProvidedValue?: boolean) => any;
     gridColumnRenderer?: (data: any, row: any, displayValue: any) => any;
     gridData?: List<Map<string, any>>;
+    inheritedFieldMsg?: string;
     rowId?: number;
     summary?: string;
     title?: string;
     user: User;
-    inheritedFieldMsg?: string;
 }
 
 export class AuditDetails extends Component<Props> {
@@ -43,8 +43,7 @@ export class AuditDetails extends Component<Props> {
     getValueDisplay = (field: string, value: string, hasProvidedValues: boolean, isInherited?: boolean): any => {
         const { fieldValueRenderer } = this.props;
 
-        if (isInherited)
-            return <span className="timeline-inherited-data display-light">Inherited</span>;
+        if (isInherited) return <span className="timeline-inherited-data display-light">Inherited</span>;
 
         let displayVal: any = value;
         if (value == null || value === '') displayVal = 'NA';
@@ -71,7 +70,12 @@ export class AuditDetails extends Component<Props> {
 
         if (!user.isSignedIn && AuditDetails.isUserFieldLabel(field)) return null;
 
-        const oldValue = this.getValueDisplay(field, oldVal, !!(providedVal || providedDeltaVal), oldVal === AUDIT_DETAIL_FIELD_VALUE_INHERITED);
+        const oldValue = this.getValueDisplay(
+            field,
+            oldVal,
+            !!(providedVal || providedDeltaVal),
+            oldVal === AUDIT_DETAIL_FIELD_VALUE_INHERITED
+        );
 
         const isInherited = newVal === AUDIT_DETAIL_FIELD_VALUE_INHERITED;
 
@@ -97,7 +101,7 @@ export class AuditDetails extends Component<Props> {
                                 <div className="ws-pre-wrap">{providedVals}</div>
                             </LabelHelpTip>
                         )}
-                        {(isInherited && !!inheritedFieldMsg )&& (
+                        {isInherited && !!inheritedFieldMsg && (
                             <LabelHelpTip
                                 iconComponent={<i className="fa fa-info-circle left-padding" />}
                                 placement="top"

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -15,6 +15,7 @@ import { UserLink } from '../user/UserLink';
 import { getEventDataValueDisplay } from './utils';
 import { AuditDetailsModel } from './models';
 import { LabelHelpTip } from '../base/LabelHelpTip';
+import { AUDIT_DETAIL_FIELD_VALUE_INHERITED } from './constants';
 
 interface Props extends PropsWithChildren {
     changeDetails?: AuditDetailsModel;
@@ -26,6 +27,7 @@ interface Props extends PropsWithChildren {
     summary?: string;
     title?: string;
     user: User;
+    inheritedFieldMsg?: string;
 }
 
 export class AuditDetails extends Component<Props> {
@@ -38,8 +40,11 @@ export class AuditDetails extends Component<Props> {
         return ['created by', 'createdby', 'modified by', 'modifiedby'].indexOf(field.toLowerCase()) > -1;
     }
 
-    getValueDisplay = (field: string, value: string, hasProvidedValues: boolean): any => {
+    getValueDisplay = (field: string, value: string, hasProvidedValues: boolean, isInherited?: boolean): any => {
         const { fieldValueRenderer } = this.props;
+
+        if (isInherited)
+            return <span className="timeline-inherited-data display-light">Inherited</span>;
 
         let displayVal: any = value;
         if (value == null || value === '') displayVal = 'NA';
@@ -62,12 +67,15 @@ export class AuditDetails extends Component<Props> {
         isUpdate: boolean,
         isInsert: boolean
     ): React.ReactNode {
-        const { user } = this.props;
+        const { user, inheritedFieldMsg } = this.props;
 
         if (!user.isSignedIn && AuditDetails.isUserFieldLabel(field)) return null;
 
-        const oldValue = this.getValueDisplay(field, oldVal, !!(providedVal || providedDeltaVal));
-        const newValue = this.getValueDisplay(field, newVal, !!(providedVal || providedDeltaVal));
+        const oldValue = this.getValueDisplay(field, oldVal, !!(providedVal || providedDeltaVal), oldVal === AUDIT_DETAIL_FIELD_VALUE_INHERITED);
+
+        const isInherited = newVal === AUDIT_DETAIL_FIELD_VALUE_INHERITED;
+
+        const newValue = this.getValueDisplay(field, newVal, !!(providedVal || providedDeltaVal), isInherited);
         const changed = oldValue !== newValue;
         const providedVals = [];
         if (providedDeltaVal) {
@@ -87,6 +95,14 @@ export class AuditDetails extends Component<Props> {
                                 placement="top"
                             >
                                 <div className="ws-pre-wrap">{providedVals}</div>
+                            </LabelHelpTip>
+                        )}
+                        {(isInherited && !!inheritedFieldMsg )&& (
+                            <LabelHelpTip
+                                iconComponent={<i className="fa fa-info-circle left-padding" />}
+                                placement="top"
+                            >
+                                <div className="ws-pre-wrap">{inheritedFieldMsg}</div>
                             </LabelHelpTip>
                         )}
                     </span>

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -120,3 +120,5 @@ export const COMMON_AUDIT_QUERIES: AuditQuery[] = [
 ];
 
 export const EXPERIMENT_AUDIT_EVENT = 'experimentauditevent';
+
+export const AUDIT_DETAIL_FIELD_VALUE_INHERITED = '$$aliquot-inherited-field$$';

--- a/packages/components/src/internal/components/auditlog/models.ts
+++ b/packages/components/src/internal/components/auditlog/models.ts
@@ -102,7 +102,7 @@ export class TimelineEventModel extends Record({
     }
 
     // timezoneStr used for jest test only, to accommodate teamcity timezone difference
-    static create(raw: any, timezoneStr?: string, inheritedFields?: string[]): TimelineEventModel {
+    static create(raw: any, timezoneStr?: string, inheritedFieldKeys?: string[]): TimelineEventModel {
         const fields = {} as TimelineEventModel;
         fields.rowId = raw['rowId'];
         fields.eventType = raw['eventType'];
@@ -127,8 +127,8 @@ export class TimelineEventModel extends Record({
             fields.metadata = fromJS(metaRows);
         }
 
-        if (raw.oldData) fields.oldData = getAuditDetailMap(raw.oldData, inheritedFields);
-        if (raw.newData) fields.newData = getAuditDetailMap(raw.newData, inheritedFields);
+        if (raw.oldData) fields.oldData = getAuditDetailMap(raw.oldData, inheritedFieldKeys);
+        if (raw.newData) fields.newData = getAuditDetailMap(raw.newData, inheritedFieldKeys);
         if (raw.providedValues) fields.providedValues = raw.providedValues;
         if (raw.providedDeltaValues) fields.providedDeltaValues = raw.providedDeltaValues;
 

--- a/packages/components/src/internal/components/auditlog/models.ts
+++ b/packages/components/src/internal/components/auditlog/models.ts
@@ -5,6 +5,7 @@
 import { fromJS, List, Map, Record } from 'immutable';
 
 import { ASSAYS_KEY, SAMPLES_KEY } from '../../app/constants';
+import { getAuditDetailMap } from './utils';
 
 export class AuditDetailsModel extends Record({
     rowId: undefined,
@@ -101,7 +102,7 @@ export class TimelineEventModel extends Record({
     }
 
     // timezoneStr used for jest test only, to accommodate teamcity timezone difference
-    static create(raw: any, timezoneStr?: string): TimelineEventModel {
+    static create(raw: any, timezoneStr?: string, inheritedFields?: string[]): TimelineEventModel {
         const fields = {} as TimelineEventModel;
         fields.rowId = raw['rowId'];
         fields.eventType = raw['eventType'];
@@ -126,8 +127,8 @@ export class TimelineEventModel extends Record({
             fields.metadata = fromJS(metaRows);
         }
 
-        if (raw.oldData) fields.oldData = fromJS(raw.oldData);
-        if (raw.newData) fields.newData = fromJS(raw.newData);
+        if (raw.oldData) fields.oldData = getAuditDetailMap(raw.oldData, inheritedFields);
+        if (raw.newData) fields.newData = getAuditDetailMap(raw.newData, inheritedFields);
         if (raw.providedValues) fields.providedValues = raw.providedValues;
         if (raw.providedDeltaValues) fields.providedDeltaValues = raw.providedDeltaValues;
 

--- a/packages/components/src/internal/components/auditlog/models.ts
+++ b/packages/components/src/internal/components/auditlog/models.ts
@@ -93,7 +93,7 @@ export class TimelineEventModel extends Record({
     declare providedDeltaValues?: Map<string, string>;
     declare userComment?: string;
 
-    constructor(values?: { [key: string]: any }) {
+    constructor(values?: Record<string, any>) {
         super(values);
     }
 

--- a/packages/components/src/internal/components/auditlog/utils.test.ts
+++ b/packages/components/src/internal/components/auditlog/utils.test.ts
@@ -13,10 +13,10 @@ import {
     TEST_LKSM_STARTER_MODULE_CONTEXT,
 } from '../../productFixtures';
 
-import { getAuditQueries, getEventDataValueDisplay, getTimelineEntityUrl } from './utils';
+import { getAuditDetailMap, getAuditQueries, getEventDataValueDisplay, getTimelineEntityUrl } from './utils';
 import {
     ASSAY_AUDIT_QUERY,
-    ASSAY_RESULT_AUDIT_QUERY,
+    ASSAY_RESULT_AUDIT_QUERY, AUDIT_DETAIL_FIELD_VALUE_INHERITED,
     DATACLASS_DATA_UPDATE_AUDIT_QUERY,
     INVENTORY_AUDIT_QUERY,
     NOTEBOOK_AUDIT_QUERY,
@@ -160,4 +160,49 @@ describe('utils', () => {
         );
         expect(getTimelineEntityUrl({ urlType: 'inventoryBox', value: 101 }).toHref()).toEqual('/labkey/DefaultTestContainer/freezermanager-app.view#/boxes/101');
     });
+
+    describe('getAuditDetailMap', () => {
+        it('data is empty', () => {
+            expect(getAuditDetailMap(null).isEmpty()).toBe(true);
+            expect(getAuditDetailMap(undefined).isEmpty()).toBe(true);
+            expect(getAuditDetailMap({}).isEmpty()).toBe(true);
+            expect(getAuditDetailMap({}, ['field1']).isEmpty()).toBe(true);
+        });
+
+        it('when no inherited fields are provided', () => {
+            const data = { field1: 'value1', field2: 'value2' };
+            const result = getAuditDetailMap(data);
+            expect(result.toJS()).toEqual(data);
+        });
+
+        it('moves inherited fields to the bottom of the OrderedMap', () => {
+            const data = { field1: 'value1', field2: null, field3: 'value3' };
+            const inheritedFields = ['field2'];
+            const result = getAuditDetailMap(data, inheritedFields);
+            expect(result.toJS()).toEqual({
+                field1: 'value1',
+                field3: 'value3',
+                field2: AUDIT_DETAIL_FIELD_VALUE_INHERITED,
+            });
+        });
+
+        it('case-insensitive inherited fields', () => {
+            const data = { Field1: 'value1', FIELD2: null, field3: 'value3' };
+            const inheritedFields = ['field2'];
+            const result = getAuditDetailMap(data, inheritedFields);
+            expect(result.toJS()).toEqual({
+                Field1: 'value1',
+                field3: 'value3',
+                FIELD2: AUDIT_DETAIL_FIELD_VALUE_INHERITED,
+            });
+        });
+
+        it('absent inherited fields', () => {
+            const data = { field1: 'value1', field2: 'value2' };
+            const inheritedFields = ['field3'];
+            const result = getAuditDetailMap(data, inheritedFields);
+            expect(result.toJS()).toEqual(data);
+        });
+    });
+
 });

--- a/packages/components/src/internal/components/auditlog/utils.test.ts
+++ b/packages/components/src/internal/components/auditlog/utils.test.ts
@@ -16,7 +16,8 @@ import {
 import { getAuditDetailMap, getAuditQueries, getEventDataValueDisplay, getTimelineEntityUrl } from './utils';
 import {
     ASSAY_AUDIT_QUERY,
-    ASSAY_RESULT_AUDIT_QUERY, AUDIT_DETAIL_FIELD_VALUE_INHERITED,
+    ASSAY_RESULT_AUDIT_QUERY,
+    AUDIT_DETAIL_FIELD_VALUE_INHERITED,
     DATACLASS_DATA_UPDATE_AUDIT_QUERY,
     INVENTORY_AUDIT_QUERY,
     NOTEBOOK_AUDIT_QUERY,
@@ -68,7 +69,12 @@ describe('getAuditQueries', () => {
             inventory: {},
             biologics: {},
             core: {
-                productFeatures: [ProductFeature.Workflow, ProductFeature.ELN, ProductFeature.Assay, ProductFeature.BiologicsRegistry],
+                productFeatures: [
+                    ProductFeature.Workflow,
+                    ProductFeature.ELN,
+                    ProductFeature.Assay,
+                    ProductFeature.BiologicsRegistry,
+                ],
             },
         };
         const auditQueries = getAuditQueries(moduleContext);
@@ -158,7 +164,9 @@ describe('utils', () => {
         expect(getTimelineEntityUrl({ urlType: 'inventoryLocation', value: ['freezer1', 101] }).toHref()).toEqual(
             '#/rd/freezerLocation/101'
         );
-        expect(getTimelineEntityUrl({ urlType: 'inventoryBox', value: 101 }).toHref()).toEqual('/labkey/DefaultTestContainer/freezermanager-app.view#/boxes/101');
+        expect(getTimelineEntityUrl({ urlType: 'inventoryBox', value: 101 }).toHref()).toEqual(
+            '/labkey/DefaultTestContainer/freezermanager-app.view#/boxes/101'
+        );
     });
 
     describe('getAuditDetailMap', () => {
@@ -204,5 +212,4 @@ describe('utils', () => {
             expect(result.toJS()).toEqual(data);
         });
     });
-
 });

--- a/packages/components/src/internal/components/auditlog/utils.ts
+++ b/packages/components/src/internal/components/auditlog/utils.ts
@@ -3,7 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import React, { ReactNode } from 'react';
-import { Map } from 'immutable';
+import { Map, OrderedMap } from 'immutable';
 
 import { FREEZER_MANAGER_PRODUCT_ID, isSampleManagerEnabled } from '../../app/products';
 import {
@@ -32,8 +32,9 @@ import {
     SOURCE_AUDIT_QUERY,
     WORKFLOW_AUDIT_QUERY,
     REPORT_AUDIT_QUERY,
-    ASSAY_RESULT_AUDIT_QUERY,
+    ASSAY_RESULT_AUDIT_QUERY, AUDIT_DETAIL_FIELD_VALUE_INHERITED,
 } from './constants';
+import { QueryKey } from '@labkey/api';
 
 export function getAuditQueries(ctx: ModuleContext): AuditQuery[] {
     const queries = [...COMMON_AUDIT_QUERIES];
@@ -143,4 +144,26 @@ export function getTimelineEntityUrl(d: Record<string, any>): AppURL {
     }
 
     return url;
+}
+
+export function getAuditDetailMap(data: Record<string, string>, inheritedFields?: string[]): OrderedMap<string, string> {
+    if (inheritedFields?.length > 0) {
+        // sort fields.newData so that inherited fields are at the bottom
+        const inheritedFieldsLc = inheritedFields.map(f => f.toLowerCase());
+        const newData = data ?? {};
+        const sortedNewData = {} as any;
+        const last = {};
+        for (const field of Object.keys(newData)) {
+            if (!newData[field] && inheritedFieldsLc.indexOf(QueryKey.encodePart(field).toLowerCase()) > -1) {
+                last[field] = AUDIT_DETAIL_FIELD_VALUE_INHERITED;
+            }
+            else {
+                sortedNewData[field] = newData[field];
+            }
+        }
+        Object.assign(sortedNewData, last);
+        return OrderedMap(sortedNewData);
+    }
+
+    return OrderedMap(data);
 }

--- a/packages/components/src/internal/components/auditlog/utils.ts
+++ b/packages/components/src/internal/components/auditlog/utils.ts
@@ -22,17 +22,18 @@ import { ModuleContext } from '../base/ServerContext';
 
 import {
     ASSAY_AUDIT_QUERY,
+    ASSAY_RESULT_AUDIT_QUERY,
+    AUDIT_DETAIL_FIELD_VALUE_INHERITED,
     AuditQuery,
     COMMON_AUDIT_QUERIES,
+    CONTAINER_AUDIT_QUERY,
     DATACLASS_DATA_UPDATE_AUDIT_QUERY,
     NOTEBOOK_AUDIT_QUERY,
     NOTEBOOK_REVIEW_AUDIT_QUERY,
-    CONTAINER_AUDIT_QUERY,
     REGISTRY_AUDIT_QUERY,
+    REPORT_AUDIT_QUERY,
     SOURCE_AUDIT_QUERY,
     WORKFLOW_AUDIT_QUERY,
-    REPORT_AUDIT_QUERY,
-    ASSAY_RESULT_AUDIT_QUERY, AUDIT_DETAIL_FIELD_VALUE_INHERITED,
 } from './constants';
 import { QueryKey } from '@labkey/api';
 
@@ -110,33 +111,33 @@ export function getTimelineEntityUrl(d: Record<string, any>): AppURL {
         const { urlType, value } = d;
 
         switch (urlType) {
-            case SAMPLES_KEY:
-                url = AppURL.create('rd', SAMPLES_KEY, value);
-                break;
-            case WORKFLOW_KEY:
-                url = AppURL.create(WORKFLOW_KEY, value);
-                break;
-            case ASSAYS_KEY:
-                url = AppURL.create(ASSAYS_KEY, 'general', value);
-                break;
-            case 'workflowTemplate':
-                url = AppURL.create(WORKFLOW_KEY, 'template', value);
-                break;
-            case USER_KEY:
-                url = undefined; // handle display render via UserLink
-                break;
             case 'assayRun':
                 if (Array.isArray(value) && value.length > 1) {
                     url = AppURL.create(ASSAYS_KEY, 'general', value[0], 'runs', value[1]);
                 }
+                break;
+            case ASSAYS_KEY:
+                url = AppURL.create(ASSAYS_KEY, 'general', value);
+                break;
+            case 'inventoryBox':
+                url = AppURL.create(BOXES_KEY, value).setProductId(FREEZER_MANAGER_PRODUCT_ID);
                 break;
             case 'inventoryLocation':
                 if (Array.isArray(value) && value.length > 1) {
                     url = AppURL.create('rd', 'freezerLocation', value[1]);
                 }
                 break;
-            case 'inventoryBox':
-                url = AppURL.create(BOXES_KEY, value).setProductId(FREEZER_MANAGER_PRODUCT_ID);
+            case SAMPLES_KEY:
+                url = AppURL.create('rd', SAMPLES_KEY, value);
+                break;
+            case USER_KEY:
+                url = undefined; // handle display render via UserLink
+                break;
+            case WORKFLOW_KEY:
+                url = AppURL.create(WORKFLOW_KEY, value);
+                break;
+            case 'workflowTemplate':
+                url = AppURL.create(WORKFLOW_KEY, 'template', value);
                 break;
             default:
                 break;
@@ -146,7 +147,10 @@ export function getTimelineEntityUrl(d: Record<string, any>): AppURL {
     return url;
 }
 
-export function getAuditDetailMap(data: Record<string, string>, inheritedFields?: string[]): OrderedMap<string, string> {
+export function getAuditDetailMap(
+    data: Record<string, string>,
+    inheritedFields?: string[]
+): OrderedMap<string, string> {
     if (inheritedFields?.length > 0) {
         // sort fields.newData so that inherited fields are at the bottom
         const inheritedFieldsLc = inheritedFields.map(f => f.toLowerCase());
@@ -156,8 +160,7 @@ export function getAuditDetailMap(data: Record<string, string>, inheritedFields?
         for (const field of Object.keys(newData)) {
             if (!newData[field] && inheritedFieldsLc.indexOf(QueryKey.encodePart(field).toLowerCase()) > -1) {
                 last[field] = AUDIT_DETAIL_FIELD_VALUE_INHERITED;
-            }
-            else {
+            } else {
                 sortedNewData[field] = newData[field];
             }
         }

--- a/packages/components/src/internal/components/auditlog/utils.ts
+++ b/packages/components/src/internal/components/auditlog/utils.ts
@@ -149,11 +149,11 @@ export function getTimelineEntityUrl(d: Record<string, any>): AppURL {
 
 export function getAuditDetailMap(
     data: Record<string, string>,
-    inheritedFields?: string[]
+    inheritedFieldKeys?: string[]
 ): OrderedMap<string, string> {
-    if (inheritedFields?.length > 0) {
+    if (inheritedFieldKeys?.length > 0) {
         // sort fields.newData so that inherited fields are at the bottom
-        const inheritedFieldsLc = inheritedFields.map(f => f.toLowerCase());
+        const inheritedFieldsLc = inheritedFieldKeys.map(f => f.toLowerCase());
         const newData = data ?? {};
         const sortedNewData = {} as any;
         const last = {};

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -83,7 +83,7 @@ export interface SamplesAPIWrapper {
         sort: string | undefined
     ) => Promise<ISelectRowsResult>;
 
-    getTimelineEvents: (sampleId: number, timezone?: string) => Promise<TimelineEventModel[]>;
+    getTimelineEvents: (sampleId: number, timezone?: string, inheritedFields?: string[]) => Promise<TimelineEventModel[]>;
 
     hasExistingSamples: (isRoot?: boolean, containerPath?: string) => Promise<boolean>;
 

--- a/packages/components/src/internal/components/samples/APIWrapper.ts
+++ b/packages/components/src/internal/components/samples/APIWrapper.ts
@@ -83,7 +83,11 @@ export interface SamplesAPIWrapper {
         sort: string | undefined
     ) => Promise<ISelectRowsResult>;
 
-    getTimelineEvents: (sampleId: number, timezone?: string, inheritedFields?: string[]) => Promise<TimelineEventModel[]>;
+    getTimelineEvents: (
+        sampleId: number,
+        timezone?: string,
+        inheritedFields?: string[]
+    ) => Promise<TimelineEventModel[]>;
 
     hasExistingSamples: (isRoot?: boolean, containerPath?: string) => Promise<boolean>;
 

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -506,7 +506,11 @@ export async function getLookupRowIdsFromSelection(
 }
 
 // optional timezone param used for teamcity jest test only
-export function getTimelineEvents(sampleId: number, timezone?: string, inheritedFields?: string[]): Promise<TimelineEventModel[]> {
+export function getTimelineEvents(
+    sampleId: number,
+    timezone?: string,
+    inheritedFields?: string[]
+): Promise<TimelineEventModel[]> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getTimeline.api'),

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -506,7 +506,7 @@ export async function getLookupRowIdsFromSelection(
 }
 
 // optional timezone param used for teamcity jest test only
-export function getTimelineEvents(sampleId: number, timezone?: string): Promise<TimelineEventModel[]> {
+export function getTimelineEvents(sampleId: number, timezone?: string, inheritedFields?: string[]): Promise<TimelineEventModel[]> {
     return new Promise((resolve, reject) => {
         Ajax.request({
             url: ActionURL.buildURL(SAMPLE_MANAGER_APP_PROPERTIES.controllerName, 'getTimeline.api'),
@@ -516,7 +516,7 @@ export function getTimelineEvents(sampleId: number, timezone?: string): Promise<
                     const events: TimelineEventModel[] = [];
                     if (response.events) {
                         (response.events as []).forEach(event =>
-                            events.push(TimelineEventModel.create(event, timezone))
+                            events.push(TimelineEventModel.create(event, timezone, inheritedFields))
                         );
                     }
                     resolve(events);


### PR DESCRIPTION
#### Rationale
Instead of showing NA for aliquot inherited parent values, we are switching to show "inherited'.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1856
- https://github.com/LabKey/labkey-ui-premium/pull/821
- https://github.com/LabKey/platform/pull/7066
- https://github.com/LabKey/limsModules/pull/1684

#### Changes
- Display "inherited" instead of NA for aliquot's parent fields in timeline view
- Preserve ordering of new and old record map for timeline event detail
