### PR TITLE
Issue 53979: TextInput to handle non-finite numeric values

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3",
+  "version": "6.62.3-nonFinite53979.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.3",
+      "version": "6.62.3-nonFinite53979.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3-nonFinite53979.1",
+  "version": "6.62.6-nonFinite53979.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.3-nonFinite53979.1",
+      "version": "6.62.6-nonFinite53979.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.6-nonFinite53979.1",
+  "version": "6.62.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.6-nonFinite53979.1",
+      "version": "6.62.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3-nonFinite53979.0",
+  "version": "6.62.3-nonFinite53979.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.3-nonFinite53979.0",
+      "version": "6.62.3-nonFinite53979.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3-nonFinite53979.0",
+  "version": "6.62.3-nonFinite53979.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.6-nonFinite53979.1",
+  "version": "6.62.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.3",
+  "version": "6.62.3-nonFinite53979.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD September 2025
+### version 6.62.6
+*Released*: 29 September 2025
 - Issue 53979: TextInput to handle non-finite numeric values
   - don't set input type = "number" since it will drop non-finite values
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD September 2025
+- Issue 53979: TextInput to handle non-finite numeric values
+  - don't set input type = "number" since it will drop non-finite values
+
 ### version 6.62.3
 *Released*: 18 September 2025
 - Workflow: Change Required Template Fields to be Required at the start of a Job

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -127,17 +127,17 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
         } = rest;
         let { validations } = inputProps;
 
-        let type = 'text';
         let step: string;
 
         if (queryColumn && !validations) {
+            // Issue 53979: don't set input type = "number" for integer or float columns because that prevents
+            // entry of values like "5.48490684590685e+7200" which are valid numbers, and are dropped when the input
+            // type = "number".  We will rely on the isInt / isFloat validation instead.
             if (queryColumn.jsonType === 'int') {
                 step = '1';
-                type = 'number';
                 validations = 'isInt';
             } else if (queryColumn.jsonType === 'float') {
                 step = 'any';
-                type = 'number';
                 validations = 'isFloat';
             }
         }
@@ -163,7 +163,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
                     labelClassName={showLabel ? labelClassName : 'hide-label'}
                     onChange={this.onChange}
                     step={step}
-                    type={type}
+                    type="text"
                     validations={validations}
                     value={this.getInputValue()}
                 />

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -125,22 +125,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
             isUpdate,
             ...inputProps
         } = rest;
-        let { validations } = inputProps;
 
-        let step: string;
-
-        if (queryColumn && !validations) {
-            // Issue 53979: don't set input type = "number" for integer or float columns because that prevents
-            // entry of values like "5.48490684590685e+7200" which are valid numbers, and are dropped when the input
-            // type = "number".  We will rely on the isInt / isFloat validation instead.
-            if (queryColumn.jsonType === 'int') {
-                step = '1';
-                validations = 'isInt';
-            } else if (queryColumn.jsonType === 'float') {
-                step = 'any';
-                validations = 'isFloat';
-            }
-        }
 
         let help: string;
         // Issue 52367: Don't show the message if we have a name that can be edited
@@ -162,9 +147,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
                     label={this.renderLabel()}
                     labelClassName={showLabel ? labelClassName : 'hide-label'}
                     onChange={this.onChange}
-                    step={step}
                     type="text"
-                    validations={validations}
                     value={this.getInputValue()}
                 />
                 {includeSpacesWarning && <InternalSpacesWarning value={this.state.inputValue} />}


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53979

The TextInput component was setting the input type = "number" for int and float fields. This has issues when the user tries to enter non-finite values for the decimal field (see issue description). There are a few scenarios where the user tries to enter the value but the onChange handler for the field is called with an empty value instead of the actual value. This PR changes the TextInput to always use input type = "text" and handle the numeric validation separately.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1858
- https://github.com/LabKey/labkey-ui-premium/pull/824
- https://github.com/LabKey/limsModules/pull/1691

#### Changes
- TextInput not to set input type = "number"
