### PR TITLE
Issue 53567: Improve "Alias" column performance

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
-        "@labkey/eslint-config": "1.1.0",
+        "@labkey/eslint-config": "1.1.1",
         "@types/history": "4.7.11",
         "@types/jest": "30.0.0",
         "@types/node": "24.10.0",
@@ -3578,9 +3578,9 @@
       }
     },
     "node_modules/@labkey/eslint-config": {
-      "version": "1.1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config/-/@labkey/eslint-config-1.1.0.tgz",
-      "integrity": "sha512-r7cuwRQg1JJgFROPdUcbRnwrnB3XV70Y0rw+Djgy3xCJyrVeTuV1G7uR+bltnl9R8fSMLyAP8QNTKdhJSDGinA==",
+      "version": "1.1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config/-/@labkey/eslint-config-1.1.1.tgz",
+      "integrity": "sha512-yTd/C0aynL/yoonEGq3/7ivwyWy0oa54iNZ4PP9afXDe9e5bpvQ2pp/dTrjBTH4WL2Re92L27uSnlu5RDL1nsA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.2-fb-alias-perf-53567.0",
+  "version": "6.70.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.2-fb-alias-perf-53567.0",
+      "version": "6.70.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.1",
+  "version": "6.70.2-fb-alias-perf-53567.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.1",
+      "version": "6.70.2-fb-alias-perf-53567.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.1",
+  "version": "6.70.2-fb-alias-perf-53567.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",
-    "@labkey/eslint-config": "1.1.0",
+    "@labkey/eslint-config": "1.1.1",
     "@types/history": "4.7.11",
     "@types/jest": "30.0.0",
     "@types/node": "24.10.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.2-fb-alias-perf-53567.0",
+  "version": "6.70.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version 6.70.2
+*Released*: 7 November 2025
+- Issue 53567: Improve "Alias" column performance
+  - Update "Alias" column usages to refer to "value" instead of "displayValue" on select rows responses.
+
 ###  version 6.70.1
 *Released*: 6 November 2025
 - use export-tools to remove unused package exports

--- a/packages/components/src/internal/components/forms/input/AliasInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AliasInput.tsx
@@ -36,7 +36,7 @@ export const AliasSelectInput: FC<Props> = memo(props => {
             ?.map(a => {
                 if (!a) return a;
                 if (typeof a === 'string') return a;
-                if (typeof a === 'object') return a.displayValue;
+                if (typeof a === 'object') return a.value;
                 return undefined;
             })
             .filter(a => !!a);

--- a/packages/components/src/internal/renderers/AliasRenderer.tsx
+++ b/packages/components/src/internal/renderers/AliasRenderer.tsx
@@ -53,7 +53,7 @@ export class AliasRenderer extends React.Component<Props, State> {
         if (data?.size > 0) {
             const truncationLength = view === 'detail' ? DETAIL_ALIAS_WORD_LENGTH : GRID_ALIAS_WORD_LENGTH;
             const extraCount = data.size - truncationLength;
-            const aliases = data.map(alias => alias.get('displayValue'));
+            const aliases = data.map(alias => alias.get('value'));
 
             return (
                 <div className="alias-renderer" title={aliases.join(', ')}>

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig([
     typeScriptESLint.configs.recommended,
     typeScriptESLint.configs.stylistic,
     pluginReact.configs.flat.recommended,
-    pluginReactHooks.configs['recommended-latest'],
+    pluginReactHooks.configs.flat['recommended-latest'],
     perfectionist.configs['recommended-natural'],
     prettierRecommended,
     {

--- a/packages/eslint-config/package-lock.json
+++ b/packages/eslint-config/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/eslint-config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/eslint-config",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint": "9.39.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/eslint-config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "shareable eslint config for typescript",
   "main": "eslint.config.mjs",
   "files": [


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53567](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53567) by refactoring the "Alias" column for data classes and sample types away from the traditional multi-value foreign key (MVFK) to an inline join on the values.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1875
- https://github.com/LabKey/platform/pull/7152
- https://github.com/LabKey/limsModules/pull/1759

#### Changes
- Update "Alias" column usages to refer to "value" instead of "displayValue" on select rows responses.
