### PR TITLE
GridPanelTest.testFilterDialogWithViews fix for double decoding of filter columnName

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.0",
+  "version": "6.63.0-gridPanelTestFilterPill.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.63.0",
+      "version": "6.63.0-gridPanelTestFilterPill.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.0-gridPanelTestFilterPill.0",
+  "version": "6.63.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.63.0-gridPanelTestFilterPill.0",
+      "version": "6.63.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.0",
+  "version": "6.63.0-gridPanelTestFilterPill.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.63.0-gridPanelTestFilterPill.0",
+  "version": "6.63.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Filter.actionValueFromFilter fix to move decode columnName out of getDisplayValue()
+
 ### version 6.62.9
 *Released*: 7 October 2025
 - Issue 53934: Remove stored amount "too precise" validation check on setting amount modal

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.63.1
+*Released*: 8 October 2025
 - Filter.actionValueFromFilter fix to move decode columnName out of getDisplayValue()
 
 ### version 6.63.0

--- a/packages/components/src/public/QueryModel/grid/actions/Filter.test.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Filter.test.ts
@@ -37,7 +37,7 @@ describe('FilterAction::actionValueFromFilter', () => {
         const filter = Filter.create('U mg$SL', '10', Filter.Types.EQUAL);
         const value: ActionValue = action.actionValueFromFilter(filter);
         expect(value.displayValue).toBe('U mg/L = 10');
-        expect(value.value).toBe('"U mg$SL" = 10');
+        expect(value.value).toBe('"U mg/L" = 10');
     });
 
     test('with label from QueryColumn', () => {
@@ -79,5 +79,18 @@ describe('FilterAction::actionValueFromFilter', () => {
         const filter = Filter.create('TimeCol', '01:02', Filter.Types.EQUAL);
         const value: ActionValue = action.actionValueFromFilter(filter, col);
         expect(value.displayValue).toBe('TimeCol = 01:02:00');
+    });
+
+    test('decodePart label vs column name', () => {
+        const col = new QueryColumn({ shortCaption: '$Bool Field./,$&' });
+        const filter = Filter.create('$DBoolField$P$S$C$D$A', true, Filter.Types.EQUAL);
+
+        let value: ActionValue = action.actionValueFromFilter(filter, col);
+        expect(value.displayValue).toBe('$Bool Field./,$& = true');
+        expect(value.value).toBe('"$Bool Field./,$&" = true');
+
+        value = action.actionValueFromFilter(filter);
+        expect(value.displayValue).toBe('$BoolField./,$& = true');
+        expect(value.value).toBe('"$BoolField./,$&" = true');
     });
 });

--- a/packages/components/src/public/QueryModel/grid/actions/Filter.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Filter.ts
@@ -161,7 +161,7 @@ export class FilterAction implements Action {
         rawValue: string | string[]
     ): { displayValue: string; inputValue: string } {
         let value: string, inputValue: string;
-        const displayParts = [decodePart(columnName), resolveSymbol(filterType)];
+        const displayParts = [columnName, resolveSymbol(filterType)];
         const inputDisplayParts = [`"${displayParts[0]}"`, displayParts[1]]; // need to quote column name for input display
 
         if (!filterType.isDataValueRequired()) {
@@ -210,7 +210,7 @@ export class FilterAction implements Action {
 
     actionValueFromFilter(filter: Filter.IFilter, column?: QueryColumn, isReadOnly?: string): ActionValue {
         const label = column?.shortCaption;
-        const columnName = filter.getColumnName();
+        const columnName = decodePart(filter.getColumnName());
         const filterType = filter.getFilterType();
         const operator = resolveSymbol(filter.getFilterType());
         let value = filter.getValue();

--- a/packages/components/src/public/QueryModel/grid/actions/Filter.ts
+++ b/packages/components/src/public/QueryModel/grid/actions/Filter.ts
@@ -160,7 +160,7 @@ export class FilterAction implements Action {
         filterType: Filter.IFilterType,
         rawValue: string | string[]
     ): { displayValue: string; inputValue: string } {
-        let value: string, inputValue: string;
+        let inputValue: string, value: string;
         const displayParts = [columnName, resolveSymbol(filterType)];
         const inputDisplayParts = [`"${displayParts[0]}"`, displayParts[1]]; // need to quote column name for input display
 


### PR DESCRIPTION
#### Rationale
A GridPanelTest case failed because of an issue where a column name filter was being decoded too many times and changing the "$Bool" column label in the filter panel into "}ool"

<img width="1254" height="444" alt="Screenshot 2025-10-07 at 2 37 13 PM" src="https://github.com/user-attachments/assets/d7203f4f-c860-4cc0-8f48-f6f24cfe5ae8" />


#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1866
- https://github.com/LabKey/limsModules/pull/1714
- https://github.com/LabKey/platform/pull/7109
- https://github.com/LabKey/testAutomation/pull/2732

#### Changes
- Filter.actionValueFromFilter fix to move decode columnName out of getDisplayValue()
