### PR TITLE
Issue 53328: AssayDefinitionModel.hasLookup to only consider the first sample lookup column for assay import cases

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.7",
+  "version": "6.62.7-assaySampleLookup53328.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.7",
+      "version": "6.62.7-assaySampleLookup53328.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.7-assaySampleLookup53328.1",
+  "version": "6.62.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.7-assaySampleLookup53328.1",
+      "version": "6.62.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.7-assaySampleLookup53328.0",
+  "version": "6.62.7-assaySampleLookup53328.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.7-assaySampleLookup53328.0",
+      "version": "6.62.7-assaySampleLookup53328.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.7-assaySampleLookup53328.0",
+  "version": "6.62.7-assaySampleLookup53328.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.7",
+  "version": "6.62.7-assaySampleLookup53328.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.7-assaySampleLookup53328.1",
+  "version": "6.62.8",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.62.8
+*Released*: 3 October 2025
 - Issue 53328: AssayDefinitionModel.hasLookup to only consider the first sample lookup column for assay import cases
 
 ### version 6.62.7

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 53328: AssayDefinitionModel.hasLookup to only consider the first sample lookup column for assay import cases
+
 ### version 6.62.7
 *Released*: 29 September 2025
 - Enumerate plate, plate set auditing events

--- a/packages/components/src/internal/AssayDefinitionModel.test.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.test.ts
@@ -37,11 +37,27 @@ describe('AssayDefinitionModel', () => {
         expect(sampleColumn.column.fieldKey).toBe('SampleID');
     });
 
-    test('hasLookup()', () => {
+    test('hasLookup() with sample lookup', () => {
         const modelWithSampleId = AssayDefinitionModel.create(assayDefJSON);
         expect(modelWithSampleId.hasLookup(new SchemaQuery('samples', 'Samples'))).toBeTruthy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('samples', 'Samples'), true)).toBeTruthy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('samples', 'Samples'), false, true)).toBeTruthy();
         expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Study'))).toBeTruthy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Study'), true)).toBeTruthy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Study'), false, true)).toBeFalsy();
         expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Other'))).toBeFalsy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Other'), true)).toBeFalsy();
