### PR TITLE
Curve Fit Statistic Access

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.1",
+  "version": "6.68.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.68.1",
+      "version": "6.68.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.1",
+  "version": "6.68.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version 6.??.?
+*Released*: ?? October 2025
+- Chart: render curve fit statistics when available
+
 ### version 6.68.1
 *Released* 2 November 2025
 - Issue 52063: Domain designer to handle lookup to a query with a pipe character

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,9 +1,9 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-###  version 6.??.?
-*Released*: ?? October 2025
-- Chart: render curve fit statistics when available
+###  version 6.68.2
+*Released*: 3 November 2025
+- SVGChart: render curve fit statistics when available
 
 ### version 6.68.1
 *Released* 2 November 2025

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -27,6 +27,7 @@ import { LoadingSpinner } from '../base/LoadingSpinner';
 import { ChartAPIWrapper, DEFAULT_API_WRAPPER } from './api';
 import { ChartConfig, ChartQueryConfig } from './models';
 import { getChartRenderMsg } from './ChartBuilderModal';
+import { CurveFitStatsGrid } from './CurveFitStatsGrid';
 
 interface ChartLoadingMaskProps {
     msg?: string;
@@ -95,6 +96,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, container, filters, query
     const [loadingData, setLoadingData] = useState<boolean>(false);
     const [measureStore, setMeasureStore] = useState<any>(undefined);
     const [trendlineData, setTrendlineData] = useState<any>(undefined);
+    const [plot, setPlot] = useState(undefined);
     const [renderMsg, setRenderMsg] = useState<string>(undefined);
     const [loadError, setLoadError] = useState<string>(undefined);
     const filterKey = useMemo(() => computeFilterKey(filters), [filters]);
@@ -163,7 +165,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, container, filters, query
                         }
                     );
                 } else {
-                    LABKEY_VIS.GenericChartHelper.generateChartSVG(
+                    const plots = LABKEY_VIS.GenericChartHelper.generateChartSVG(
                         divId,
                         {
                             ...chartConfig,
@@ -173,6 +175,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, container, filters, query
                         measureStore,
                         trendlineData
                     );
+                    setPlot(plots[0]);
                 }
             }
         };
@@ -189,6 +192,7 @@ export const SVGChart: FC<Props> = memo(({ api, chart, container, filters, query
             {(isLoading(loadingState) || loadingData) && <ChartLoadingMask />}
             {renderMsg && <span className="gray-text pull-right">{renderMsg}</span>}
             <div className="svg-chart__chart" id={divId} ref={ref} />
+            {trendlineData !== undefined && <CurveFitStatsGrid trendLineData={trendlineData} plot={plot} />}
         </div>
     );
 });

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -192,7 +192,9 @@ export const SVGChart: FC<Props> = memo(({ api, chart, container, filters, query
             {(isLoading(loadingState) || loadingData) && <ChartLoadingMask />}
             {renderMsg && <span className="gray-text pull-right">{renderMsg}</span>}
             <div className="svg-chart__chart" id={divId} ref={ref} />
-            {trendlineData !== undefined && <CurveFitStatsGrid plot={plot} trendLineData={trendlineData} />}
+            {trendlineData !== undefined && (
+                <CurveFitStatsGrid name={chart.name} plot={plot} trendLineData={trendlineData} />
+            )}
         </div>
     );
 });

