### PR TITLE
Issue 52310: Change application dropdowns to include the current value in the listed options

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.66.1-showSelectedValue-52310.3",
+  "version": "6.66.1-showSelectedValue-52310.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.66.1-showSelectedValue-52310.3",
+      "version": "6.66.1-showSelectedValue-52310.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.65.3-showSelectedValue-52310.2",
+  "version": "6.65.3-showSelectedValue-52310.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.65.3-showSelectedValue-52310.2",
+      "version": "6.65.3-showSelectedValue-52310.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3",
+  "version": "6.64.4-showSelectedValue-52310.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.64.3",
+      "version": "6.64.4-showSelectedValue-52310.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.66.1-showSelectedValue-52310.4",
+  "version": "6.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.66.1-showSelectedValue-52310.4",
+      "version": "6.67.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.65.2-showSelectedValue-52310.1",
+  "version": "6.65.2-showSelectedValue-52310.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.65.2-showSelectedValue-52310.1",
+      "version": "6.65.2-showSelectedValue-52310.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.64.3",
+  "version": "6.64.4-showSelectedValue-52310.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.65.3-showSelectedValue-52310.2",
+  "version": "6.65.3-showSelectedValue-52310.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.66.1-showSelectedValue-52310.3",
+  "version": "6.66.1-showSelectedValue-52310.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.65.2-showSelectedValue-52310.1",
+  "version": "6.65.2-showSelectedValue-52310.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.66.1-showSelectedValue-52310.4",
+  "version": "6.67.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released* TBD
+### version 6.67.0
+*Released* 29 October 2025
 - Issue 52310: Change application single-value dropdowns to include the current value in the listed options
 
 ### version 6.66.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released* TBD
+- Issue 52310: Change application single-value dropdowns to include the current value in the listed options
+
 ### version 6.64.3
 *Released*: 13 October 2025
 - Search: escape all quotes in search terms

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -42,6 +42,7 @@ import { TextChoiceInput } from './input/TextChoiceInput';
 
 import { getQueryFormLabelFieldName, isQueryFormLabelField } from './utils';
 import { InternalSpacesWarning } from './InternalSpacesWarning';
