### PR TITLE
Issue 52878: Attachment thumbnails from ancestor columns not rendered in Sample Type grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2-fb-issue52878.2",
+  "version": "6.64.2-fb-issue52878.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.2-fb-issue52878.2",
+      "version": "6.64.2-fb-issue52878.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.1-fb-issue52878.1",
+  "version": "6.63.1-fb-issue52878.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.63.1-fb-issue52878.1",
+      "version": "6.63.1-fb-issue52878.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2-fb-issue52878.3",
+  "version": "6.64.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.2-fb-issue52878.3",
+      "version": "6.64.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.8",
+  "version": "6.62.9-fb-issue52878.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.8",
+      "version": "6.62.9-fb-issue52878.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.0",
+  "version": "6.63.1-fb-issue52878.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.63.0",
+      "version": "6.63.1-fb-issue52878.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2-fb-issue52878.1",
+  "version": "6.64.2-fb-issue52878.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.2-fb-issue52878.1",
+      "version": "6.64.2-fb-issue52878.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2-fb-issue52878.1",
+  "version": "6.64.2-fb-issue52878.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2-fb-issue52878.3",
+  "version": "6.64.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.1-fb-issue52878.1",
+  "version": "6.63.1-fb-issue52878.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.8",
+  "version": "6.62.9-fb-issue52878.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2-fb-issue52878.2",
+  "version": "6.64.2-fb-issue52878.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.X
-*Released*: X October 2025
+### version 6.64.2
+*Released*: 10 October 2025
 - Issue 52878: Attachment thumbnails from ancestor columns not rendered in Sample Type grid
   - Modify `AncestorRenderer` and `MultiValueRenderer` to handle file/attachment columns
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.X
+*Released*: X October 2025
+- Issue 52878: Attachment thumbnails from ancestor columns not rendered in Sample Type grid
+  - Modify `AncestorRenderer` and `MultiValueRenderer` to handle file/attachment columns
+
 ### version 6.62.8
 *Released*: 3 October 2025
 - Issue 53328: AssayDefinitionModel.hasLookup to only consider the first sample lookup column for assay import cases

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -216,6 +216,7 @@ export function getSelectionLineageData(
 
 export interface GroupedSampleDisplayColumns {
     aliquotHeaderDisplayColumns: QueryColumn[];
+    aliquotOnlyColumns: string[]; // should hide from parent panel
     displayColumns: QueryColumn[];
     editColumns: QueryColumn[];
 }
@@ -239,6 +240,7 @@ export function getGroupedSampleDisplayColumns(
     const editColumns = [];
     const displayColumns = [];
     const aliquotHeaderDisplayColumns = [];
+    const aliquotOnlyColumns = [];
 
     allDisplayColumns.forEach(col => {
         const lcFieldKey = col.fieldKey.toLowerCase();
@@ -259,6 +261,8 @@ export function getGroupedSampleDisplayColumns(
                 sampleTypeDomainFields.independentFields.indexOf(lcFieldKey) > -1
             ) {
                 aliquotHeaderDisplayColumns.push(col);
+                if (sampleTypeDomainFields.aliquotFields.indexOf(lcFieldKey) > -1)
+                    aliquotOnlyColumns.push(col.fieldKey);
             }
         } else {
             if (sampleTypeDomainFields.aliquotFields.indexOf(lcFieldKey) === -1) {
@@ -294,6 +298,7 @@ export function getGroupedSampleDisplayColumns(
 
     return {
         aliquotHeaderDisplayColumns,
+        aliquotOnlyColumns,
         displayColumns,
         editColumns,
     };

--- a/packages/components/src/internal/renderers/AncestorRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/AncestorRenderer.test.tsx
@@ -4,6 +4,7 @@ import { Map } from 'immutable';
 import { render } from '@testing-library/react';
 
 import { AncestorRenderer } from './AncestorRenderer';
+import { QueryColumn } from '../../public/QueryColumn';
 
 describe('AncestorRenderer', () => {
     test('No data', () => {
@@ -28,6 +29,18 @@ describe('AncestorRenderer', () => {
         expect(links).toHaveLength(1);
         expect(links[0].getAttribute('href')).toBe(data.url);
         expect(links[0].textContent).toBe(data.displayValue);
+        expect(document.querySelectorAll('.attachment-card')).toHaveLength(0);
+    });
+
+    test('positive value, and file type column', () => {
+        const data = {
+            value: 'a.txt',
+            displayValue: 'a.txt',
+            url: 'http://samples.org/Sample-123',
+        };
+        render(<AncestorRenderer data={Map(data)} col={new QueryColumn({type: 'file'})}/>);
+        expect(document.querySelectorAll('span.text-muted')).toHaveLength(0);
+        expect(document.querySelectorAll('.attachment-card')).toHaveLength(1);
     });
 
     test('negative value', () => {

--- a/packages/components/src/internal/renderers/AncestorRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/AncestorRenderer.test.tsx
@@ -38,7 +38,7 @@ describe('AncestorRenderer', () => {
             displayValue: 'a.txt',
             url: 'http://samples.org/Sample-123',
         };
-        render(<AncestorRenderer col={new QueryColumn({ type: 'file' })} data={Map(data)} />);
+        render(<AncestorRenderer col={new QueryColumn({ inputType: 'file' })} data={Map(data)} />);
         expect(document.querySelectorAll('span.text-muted')).toHaveLength(0);
         expect(document.querySelectorAll('.attachment-card')).toHaveLength(1);
     });

--- a/packages/components/src/internal/renderers/AncestorRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/AncestorRenderer.test.tsx
@@ -38,7 +38,7 @@ describe('AncestorRenderer', () => {
             displayValue: 'a.txt',
             url: 'http://samples.org/Sample-123',
         };
-        render(<AncestorRenderer data={Map(data)} col={new QueryColumn({type: 'file'})}/>);
+        render(<AncestorRenderer col={new QueryColumn({ type: 'file' })} data={Map(data)} />);
         expect(document.querySelectorAll('span.text-muted')).toHaveLength(0);
         expect(document.querySelectorAll('.attachment-card')).toHaveLength(1);
     });

--- a/packages/components/src/internal/renderers/AncestorRenderer.tsx
+++ b/packages/components/src/internal/renderers/AncestorRenderer.tsx
@@ -22,9 +22,10 @@ export const ANCESTOR_LOOKUP_CONCEPT_URI = 'http://www.labkey.org/types#ancestor
 
 interface Props {
     data: Map<any, any>;
+    col?: any;
 }
 
-export const AncestorRenderer: FC<Props> = memo(({ data }) => {
+export const AncestorRenderer: FC<Props> = memo(({ data, col }) => {
     if (Map.isMap(data) && data.size > 0) {
         const { displayValue, value } = data.toJS();
         if (value < 0 && displayValue) {
@@ -35,7 +36,7 @@ export const AncestorRenderer: FC<Props> = memo(({ data }) => {
             );
         }
 
-        return <DefaultRenderer data={data} />;
+        return <DefaultRenderer data={data} col={col} />;
     }
 
     return null;

--- a/packages/components/src/internal/renderers/AncestorRenderer.tsx
+++ b/packages/components/src/internal/renderers/AncestorRenderer.tsx
@@ -21,8 +21,8 @@ import { DefaultRenderer } from './DefaultRenderer';
 export const ANCESTOR_LOOKUP_CONCEPT_URI = 'http://www.labkey.org/types#ancestorLookup';
 
 interface Props {
-    data: Map<any, any>;
     col?: any;
+    data: Map<any, any>;
 }
 
 export const AncestorRenderer: FC<Props> = memo(({ data, col }) => {
@@ -36,7 +36,7 @@ export const AncestorRenderer: FC<Props> = memo(({ data, col }) => {
             );
         }
 
-        return <DefaultRenderer data={data} col={col} />;
+        return <DefaultRenderer col={col} data={data} />;
     }
 
     return null;

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -56,8 +56,6 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
         } else if (List.isList(data)) {
             // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
             return <MultiValueRenderer data={data} col={col} />;
-        } else if (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file') {
-            return <FileColumnRenderer data={data} />;
         } else {
             if (isConditionalFormattingEnabled()) {
                 style = getDataStyling(data);
@@ -65,6 +63,10 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
                     className += ' status-pill';
                 }
             }
+
+            if (!style && (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file'))
+                return <FileColumnRenderer data={data} />;
+
             if (data.has('formattedValue')) {
                 display = data.get('formattedValue');
             } else {

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -55,7 +55,7 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
             display = data ? 'true' : 'false';
         } else if (List.isList(data)) {
             // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
-            return <MultiValueRenderer data={data} />;
+            return <MultiValueRenderer data={data} col={col} />;
         } else if (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file') {
             return <FileColumnRenderer data={data} />;
         } else {

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -56,17 +56,16 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
         } else if (List.isList(data)) {
             // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
             return <MultiValueRenderer data={data} col={col} />;
-        } else {
+        } if ((col?.isFileInput)) {
+            return <FileColumnRenderer data={data} />;
+        }
+        else {
             if (isConditionalFormattingEnabled()) {
                 style = getDataStyling(data);
                 if (style?.backgroundColor) {
                     className += ' status-pill';
                 }
             }
-
-            if (!style && (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file'))
-                return <FileColumnRenderer data={data} />;
-
             if (data.has('formattedValue')) {
                 display = data.get('formattedValue');
             } else {

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -56,7 +56,7 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
         } else if (List.isList(data)) {
             // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
             return <MultiValueRenderer data={data} col={col} />;
-        } if ((col?.isFileInput)) {
+        } else if ((col?.isFileInput)) {
             return <FileColumnRenderer data={data} />;
         }
         else {

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -56,7 +56,7 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
         } else if (List.isList(data)) {
             // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
             return <MultiValueRenderer data={data} col={col} />;
-        } else if ((col?.isFileInput)) {
+        } else if (col?.isFileInput) {
             return <FileColumnRenderer data={data} />;
         }
         else {

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -77,7 +77,7 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
             if (url && !noLink) {
                 const targetBlank = data.get('urlTarget') === TARGET_BLANK;
                 return (
-                    <AppLink className={className} to={url} targetBlank={targetBlank} style={style}>
+                    <AppLink className={className} style={style} targetBlank={targetBlank} to={url}>
                         {display}
                     </AppLink>
                 );

--- a/packages/components/src/internal/renderers/DefaultRenderer.tsx
+++ b/packages/components/src/internal/renderers/DefaultRenderer.tsx
@@ -24,6 +24,7 @@ import { isConditionalFormattingEnabled } from '../app/utils';
 import { AppLink } from '../url/AppLink';
 
 import { MultiValueRenderer } from './MultiValueRenderer';
+import { FileColumnRenderer } from './FileColumnRenderer';
 
 interface Props {
     col?: QueryColumn;
@@ -55,6 +56,8 @@ export const DefaultRenderer: FC<Props> = memo(({ col, data, noLink }) => {
         } else if (List.isList(data)) {
             // defensively return a MultiValueRenderer, this column likely wasn't declared properly as "multiValue"
             return <MultiValueRenderer data={data} />;
+        } else if (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file') {
+            return <FileColumnRenderer data={data} />;
         } else {
             if (isConditionalFormattingEnabled()) {
                 style = getDataStyling(data);

--- a/packages/components/src/internal/renderers/FileColumnRenderer.tsx
+++ b/packages/components/src/internal/renderers/FileColumnRenderer.tsx
@@ -56,11 +56,11 @@ export const getAttachmentCardProp = (
     let url, value, display;
     if (Iterable.isIterable(data)) {
         url = data.get('url');
-        value = data.get('value');
+        value = data.get('value')?.toString();
         display = getFileDisplayValue(data.get('displayValue') ?? value);
     } else {
         url = caseInsensitive(data, 'url');
-        value = caseInsensitive(data, 'value');
+        value = caseInsensitive(data, 'value')?.toString();
         display = getFileDisplayValue(caseInsensitive(data, 'displayValue') ?? value);
     }
     const titleStyle = isConditionalFormattingEnabled() ? getDataStyling(data) : undefined;

--- a/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
@@ -4,6 +4,7 @@ import { fromJS, Map } from 'immutable';
 import { render } from '@testing-library/react';
 
 import { MultiValueRenderer } from './MultiValueRenderer';
+import { QueryColumn } from '../../public/QueryColumn';
 
 describe('MultiValueRenderer', () => {
     test('empty data', () => {
@@ -21,6 +22,20 @@ describe('MultiValueRenderer', () => {
         const data = fromJS({ 24: { value: 24 } });
         render(<MultiValueRenderer data={data} />);
         expect(document.body.textContent).toBe('24');
+    });
+
+    test('data shapes, value, file column', () => {
+        const data = fromJS({24: {value: 'a.txt', url: 'a.txt' }});
+        render(<MultiValueRenderer data={data} col={new QueryColumn({type: 'file'})} />);
+        expect(document.body.textContent).toBe('a.txt');
+        expect(document.querySelectorAll('.attachment-card')).toHaveLength(0);
+    });
+
+    test('data list, value, file column', () => {
+        const data = fromJS([{value: 'a.txt', url: 'a.txt' }]);
+        render(<MultiValueRenderer data={data} col={new QueryColumn({type: 'file'})} />);
+        expect(document.body.textContent).toBe('a.txtDownload');
+        expect(document.querySelectorAll('.attachment-card')).toHaveLength(1);
     });
 
     test('data shapes, displayValue', () => {
@@ -57,6 +72,26 @@ describe('MultiValueRenderer', () => {
         const link = spans[2].querySelectorAll('a');
         expect(link).toHaveLength(1);
         expect(link[0].getAttribute('href')).toEqual('https://www.mariners.com/ichiro');
+    });
+
+    test('multiple values, file column', () => {
+        const data = fromJS({
+            11: { value: 'a.txt', url: 'a.txt'},
+            24: { value: 'b.txt', url: 'b.txt' },
+            51: { value: 'c.txt', url: 'c.txt' },
+        });
+        render(<MultiValueRenderer data={data} col={new QueryColumn({type: 'file'})} />);
+        const spans = document.querySelectorAll('span');
+        expect(spans.length).toBe(3);
+        expect(spans[0].textContent).toEqual('a.txt');
+        expect(spans[1].textContent).toEqual(', b.txt');
+        expect(spans[2].textContent).toEqual(', c.txt');
+
+        const link = spans[2].querySelectorAll('a');
+        expect(link).toHaveLength(1);
+        expect(link[0].getAttribute('href')).toEqual('c.txt');
+
+        expect(document.querySelectorAll('.attachment-card')).toHaveLength(0);
     });
 
     test('non-Map values', () => {

--- a/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
@@ -26,14 +26,14 @@ describe('MultiValueRenderer', () => {
 
     test('data shapes, value, file column', () => {
         const data = fromJS({ 24: { value: 'a.txt', url: 'a.txt' } });
-        render(<MultiValueRenderer col={new QueryColumn({ type: 'file' })} data={data} />);
+        render(<MultiValueRenderer col={new QueryColumn({ inputType: 'file' })} data={data} />);
         expect(document.body.textContent).toBe('a.txt');
         expect(document.querySelectorAll('.attachment-card')).toHaveLength(0);
     });
 
     test('data list, value, file column', () => {
         const data = fromJS([{ value: 'a.txt', url: 'a.txt' }]);
-        render(<MultiValueRenderer col={new QueryColumn({ type: 'file' })} data={data} />);
+        render(<MultiValueRenderer col={new QueryColumn({ inputType: 'file' })} data={data} />);
         expect(document.body.textContent).toBe('a.txtDownload');
         expect(document.querySelectorAll('.attachment-card')).toHaveLength(1);
     });
@@ -80,7 +80,7 @@ describe('MultiValueRenderer', () => {
             24: { value: 'b.txt', url: 'b.txt' },
             51: { value: 'c.txt', url: 'c.txt' },
         });
-        render(<MultiValueRenderer col={new QueryColumn({ type: 'file' })} data={data} />);
+        render(<MultiValueRenderer col={new QueryColumn({ inputType: 'file' })} data={data} />);
         const spans = document.querySelectorAll('span');
         expect(spans.length).toBe(3);
         expect(spans[0].textContent).toEqual('a.txt');

--- a/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.test.tsx
@@ -25,15 +25,15 @@ describe('MultiValueRenderer', () => {
     });
 
     test('data shapes, value, file column', () => {
-        const data = fromJS({24: {value: 'a.txt', url: 'a.txt' }});
-        render(<MultiValueRenderer data={data} col={new QueryColumn({type: 'file'})} />);
+        const data = fromJS({ 24: { value: 'a.txt', url: 'a.txt' } });
+        render(<MultiValueRenderer col={new QueryColumn({ type: 'file' })} data={data} />);
         expect(document.body.textContent).toBe('a.txt');
         expect(document.querySelectorAll('.attachment-card')).toHaveLength(0);
     });
 
     test('data list, value, file column', () => {
-        const data = fromJS([{value: 'a.txt', url: 'a.txt' }]);
-        render(<MultiValueRenderer data={data} col={new QueryColumn({type: 'file'})} />);
+        const data = fromJS([{ value: 'a.txt', url: 'a.txt' }]);
+        render(<MultiValueRenderer col={new QueryColumn({ type: 'file' })} data={data} />);
         expect(document.body.textContent).toBe('a.txtDownload');
         expect(document.querySelectorAll('.attachment-card')).toHaveLength(1);
     });
@@ -76,11 +76,11 @@ describe('MultiValueRenderer', () => {
 
     test('multiple values, file column', () => {
         const data = fromJS({
-            11: { value: 'a.txt', url: 'a.txt'},
+            11: { value: 'a.txt', url: 'a.txt' },
             24: { value: 'b.txt', url: 'b.txt' },
             51: { value: 'c.txt', url: 'c.txt' },
         });
-        render(<MultiValueRenderer data={data} col={new QueryColumn({type: 'file'})} />);
+        render(<MultiValueRenderer col={new QueryColumn({ type: 'file' })} data={data} />);
         const spans = document.querySelectorAll('span');
         expect(spans.length).toBe(3);
         expect(spans[0].textContent).toEqual('a.txt');

--- a/packages/components/src/internal/renderers/MultiValueRenderer.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 import React, { FC, Fragment, memo, ReactNode } from 'react';
-import { Map } from 'immutable';
+import { List, Map } from 'immutable';
 import { QueryColumn } from '../../public/QueryColumn';
 import { FileColumnRenderer } from './FileColumnRenderer';
 
 export interface MultiValueRendererProps {
-    data: Map<any, any>;
     col?: QueryColumn;
+    data: Map<any, any>;
 }
 
 export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data, col }) => {
@@ -28,7 +28,7 @@ export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data, col
         return null;
     }
 
-    if (data.size === 1 && (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file')) {
+    if (List.isList(data) && data.size === 1 && (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file')) {
         return <FileColumnRenderer data={data.get(0)} />;
     }
 
@@ -65,7 +65,7 @@ export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data, col
                     return (
                         // IntelliJ mistakenly presumes that key is an index.
                         // In fact, it is the key of the map which is unique.
-                        // eslint-disable-next-line react/no-array-index-key
+
                         <span key={key}>
                             {++i > 0 ? ', ' : ''}
                             {url ? <a href={url}>{text}</a> : text}

--- a/packages/components/src/internal/renderers/MultiValueRenderer.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.tsx
@@ -28,7 +28,11 @@ export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data, col
         return null;
     }
 
-    if (List.isList(data) && data.size === 1 && (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file')) {
+    if (
+        List.isList(data) &&
+        data.size === 1 &&
+        (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file')
+    ) {
         return <FileColumnRenderer data={data.get(0)} />;
     }
 

--- a/packages/components/src/internal/renderers/MultiValueRenderer.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.tsx
@@ -15,14 +15,21 @@
  */
 import React, { FC, Fragment, memo, ReactNode } from 'react';
 import { Map } from 'immutable';
+import { QueryColumn } from '../../public/QueryColumn';
+import { FileColumnRenderer } from './FileColumnRenderer';
 
 export interface MultiValueRendererProps {
     data: Map<any, any>;
+    col?: QueryColumn;
 }
 
-export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data }) => {
+export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data, col }) => {
     if (!data || data.size === 0) {
         return null;
+    }
+
+    if (data.size === 1 && (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file')) {
+        return <FileColumnRenderer data={data.get(0)} />;
     }
 
     let i = -1;

--- a/packages/components/src/internal/renderers/MultiValueRenderer.tsx
+++ b/packages/components/src/internal/renderers/MultiValueRenderer.tsx
@@ -31,7 +31,7 @@ export const MultiValueRenderer: FC<MultiValueRendererProps> = memo(({ data, col
     if (
         List.isList(data) &&
         data.size === 1 &&
-        (col?.type?.toLowerCase() === 'file' || col?.inputType?.toLowerCase() === 'file')
+        (col?.isFileInput)
     ) {
         return <FileColumnRenderer data={data.get(0)} />;
     }


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1863
- https://github.com/LabKey/labkey-ui-premium/pull/830
- https://github.com/LabKey/platform/pull/7106
- https://github.com/LabKey/limsModules/pull/1711

#### Changes
- Modify `AncestorRenderer` and `MultiValueRenderer` to handle file/attachment columns
- Update `DefaultRenderer` to use `FileColumnRenderer`