### PR TITLE
Issue 53934: Remove stored amount "too precise" validation check on setting amount modal

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.9",
+  "version": "6.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.62.9",
+      "version": "6.63.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.62.9",
+  "version": "6.63.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.62.9
+### version 6.63.0
 *Released*: 7 October 2025
 - Issue 53934: Remove stored amount "too precise" validation check on setting amount modal
   - remove isValuePrecisionValid() and the related isPrecisionValid()


### PR DESCRIPTION
#### Rationale
I missed pushing these commits before merging.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1861