+import { LOOKUP_DEFAULT_SIZE } from '../../constants';
 
 export interface QueryFormInputsProps {
     allowFieldDisable?: boolean;
@@ -278,7 +279,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                         joinValues={joinValues}
                                         label={col.caption}
                                         loadOnFocus
-                                        maxRows={10}
+                                        maxRows={LOOKUP_DEFAULT_SIZE}
                                         multiple={multiple}
                                         name={fieldKey}
                                         notFoundValuesEnabled={!(col.isExpInput() || col.isAliquotParent())} // Issue 53153

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -41,6 +41,7 @@ import { ExpirationDateColumnRenderer } from '../../../renderers/ExpirationDateC
 import { getContainerFilterForLookups } from '../../../query/api';
 import { FolderColumnRenderer } from '../../../renderers/FolderColumnRenderer';
 import { FILELINK_RANGE_URI } from '../../domainproperties/constants';
+import { LOOKUP_DEFAULT_SIZE } from '../../../constants';
 
 export type Renderer = (data: any, row?: any) => ReactNode;
 
@@ -338,7 +339,7 @@ export function resolveDetailEditRenderer(
                         joinValues={joinValues}
                         key={col.fieldKey}
                         label={col.caption}
-                        maxRows={10}
+                        maxRows={LOOKUP_DEFAULT_SIZE}
                         multiple={multiple}
                         name={col.fieldKey}
                         notFoundValuesEnabled={!(col.isExpInput() || col.isAliquotParent())} // Issue 53153

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -308,7 +308,7 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
         showDropdownIndicator: true,
         showDropdownMenu: true,
         showIndicatorSeparator: true,
-        tabSelectsValue: false,
+        tabSelectsValue: false, // Issue 52310
         valueKey: 'value',
     };
 

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -308,7 +308,7 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
         showDropdownIndicator: true,
         showDropdownMenu: true,
         showIndicatorSeparator: true,
-        tabSelectsValue: true,
+        tabSelectsValue: false,
         valueKey: 'value',
     };
 

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -222,6 +222,7 @@ export interface SelectInputProps {
     formsy?: boolean;
     help?: ReactNode;
     helpTipRenderer?: string;
+    hideSelectedOptions?: boolean;
     id?: any;
     initiallyDisabled?: boolean;
     inputClass?: string;
@@ -289,11 +290,12 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
         allowDisable: false,
         autoValue: true,
         clearable: true,
-        clearCacheOnChange: true,
+        clearCacheOnChange: false,
         closeMenuOnSelect: true,
         containerClass: INPUT_CONTAINER_CLASS_NAME,
         defaultOptions: true,
         delimiter: DELIMITER,
+        hideSelectedOptions: true,
         initiallyDisabled: false,
         inputClass: INPUT_WRAPPER_CLASS_NAME,
         labelClass: INPUT_LABEL_CLASS_NAME,

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -295,7 +295,7 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
         containerClass: INPUT_CONTAINER_CLASS_NAME,
         defaultOptions: true,
         delimiter: DELIMITER,
-        hideSelectedOptions: true,
+        hideSelectedOptions: false,
         initiallyDisabled: false,
         inputClass: INPUT_WRAPPER_CLASS_NAME,
         labelClass: INPUT_LABEL_CLASS_NAME,

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -130,7 +130,7 @@ export function formatSavedResults(
     const { key, orderedModels } = result;
     const models = fromJS(result.models[key]);
     const filteredResults = orderedModels[key]
-        .filter(k => !selectedItems.has(k))
+        // .filter(k => !selectedItems.has(k))
         .reduce((ordered, k) => ordered.set(k, models.get(k)), OrderedMap<string, any>());
 
     return formatResults(model, filteredResults, token);

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -121,7 +121,7 @@ export function formatSavedResults(
     result: ISelectRowsResult,
     token?: string
 ): SelectInputOption[] {
-    const { queryInfo, selectedItems } = model;
+    const { queryInfo } = model;
 
     if (!queryInfo) {
         return [];
@@ -129,11 +129,10 @@ export function formatSavedResults(
 
     const { key, orderedModels } = result;
     const models = fromJS(result.models[key]);
-    const filteredResults = orderedModels[key]
-        // .filter(k => !selectedItems.has(k))
+    const orderedResults = orderedModels[key]
         .reduce((ordered, k) => ordered.set(k, models.get(k)), OrderedMap<string, any>());
 
-    return formatResults(model, filteredResults, token);
+    return formatResults(model, orderedResults, token);
 }
 
 export function saveSearchResults(model: QuerySelectModel, result: ISelectRowsResult): QuerySelectModel {

--- a/packages/components/src/internal/components/labelPrinting/PrintLabelsModal.tsx
+++ b/packages/components/src/internal/components/labelPrinting/PrintLabelsModal.tsx
@@ -17,6 +17,7 @@ import { BarTenderResponse } from './models';
 import { BAR_TENDER_TOPIC, LABEL_NOT_FOUND_ERROR, LABEL_TEMPLATE_SQ } from './constants';
 import { ViewInfo } from '../../ViewInfo';
 import { SchemaQuery } from '../../../public/SchemaQuery';
+import { LOOKUP_DEFAULT_SIZE } from '../../constants';
 
 export interface PrintModalProps {
     afterPrint?: (numSamples: number, numLabels: number) => void;
@@ -239,7 +240,7 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                                     fireQSChangeOnInit={true}
                                     showLabel={false}
                                     loadOnFocus
-                                    maxRows={10}
+                                    maxRows={LOOKUP_DEFAULT_SIZE}
                                     multiple={true}
                                     name="label-samples"
                                     onQSChange={this.changeSampleSelection}
@@ -259,7 +260,7 @@ export class PrintLabelsModalImpl extends PureComponent<PrintModalProps & Inject
                                 fireQSChangeOnInit
                                 showLabel={false}
                                 loadOnFocus
-                                maxRows={10}
+                                maxRows={LOOKUP_DEFAULT_SIZE}
                                 name="label-template"
                                 onQSChange={this.changeTemplateSelection}
                                 placeholder="Select or type to search..."

--- a/packages/components/src/internal/util/Date.test.ts
+++ b/packages/components/src/internal/util/Date.test.ts
@@ -1093,8 +1093,6 @@ describe('Date Utilities', () => {
             expect(isDateTimeInPast(datePlusHours(utcNow, -1), TZ)).toBeTruthy();
             expect(isDateTimeInPast(datePlusHours(utcNow, 1), TZ)).toBeTruthy();
             expect(isDateTimeInPast(datePlusHours(utcNow, 2), TZ)).toBeTruthy();
-            expect(isDateTimeInPast(datePlusHours(utcNow, 3), TZ)).toBeTruthy();
-
             // Europe/Kyiv timezone is +3 hours UTC
             expect(isDateTimeInPast(datePlusHours(utcNow, 4), TZ)).toBeFalsy();
             expect(isDateTimeInPast(datePlusHours(utcNow, 5), TZ)).toBeFalsy();


### PR DESCRIPTION
#### Rationale
Issue [52310](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52310) - Up to now, we have been removing the selected option from our drop down menus, which means that when the menu is opened the first item in the menu gets highlight and can be chosen if the user interacts in certain ways. By showing the option in our single-select menus (the default behavior for the [ReactSelect component](https://react-select.com/props) we use), it becomes the highlighted option when opened.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/837
- https://github.com/LabKey/limsModules/pull/1750

#### Changes
- Introduce `hideSelectedOptions` property for `SelectInput` to mirror the property from [ReactSelect](https://react-select.com/props)
- Change the default value for `clearCacheOnChange` to `false` since if showing the selected option the option set should not change 
