### PR TITLE
Multi chart rendering

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3",
+  "version": "6.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.3",
+      "version": "6.65.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3",
+  "version": "6.65.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,7 +1,7 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 6.xx.x
+### version 6.65.0
 *Released*: ? October 2025
 - QueryModel: remove selectedReportId, add selectedReportIds
 - withQueryModels: update selectReport, add clearSelectedReports

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.xx.x
+*Released*: ? October 2025
+- QueryModel: remove selectedReportId, add selectedReportIds
+- withQueryModels: update selectReport, add clearSelectedReports
+- ChartMenu: support multiple report selections
+- Add ChartList
+
 ### version 6.64.3
 *Released*: 13 October 2025
 - Search: escape all quotes in search terms

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages
 
 ### version 6.65.0
-*Released*: ? October 2025
+*Released*: 20 October 2025
 - QueryModel: remove selectedReportId, add selectedReportIds
 - withQueryModels: update selectReport, add clearSelectedReports
 - ChartMenu: support multiple report selections

--- a/packages/components/src/internal/components/chart/ChartBuilderMenuItem.test.tsx
+++ b/packages/components/src/internal/components/chart/ChartBuilderMenuItem.test.tsx
@@ -46,11 +46,20 @@ describe('ChartBuilderMenuItem', () => {
     };
 
     test('default props', async () => {
-        renderWithAppContext(<ChartBuilderMenuItem actions={actions} model={model} />, {
-            serverContext: {
-                user: TEST_USER_EDITOR,
-            },
-        });
+        renderWithAppContext(
+            <ChartBuilderMenuItem
+                actions={actions}
+                disabledMessage=""
+                maxCharts={5}
+                model={model}
+                selectedReportIds={[]}
+            />,
+            {
+                serverContext: {
+                    user: TEST_USER_EDITOR,
+                },
+            }
+        );
         const menuItems = document.querySelectorAll('.lk-menu-item a');
         expect(menuItems).toHaveLength(1);
         expect(document.querySelector('.chart-menu-label').textContent).toBe('Create Chart');
@@ -58,5 +67,29 @@ describe('ChartBuilderMenuItem', () => {
 
         await userEvent.click(menuItems[0]);
         expect(document.querySelectorAll('.chart-builder-modal')).toHaveLength(1);
+    });
+
+    test('max charts', async () => {
+        renderWithAppContext(
+            <ChartBuilderMenuItem
+                actions={actions}
+                disabledMessage="too many charts"
+                maxCharts={5}
+                model={model}
+                selectedReportIds={['db:1', 'db:2', 'db:3', 'db:4', 'db:5', 'db:6']}
+            />,
+            {
+                serverContext: {
+                    user: TEST_USER_EDITOR,
+                },
+            }
+        );
+        const menuItems = document.querySelectorAll('.lk-menu-item.disabled');
+        expect(menuItems).toHaveLength(1);
+        expect(document.querySelector('.chart-menu-label').textContent).toBe('Create Chart');
+        expect(document.querySelectorAll('.chart-builder-modal')).toHaveLength(0);
+
+        await userEvent.click(menuItems[0]);
+        expect(document.querySelectorAll('.chart-builder-modal')).toHaveLength(0);
     });
 });

--- a/packages/components/src/internal/components/chart/ChartBuilderMenuItem.tsx
+++ b/packages/components/src/internal/components/chart/ChartBuilderMenuItem.tsx
@@ -1,13 +1,20 @@
 import React, { FC, memo, useCallback, useState } from 'react';
 
-import { MenuItem } from '../../dropdowns';
 import { RequiresModelAndActions } from '../../../public/QueryModel/withQueryModels';
 
 import { useNotificationsContext } from '../notifications/NotificationsContext';
 
 import { ChartBuilderModal } from './ChartBuilderModal';
+import { DisableableMenuItem } from '../samples/DisableableMenuItem';
 
-export const ChartBuilderMenuItem: FC<RequiresModelAndActions> = memo(({ actions, model }) => {
+interface Props extends RequiresModelAndActions {
+    disabledMessage: string;
+    maxCharts: number;
+    selectedReportIds: string[];
+}
+
+export const ChartBuilderMenuItem: FC<Props> = memo(props => {
+    const { actions, disabledMessage, maxCharts, model, selectedReportIds } = props;
     const [showModal, setShowModal] = useState<boolean>(false);
     const { createNotification } = useNotificationsContext();
 
@@ -24,13 +31,14 @@ export const ChartBuilderMenuItem: FC<RequiresModelAndActions> = memo(({ actions
         },
         [createNotification]
     );
+    const disabled = selectedReportIds.length >= maxCharts;
 
     return (
         <>
-            <MenuItem onClick={onShowModal}>
+            <DisableableMenuItem disabled={disabled} disabledMessage={disabledMessage} onClick={onShowModal}>
                 <i className="fa fa-plus-circle" />
                 <span className="chart-menu-label">Create Chart</span>
-            </MenuItem>
+            </DisableableMenuItem>
             {showModal && <ChartBuilderModal actions={actions} model={model} onHide={onHideModal} />}
         </>
     );

--- a/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
+++ b/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
@@ -774,14 +774,10 @@ export const ChartBuilderModal: FC<ChartBuilderModalProps> = memo(({ actions, mo
         setSaving(true);
         setError(undefined);
         try {
-            const response = await saveChart(_reportConfig);
+            await saveChart(_reportConfig);
             setSaving(false);
             onHide(`Successfully ${savedChartModel ? 'updated' : 'created'} chart: ${_reportConfig.name}.`);
-
-            // clear the selected report, if we are saving/updating it, so that it will refresh in ChartPanel.tsx
-            await actions.selectReport(model.id, undefined);
-            await actions.loadCharts(model.id);
-            actions.selectReport(model.id, response.reportId);
+            actions.loadCharts(model.id);
         } catch (e) {
             setError(e.exception ?? e);
             setSaving(false);
@@ -790,8 +786,8 @@ export const ChartBuilderModal: FC<ChartBuilderModalProps> = memo(({ actions, mo
 
     const afterDelete = useCallback(async () => {
         onHide('Successfully deleted chart: ' + savedChartModel.name + '.');
-        await actions.selectReport(model.id, undefined);
-        await actions.loadCharts(model.id);
+        actions.selectReport(model.id, savedChartModel.reportId, false);
+        actions.loadCharts(model.id);
     }, [actions, model.id, onHide, savedChartModel]);
 
     const onCancel = useCallback(() => {

--- a/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
+++ b/packages/components/src/internal/components/chart/ChartBuilderModal.tsx
@@ -774,10 +774,11 @@ export const ChartBuilderModal: FC<ChartBuilderModalProps> = memo(({ actions, mo
         setSaving(true);
         setError(undefined);
         try {
-            await saveChart(_reportConfig);
+            const response = await saveChart(_reportConfig);
             setSaving(false);
             onHide(`Successfully ${savedChartModel ? 'updated' : 'created'} chart: ${_reportConfig.name}.`);
             actions.loadCharts(model.id);
+            actions.selectReport(model.id, response.reportId, true);
         } catch (e) {
             setError(e.exception ?? e);
             setSaving(false);

--- a/packages/components/src/public/QueryModel/ChartMenu.test.tsx
+++ b/packages/components/src/public/QueryModel/ChartMenu.test.tsx
@@ -15,6 +15,7 @@ import { LABKEY_VIS } from '../../internal/constants';
 
 import { makeTestActions, makeTestQueryModel } from './testUtils';
 import { ChartMenu, ChartMenuItem } from './ChartMenu';
+import { userEvent } from '@testing-library/user-event';
 
 LABKEY_VIS = {
     GenericChartHelper: {
@@ -25,22 +26,40 @@ LABKEY_VIS = {
 describe('ChartMenuItem', () => {
     test('use chart icon', () => {
         const chart = { name: 'TestChart', icon: 'icon.png', iconCls: 'fa-icon' } as DataViewInfo;
-        render(<ChartMenuItem chart={chart} showChart={jest.fn()} />);
+        render(<ChartMenuItem chart={chart} selectChart={jest.fn()} selectedReportIds={[]} />);
 
         expect(document.querySelector('.chart-menu-label').textContent).toBe('TestChart');
         expect(document.querySelectorAll('img')).toHaveLength(0);
         expect(document.querySelectorAll('.chart-menu-icon')).toHaveLength(1);
         expect(document.querySelectorAll('.fa-icon')).toHaveLength(1);
+        expect(document.querySelector('.chart-menu-checkbox')).toHaveClass('fa-square-o');
     });
 
     test('use svg img', () => {
         const chart = { name: 'TestChart', icon: 'icon.svg', iconCls: 'fa-icon' } as DataViewInfo;
-        render(<ChartMenuItem chart={chart} showChart={jest.fn()} />);
+        render(<ChartMenuItem chart={chart} selectChart={jest.fn()} selectedReportIds={[]} />);
 
         expect(document.querySelector('.chart-menu-label').textContent).toBe('TestChart');
         expect(document.querySelectorAll('img')).toHaveLength(1);
         expect(document.querySelectorAll('.chart-menu-icon')).toHaveLength(0);
         expect(document.querySelectorAll('.fa-icon')).toHaveLength(0);
+        expect(document.querySelector('.chart-menu-checkbox')).toHaveClass('fa-square-o');
+    });
+
+    test('selectChart', async () => {
+        const selectChart = jest.fn();
+        const chart = { name: 'TestChart', icon: 'icon.png', iconCls: 'fa-icon', reportId: 'db:12' } as DataViewInfo;
+        const { rerender } = render(<ChartMenuItem chart={chart} selectChart={selectChart} selectedReportIds={[]} />);
+
+        expect(document.querySelector('.chart-menu-checkbox')).toHaveClass('fa-square-o');
+        await userEvent.click(document.querySelector('a'));
+        expect(selectChart).toHaveBeenCalledWith('db:12', true);
+
+        rerender(<ChartMenuItem chart={chart} selectChart={selectChart} selectedReportIds={['db:12']} />);
+
+        expect(document.querySelector('.chart-menu-checkbox')).toHaveClass('fa-check-square');
+        await userEvent.click(document.querySelector('a'));
+        expect(selectChart).toHaveBeenCalledWith('db:12', false);
     });
 });
 

--- a/packages/components/src/public/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/public/QueryModel/ChartMenu.tsx
@@ -17,7 +17,7 @@ import { RequiresModelAndActions } from './withQueryModels';
 import { DisableableMenuItem } from '../../internal/components/samples/DisableableMenuItem';
 
 const MAX_CHARTS = 5;
-const DISABLED_MESSAGE = `Only ${MAX_CHARTS} charts can be shown at once`;
+const DISABLED_MESSAGE = `Only ${MAX_CHARTS} charts can be shown at once.`;
 
 interface ChartMenuItemProps {
     chart: DataViewInfo;

--- a/packages/components/src/public/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/public/QueryModel/ChartMenu.tsx
@@ -1,10 +1,8 @@
-import React, { FC, useCallback, useEffect } from 'react';
-
+import React, { FC, memo, useCallback, useEffect, useMemo } from 'react';
 import { PermissionTypes } from '@labkey/api';
+import classNames from 'classnames';
 
 import { DataViewInfo } from '../../internal/DataViewInfo';
-
-import { blurActiveElement } from '../../internal/util/utils';
 
 import { DropdownButton, MenuDivider, MenuHeader, MenuItem } from '../../internal/dropdowns';
 
@@ -16,29 +14,57 @@ import { ChartBuilderMenuItem } from '../../internal/components/chart/ChartBuild
 import { hasPermissions } from '../../internal/components/base/models/User';
 
 import { RequiresModelAndActions } from './withQueryModels';
+import { DisableableMenuItem } from '../../internal/components/samples/DisableableMenuItem';
+
+const MAX_CHARTS = 5;
+const DISABLED_MESSAGE = `Only ${MAX_CHARTS} charts can be shown at once`;
 
 interface ChartMenuItemProps {
     chart: DataViewInfo;
-    showChart: (chart: DataViewInfo) => void;
+    selectChart: (reportId: string, selected: boolean) => void;
+    selectedReportIds: string[];
 }
 
-export const ChartMenuItem: FC<ChartMenuItemProps> = ({ chart, showChart }) => {
-    const onClick = useCallback(() => showChart(chart), [showChart, chart]);
+export const ChartMenuItem: FC<ChartMenuItemProps> = ({ chart, selectChart, selectedReportIds }) => {
+    const { reportId } = chart;
+    const selected = useMemo(() => selectedReportIds.includes(reportId), [reportId, selectedReportIds]);
+    const onClick = useCallback(() => selectChart(reportId, !selected), [reportId, selectChart, selected]);
     const useSVG = chart.icon?.indexOf('.svg') > -1;
+    const className = classNames('chart-menu-checkbox', 'fa', {
+        'fa-check-square': selected,
+        'fa-square-o': !selected,
+    });
+    const disabled = !selected && selectedReportIds.length >= MAX_CHARTS;
 
     return (
-        <MenuItem onClick={onClick}>
-            {useSVG && <img src={chart.icon} width={16} alt={chart.icon} />}
+        <DisableableMenuItem disabled={disabled} disabledMessage={DISABLED_MESSAGE} onClick={onClick}>
+            <span className={className} />
+            {useSVG && <img alt={chart.icon} src={chart.icon} width={16} />}
             {!useSVG && <i className={`chart-menu-icon ${chart.iconCls ?? ''}`} />}
             <span className="chart-menu-label">{chart.name}</span>
-        </MenuItem>
+        </DisableableMenuItem>
     );
 };
+ChartMenuItem.displayName = 'ChartMenuItem';
 
-export const ChartMenu: FC<RequiresModelAndActions> = props => {
-    const { model, actions } = props;
+interface ChartMenuTitleProps {
+    isLoading: boolean;
+}
+export const ChartMenuTitle: FC<ChartMenuTitleProps> = memo(({ isLoading }) => {
+    if (isLoading) return <span className="fa fa-spinner fa-pulse" />;
+    return (
+        <span>
+            <span className="fa fa-area-chart" />
+            <span> Charts</span>
+        </span>
+    );
+});
+ChartMenuTitle.displayName = 'ChartMenuTitle';
+
+export const ChartMenu: FC<RequiresModelAndActions> = memo(({ actions, model }) => {
     const { moduleContext, user } = useServerContext();
-    const { charts, chartsError, hasCharts, isLoading, isLoadingCharts, rowsError, queryInfoError } = model;
+    const { charts, chartsError, hasCharts, isLoading, isLoadingCharts, rowsError, selectedReportIds, queryInfoError } =
+        model;
     const viewCharts = charts?.filter(chart => chart.viewName === model.schemaQuery.viewName) ?? []; // filter chart menu based on selected view
     const privateCharts = hasCharts ? viewCharts.filter(chart => !chart.shared) : [];
     const publicCharts = hasCharts ? viewCharts.filter(chart => chart.shared) : [];
@@ -49,26 +75,18 @@ export const ChartMenu: FC<RequiresModelAndActions> = props => {
     const hasError = queryInfoError !== undefined || rowsError !== undefined;
     const disabled = isLoading || isLoadingCharts || hasError || (noCharts && !showCreateChart);
 
-    useEffect(
-        () => {
-            actions.loadCharts(model.id);
-        },
-        [
-            /* on mount */
-        ]
-    );
+    useEffect(() => {
+        actions.loadCharts(model.id);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps -- only desired on mount
 
-    const chartClicked = useCallback(
-        (chart: DataViewInfo): void => {
-            blurActiveElement();
-            actions.selectReport(model.id, chart.reportId);
+    const selectChart = useCallback(
+        (reportId: string, selected: boolean): void => {
+            actions.selectReport(model.id, reportId, selected);
         },
         [actions, model]
     );
 
-    if (noCharts && !showCreateChart) {
-        return null;
-    }
+    if (noCharts && !showCreateChart) return null;
 
     return (
         <div className="chart-menu">
@@ -76,16 +94,7 @@ export const ChartMenu: FC<RequiresModelAndActions> = props => {
                 buttonClassName="chart-menu-button"
                 disabled={disabled}
                 pullRight
-                title={
-                    isLoadingCharts ? (
-                        <span className="fa fa-spinner fa-pulse" />
-                    ) : (
-                        <span>
-                            <span className="fa fa-area-chart" />
-                            <span> Charts</span>
-                        </span>
-                    )
-                }
+                title={<ChartMenuTitle isLoading={isLoadingCharts} />}
             >
                 {chartsError !== undefined && <MenuItem>{chartsError}</MenuItem>}
 
@@ -97,7 +106,12 @@ export const ChartMenu: FC<RequiresModelAndActions> = props => {
 
                 {privateCharts.length > 0 &&
                     privateCharts.map(chart => (
-                        <ChartMenuItem key={chart.reportId} chart={chart} showChart={chartClicked} />
+                        <ChartMenuItem
+                            chart={chart}
+                            key={chart.reportId}
+                            selectChart={selectChart}
+                            selectedReportIds={selectedReportIds}
+                        />
                     ))}
 
                 {privateCharts.length > 0 && publicCharts.length > 0 && <MenuDivider />}
@@ -106,9 +120,15 @@ export const ChartMenu: FC<RequiresModelAndActions> = props => {
 
                 {publicCharts.length > 0 &&
                     publicCharts.map(chart => (
-                        <ChartMenuItem key={chart.reportId} chart={chart} showChart={chartClicked} />
+                        <ChartMenuItem
+                            chart={chart}
+                            key={chart.reportId}
+                            selectChart={selectChart}
+                            selectedReportIds={selectedReportIds}
+                        />
                     ))}
             </DropdownButton>
         </div>
     );
-};
+});
+ChartMenu.displayName = 'ChartMenu';

--- a/packages/components/src/public/QueryModel/ChartMenu.tsx
+++ b/packages/components/src/public/QueryModel/ChartMenu.tsx
@@ -98,7 +98,15 @@ export const ChartMenu: FC<RequiresModelAndActions> = memo(({ actions, model }) 
             >
                 {chartsError !== undefined && <MenuItem>{chartsError}</MenuItem>}
 
-                {showCreateChart && <ChartBuilderMenuItem actions={actions} model={model} />}
+                {showCreateChart && (
+                    <ChartBuilderMenuItem
+                        actions={actions}
+                        disabledMessage={DISABLED_MESSAGE}
+                        maxCharts={MAX_CHARTS}
+                        model={model}
+                        selectedReportIds={selectedReportIds}
+                    />
+                )}
 
                 {showCreateChartDivider && <MenuDivider />}
 

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Chart } from '../../internal/components/chart/Chart';
 
@@ -25,6 +25,7 @@ export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER,
     const [savedChartModel, setSavedChartModel] = useState<GenericChartModel>(undefined);
     const [showEditModal, setShowEditModal] = useState<boolean>(false);
     const { moduleContext } = useServerContext();
+    const divRef = useRef(undefined);
 
     // useNotificationsContext will not always be available depending on if the app wraps the NotificationsContext.Provider
     let _createNotification;
@@ -62,7 +63,7 @@ export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER,
 
     const onExportChart = useCallback(
         (type: string) => {
-            const svg = document.querySelector('.chart-panel svg');
+            const svg = divRef.current.querySelector('.chart-panel svg');
             if (svg) {
                 LABKEY_VIS.SVGConverter.convert(svg, type, chart.name);
             }
@@ -91,7 +92,7 @@ export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER,
     if (chart === undefined) return null;
 
     return (
-        <div className="chart-panel">
+        <div className="chart-panel" ref={divRef}>
             <div className="chart-panel__heading">
                 <div className="chart-panel__heading-title">
                     {chart.name}

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -29,7 +29,7 @@ export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER,
     // useNotificationsContext will not always be available depending on if the app wraps the NotificationsContext.Provider
     let _createNotification;
     try {
-        // ESLint incorrectly complains that useNotificationsContext is called conditionally. Itt's always called, even
+        // ESLint incorrectly complains that useNotificationsContext is called conditionally. It's always called, even
         // though it's in a try/catch.
         // eslint-disable-next-line react-hooks/rules-of-hooks
         _createNotification = useNotificationsContext().createNotification;

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -17,10 +17,11 @@ import { RequiresModelAndActions } from './withQueryModels';
 
 interface Props extends RequiresModelAndActions {
     api?: ChartAPIWrapper;
+    reportId: string; // Maybe pass the chart
 }
 
-export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_WRAPPER }) => {
-    const { charts, containerPath, id, queryInfo, selectedReportId } = model;
+export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER, model, reportId }) => {
+    const { charts, containerPath, id } = model;
     const [savedChartModel, setSavedChartModel] = useState<GenericChartModel>(undefined);
     const [showEditModal, setShowEditModal] = useState<boolean>(false);
     const { moduleContext } = useServerContext();
@@ -28,32 +29,32 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
     // useNotificationsContext will not always be available depending on if the app wraps the NotificationsContext.Provider
     let _createNotification;
     try {
+        // ESLint incorrectly complains that useNotificationsContext is called conditionally. Itt's always called, even
+        // though it's in a try/catch.
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         _createNotification = useNotificationsContext().createNotification;
-    } catch (e) {
+    } catch {
         // this is expected for LKS usages, so don't throw or console.error
     }
 
-    const selectedChart = useMemo(
-        () => charts?.find(chart => chart.reportId === selectedReportId),
-        [selectedReportId, charts]
-    );
+    const chart = useMemo(() => charts?.find(chart => chart.reportId === reportId), [charts, reportId]);
 
     useEffect(() => {
         (async () => {
             setSavedChartModel(undefined);
             // only allowing edit of generic charts in the apps at this time
-            if (selectedChart && GENERIC_CHART_REPORTS.indexOf(selectedChart.type) > -1) {
+            if (chart && GENERIC_CHART_REPORTS.indexOf(chart.type) > -1) {
                 try {
-                    const savedChartModel_ = await api.fetchGenericChart(selectedChart.reportId);
+                    const savedChartModel_ = await api.fetchGenericChart(chart.reportId);
                     setSavedChartModel(savedChartModel_);
                 } catch (e) {
                     // no-op as we are only using this to determine if we can edit the chart
                 }
             }
         })();
-    }, [api, selectedChart]);
+    }, [api, chart]);
 
-    const clearChart = useCallback(() => actions.selectReport(id, undefined), [actions, id]);
+    const clearChart = useCallback(() => actions.selectReport(id, reportId, false), [actions, id, reportId]);
 
     const onShowEditChart = useCallback(() => {
         setShowEditModal(true);
@@ -63,10 +64,10 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
         (type: string) => {
             const svg = document.querySelector('.chart-panel svg');
             if (svg) {
-                LABKEY_VIS.SVGConverter.convert(svg, type, selectedChart.name);
+                LABKEY_VIS.SVGConverter.convert(svg, type, chart.name);
             }
         },
-        [selectedChart]
+        [chart]
     );
 
     const onExportChartPDF = useCallback(() => {
@@ -87,24 +88,21 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
         [_createNotification]
     );
 
-    // If we don't have a queryInfo we can't get filters off the model, so we can't render the chart
-    const showChart = queryInfo !== undefined && selectedChart !== undefined;
-
-    if (!showChart) return null;
+    if (chart === undefined) return null;
 
     return (
         <div className="chart-panel">
             <div className="chart-panel__heading">
                 <div className="chart-panel__heading-title">
-                    {selectedChart.name}
+                    {chart.name}
 
                     {savedChartModel?.canEdit && isChartBuilderEnabled(moduleContext) && (
                         <span className="margin-left">
                             <button
-                                type="button"
-                                title="Edit chart"
                                 className="btn btn-default"
                                 onClick={onShowEditChart}
+                                title="Edit chart"
+                                type="button"
                             >
                                 <span className="fa fa-pencil" />
                             </button>
@@ -113,8 +111,8 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
                     <span className="margin-left">
                         <DropdownButton
                             buttonClassName="chart-panel-export-btn"
-                            title={<i className="fa fa-download" />}
                             noCaret
+                            title={<i className="fa fa-download" />}
                         >
                             <MenuHeader text="Export Chart" />
                             <MenuItem onClick={onExportChartPDF}>
@@ -130,17 +128,19 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
                 </div>
 
                 <div className="chart-panel__hide-icon">
-                    <button type="button" title="Hide chart" className="btn btn-default" onClick={clearChart}>
+                    <button className="btn btn-default" onClick={clearChart} title="Hide chart" type="button">
                         <span className="fa fa-close" /> Close
                     </button>
                 </div>
             </div>
 
+            {/* Note: we use chart.modified as the key here so the chart reloads when the user edits the chart */}
             <Chart
                 api={api}
-                chart={selectedChart}
+                chart={chart}
                 container={containerPath}
                 filters={model.filters}
+                key={chart.modified.toString()}
                 queryParameters={model.queryParameters}
             />
 
@@ -155,3 +155,20 @@ export const ChartPanel: FC<Props> = memo(({ actions, model, api = DEFAULT_API_W
         </div>
     );
 });
+ChartPanel.displayName = 'ChartPanel';
+
+export const ChartList: FC<RequiresModelAndActions> = memo(({ actions, model }) => {
+    const { queryInfo, selectedReportIds } = model;
+
+    // If we don't have a queryInfo we can't get filters off the model, so we can't render any charts
+    if (queryInfo === undefined || selectedReportIds.length === 0) return null;
+
+    return (
+        <div className="chart-list">
+            {model.selectedReportIds.map(reportId => (
+                <ChartPanel actions={actions} key={reportId} model={model} reportId={reportId} />
+            ))}
+        </div>
+    );
+});
+ChartList.displayName = 'ChartList';

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -2,7 +2,7 @@ import React, { FC, memo, useCallback, useEffect, useMemo, useRef, useState } fr
 
 import { Chart } from '../../internal/components/chart/Chart';
 
-import { GENERIC_CHART_REPORTS, LABKEY_VIS } from '../../internal/constants';
+import { DataViewInfoTypes, GENERIC_CHART_REPORTS, LABKEY_VIS } from '../../internal/constants';
 import { ChartAPIWrapper, DEFAULT_API_WRAPPER } from '../../internal/components/chart/api';
 import { GenericChartModel } from '../../internal/components/chart/models';
 import { ChartBuilderModal } from '../../internal/components/chart/ChartBuilderModal';
@@ -91,6 +91,8 @@ export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER,
 
     if (chart === undefined) return null;
 
+    const isSvg = chart.type !== DataViewInfoTypes.RReport;
+
     return (
         <div className="chart-panel" ref={divRef}>
             <div className="chart-panel__heading">
@@ -109,23 +111,25 @@ export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER,
                             </button>
                         </span>
                     )}
-                    <span className="margin-left">
-                        <DropdownButton
-                            buttonClassName="chart-panel-export-btn"
-                            noCaret
-                            title={<i className="fa fa-download" />}
-                        >
-                            <MenuHeader text="Export Chart" />
-                            <MenuItem onClick={onExportChartPDF}>
-                                <i className="fa fa-file-pdf-o" />
-                                &nbsp; PDF
-                            </MenuItem>
-                            <MenuItem onClick={onExportChartPNG}>
-                                <i className="fa fa-file-image-o" />
-                                &nbsp; PNG
-                            </MenuItem>
-                        </DropdownButton>
-                    </span>
+                    {isSvg && (
+                        <span className="margin-left">
+                            <DropdownButton
+                                buttonClassName="chart-panel-export-btn"
+                                noCaret
+                                title={<i className="fa fa-download" />}
+                            >
+                                <MenuHeader text="Export Chart" />
+                                <MenuItem onClick={onExportChartPDF}>
+                                    <span className="fa fa-file-pdf-o" />
+                                    &nbsp; PDF
+                                </MenuItem>
+                                <MenuItem onClick={onExportChartPNG}>
+                                    <span className="fa fa-file-image-o" />
+                                    &nbsp; PNG
+                                </MenuItem>
+                            </DropdownButton>
+                        </span>
+                    )}
                 </div>
 
                 <div className="chart-panel__hide-icon">

--- a/packages/components/src/public/QueryModel/GridPanel.tsx
+++ b/packages/components/src/public/QueryModel/GridPanel.tsx
@@ -74,7 +74,7 @@ import { SaveViewModal } from './SaveViewModal';
 import { CustomizeGridViewModal } from './CustomizeGridViewModal';
 import { ManageViewsModal } from './ManageViewsModal';
 import { Actions, InjectedQueryModels, RequiresModelAndActions, withQueryModels } from './withQueryModels';
-import { ChartPanel } from './ChartPanel';
+import { ChartList, ChartPanel } from './ChartPanel';
 
 export interface GridPanelProps<ButtonsComponentProps> {
     advancedExportOptions?: Record<string, any>;
@@ -947,8 +947,8 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
         }
 
         // since the grid ChartMenu filters to charts for a given view, when the view changes clear the selectedReportId
-        if (model.selectedReportId) {
-            actions.selectReport(model.id, undefined);
+        if (model.selectedReportIds.length > 0) {
+            actions.clearSelectedReports(model.id);
         }
     };
 
@@ -1133,7 +1133,7 @@ export class GridPanel<T = {}> extends PureComponent<Props<T>, State> {
                     <div
                         className={classNames('grid-panel__body', { 'panel-body': asPanel, 'top-padding': !hasHeader })}
                     >
-                        {!gridIsLoading && <ChartPanel actions={actions} model={model} />}
+                        {!gridIsLoading && <ChartList actions={actions} model={model} />}
 
                         {showButtonBar && (
                             <ButtonBar

--- a/packages/components/src/public/QueryModel/QueryModel.test.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.test.ts
@@ -438,7 +438,7 @@ describe('attributesForURLQueryParams', () => {
             maxRows: DEFAULT_MAX_ROWS,
             offset: DEFAULT_OFFSET,
             schemaQuery: SCHEMA_QUERY,
-            selectedReportId: undefined,
+            selectedReportIds: [],
             sorts: [],
         };
         const model = new QueryModel({
@@ -477,12 +477,12 @@ describe('attributesForURLQueryParams', () => {
 
         // reportId should be honored
         searchParams = new URLSearchParams({
-            'query.reportId': 'db:99',
+            'query.selectedReportIds': 'db:99',
         });
         values = model.attributesForURLQueryParams(searchParams);
         expect(values).toEqual({
             ...defaultExpected,
-            selectedReportId: 'db:99',
+            selectedReportIds: ['db:99'],
         });
 
         // custom views should alter schemaQuery
@@ -527,7 +527,7 @@ describe('attributesForURLQueryParams', () => {
             'query.otherCol~neq=': '1',
             'query.p': '3',
             'query.pageSize': '100',
-            'query.reportId': 'db:99',
+            'query.selectedReportIds': 'db:99;db:100',
             'query.sort': '-testCol,otherCol',
             'query.view': 'custom view',
         });
@@ -537,7 +537,7 @@ describe('attributesForURLQueryParams', () => {
             maxRows: 100,
             offset: 200,
             schemaQuery: new SchemaQuery(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, 'custom view'),
-            selectedReportId: 'db:99',
+            selectedReportIds: ['db:99', 'db:100'],
             sorts: expectedSorts,
         });
     });
@@ -548,10 +548,10 @@ describe('attributesForURLQueryParams', () => {
             maxRows: 10,
             offset: 60,
             schemaQuery: new SchemaQuery(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, 'existing custom view'),
-            selectedReportId: 'db:900',
+            selectedReportIds: ['db:900'],
             sorts: [new QuerySort({ dir: '-', fieldKey: 'existingCol' })],
         };
-        const model = new QueryModel({ ...defaultExpected }).mutate({ selectedReportId: 'db:900' });
+        const model = new QueryModel({ ...defaultExpected }).mutate({ selectedReportIds: ['db:900'] });
         let searchParams = new URLSearchParams({});
 
         let values = model.attributesForURLQueryParams(searchParams, true);
@@ -582,12 +582,20 @@ describe('attributesForURLQueryParams', () => {
 
         // reportId should be honored
         searchParams = new URLSearchParams({
-            'query.reportId': 'db:99',
+            'query.selectedReportIds': 'db:99',
         });
         values = model.attributesForURLQueryParams(searchParams, true);
         expect(values).toEqual({
             ...defaultExpected,
-            selectedReportId: 'db:99',
+            selectedReportIds: ['db:99'],
+        });
+        searchParams = new URLSearchParams({
+            'query.selectedReportIds': 'db:99;db:100',
+        });
+        values = model.attributesForURLQueryParams(searchParams, true);
+        expect(values).toEqual({
+            ...defaultExpected,
+            selectedReportIds: ['db:99', 'db:100'],
         });
 
         // custom views should alter schemaQuery
@@ -632,7 +640,7 @@ describe('attributesForURLQueryParams', () => {
             'query.otherCol~neq=': '1',
             'query.p': '3',
             'query.pageSize': '100',
-            'query.reportId': 'db:99',
+            'query.selectedReportIds': 'db:99',
             'query.sort': '-testCol,otherCol',
             'query.view': 'custom view',
         });
@@ -642,7 +650,7 @@ describe('attributesForURLQueryParams', () => {
             maxRows: 100,
             offset: 200,
             schemaQuery: new SchemaQuery(SCHEMA_QUERY.schemaName, SCHEMA_QUERY.queryName, 'custom view'),
-            selectedReportId: 'db:99',
+            selectedReportIds: ['db:99'],
             sorts: expectedSorts,
         });
     });

--- a/packages/components/src/public/QueryModel/QueryModel.test.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.test.ts
@@ -404,7 +404,8 @@ describe('locationHasQueryParamSettings', () => {
     });
 
     test('with matching queryParams', () => {
-        expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.reportId': '1' }))).toBe(true);
+        expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.selectedReportIds': '1' }))).toBe(true);
+        expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.selectedReportIds': '1;2' }))).toBe(true);
         expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.view': '1' }))).toBe(true);
         expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.q': '1' }))).toBe(true);
         expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.sort': '1' }))).toBe(true);
@@ -414,7 +415,7 @@ describe('locationHasQueryParamSettings', () => {
     });
 
     test('with mismatched prefix', () => {
-        expect(locationHasQueryParamSettings('bogus', new URLSearchParams({ 'test.reportId': '1' }))).toBe(false);
+        expect(locationHasQueryParamSettings('bogus', new URLSearchParams({ 'test.selectedReportIds': '1' }))).toBe(false);
         expect(locationHasQueryParamSettings('bogus', new URLSearchParams({ 'test.view': '1' }))).toBe(false);
         expect(locationHasQueryParamSettings('bogus', new URLSearchParams({ 'test.q': '1' }))).toBe(false);
         expect(locationHasQueryParamSettings('bogus', new URLSearchParams({ 'test.sort': '1' }))).toBe(false);
@@ -426,6 +427,8 @@ describe('locationHasQueryParamSettings', () => {
     test('with mismatched queryParams', () => {
         expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.reportid': '1' }))).toBe(false);
         expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.reportIdd': '1' }))).toBe(false);
+        expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.selectedreportids': '1' }))).toBe(false);
+        expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.selectedReportIdss': '1' }))).toBe(false);
         expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.bogus': '1' }))).toBe(false);
         expect(locationHasQueryParamSettings('test', new URLSearchParams({ 'test.col~eq': '1' }))).toBe(true);
     });

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -432,7 +432,7 @@ export class QueryModel {
     /**
      * ReportId, from the URL, to be used for showing a chart via the [[ChartMenu]].
      */
-    readonly selectedReportId: string;
+    readonly selectedReportIds: string[];
     /**
      * [[SelectionPivot]] object that describes the current selection pivot row for shift-select behavior.
      */
@@ -527,7 +527,7 @@ export class QueryModel {
         this.rows = undefined;
         this.rowCount = undefined;
         this.rowsLoadingState = LoadingState.INITIALIZED;
-        this.selectedReportId = undefined;
+        this.selectedReportIds = [];
         this.selectionPivot = undefined;
         this.selections = undefined;
         this.selectionsError = undefined;
@@ -814,7 +814,7 @@ export class QueryModel {
      * true.
      */
     get urlQueryParams(): Record<string, string> {
-        const { currentPage, urlPrefix, filterArray, maxRows, selectedReportId, sorts, viewName } = this;
+        const { currentPage, urlPrefix, filterArray, maxRows, selectedReportIds, sorts, viewName } = this;
         const filters = filterArray.filter(f => f.getColumnName() !== '*');
         const searches = filterArray
             .filter(f => f.getColumnName() === '*')
@@ -843,8 +843,8 @@ export class QueryModel {
             modelParams[`${urlPrefix}.q`] = searches;
         }
 
-        if (selectedReportId) {
-            modelParams[`${urlPrefix}.reportId`] = selectedReportId;
+        if (selectedReportIds.length > 0) {
+            modelParams[`${urlPrefix}.selectedReportIds`] = selectedReportIds.join(';');
         }
 
         filters.forEach((filter): void => {
@@ -1215,7 +1215,7 @@ export class QueryModel {
         if (isNaN(maxRows)) maxRows = DEFAULT_MAX_ROWS;
         let offset = offsetFromString(maxRows, searchParams.get(`${prefix}.p`)) ?? DEFAULT_OFFSET;
         let schemaQuery = new SchemaQuery(this.schemaName, this.queryName, viewName);
-        let selectedReportId = searchParams.get(`${prefix}.reportId`) ?? undefined;
+        let selectedReportIds = searchParams.get(`${prefix}.selectedReportIds`)?.split(';') ?? [];
         let sorts = querySortsFromString(searchParams.get(`${prefix}.sort`)) ?? [];
 
         // If useExistingValues is true we'll assume any value not present on the URL can be overridden by the current
@@ -1237,8 +1237,8 @@ export class QueryModel {
                 schemaQuery = this.schemaQuery;
             }
 
-            if (selectedReportId === undefined && this.selectedReportId) {
-                selectedReportId = this.selectedReportId;
+            if (selectedReportIds.length === 0 && this.selectedReportIds.length > 0) {
+                selectedReportIds = this.selectedReportIds;
             }
 
             if (sorts.length === 0 && this.sorts.length > 0) {
@@ -1246,7 +1246,7 @@ export class QueryModel {
             }
         }
 
-        return { filterArray, maxRows, offset, schemaQuery, selectedReportId, sorts };
+        return { filterArray, maxRows, offset, schemaQuery, selectedReportIds, sorts };
     }
 
     /**
@@ -1263,7 +1263,7 @@ export class QueryModel {
 
 type QueryModelURLState = Pick<
     QueryModel,
-    'filterArray' | 'maxRows' | 'offset' | 'schemaQuery' | 'selectedReportId' | 'sorts'
+    'filterArray' | 'maxRows' | 'offset' | 'schemaQuery' | 'selectedReportIds' | 'sorts'
 >;
 type QueryModelSettings = Partial<Pick<QueryModel, 'filterArray' | 'maxRows' | 'sorts' | 'viewName'>>;
 const LOCAL_STORAGE_PREFIX = 'QUERY_MODEL_SETTINGS';

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -83,8 +83,8 @@ function searchFiltersFromString(searchStr: string): Filter.IFilter[] {
  */
 export function locationHasQueryParamSettings(prefix: string, searchParams?: URLSearchParams): boolean {
     if (searchParams === undefined) return false;
-    // Report
-    if (searchParams.get(`${prefix}.reportId`) !== null) return true;
+    // Reports
+    if (searchParams.get(`${prefix}.selectedReportIds`) !== null) return true;
     // View
     if (searchParams.get(`${prefix}.view`) !== null) return true;
     // Search Filters

--- a/packages/components/src/public/QueryModel/testUtils.ts
+++ b/packages/components/src/public/QueryModel/testUtils.ts
@@ -61,7 +61,7 @@ export const makeTestActions = (mockFn = (): any => () => {}, overrides: Partial
     const defaultActions: Actions = {
         addModel: mockFn(),
         addMessage: mockFn(),
-        clearSelectedReportIds: mockFn(),
+        clearSelectedReports: mockFn(),
         clearSelections: mockFn(),
         loadModel: mockFn(),
         loadAllModels: mockFn(),

--- a/packages/components/src/public/QueryModel/testUtils.ts
+++ b/packages/components/src/public/QueryModel/testUtils.ts
@@ -61,6 +61,7 @@ export const makeTestActions = (mockFn = (): any => () => {}, overrides: Partial
     const defaultActions: Actions = {
         addModel: mockFn(),
         addMessage: mockFn(),
+        clearSelectedReportIds: mockFn(),
         clearSelections: mockFn(),
         loadModel: mockFn(),
         loadAllModels: mockFn(),

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -110,6 +110,7 @@ export type ModelChange = AddChange | DeleteChange | UpdateChange;
 export interface Actions {
     addMessage: (id: string, message: GridMessage, duration?: number) => void;
     addModel: (queryConfig: QueryConfig, load?: boolean, loadSelections?: boolean) => void;
+    clearSelectedReportIds: (id: string) => void;
     clearSelections: (id: string) => void;
     loadAllModels: (loadSelections?: boolean, reloadTotalCount?: boolean) => void;
     loadCharts: (id: string) => void;
@@ -124,7 +125,7 @@ export interface Actions {
     resetTotalCountState: () => void;
     selectAllRows: (id: string) => void;
     selectPage: (id: string, checked: boolean) => void;
-    selectReport: (id: string, reportId: string) => void;
+    selectReport: (id: string, reportId: string, selected: boolean) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     selectRow: (id: string, checked: boolean, row: Record<string, any>, useSelectionPivot?: boolean) => void;
     setFilters: (id: string, filters: Filter.IFilter[], loadSelections?: boolean) => void;
@@ -318,6 +319,7 @@ export function withQueryModels<Props>(
             this.actions = {
                 addModel: this.addModel,
                 addMessage: this.addMessage,
+                clearSelectedReportIds: this.clearSelectedReportIds,
                 clearSelections: this.clearSelections,
                 loadModel: this.loadModel,
                 loadAllModels: this.loadAllModels,
@@ -685,11 +687,29 @@ export function withQueryModels<Props>(
             this.setSelections(id, checked, this.state.queryModels[id].orderedRows);
         };
 
-        selectReport = (id: string, reportId: string): void => {
+        selectReport = (id: string, reportId: string, selected: boolean): void => {
             this.setState(
                 produce<State>((draft: WritableDraft<State>) => {
                     const model = draft.queryModels[id];
-                    model.selectedReportId = reportId;
+                    if (selected && !model.selectedReportIds.includes(reportId)) {
+                        model.selectedReportIds.push(reportId);
+                    } else if (!selected) {
+                        model.selectedReportIds = model.selectedReportIds.filter(id => id !== reportId);
+                    }
+                }),
+                () => {
+                    if (this.state.queryModels[id].bindURL) {
+                        this.bindURL(id);
+                    }
+                }
+            );
+        };
+
+        clearSelectedReportIds = (id: string): void => {
+            this.setState(
+                produce<State>((draft: WritableDraft<State>) => {
+                    const model = draft.queryModels[id];
+                    model.selectedReportIds = [];
                 }),
                 () => {
                     if (this.state.queryModels[id].bindURL) {

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -110,7 +110,7 @@ export type ModelChange = AddChange | DeleteChange | UpdateChange;
 export interface Actions {
     addMessage: (id: string, message: GridMessage, duration?: number) => void;
     addModel: (queryConfig: QueryConfig, load?: boolean, loadSelections?: boolean) => void;
-    clearSelectedReportIds: (id: string) => void;
+    clearSelectedReports: (id: string) => void;
     clearSelections: (id: string) => void;
     loadAllModels: (loadSelections?: boolean, reloadTotalCount?: boolean) => void;
     loadCharts: (id: string) => void;
@@ -319,7 +319,7 @@ export function withQueryModels<Props>(
             this.actions = {
                 addModel: this.addModel,
                 addMessage: this.addMessage,
-                clearSelectedReportIds: this.clearSelectedReportIds,
+                clearSelectedReports: this.clearSelectedReports,
                 clearSelections: this.clearSelections,
                 loadModel: this.loadModel,
                 loadAllModels: this.loadAllModels,
@@ -705,7 +705,7 @@ export function withQueryModels<Props>(
             );
         };
 
-        clearSelectedReportIds = (id: string): void => {
+        clearSelectedReports = (id: string): void => {
             this.setState(
                 produce<State>((draft: WritableDraft<State>) => {
                     const model = draft.queryModels[id];

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -118,6 +118,17 @@
 .report-list__chart-preview .chart-body {
     min-height: 300px;
 }
+.chart-menu-checkbox {
+    margin-right: 8px;
+}
+.chart-menu-checkbox.fa-check-square {
+    color: $grid-action-item-color;
+}
+.chart-list {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    margin-bottom: 16px;
+}
 .chart-panel__heading {
     display: flex;
 }
@@ -127,10 +138,7 @@
     vertical-align: middle;
 }
 .chart-panel {
-    margin-bottom: 16px;
     min-height: 100px;
-    border: 1px solid #ddd;
-    border-radius: 8px;
     padding: 15px;
 }
 .chart-panel__hide-icon {


### PR DESCRIPTION
#### Rationale
This PR adds the ability to render multiple charts at the same time on a grid.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1867
- https://github.com/LabKey/platform/pull/7113
- https://github.com/LabKey/limsModules/pull/1721
- https://github.com/LabKey/testAutomation/pull/2750

#### Changes
- QueryModel: remove selectedReportId, add selectedReportIds
- withQueryModels: update selectReport, add clearSelectedReports
- ChartMenu: support multiple report selections
- Add ChartList