+        expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Other'), false, true)).toBeFalsy();
+    });
+
+    test('hasLookup() with sample lookup', () => {
+        const modelWithout = AssayDefinitionModel.create(assayDefNoSampleIdJSON);
+        expect(modelWithout.hasLookup(new SchemaQuery('samples', 'Samples'))).toBeFalsy();
+        expect(modelWithout.hasLookup(new SchemaQuery('samples', 'Samples'), true)).toBeFalsy();
+        expect(modelWithout.hasLookup(new SchemaQuery('samples', 'Samples'), false, true)).toBeFalsy();
+        expect(modelWithout.hasLookup(new SchemaQuery('study', 'Study'))).toBeTruthy();
+        expect(modelWithout.hasLookup(new SchemaQuery('study', 'Study'), true)).toBeTruthy();
+        expect(modelWithout.hasLookup(new SchemaQuery('study', 'Study'), false, true)).toBeFalsy();
     });
 
     test('getSampleColumnFieldKeys()', () => {

--- a/packages/components/src/internal/AssayDefinitionModel.test.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.test.ts
@@ -50,7 +50,7 @@ describe('AssayDefinitionModel', () => {
         expect(modelWithSampleId.hasLookup(new SchemaQuery('study', 'Other'), false, true)).toBeFalsy();
     });
 
-    test('hasLookup() with sample lookup', () => {
+    test('hasLookup() without sample lookup', () => {
         const modelWithout = AssayDefinitionModel.create(assayDefNoSampleIdJSON);
         expect(modelWithout.hasLookup(new SchemaQuery('samples', 'Samples'))).toBeFalsy();
         expect(modelWithout.hasLookup(new SchemaQuery('samples', 'Samples'), true)).toBeFalsy();

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -14,6 +14,7 @@ import { AppURL } from './url/AppURL';
 import { SCHEMAS } from './schemas';
 import { ASSAYS_KEY } from './app/constants';
 import { ComponentsAPIWrapper } from './APIWrapper';
+import {isAllSamplesSchema} from "./components/samples/utils";
 
 export enum AssayDomainTypes {
     BATCH = 'Batch',
@@ -173,7 +174,7 @@ export class AssayDefinitionModel extends ImmutableRecord({
         const findLookup = (col: QueryColumn): boolean => {
             if (col.isLookup()) {
                 const lookupSQ = col.lookup.schemaQuery;
-                const isAllSamplesLookup = SCHEMAS.EXP_TABLES.MATERIALS.isEqual(lookupSQ);
+                const isAllSamplesLookup = isAllSamplesSchema(lookupSQ);
                 const isMatch = targetSQ.isEqual(lookupSQ) || (isTargetAllSamples && isAllSamplesLookup);
 
                 // 35881: If targetSQ is a Sample Set then allow targeting exp.materials table as well

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -1,4 +1,4 @@
-import { fromJS, List, Map, Record as ImmutableRecord } from 'immutable';
+import { fromJS, Record as ImmutableRecord, List, Map } from 'immutable';
 import { Filter } from '@labkey/api';
 
 import { ExtendedMap } from '../public/ExtendedMap';
@@ -14,7 +14,7 @@ import { AppURL } from './url/AppURL';
 import { SCHEMAS } from './schemas';
 import { ASSAYS_KEY } from './app/constants';
 import { ComponentsAPIWrapper } from './APIWrapper';
-import {isAllSamplesSchema} from "./components/samples/utils";
+import { isAllSamplesSchema } from './components/samples/utils';
 
 export enum AssayDomainTypes {
     BATCH = 'Batch',
@@ -126,7 +126,7 @@ export class AssayDefinitionModel extends ImmutableRecord({
         selectionKey?: string,
         filters?: Filter.IFilter[],
         containerPath?: string,
-        params?: Record<string, string | number | boolean>
+        params?: Record<string, boolean | number | string>
     ): string {
         let url: string;
         // Note, will need to handle the re-import run case separately. Possibly introduce another URL via links

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -162,7 +162,7 @@ export class AssayDefinitionModel extends ImmutableRecord({
         return AppURL.create(ASSAYS_KEY, this.type, this.name, 'runs');
     }
 
-    hasLookup(targetSQ: SchemaQuery, isPicklist?: boolean): boolean {
+    hasLookup(targetSQ: SchemaQuery, isPicklist?: boolean, forImport = false): boolean {
         const isSampleSet = targetSQ.hasSchema(SCHEMAS.SAMPLE_SETS.SCHEMA);
 
         // 44339: the SourceSamples custom query is backed by exp.materials
@@ -173,13 +173,12 @@ export class AssayDefinitionModel extends ImmutableRecord({
         const findLookup = (col: QueryColumn): boolean => {
             if (col.isLookup()) {
                 const lookupSQ = col.lookup.schemaQuery;
-                const isMatch =
-                    targetSQ.isEqual(lookupSQ) ||
-                    (isTargetAllSamples && SCHEMAS.EXP_TABLES.MATERIALS.isEqual(lookupSQ));
+                const isAllSamplesLookup = SCHEMAS.EXP_TABLES.MATERIALS.isEqual(lookupSQ);
+                const isMatch = targetSQ.isEqual(lookupSQ) || (isTargetAllSamples && isAllSamplesLookup);
 
                 // 35881: If targetSQ is a Sample Set then allow targeting exp.materials table as well
                 if (isSampleSet) {
-                    return isMatch || SCHEMAS.EXP_TABLES.MATERIALS.isEqual(lookupSQ);
+                    return isMatch || isAllSamplesLookup;
                 }
 
                 return isMatch;
@@ -187,6 +186,12 @@ export class AssayDefinitionModel extends ImmutableRecord({
 
             return false;
         };
+
+        // Issue 53328: only consider the first sample lookup column here since it will be used on the assay import page
+        if (forImport) {
+            const sampleLookupCol = this.getSampleColumn();
+            return sampleLookupCol ? findLookup(sampleLookupCol.column) : false;
+        }
 
         // Traditional for loop so we can short circuit.
         for (const k of Object.keys(AssayDomainTypes)) {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53328
The sample assay import menu items should only show an assay if the "first" sample column in the assay design is valid for the given sample type (i.e. lookup to All Samples or the specific sample type).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1859
- https://github.com/LabKey/labkey-ui-premium/pull/826
- https://github.com/LabKey/limsModules/pull/1701

#### Changes
- assayDef.hasLookup to use just the first sample column for assay import case
