### PR TITLE
Misc exception fixes based on Mothership reports

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3",
+  "version": "6.64.4-miscExceptionFixes-2511.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.3",
+      "version": "6.64.4-miscExceptionFixes-2511.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.4-miscExceptionFixes-2511.1",
+  "version": "6.65.2-miscExceptionFixes-2511.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.4-miscExceptionFixes-2511.1",
+      "version": "6.65.2-miscExceptionFixes-2511.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.65.2-miscExceptionFixes-2511.1",
+  "version": "6.65.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.65.2-miscExceptionFixes-2511.1",
+      "version": "6.65.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.65.2-miscExceptionFixes-2511.1",
+  "version": "6.65.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3",
+  "version": "6.64.4-miscExceptionFixes-2511.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Various minor fixes for exception reports
+
 ### version 6.64.3
 *Released*: 13 October 2025
 - Search: escape all quotes in search terms

--- a/packages/components/src/internal/Modal.tsx
+++ b/packages/components/src/internal/Modal.tsx
@@ -25,9 +25,9 @@ export const BaseModal: FC<BaseModalProps> = ({ bsSize, children, className }) =
 
     useEffect(() => {
         // Prevent scrolling the body when a modal is shown
-        document.body.classList.toggle('no-scroll', true);
+        document.body.classList?.toggle('no-scroll', true);
         return () => {
-            document.body.classList.toggle('no-scroll', false);
+            document.body.classList?.toggle('no-scroll', false);
         };
     }, []);
 

--- a/packages/components/src/internal/components/base/models/User.ts
+++ b/packages/components/src/internal/components/base/models/User.ts
@@ -142,7 +142,7 @@ export function checkPermissions(
  * @param perms Array of permission strings (See models/constants)
  * @param checkIsAdmin Indicates if user.isAdmin should override check. Defaults to true.
  * @param permissionCheck Sets which "has permissions" check logic is used.
- *   `all` - Require user to have all of the specified permissions (default).
+ *   `all` - Require user to have all the specified permissions (default).
  *   `any` - Require user to have any of the specified permissions.
  */
 export function hasPermissions(
@@ -151,7 +151,7 @@ export function hasPermissions(
     checkIsAdmin = true,
     permissionCheck: 'all' | 'any' = 'all'
 ): boolean {
-    return checkPermissions(user.isAdmin, user.permissionsList, perms, checkIsAdmin, permissionCheck);
+    return checkPermissions(user?.isAdmin, user?.permissionsList, perms, checkIsAdmin, permissionCheck);
 }
 
 /**

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -779,7 +779,7 @@ export class QueryModel {
         }
 
         let sortStrings = sorts.map(sortStringMapper);
-        const viewSorts = queryInfo.getSorts(viewName).map(sortStringMapper);
+        const viewSorts = queryInfo.getSorts(viewName)?.map(sortStringMapper) ?? [];
 
         if (viewSorts.length > 0) {
             sortStrings = sortStrings.concat(viewSorts);


### PR DESCRIPTION
#### Rationale
We've gotten various exception reports for null-like values. They seem like rare cases (or cases that I can't see how they would happen), but they are easy enough to protect against.

- [44342](https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=44342) 
- [44265](https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=44265)
- [43821](https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=43821)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1745

#### Changes
- Add some protections for undefined values
