### PR TITLE
Issue 53324: LKSM: Custom Grid View Column Limit

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.2-fb-issue53324.2",
+  "version": "6.63.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.63.2-fb-issue53324.2",
+      "version": "6.63.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.1",
+  "version": "6.63.2-fb-issue53324.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.63.1",
+      "version": "6.63.2-fb-issue53324.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.8",
+  "version": "6.62.9-fb-issue53324.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.8",
+      "version": "6.62.9-fb-issue53324.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.8",
+  "version": "6.62.9-fb-issue53324.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.2-fb-issue53324.1",
+  "version": "6.63.2-fb-issue53324.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.2-fb-issue53324.2",
+  "version": "6.63.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X October 2025
+### version 6.63.2
+*Released*: 8 October 2025
 - Issue 53324: LKSM: Custom Grid View Column Limit
   - Don't serialize ViewInfoJson.fields
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X October 2025
+- Issue 53324: LKSM: Custom Grid View Column Limit
+  - Don't serialize ViewInfoJson.fields
+
 ### version 6.62.8
 *Released*: 3 October 2025
 - Issue 53328: AssayDefinitionModel.hasLookup to only consider the first sample lookup column for assay import cases

--- a/packages/components/src/internal/ViewInfo.test.ts
+++ b/packages/components/src/internal/ViewInfo.test.ts
@@ -1,7 +1,7 @@
 import { ExtendedMap } from '../public/ExtendedMap';
 
 import { QueryInfo } from '../public/QueryInfo';
-import { QueryColumn } from '../public/QueryColumn';
+import { IQueryColumn, QueryColumn } from '../public/QueryColumn';
 
 import { ViewInfo } from './ViewInfo';
 
@@ -35,6 +35,11 @@ describe('ViewInfo', () => {
         view = ViewInfo.fromJson({ sort: [sortObj] });
         expect((ViewInfo.serialize(view) as any).sorts).toBe(undefined);
         expect(ViewInfo.serialize(view).sort).toStrictEqual([sortObj]);
+
+        view = ViewInfo.fromJson({ columns: [{ name: 'col1', key: 'col1', fieldKey: 'col1' }], fields: [{name: 'col1'} as IQueryColumn] });
+        expect((ViewInfo.serialize(view) as any).fields).toBeUndefined()
+        expect(ViewInfo.serialize(view).fields).toBeUndefined();
+        expect(ViewInfo.serialize(view).columns).toStrictEqual([{ name: 'col1', key: 'col1', fieldKey: 'col1' }]);
     });
 
     test('isVisible', () => {

--- a/packages/components/src/internal/ViewInfo.test.ts
+++ b/packages/components/src/internal/ViewInfo.test.ts
@@ -36,8 +36,11 @@ describe('ViewInfo', () => {
         expect((ViewInfo.serialize(view) as any).sorts).toBe(undefined);
         expect(ViewInfo.serialize(view).sort).toStrictEqual([sortObj]);
 
-        view = ViewInfo.fromJson({ columns: [{ name: 'col1', key: 'col1', fieldKey: 'col1' }], fields: [{name: 'col1'} as IQueryColumn] });
-        expect((ViewInfo.serialize(view) as any).fields).toBeUndefined()
+        view = ViewInfo.fromJson({
+            columns: [{ name: 'col1', key: 'col1', fieldKey: 'col1' }],
+            fields: [{ name: 'col1' } as IQueryColumn],
+        });
+        expect((ViewInfo.serialize(view) as any).fields).toBeUndefined();
         expect(ViewInfo.serialize(view).fields).toBeUndefined();
         expect(ViewInfo.serialize(view).columns).toStrictEqual([{ name: 'col1', key: 'col1', fieldKey: 'col1' }]);
     });

--- a/packages/components/src/internal/ViewInfo.test.ts
+++ b/packages/components/src/internal/ViewInfo.test.ts
@@ -40,7 +40,6 @@ describe('ViewInfo', () => {
             columns: [{ name: 'col1', key: 'col1', fieldKey: 'col1' }],
             fields: [{ name: 'col1' } as IQueryColumn],
         });
-        expect((ViewInfo.serialize(view) as any).fields).toBeUndefined();
         expect(ViewInfo.serialize(view).fields).toBeUndefined();
         expect(ViewInfo.serialize(view).columns).toStrictEqual([{ name: 'col1', key: 'col1', fieldKey: 'col1' }]);
     });

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -127,6 +127,7 @@ export class ViewInfo {
         const { columns, filters, isDefault, sorts, ...rest } = viewInfo;
         const json = rest as unknown as ViewInfoJson;
 
+        delete json.fields; // Issue 53324: not needed for serialization and takes up space
         json.columns = [...columns];
         json.default = isDefault;
 

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -32,7 +32,7 @@ interface ViewInfoColumn {
 interface ViewInfoFilter {
     fieldKey: string;
     op: string;
-    value: string | number | boolean;
+    value: boolean | number | string;
 }
 
 export interface ViewInfoJson {
@@ -216,4 +216,3 @@ export class ViewInfo {
         });
     }
 }
-


### PR DESCRIPTION
#### Rationale
The entire serialized ViewInfoJson is included in the json for saving custom view, which include a `fields` array which include full detail for each column. `fields` is only useful on the client and not needed as request detail.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1862
- https://github.com/LabKey/limsModules/pull/1707

#### Changes
- Don't serialize ViewInfoJson.fields