### PR TITLE
Issue 53563: Domain designer lookups don't show newly added entity types after initial load/view

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.66.0",
+  "version": "6.66.0-fetchQueries53563.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.66.0",
+      "version": "6.66.0-fetchQueries53563.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.67.0",
+  "version": "6.67.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.67.0",
+      "version": "6.67.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.67.0",
+  "version": "6.67.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.66.0",
+  "version": "6.66.0-fetchQueries53563.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Issue 53563: Domain designer lookups don't show newly added entity types after initial load/view
+  - Remove fetchQueries from client cache
+
 ### version 6.66.0
 *Released*: 23 October 2025
 - ChartBuilderModal support for bar/line chart aggregate method and error bar options

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 6.67.1
+*Released* 29 October 2025
 - Issue 53563: Domain designer lookups don't show newly added entity types after initial load/view
   - Remove fetchQueries from client cache
 

--- a/packages/components/src/internal/components/domainproperties/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/actions.ts
@@ -208,27 +208,20 @@ export function fetchDomainDetails(options: FetchDomainDetailsOptions): Promise<
 }
 
 export function fetchQueries(containerPath: string, schemaName: string): Promise<QueryInfoLite[]> {
-    const key = [containerPath, schemaName].join('|').toLowerCase();
-
-    return cache<QueryInfoLite[]>(
-        'query-cache',
-        key,
-        () =>
-            new Promise(resolve => {
-                if (schemaName) {
-                    Query.getQueries({
-                        containerPath,
-                        schemaName,
-                        queryDetailColumns: true,
-                        success: data => {
-                            resolve(processQueries(data));
-                        },
-                    });
-                } else {
-                    resolve(null);
-                }
-            })
-    );
+    return new Promise(resolve => {
+        if (schemaName) {
+            Query.getQueries({
+                containerPath,
+                schemaName,
+                queryDetailColumns: true,
+                success: data => {
+                    resolve(processQueries(data));
+                },
+            });
+        } else {
+            resolve(null);
+        }
+    });
 }
 
 export function getRequiredParentTypes(


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53563

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1877
- https://github.com/LabKey/limsModules/pull/1763
- https://github.com/LabKey/testAutomation/pull/2770

#### Changes
- Remove fetchQueries from client cache