--- a/packages/components/src/internal/components/chart/Chart.tsx
+++ b/packages/components/src/internal/components/chart/Chart.tsx
@@ -83,7 +83,7 @@ interface Props {
     chart: DataViewInfo;
     container?: string;
     filters?: Filter.IFilter[];
-    queryParameters?: { [key: string]: any };
+    queryParameters?: Record<string, any>;
 }
 
 export const SVGChart: FC<Props> = memo(({ api, chart, container, filters, queryParameters }) => {
@@ -192,18 +192,20 @@ export const SVGChart: FC<Props> = memo(({ api, chart, container, filters, query
             {(isLoading(loadingState) || loadingData) && <ChartLoadingMask />}
             {renderMsg && <span className="gray-text pull-right">{renderMsg}</span>}
             <div className="svg-chart__chart" id={divId} ref={ref} />
-            {trendlineData !== undefined && <CurveFitStatsGrid trendLineData={trendlineData} plot={plot} />}
+            {trendlineData !== undefined && <CurveFitStatsGrid plot={plot} trendLineData={trendlineData} />}
         </div>
     );
 });
 SVGChart.displayName = 'SVGChart';
 
+interface FileAnchor {
+    href: string;
+    text: string;
+}
+
 interface RReportData {
     error?: string;
-    fileAnchors: Array<{
-        href: string;
-        text: string;
-    }>;
+    fileAnchors: FileAnchor[];
     imageUrls: string[];
 }
 
@@ -313,7 +315,7 @@ const RReport: FC<Props> = memo(({ api, chart, container, filters }) => {
             {imageUrls !== undefined && (
                 <div className="r-report__images">
                     {imageUrls.map(url => (
-                        <div key={url} className="r-report__image">
+                        <div className="r-report__image" key={url}>
                             <img alt="R Report Image Output" src={url} />
                         </div>
                     ))}

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -313,8 +313,8 @@ export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData })
 
     return (
         <div className="curve-fit-statistics">
-            <div className="curve-fit-statistics__header">
-                <h5 className="curve-fit-statistics__title">Statistics</h5>
+            <div className="curve-fit-statistics__header margin-bottom">
+                <div className="curve-fit-statistics__title">Statistics</div>
                 <DropdownButton
                     buttonClassName="curve-fit-statistics__dropdown-button"
                     className="curve-fit-statistics__export-menu"

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -19,24 +19,28 @@ const roundedValue = (value: number) => {
     const rounded = Utils.roundNumber(value, 4);
     return !isNaN(rounded) ? rounded : value;
 };
-const MIN_COL = new GridColumn({ index: 'min', title: 'Min', cell: roundedValue });
-const MAX_COL = new GridColumn({ index: 'max', title: 'Max', cell: roundedValue });
-const ASYMMETRY_COLUMN = new GridColumn({ index: 'asymmetry', title: 'Asymmetry', cell: roundedValue });
-const INFLECTION_COLUMN = new GridColumn({ index: 'inflection', title: 'Inflection', cell: roundedValue });
-const R_SQUARED_COLUMN = new GridColumn({ index: 'RSquared', title: 'R-Squared', cell: roundedValue });
+const roundedColumn = (value: number) => {
+    const str = roundedValue(value);
+    return <div className="curve-fit-value-cell">{str}</div>;
+};
+const MIN_COL = new GridColumn({ index: 'min', title: 'Min', cell: roundedColumn });
+const MAX_COL = new GridColumn({ index: 'max', title: 'Max', cell: roundedColumn });
+const ASYMMETRY_COLUMN = new GridColumn({ index: 'asymmetry', title: 'Asymmetry', cell: roundedColumn });
+const INFLECTION_COLUMN = new GridColumn({ index: 'inflection', title: 'Inflection', cell: roundedColumn });
+const R_SQUARED_COLUMN = new GridColumn({ index: 'RSquared', title: 'R-Squared', cell: roundedColumn });
 const ADJUSTED_R_SQUARED_COLUMN = new GridColumn({
     index: 'adjustedRSquared',
     title: 'Adjusted R-Squared',
-    cell: roundedValue,
+    cell: roundedColumn,
 });
-const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'RSS', cell: roundedValue });
-const TSS_COLUMN = new GridColumn({ index: 'TSS', title: 'TSS', cell: roundedValue });
-const RMSE_COLUMN = new GridColumn({ index: 'RMSE', title: 'RMSE', cell: roundedValue });
-const SLOPE_COLUMN = new GridColumn({ index: 'slope', title: 'Slope', cell: roundedValue });
-const INTERCEPT_COLUMN = new GridColumn({ index: 'intercept', title: 'Intercept', cell: roundedValue });
-const COEFFICIENT_1_COLUMN = new GridColumn({ index: 'coefficient1', title: 'Coefficient 1', cell: roundedValue });
-const COEFFICIENT_2_COLUMN = new GridColumn({ index: 'coefficient2', title: 'Coefficient 2', cell: roundedValue });
-const COEFFICIENT_3_COLUMN = new GridColumn({ index: 'coefficient3', title: 'Coefficient 3', cell: roundedValue });
+const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'RSS', cell: roundedColumn });
+const TSS_COLUMN = new GridColumn({ index: 'TSS', title: 'TSS', cell: roundedColumn });
+const RMSE_COLUMN = new GridColumn({ index: 'RMSE', title: 'RMSE', cell: roundedColumn });
+const SLOPE_COLUMN = new GridColumn({ index: 'slope', title: 'Slope', cell: roundedColumn });
+const INTERCEPT_COLUMN = new GridColumn({ index: 'intercept', title: 'Intercept', cell: roundedColumn });
+const COEFFICIENT_1_COLUMN = new GridColumn({ index: 'coefficient1', title: 'Coefficient 1', cell: roundedColumn });
+const COEFFICIENT_2_COLUMN = new GridColumn({ index: 'coefficient2', title: 'Coefficient 2', cell: roundedColumn });
+const COEFFICIENT_3_COLUMN = new GridColumn({ index: 'coefficient3', title: 'Coefficient 3', cell: roundedColumn });
 const STATS_COLUMNS = [RSS_COLUMN, TSS_COLUMN, RMSE_COLUMN, R_SQUARED_COLUMN];
 const NONLINEAR_COLUMNS = [
     MIN_COL,
@@ -256,7 +260,7 @@ const SeriesCell: FC<SeriesCellProps> = memo(({ colorScale, series, shapeScale }
             <svg height={15} width={15}>
                 <path d={shape} fill={color} stroke={color} transform="translate(7.5, 7.5)" />
             </svg>
-            <span className="margin-left-small">{series}</span>
+            <div className="curve-fit-series-cell__name">{series}</div>
         </div>
     );
 });

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -38,6 +38,7 @@ const STATS_COLUMNS = [RSS_COLUMN, TSS_COLUMN, RMSE_COLUMN, R_SQUARED_COLUMN];
 const NONLINEAR_COLUMNS = [
     MIN_COL,
     MAX_COL,
+    SLOPE_COLUMN,
     ASYMMETRY_COLUMN,
     INFLECTION_COLUMN,
     ...STATS_COLUMNS,
@@ -90,6 +91,7 @@ interface NonlinearCurveFitData {
     inflection: number;
     max: number;
     min: number;
+    slope: number;
 }
 
 interface NonlinearCurveFit extends CurveFit, NonlinearCurveFitData {
@@ -144,21 +146,21 @@ function trendLineToCurveFitRow(trendline: PossibleTrendlines): CurveFitRow {
     if (curveFit.type === 'Polynomial') {
         return {
             ...stats,
-            series,
             coefficient1: curveFit.coefficients[0],
             coefficient2: curveFit.coefficients[1],
             coefficient3: curveFit.coefficients[2],
+            series,
         };
     }
 
     if (curveFit.type === 'Linear') {
         const { intercept, slope } = curveFit;
-        return { ...stats, series, intercept, slope };
+        return { ...stats, intercept, series, slope };
     }
 
     if (isNonlinearTrendline(trendline)) {
-        const { asymmetry, inflection, max, min } = curveFit;
-        return { ...(stats as NonlinearCurveFitStats), series, asymmetry, inflection, max, min };
+        const { asymmetry, inflection, max, min, slope } = curveFit;
+        return { ...(stats as NonlinearCurveFitStats), asymmetry, inflection, max, min, series, slope };
     }
 
     return undefined;

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -143,8 +143,10 @@ function isNonlinearTrendline(
 }
 
 function trendLineToCurveFitRow(trendline: PossibleTrendlines): CurveFitRow {
-    const { curveFit, stats } = trendline.data;
     const series = trendline.name;
+    // We want to render empty rows in the grid if the series doesn't have data
+    if (trendline.data === undefined) return { series } as CurveFitRow;
+    const { curveFit, stats } = trendline.data;
 
     if (curveFit.type === 'Polynomial') {
         return {
@@ -271,20 +273,24 @@ interface Props {
 }
 
 export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData }) => {
-    const type = trendLineData[0].data.curveFit.type;
+    // A trendline will not have a data attribute if the series doesn't have enough data
+    const validTrendlines = trendLineData.filter(t => t.data !== undefined);
+    const hasValidTrendlines = validTrendlines.length > 0;
+    const type = validTrendlines[0]?.data.curveFit.type;
     const hasSeries = !(trendLineData.length === 1 && trendLineData[0].name === 'All');
-    const gridData = useMemo<CurveFitRow[]>(
-        () => trendLineData.map(trendLineToCurveFitRow).sort(naturalSortByProperty('series')),
-        [trendLineData]
-    );
-    const colorScale = plot?.scales.color;
-    const shapeScale = plot?.scales.shape;
+    const gridData = useMemo<CurveFitRow[]>(() => {
+        if (!hasValidTrendlines) return undefined;
+        return trendLineData.map(trendLineToCurveFitRow).sort(naturalSortByProperty('series'));
+    }, [hasValidTrendlines, trendLineData]);
 
     const gridColumns = useMemo(() => {
+        if (!hasValidTrendlines) return undefined;
         let seriesColumn: GridColumn;
 
         if (hasSeries) {
             const colConfig = { cell: undefined, index: 'series', title: 'Series' };
+            const colorScale = plot?.scales.color;
+            const shapeScale = plot?.scales.shape;
 
             if (colorScale && shapeScale) {
                 colConfig.cell = (series: string) => (
@@ -302,7 +308,7 @@ export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData })
         else columns = columns.concat(NONLINEAR_COLUMNS);
 
         return ImmutableList(columns);
-    }, [type, hasSeries, colorScale, shapeScale]);
+    }, [hasSeries, hasValidTrendlines, plot, type]);
 
     const onExportTextFile = useCallback(
         (delimiter: ExportType) => {
@@ -326,6 +332,8 @@ export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData })
     const onExportCsv = useCallback(() => onExportTextFile(ExportType.COMMA), [onExportTextFile]);
     const onExportExcel = useCallback(() => onExportTextFile(ExportType.EXCEL), [onExportTextFile]);
     const onExportTsv = useCallback(() => onExportTextFile(ExportType.TAB), [onExportTextFile]);
+
+    if (!hasValidTrendlines) return null;
 
     return (
         <div className="curve-fit-statistics">

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -1,0 +1,184 @@
+import React, { FC, memo, useMemo } from 'react';
+import { Utils } from '@labkey/api';
+
+import { Row } from '../../query/selectRows';
+import { GridColumn } from '../base/models/GridColumn';
+import { Grid } from '../base/Grid';
+import { List as ImmutableList } from 'immutable';
+import { naturalSortByProperty } from '../../../public/sort';
+
+// Equivalent to what we're doing when generating the hoverText in GenericChartHelper generateTrendlinePathHover
+const roundedCell = (value: number) => Utils.roundNumber(value, 4);
+const R_SQUARED_COLUMN = new GridColumn({ index: 'RSquared', title: 'R-Squared', cell: roundedCell });
+const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'TSS', cell: roundedCell });
+const TSS_COLUMN = new GridColumn({ index: 'TSS', title: 'TSS', cell: roundedCell });
+const RMSE_COLUMN = new GridColumn({ index: 'RMSE', title: 'RMSE', cell: roundedCell });
+const SLOPE_COLUMN = new GridColumn({ index: 'slope', title: 'Slope', cell: roundedCell });
+const INTERCEPT_COLUMN = new GridColumn({ index: 'intercept', title: 'Intercept', cell: roundedCell });
+const COEFFICIENTS_COLUMN = new GridColumn({
+    index: 'coefficients',
+    title: 'Coefficients',
+    cell: data => {
+        return data.map((coefficient: number, idx: number) => (
+            <div className="small-margin-bottom" key={idx}>
+                {Utils.roundNumber(coefficient, 4)}
+            </div>
+        ));
+    },
+});
+const STATS_COLUMNS = [R_SQUARED_COLUMN, RSS_COLUMN, TSS_COLUMN, RMSE_COLUMN];
+const LINEAR_REGRESSION_COLUMNS = [SLOPE_COLUMN, INTERCEPT_COLUMN, ...STATS_COLUMNS];
+const POLYNOMIAL_COLUMNS = [COEFFICIENTS_COLUMN, ...STATS_COLUMNS];
+
+interface GeneratedPoint {
+    x: number;
+    y: number;
+}
+
+interface CurveFitStats {
+    RMSE: number;
+    RSquared: number;
+    RSS: number;
+    TSS: number;
+}
+
+interface CurveFit {
+    type: string; // change to enum or string union
+}
+
+interface PolynomialCurveFit extends CurveFit {
+    coefficients: number[];
+    type: 'Polynomial';
+}
+
+interface LinearRegressionCurveFit extends CurveFit {
+    intercept: number;
+    slope: number;
+    type: 'Linear';
+}
+
+interface CurveFitData<T extends CurveFit> {
+    curveFit: T;
+    generatedPoints: GeneratedPoint[];
+    stats: CurveFitStats;
+}
+
+interface Trendline<T extends CurveFit> {
+    count: number;
+    data: CurveFitData<T>;
+    generatedPoints: GeneratedPoint[];
+    name: string;
+    rawData: Row[];
+    total: number;
+}
+
+interface BaseCurveFitRow extends CurveFitStats {
+    series: string;
+}
+
+interface PolynomialCurveFitRow extends BaseCurveFitRow {
+    coefficients: number[];
+}
+
+interface LinearRegressionCurveFitRow extends BaseCurveFitRow {
+    intercept: number;
+    slope: number;
+}
+
+type CurveFitRow = LinearRegressionCurveFitRow | PolynomialCurveFitRow;
+
+export function trendLineToCurveFitRow(
+    trendline: Trendline<LinearRegressionCurveFit | PolynomialCurveFit>
+): CurveFitRow {
+    const { curveFit, stats } = trendline.data;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- type intentionally ignored
+    const { type, ...curveFitRest } = curveFit;
+    return {
+        series: trendline.name,
+        ...curveFitRest,
+        ...stats,
+    };
+}
+
+type ShapeMethod = (size: number) => string;
+type ScaleMethod<T> = (value: string) => T;
+
+/**
+ * This is a subset of what our scale objects look like in our Vis API. Only defining what we're using at this moment.
+ */
+interface PlotScale<T> {
+    scale: ScaleMethod<T>;
+}
+
+/**
+ * This is the subset of attributes from the object returned by new LABKEY.vis.Plot that we need in order to render the
+ * curve fit statistics.
+ */
+interface PlotObject {
+    scales: {
+        color: PlotScale<string>;
+        shape: PlotScale<ShapeMethod>;
+    };
+}
+
+interface SeriesCellProps {
+    colorScale: ScaleMethod<string>;
+    series: string;
+    shapeScale: ScaleMethod<ShapeMethod>;
+}
+const SeriesCell: FC<SeriesCellProps> = memo(({ colorScale, series, shapeScale }) => {
+    const color = colorScale(series);
+    // hard coded size 5 because that's what our chart legends already do
+    const shape = shapeScale(series)(5);
+    return (
+        <div>
+            <svg height={15} width={15}>
+                <path d={shape} fill={color} stroke={color} transform="translate(7.5, 7.5)" />
+            </svg>
+            <span className="margin-left-small">{series}</span>
+        </div>
+    );
+});
+SeriesCell.displayName = 'SeriesCell';
+
+interface Props {
+    plot: PlotObject | undefined;
+    trendLineData: Trendline<LinearRegressionCurveFit>[] | Trendline<PolynomialCurveFit>[];
+}
+
+export const CurveFitStatsGrid: FC<Props> = memo(({ plot, trendLineData }) => {
+    const type = trendLineData[0].data.curveFit.type;
+    const hasSeries = !(trendLineData.length === 1 && trendLineData[0].name === 'All');
+    const gridData = useMemo<CurveFitRow[]>(
+        () => trendLineData.map(trendLineToCurveFitRow).sort(naturalSortByProperty('series')),
+        [trendLineData]
+    );
+    const colorScale = plot?.scales.color;
+    const shapeScale = plot?.scales.shape;
+    const gridColumns = useMemo(() => {
+        const statColumns = type === 'Polynomial' ? POLYNOMIAL_COLUMNS : LINEAR_REGRESSION_COLUMNS;
+        let seriesColumn: GridColumn;
+
+        if (hasSeries) {
+            const colConfig = { cell: undefined, index: 'series', title: 'Series' };
+
+            if (colorScale && shapeScale) {
+                colConfig.cell = (series: string) => (
+                    <SeriesCell colorScale={colorScale.scale} series={series} shapeScale={shapeScale.scale} />
+                );
+            }
+
+            seriesColumn = new GridColumn(colConfig);
+        }
+        const columns = (seriesColumn ? [seriesColumn] : []).concat(statColumns);
+        return ImmutableList(columns);
+    }, [type, hasSeries, colorScale, shapeScale]);
+
+    return (
+        <div className="curve-fit-statistics">
+            <h5 className="curve-fit-statistics__title">Statistics</h5>
+            <Grid columns={gridColumns} data={gridData} />
+        </div>
+    );
+});
+CurveFitStatsGrid.displayName = 'CurveFitStatsGrid';

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -15,25 +15,28 @@ enum ExportType {
 }
 
 // Equivalent to what we're doing when generating the hoverText in GenericChartHelper generateTrendlinePathHover
-const roundedCell = (value: number) => Utils.roundNumber(value, 4);
-const MIN_COL = new GridColumn({ index: 'min', title: 'Min', cell: roundedCell });
-const MAX_COL = new GridColumn({ index: 'max', title: 'Max', cell: roundedCell });
-const ASYMMETRY_COLUMN = new GridColumn({ index: 'asymmetry', title: 'Asymmetry', cell: roundedCell });
-const INFLECTION_COLUMN = new GridColumn({ index: 'inflection', title: 'Inflection', cell: roundedCell });
-const R_SQUARED_COLUMN = new GridColumn({ index: 'RSquared', title: 'R-Squared', cell: roundedCell });
+const roundedValue = (value: number) => {
+    const rounded = Utils.roundNumber(value, 4);
+    return !isNaN(rounded) ? rounded : value;
+};
+const MIN_COL = new GridColumn({ index: 'min', title: 'Min', cell: roundedValue });
+const MAX_COL = new GridColumn({ index: 'max', title: 'Max', cell: roundedValue });
+const ASYMMETRY_COLUMN = new GridColumn({ index: 'asymmetry', title: 'Asymmetry', cell: roundedValue });
+const INFLECTION_COLUMN = new GridColumn({ index: 'inflection', title: 'Inflection', cell: roundedValue });
+const R_SQUARED_COLUMN = new GridColumn({ index: 'RSquared', title: 'R-Squared', cell: roundedValue });
 const ADJUSTED_R_SQUARED_COLUMN = new GridColumn({
     index: 'adjustedRSquared',
     title: 'Adjusted R-Squared',
-    cell: roundedCell,
+    cell: roundedValue,
 });
-const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'RSS', cell: roundedCell });
-const TSS_COLUMN = new GridColumn({ index: 'TSS', title: 'TSS', cell: roundedCell });
-const RMSE_COLUMN = new GridColumn({ index: 'RMSE', title: 'RMSE', cell: roundedCell });
-const SLOPE_COLUMN = new GridColumn({ index: 'slope', title: 'Slope', cell: roundedCell });
-const INTERCEPT_COLUMN = new GridColumn({ index: 'intercept', title: 'Intercept', cell: roundedCell });
-const COEFFICIENT_1_COLUMN = new GridColumn({ index: 'coefficient1', title: 'Coefficient 1', cell: roundedCell });
-const COEFFICIENT_2_COLUMN = new GridColumn({ index: 'coefficient2', title: 'Coefficient 2', cell: roundedCell });
-const COEFFICIENT_3_COLUMN = new GridColumn({ index: 'coefficient3', title: 'Coefficient 3', cell: roundedCell });
+const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'RSS', cell: roundedValue });
+const TSS_COLUMN = new GridColumn({ index: 'TSS', title: 'TSS', cell: roundedValue });
+const RMSE_COLUMN = new GridColumn({ index: 'RMSE', title: 'RMSE', cell: roundedValue });
+const SLOPE_COLUMN = new GridColumn({ index: 'slope', title: 'Slope', cell: roundedValue });
+const INTERCEPT_COLUMN = new GridColumn({ index: 'intercept', title: 'Intercept', cell: roundedValue });
+const COEFFICIENT_1_COLUMN = new GridColumn({ index: 'coefficient1', title: 'Coefficient 1', cell: roundedValue });
+const COEFFICIENT_2_COLUMN = new GridColumn({ index: 'coefficient2', title: 'Coefficient 2', cell: roundedValue });
+const COEFFICIENT_3_COLUMN = new GridColumn({ index: 'coefficient3', title: 'Coefficient 3', cell: roundedValue });
 const STATS_COLUMNS = [RSS_COLUMN, TSS_COLUMN, RMSE_COLUMN, R_SQUARED_COLUMN];
 const NONLINEAR_COLUMNS = [
     MIN_COL,
@@ -209,9 +212,7 @@ function curveFitRowsToExportFormat(hasSeries: boolean, type: string, rows: Curv
         cols = cols.concat(NONLINEAR_EXPORT_COLS);
     }
 
-    const exportRows = rows.map((row: CurveFitRow) => {
-        return cols.map(col => row[col]);
-    });
+    const exportRows = rows.map((row: CurveFitRow) => cols.map(col => roundedValue(row[col])?.toString(10)));
     exportRows.unshift(headers);
     return exportRows;
 }

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -18,7 +18,7 @@ enum ExportType {
 const roundedCell = (value: number) => Utils.roundNumber(value, 4);
 const MIN_COL = new GridColumn({ index: 'min', title: 'Min', cell: roundedCell });
 const MAX_COL = new GridColumn({ index: 'max', title: 'Max', cell: roundedCell });
-const ASYMMETRY_COLUMN = new GridColumn({ index: 'asymmetry', title: 'Asymmetry' });
+const ASYMMETRY_COLUMN = new GridColumn({ index: 'asymmetry', title: 'Asymmetry', cell: roundedCell });
 const INFLECTION_COLUMN = new GridColumn({ index: 'inflection', title: 'Inflection', cell: roundedCell });
 const R_SQUARED_COLUMN = new GridColumn({ index: 'RSquared', title: 'R-Squared', cell: roundedCell });
 const ADJUSTED_R_SQUARED_COLUMN = new GridColumn({
@@ -169,7 +169,15 @@ function trendLineToCurveFitRow(trendline: PossibleTrendlines): CurveFitRow {
 const STATS_EXPORT_COLS = ['RSS', 'TSS', 'RMSE', 'RSquared'];
 const LINEAR_EXPORT_COLS = ['slope', 'intercept', ...STATS_EXPORT_COLS];
 const POLYNOMIAL_EXPORT_COLS = ['coefficient1', 'coefficient2', 'coefficient3', ...STATS_EXPORT_COLS];
-const NONLINEAR_EXPORT_COLS = ['min', 'max', 'asymmetry', 'inflection', ...STATS_EXPORT_COLS, 'adjustedRSquared'];
+const NONLINEAR_EXPORT_COLS = [
+    'min',
+    'max',
+    'slope',
+    'asymmetry',
+    'inflection',
+    ...STATS_EXPORT_COLS,
+    'adjustedRSquared',
+];
 
 const STATS_EXPORT_HEADERS = ['RSS', 'TSS', 'RMSE', 'R-Squared'];
 const LINEAR_EXPORT_HEADERS = ['Slope', 'Intercept', ...STATS_EXPORT_HEADERS];
@@ -177,6 +185,7 @@ const POLYNOMIAL_EXPORT_HEADERS = ['Coefficient 1', 'Coefficient 2', 'Coefficien
 const NONLINEAR_EXPORT_HEADERS = [
     'Min',
     'Max',
+    'Slope',
     'Asymmetry',
     'Inflection',
     ...STATS_EXPORT_HEADERS,
@@ -250,10 +259,14 @@ const SeriesCell: FC<SeriesCellProps> = memo(({ colorScale, series, shapeScale }
 });
 SeriesCell.displayName = 'SeriesCell';
 
+type PossibleTrendlineArrays =
+    | Trendline<LinearRegressionCurveFit>[]
+    | Trendline<NonlinearCurveFit, NonlinearCurveFitStats>[]
+    | Trendline<PolynomialCurveFit>[];
 interface Props {
     name: string;
     plot: PlotObject | undefined;
-    trendLineData: Trendline<LinearRegressionCurveFit>[] | Trendline<PolynomialCurveFit>[];
+    trendLineData: PossibleTrendlineArrays;
 }
 
 export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData }) => {

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -1,34 +1,50 @@
-import React, { FC, memo, useMemo } from 'react';
-import { Utils } from '@labkey/api';
+import React, { FC, memo, useCallback, useMemo } from 'react';
+import { Utils, UtilsDOM } from '@labkey/api';
 
 import { Row } from '../../query/selectRows';
 import { GridColumn } from '../base/models/GridColumn';
 import { Grid } from '../base/Grid';
 import { List as ImmutableList } from 'immutable';
 import { naturalSortByProperty } from '../../../public/sort';
+import { DropdownButton, MenuHeader, MenuItem } from '../../dropdowns';
+
+enum DelimiterType {
+    COMMA = 'COMMA',
+    EXCEL = 'EXCEL',
+    TAB = 'TAB',
+}
 
 // Equivalent to what we're doing when generating the hoverText in GenericChartHelper generateTrendlinePathHover
 const roundedCell = (value: number) => Utils.roundNumber(value, 4);
+const MIN_COL = new GridColumn({ index: 'min', title: 'Min', cell: roundedCell });
+const MAX_COL = new GridColumn({ index: 'max', title: 'Max', cell: roundedCell });
+const ASYMMETRY_COLUMN = new GridColumn({ index: 'asymmetry', title: 'Asymmetry' });
+const INFLECTION_COLUMN = new GridColumn({ index: 'inflection', title: 'Inflection', cell: roundedCell });
 const R_SQUARED_COLUMN = new GridColumn({ index: 'RSquared', title: 'R-Squared', cell: roundedCell });
+const ADJUSTED_R_SQUARED_COLUMN = new GridColumn({
+    index: 'adjustedRSquared',
+    title: 'Adjusted R-Squared',
+    cell: roundedCell,
+});
 const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'TSS', cell: roundedCell });
 const TSS_COLUMN = new GridColumn({ index: 'TSS', title: 'TSS', cell: roundedCell });
 const RMSE_COLUMN = new GridColumn({ index: 'RMSE', title: 'RMSE', cell: roundedCell });
 const SLOPE_COLUMN = new GridColumn({ index: 'slope', title: 'Slope', cell: roundedCell });
 const INTERCEPT_COLUMN = new GridColumn({ index: 'intercept', title: 'Intercept', cell: roundedCell });
-const COEFFICIENTS_COLUMN = new GridColumn({
-    index: 'coefficients',
-    title: 'Coefficients',
-    cell: data => {
-        return data.map((coefficient: number, idx: number) => (
-            <div className="small-margin-bottom" key={idx}>
-                {Utils.roundNumber(coefficient, 4)}
-            </div>
-        ));
-    },
-});
-const STATS_COLUMNS = [R_SQUARED_COLUMN, RSS_COLUMN, TSS_COLUMN, RMSE_COLUMN];
+const COEFFICIENT_1_COLUMN = new GridColumn({ index: 'coefficient1', title: 'Coefficient 1', cell: roundedCell });
+const COEFFICIENT_2_COLUMN = new GridColumn({ index: 'coefficient2', title: 'Coefficient 2', cell: roundedCell });
+const COEFFICIENT_3_COLUMN = new GridColumn({ index: 'coefficient3', title: 'Coefficient 3', cell: roundedCell });
+const STATS_COLUMNS = [RSS_COLUMN, TSS_COLUMN, RMSE_COLUMN, R_SQUARED_COLUMN];
+const NONLINEAR_COLUMNS = [
+    MIN_COL,
+    MAX_COL,
+    ASYMMETRY_COLUMN,
+    INFLECTION_COLUMN,
+    ...STATS_COLUMNS,
+    ADJUSTED_R_SQUARED_COLUMN,
+];
 const LINEAR_REGRESSION_COLUMNS = [SLOPE_COLUMN, INTERCEPT_COLUMN, ...STATS_COLUMNS];
-const POLYNOMIAL_COLUMNS = [COEFFICIENTS_COLUMN, ...STATS_COLUMNS];
+const POLYNOMIAL_COLUMNS = [COEFFICIENT_1_COLUMN, COEFFICIENT_2_COLUMN, COEFFICIENT_3_COLUMN, ...STATS_COLUMNS];
 
 interface GeneratedPoint {
     x: number;
@@ -42,30 +58,53 @@ interface CurveFitStats {
     TSS: number;
 }
 
-interface CurveFit {
-    type: string; // change to enum or string union
+interface NonlinearCurveFitStats extends CurveFitStats {
+    adjustedRSquared: number;
 }
 
-interface PolynomialCurveFit extends CurveFit {
+interface CurveFit {
+    type: string;
+}
+
+interface PolynomialCurveFitData {
     coefficients: number[];
+}
+
+interface PolynomialCurveFit extends CurveFit, PolynomialCurveFitData {
     type: 'Polynomial';
 }
 
-interface LinearRegressionCurveFit extends CurveFit {
+interface LinearRegressionCurveFitData {
     intercept: number;
     slope: number;
+}
+
+interface LinearRegressionCurveFit extends CurveFit, LinearRegressionCurveFitData {
     type: 'Linear';
 }
 
-interface CurveFitData<T extends CurveFit> {
-    curveFit: T;
-    generatedPoints: GeneratedPoint[];
-    stats: CurveFitStats;
+// Note: most nonlinear curve fits also have a fitError attribute, however we are ignoring that because it's just RMSE
+// or R-Squared.
+interface NonlinearCurveFitData {
+    asymmetry: number;
+    inflection: number;
+    max: number;
+    min: number;
 }
 
-interface Trendline<T extends CurveFit> {
+interface NonlinearCurveFit extends CurveFit, NonlinearCurveFitData {
+    type: '3 Parameter' | '4 Parameter' | 'Five Parameter' | 'Four Parameter' | 'Three Parameter';
+}
+
+interface CurveFitData<T extends CurveFit, S extends CurveFitStats> {
+    curveFit: T;
+    generatedPoints: GeneratedPoint[];
+    stats: S;
+}
+
+interface Trendline<T extends CurveFit, S extends CurveFitStats = CurveFitStats> {
     count: number;
-    data: CurveFitData<T>;
+    data: CurveFitData<T, S>;
     generatedPoints: GeneratedPoint[];
     name: string;
     rawData: Row[];
@@ -77,27 +116,93 @@ interface BaseCurveFitRow extends CurveFitStats {
 }
 
 interface PolynomialCurveFitRow extends BaseCurveFitRow {
-    coefficients: number[];
+    coefficient1: number;
+    coefficient2: number;
+    coefficient3: number;
 }
 
-interface LinearRegressionCurveFitRow extends BaseCurveFitRow {
-    intercept: number;
-    slope: number;
+type LinearRegressionCurveFitRow = BaseCurveFitRow & LinearRegressionCurveFitData;
+type NonlinearCurveFitRow = BaseCurveFitRow & NonlinearCurveFitData & NonlinearCurveFitStats;
+type CurveFitRow = LinearRegressionCurveFitRow | NonlinearCurveFitRow | PolynomialCurveFitRow;
+type PossibleTrendlines =
+    | Trendline<LinearRegressionCurveFit>
+    | Trendline<NonlinearCurveFit, NonlinearCurveFitStats>
+    | Trendline<PolynomialCurveFit>;
+
+const nonLinearTrendlineTypes = ['3 Parameter', '4 Parameter', 'Five Parameter', 'Four Parameter', 'Three Parameter'];
+function isNonlinearTrendline(
+    trendline: PossibleTrendlines
+): trendline is Trendline<NonlinearCurveFit, NonlinearCurveFitStats> {
+    const type = trendline.data.curveFit.type;
+    return nonLinearTrendlineTypes.includes(type);
 }
 
-type CurveFitRow = LinearRegressionCurveFitRow | PolynomialCurveFitRow;
-
-export function trendLineToCurveFitRow(
-    trendline: Trendline<LinearRegressionCurveFit | PolynomialCurveFit>
-): CurveFitRow {
+function trendLineToCurveFitRow(trendline: PossibleTrendlines): CurveFitRow {
     const { curveFit, stats } = trendline.data;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- type intentionally ignored
-    const { type, ...curveFitRest } = curveFit;
-    return {
-        series: trendline.name,
-        ...curveFitRest,
-        ...stats,
-    };
+    const series = trendline.name;
+
+    if (curveFit.type === 'Polynomial') {
+        return {
+            ...stats,
+            series,
+            coefficient1: curveFit.coefficients[0],
+            coefficient2: curveFit.coefficients[1],
+            coefficient3: curveFit.coefficients[2],
+        };
+    }
+
+    if (curveFit.type === 'Linear') {
+        const { intercept, slope } = curveFit;
+        return { ...stats, series, intercept, slope };
+    }
+
+    if (isNonlinearTrendline(trendline)) {
+        const { asymmetry, inflection, max, min } = curveFit;
+        return { ...(stats as NonlinearCurveFitStats), series, asymmetry, inflection, max, min };
+    }
+
+    return undefined;
+}
+
+const STATS_EXPORT_COLS = ['RSS', 'TSS', 'RMSE', 'RSquared'];
+const LINEAR_EXPORT_COLS = ['slope', 'intercept', ...STATS_EXPORT_COLS];
+const POLYNOMIAL_EXPORT_COLS = ['coefficient1', 'coefficient2', 'coefficient3', ...STATS_EXPORT_COLS];
+const NONLINEAR_EXPORT_COLS = ['min', 'max', 'asymmetry', 'inflection', ...STATS_EXPORT_COLS, 'adjustedRSquared'];
+
+const STATS_EXPORT_HEADERS = ['RSS', 'TSS', 'RMSE', 'R-Squared'];
+const LINEAR_EXPORT_HEADERS = ['Slope', 'Intercept', ...STATS_EXPORT_HEADERS];
+const POLYNOMIAL_EXPORT_HEADERS = ['Coefficient 1', 'Coefficient 2', 'Coefficient 3', ...STATS_EXPORT_HEADERS];
+const NONLINEAR_EXPORT_HEADERS = [
+    'Min',
+    'Max',
+    'Asymmetry',
+    'Inflection',
+    ...STATS_EXPORT_HEADERS,
+    'Adjusted R-Squared',
+];
+
+/**
+ * Converts CurveFitRow[] to an array of arrays as expected by convertToExcel and convertToTable
+ */
+function curveFitRowsToExportFormat(hasSeries: boolean, type: string, rows: CurveFitRow[]): (number | string)[][] {
+    let headers = hasSeries ? ['Series'] : [];
+    let cols = hasSeries ? ['series'] : [];
+    if (type === 'Polynomial') {
+        headers = headers.concat(POLYNOMIAL_EXPORT_HEADERS);
+        cols = cols.concat(POLYNOMIAL_EXPORT_COLS);
+    } else if (type === 'Linear') {
+        headers = headers.concat(LINEAR_EXPORT_HEADERS);
+        cols = cols.concat(LINEAR_EXPORT_COLS);
+    } else {
+        headers = headers.concat(NONLINEAR_EXPORT_HEADERS);
+        cols = cols.concat(NONLINEAR_EXPORT_COLS);
+    }
+
+    const exportRows = rows.map((row: CurveFitRow) => {
+        return cols.map(col => row[col]);
+    });
+    exportRows.unshift(headers);
+    return exportRows;
 }
 
 type ShapeMethod = (size: number) => string;
@@ -121,17 +226,19 @@ interface PlotObject {
     };
 }
 
+const SHAPE_SIZE = 5; // hard coded size 5 because that's what our chart legends already do
+
 interface SeriesCellProps {
     colorScale: ScaleMethod<string>;
     series: string;
     shapeScale: ScaleMethod<ShapeMethod>;
 }
+
 const SeriesCell: FC<SeriesCellProps> = memo(({ colorScale, series, shapeScale }) => {
     const color = colorScale(series);
-    // hard coded size 5 because that's what our chart legends already do
-    const shape = shapeScale(series)(5);
+    const shape = shapeScale(series)(SHAPE_SIZE);
     return (
-        <div>
+        <div className="curve-fit-series-cell">
             <svg height={15} width={15}>
                 <path d={shape} fill={color} stroke={color} transform="translate(7.5, 7.5)" />
             </svg>
@@ -142,11 +249,12 @@ const SeriesCell: FC<SeriesCellProps> = memo(({ colorScale, series, shapeScale }
 SeriesCell.displayName = 'SeriesCell';
 
 interface Props {
+    name: string;
     plot: PlotObject | undefined;
     trendLineData: Trendline<LinearRegressionCurveFit>[] | Trendline<PolynomialCurveFit>[];
 }
 
-export const CurveFitStatsGrid: FC<Props> = memo(({ plot, trendLineData }) => {
+export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData }) => {
     const type = trendLineData[0].data.curveFit.type;
     const hasSeries = !(trendLineData.length === 1 && trendLineData[0].name === 'All');
     const gridData = useMemo<CurveFitRow[]>(
@@ -155,8 +263,8 @@ export const CurveFitStatsGrid: FC<Props> = memo(({ plot, trendLineData }) => {
     );
     const colorScale = plot?.scales.color;
     const shapeScale = plot?.scales.shape;
+
     const gridColumns = useMemo(() => {
-        const statColumns = type === 'Polynomial' ? POLYNOMIAL_COLUMNS : LINEAR_REGRESSION_COLUMNS;
         let seriesColumn: GridColumn;
 
         if (hasSeries) {
@@ -170,13 +278,73 @@ export const CurveFitStatsGrid: FC<Props> = memo(({ plot, trendLineData }) => {
 
             seriesColumn = new GridColumn(colConfig);
         }
-        const columns = (seriesColumn ? [seriesColumn] : []).concat(statColumns);
+
+        let columns = seriesColumn ? [seriesColumn] : [];
+
+        if (type === 'Polynomial') columns = columns.concat(POLYNOMIAL_COLUMNS);
+        else if (type === 'Linear') columns = columns.concat(LINEAR_REGRESSION_COLUMNS);
+        else columns = columns.concat(NONLINEAR_COLUMNS);
+
         return ImmutableList(columns);
     }, [type, hasSeries, colorScale, shapeScale]);
 
+    const onExportTextFile = useCallback(
+        (delimiter: DelimiterType) => {
+            const exportData = curveFitRowsToExportFormat(hasSeries, type, gridData);
+
+            if (delimiter === DelimiterType.EXCEL) {
+                UtilsDOM.convertToExcel({
+                    fileName: `${name}_statistics.xlsx`,
+                    sheets: [
+                        {
+                            name: 'statistics',
+                            data: exportData,
+                        },
+                    ],
+                });
+            } else {
+                UtilsDOM.convertToTable({
+                    fileNamePrefix: `${name}_statistics`,
+                    delim:
+                        delimiter === DelimiterType.COMMA ? UtilsDOM.DelimiterType.COMMA : UtilsDOM.DelimiterType.TAB,
+                    rows: exportData,
+                });
+            }
+        },
+        [gridData, hasSeries, name, type]
+    );
+    const onExportCsv = useCallback(() => onExportTextFile(DelimiterType.COMMA), [onExportTextFile]);
+    const onExportExcel = useCallback(() => onExportTextFile(DelimiterType.EXCEL), [onExportTextFile]);
+    const onExportTsv = useCallback(() => onExportTextFile(DelimiterType.TAB), [onExportTextFile]);
+
     return (
         <div className="curve-fit-statistics">
-            <h5 className="curve-fit-statistics__title">Statistics</h5>
+            <div className="curve-fit-statistics__header">
+                <h5 className="curve-fit-statistics__title">Statistics</h5>
+                <DropdownButton
+                    buttonClassName="curve-fit-statistics__dropdown-button"
+                    className="curve-fit-statistics__export-menu"
+                    noCaret
+                    title={<span className="fa fa-download" />}
+                >
+                    <MenuHeader text="Export Statistics" />
+
+                    <MenuItem onClick={onExportCsv}>
+                        <span className="fa fa-file-o margin-right-small" />
+                        CSV
+                    </MenuItem>
+
+                    <MenuItem onClick={onExportExcel}>
+                        <span className="fa fa-file-excel-o margin-right-small" />
+                        Excel
+                    </MenuItem>
+
+                    <MenuItem onClick={onExportTsv}>
+                        <span className="fa fa-file-text-o margin-right-small" />
+                        TSV
+                    </MenuItem>
+                </DropdownButton>
+            </div>
             <Grid columns={gridColumns} data={gridData} />
         </div>
     );

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -323,6 +323,7 @@ export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData })
                 UtilsDOM.convertToTable({
                     fileNamePrefix: `${name}_statistics`,
                     delim: delimiter === ExportType.COMMA ? UtilsDOM.DelimiterType.COMMA : UtilsDOM.DelimiterType.TAB,
+                    quoteChar: UtilsDOM.QuoteCharType.DOUBLE,
                     rows: exportData,
                 });
             }

--- a/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
+++ b/packages/components/src/internal/components/chart/CurveFitStatsGrid.tsx
@@ -8,7 +8,7 @@ import { List as ImmutableList } from 'immutable';
 import { naturalSortByProperty } from '../../../public/sort';
 import { DropdownButton, MenuHeader, MenuItem } from '../../dropdowns';
 
-enum DelimiterType {
+enum ExportType {
     COMMA = 'COMMA',
     EXCEL = 'EXCEL',
     TAB = 'TAB',
@@ -26,7 +26,7 @@ const ADJUSTED_R_SQUARED_COLUMN = new GridColumn({
     title: 'Adjusted R-Squared',
     cell: roundedCell,
 });
-const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'TSS', cell: roundedCell });
+const RSS_COLUMN = new GridColumn({ index: 'RSS', title: 'RSS', cell: roundedCell });
 const TSS_COLUMN = new GridColumn({ index: 'TSS', title: 'TSS', cell: roundedCell });
 const RMSE_COLUMN = new GridColumn({ index: 'RMSE', title: 'RMSE', cell: roundedCell });
 const SLOPE_COLUMN = new GridColumn({ index: 'slope', title: 'Slope', cell: roundedCell });
@@ -289,33 +289,27 @@ export const CurveFitStatsGrid: FC<Props> = memo(({ name, plot, trendLineData })
     }, [type, hasSeries, colorScale, shapeScale]);
 
     const onExportTextFile = useCallback(
-        (delimiter: DelimiterType) => {
+        (delimiter: ExportType) => {
             const exportData = curveFitRowsToExportFormat(hasSeries, type, gridData);
 
-            if (delimiter === DelimiterType.EXCEL) {
+            if (delimiter === ExportType.EXCEL) {
                 UtilsDOM.convertToExcel({
                     fileName: `${name}_statistics.xlsx`,
-                    sheets: [
-                        {
-                            name: 'statistics',
-                            data: exportData,
-                        },
-                    ],
+                    sheets: [{ name: 'statistics', data: exportData }],
                 });
             } else {
                 UtilsDOM.convertToTable({
                     fileNamePrefix: `${name}_statistics`,
-                    delim:
-                        delimiter === DelimiterType.COMMA ? UtilsDOM.DelimiterType.COMMA : UtilsDOM.DelimiterType.TAB,
+                    delim: delimiter === ExportType.COMMA ? UtilsDOM.DelimiterType.COMMA : UtilsDOM.DelimiterType.TAB,
                     rows: exportData,
                 });
             }
         },
         [gridData, hasSeries, name, type]
     );
-    const onExportCsv = useCallback(() => onExportTextFile(DelimiterType.COMMA), [onExportTextFile]);
-    const onExportExcel = useCallback(() => onExportTextFile(DelimiterType.EXCEL), [onExportTextFile]);
-    const onExportTsv = useCallback(() => onExportTextFile(DelimiterType.TAB), [onExportTextFile]);
+    const onExportCsv = useCallback(() => onExportTextFile(ExportType.COMMA), [onExportTextFile]);
+    const onExportExcel = useCallback(() => onExportTextFile(ExportType.EXCEL), [onExportTextFile]);
+    const onExportTsv = useCallback(() => onExportTextFile(ExportType.TAB), [onExportTextFile]);
 
     return (
         <div className="curve-fit-statistics">

--- a/packages/components/src/public/QueryModel/ChartPanel.tsx
+++ b/packages/components/src/public/QueryModel/ChartPanel.tsx
@@ -120,12 +120,12 @@ export const ChartPanel: FC<Props> = memo(({ actions, api = DEFAULT_API_WRAPPER,
                             >
                                 <MenuHeader text="Export Chart" />
                                 <MenuItem onClick={onExportChartPDF}>
-                                    <span className="fa fa-file-pdf-o" />
-                                    &nbsp; PDF
+                                    <span className="fa fa-file-pdf-o margin-right-small" />
+                                    PDF
                                 </MenuItem>
                                 <MenuItem onClick={onExportChartPNG}>
-                                    <span className="fa fa-file-image-o" />
-                                    &nbsp; PNG
+                                    <span className="fa fa-file-image-o margin-right-small" />
+                                    PNG
                                 </MenuItem>
                             </DropdownButton>
                         </span>

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -322,6 +322,11 @@
     font-size: 13px;
 }
 
+.curve-fit-statistics__header {
+    display: flex;
+    gap: 5px;
+}
+
 .curve-fit-statistics__title {
     font-size: 16px;
     font-weight: normal;

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -332,3 +332,17 @@
     font-size: 16px;
     font-weight: normal;
 }
+
+.curve-fit-series-cell {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.curve-fit-series-cell__name {
+    padding-top: 2px;
+}
+
+.curve-fit-value-cell {
+    text-align: right;
+}

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -324,7 +324,8 @@
 
 .curve-fit-statistics__header {
     display: flex;
-    gap: 5px;
+    gap: 10px;
+    align-items: center;
 }
 
 .curve-fit-statistics__title {

--- a/packages/components/src/theme/charts.scss
+++ b/packages/components/src/theme/charts.scss
@@ -321,3 +321,8 @@
     font-family: monospace;
     font-size: 13px;
 }
+
+.curve-fit-statistics__title {
+    font-size: 16px;
+    font-weight: normal;
+}

--- a/packages/components/src/theme/utils.scss
+++ b/packages/components/src/theme/utils.scss
@@ -50,6 +50,10 @@
     margin-right: 10px;
 }
 
+.margin-right-small {
+    margin-right: 5px;
+}
+
 .margin-right-more {
     margin-right: 20px;
 }

--- a/packages/components/src/theme/utils.scss
+++ b/packages/components/src/theme/utils.scss
@@ -70,6 +70,10 @@
     margin-left: 10px;
 }
 
+.margin-left-small {
+    margin-left: 5px;
+}
+
 .margin-left-more {
     margin-left: 20px;
 }


### PR DESCRIPTION
#### Rationale
This PR adds the CurveFitStatsGrid component and renders it below charts with curve fits, giving the user easier access to the underlying statistics for a curve fit.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1878
- https://github.com/LabKey/platform/pull/7162
- https://github.com/LabKey/limsModules/pull/1764
- https://github.com/LabKey/testAutomation/pull/2772

#### Changes
- Add CurveFitStatsGrid
- SVGChart: render CurveFitStatsGrid when trendlineData is available
- Chart.tsx: lint file

