### PR TITLE
Search: escape all quotes in search terms

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3-fb-escape-search.0",
+  "version": "6.64.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.3-fb-escape-search.0",
+      "version": "6.64.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2",
+  "version": "6.64.3-fb-escape-search.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.2",
+      "version": "6.64.3-fb-escape-search.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.2",
+  "version": "6.64.3-fb-escape-search.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3-fb-escape-search.0",
+  "version": "6.64.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.64.3
+*Released*: 13 October 2025
+- Search: escape all quotes in search terms
+
 ### version 6.64.2
 *Released*: 10 October 2025
 - Issue 52878: Attachment thumbnails from ancestor columns not rendered in Sample Type grid

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -1589,13 +1589,28 @@ describe('escapeSearchQuery', () => {
         luceneCharacters.forEach(char => {
             expect(escapeSearchQuery(char, true)).toEqual(`\\${char} OR \\${char}*`);
         });
+        expect(escapeSearchQuery('a && b || c && d', true)).toEqual(
+            'a \\&& b \\|| c \\&& d OR a \\&& b \\|| c \\&& d*'
+        );
+        expect(escapeSearchQuery('a|b', true)).toEqual('a|b OR a|b*');
+        expect(escapeSearchQuery('a&b', true)).toEqual('a&b OR a&b*');
     });
     test('handles UTF-8 characters', () => {
         expect(escapeSearchQuery('(I am a little 🫖)')).toEqual('\\(I am a little 🫖\\) OR \\(I am a little 🫖\\)*');
         expect(escapeSearchQuery('野球が大好きです')).toEqual('野球が大好きです OR 野球が大好きです*');
+        expect(escapeSearchQuery('🙂-(ok)', true)).toEqual('🙂\\-\\(ok\\) OR 🙂\\-\\(ok\\)*');
     });
     test('handles quotes well', () => {
         expect(escapeSearchQuery('"Fresh" and "Flowers"', false)).toEqual('"Fresh" and "Flowers"');
         expect(escapeSearchQuery('Fl"ower', true)).toEqual('Fl\\"ower OR Fl\\"ower*');
+        expect(escapeSearchQuery('D_"fee{-e>4_b4"', false)).toEqual('D_"fee\\{\\-e>4_b4"');
+        expect(escapeSearchQuery('D_"fee{-e>4_b4"', true)).toEqual(
+            'D_\\"fee\\{\\-e>4_b4\\" OR D_\\"fee\\{\\-e>4_b4\\"*'
+        );
+    });
+    test('trims', () => {
+        expect(escapeSearchQuery('   test  &&    sp"ace    ', true)).toEqual(
+            'test  \\&&    sp\\"ace OR test  \\&&    sp\\"ace*'
+        );
     });
 });

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -690,18 +690,16 @@ export function escapeSearchQuery(q: string, escapeQuotes = false): string {
 
         // Escape special lucene characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \
         // https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters
-        q = q
-            .replace(/(?<specialChar>[\+\-!\(\){}\[\]^~*?:\\])/gi, '\\$<specialChar>')
-            .replace('&&', '\\&&')
-            .replace('||', '\\||');
+        q = q.trim().replace(/&&|\|\||[+\-!(){}\[\]^~*?:\\]/g, m => `\\${m}`);
+
         if (escapeQuotes) {
-            q = q.replace('"', '\\"');
+            q = q.replace(/"/g, '\\"');
         }
 
         // Append an additional wildcard search clause to include prefix matching
         // Example: "M-" will result in a query of "M\- OR M\-*"
         if (!hasQuotes || escapeQuotes) {
-            q = [q, `${q.trim()}*`].join(' OR ');
+            q = [q, `${q}*`].join(' OR ');
         }
     }
 


### PR DESCRIPTION
#### Rationale
This addresses a bug in escaping search term quoting where we were not escaping beyond the first quote. An example of this is a test case where an ELN is named with multiple quotes. Searching to reference for that quote would end up displaying an error like the following:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/ac8c11ac-e0ee-43af-99c5-fd51dc101bb3" />

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1725

#### Changes
- Search: escape all quotes
- always trim query
- optimize replacement with a single regex
- drop insensitive check as it is not necessary
- Add unit tests