### PR TITLE
Issue 53449: resolve lineage items from container path

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.67.1",
+  "version": "6.67.2-fb-lineage-53449.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.67.1",
+      "version": "6.67.2-fb-lineage-53449.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.67.2-fb-lineage-53449.0",
+  "version": "6.67.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.67.2-fb-lineage-53449.0",
+      "version": "6.67.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.0",
+        "@labkey/api": "1.43.1-fb-lineage-53449.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.0.tgz",
-      "integrity": "sha512-4hOQz+pM/QaCey6ooJEmEbElnR9+TDEzWG+8caFfeIX1iAg1335NXW3+/Xzs6a+L9ysRKds8bNgFPu2sxjPzfg==",
+      "version": "1.43.1-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.1-fb-lineage-53449.0",
+        "@labkey/api": "1.43.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",
@@ -3492,9 +3492,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.1-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
+      "version": "1.43.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1.tgz",
+      "integrity": "sha512-PkbI+OlnljpSLO7PkwfRRw/AH76pRRZbF8929ygxVZsrBXVFDSR+lSsSbJREiuMWkBTVcAOycwftwZB/O4QGHw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.43.1-fb-lineage-53449.0",
+    "@labkey/api": "1.43.1",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.43.0",
+    "@labkey/api": "1.43.1-fb-lineage-53449.0",
     "@testing-library/dom": "~10.4.0",
     "@testing-library/jest-dom": "~6.6.3",
     "@testing-library/react": "~16.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.67.2-fb-lineage-53449.0",
+  "version": "6.67.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.67.1",
+  "version": "6.67.2-fb-lineage-53449.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 6.67.2
+*Released* 31 October 2025
+- Issue 53449: resolve lineage items from container path
+  - Refer to `item.containerPath` instead of `item.container` in lineage details
+
 ### version 6.67.1
 *Released* 29 October 2025
 - Issue 53563: Domain designer lookups don't show newly added entity types after initial load/view

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -170,6 +170,7 @@ export class LineageRunStep implements LineageRunStepConfig {
     readonly activityDate: string;
     readonly activitySequence: number;
     readonly container: string;
+    readonly containerPath: string;
     readonly created: string;
     readonly createdBy: string;
     readonly dataInputs: LineageIO[];
@@ -202,6 +203,7 @@ export class LineageIO implements LineageItemWithMetadata {
     [immerable] = true;
 
     readonly container: string;
+    readonly containerPath: string;
     readonly created: string;
     readonly createdBy: string;
     readonly expType: string;

--- a/packages/components/src/internal/components/lineage/models.ts
+++ b/packages/components/src/internal/components/lineage/models.ts
@@ -3,7 +3,7 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import { immerable, produce } from 'immer';
-import { List, Map, Record as ImmutableRecord } from 'immutable';
+import { Record as ImmutableRecord, List, Map } from 'immutable';
 import { DataSet } from 'vis-data';
 import { Edge, IdType, Node } from 'vis-network';
 
@@ -159,9 +159,9 @@ export interface LineageIOWithMetadata extends LineageIOConfig {
     objectOutputs?: LineageItemWithMetadata[];
 }
 
-export interface LineageItemWithIOMetadata extends LineageItemWithMetadata, LineageIOWithMetadata {}
+export interface LineageItemWithIOMetadata extends LineageIOWithMetadata, LineageItemWithMetadata {}
 
-export interface LineageRunStepConfig extends Experiment.LineageRunStepBase, LineageItemWithIOMetadata {}
+export interface LineageRunStepConfig extends LineageItemWithIOMetadata, Experiment.LineageRunStepBase {}
 
 export class LineageRunStep implements LineageRunStepConfig {
     [immerable] = true;
@@ -248,15 +248,15 @@ export class LineageIO implements LineageItemWithMetadata {
 }
 
 interface LineageNodeConfig
-    extends Omit<Experiment.LineageNodeBase, 'children' | 'parents' | 'steps'>,
-        LineageItemWithIOMetadata {
-    children: List<LineageLink> | LineageLink[] | ILineageLink[];
+    extends LineageItemWithIOMetadata,
+        Omit<Experiment.LineageNodeBase, 'children' | 'parents' | 'steps'> {
+    children: ILineageLink[] | LineageLink[] | List<LineageLink>;
     // computed properties
     distance: number;
     listURL: string;
 
     meta: LineageNodeMetadata;
-    parents: List<LineageLink> | LineageLink[] | ILineageLink[];
+    parents: ILineageLink[] | LineageLink[] | List<LineageLink>;
     steps: List<LineageRunStep>;
 }
 
@@ -396,11 +396,11 @@ export class LineageResult extends ImmutableRecord({
         });
     }
 
-    filterIn(field: string, value: undefined | string | string[]): LineageResult {
+    filterIn(field: string, value: string | string[] | undefined): LineageResult {
         return LineageResult._filter(this, field, value, true);
     }
 
-    filterOut(field: string, value: undefined | string | string[]): LineageResult {
+    filterOut(field: string, value: string | string[] | undefined): LineageResult {
         return LineageResult._filter(this, field, value, false);
     }
 
@@ -414,7 +414,7 @@ export class LineageResult extends ImmutableRecord({
     private static _filter(
         result: LineageResult,
         field: string,
-        value: undefined | string | string[],
+        value: string | string[] | undefined,
         filterIn: boolean
     ): LineageResult {
         if (field === undefined) throw new Error('field must not be undefined');
@@ -461,7 +461,7 @@ export class LineageResult extends ImmutableRecord({
     private static _matches(
         node: LineageNode,
         field: string,
-        value: undefined | string | string[],
+        value: string | string[] | undefined,
         filterIn: boolean
     ): boolean {
         if (filterIn) {
@@ -512,7 +512,7 @@ export class LineageResult extends ImmutableRecord({
         value: any,
         filterIn: boolean,
         walked: Record<string, string>
-    ): Array<{ lsid: string; role: string }> {
+    ): { lsid: string; role: string }[] {
         let heritage = [];
         const lsid = edge.lsid;
         const toNode = nodes.get(lsid);
@@ -633,7 +633,7 @@ export class Lineage {
 export class LineageGridModel {
     [immerable] = true;
 
-    readonly columns: List<string | GridColumn> = LINEAGE_GRID_COLUMNS;
+    readonly columns: List<GridColumn | string> = LINEAGE_GRID_COLUMNS;
     readonly data: List<LineageNode> = List();
     readonly distance: number = DEFAULT_LINEAGE_DISTANCE;
     readonly isError: boolean = false;
@@ -692,7 +692,7 @@ interface VisGraphClusterNode {
     nodesInCluster: VisGraphNodeType[];
 }
 
-export type VisGraphNodeType = VisGraphNode | VisGraphCombinedNode | VisGraphClusterNode;
+export type VisGraphNodeType = VisGraphClusterNode | VisGraphCombinedNode | VisGraphNode;
 
 export function isBasicNode(item: VisGraphNodeType): item is VisGraphNode {
     return item && item.kind === 'node';
@@ -711,7 +711,7 @@ export class VisGraphOptions {
 
     readonly edges: DataSet<Edge>;
     readonly initialSelection: string[];
-    readonly nodes: DataSet<VisGraphNode | VisGraphCombinedNode>;
+    readonly nodes: DataSet<VisGraphCombinedNode | VisGraphNode>;
     readonly options: Record<string, any>;
 
     constructor(config?: Partial<VisGraphOptions>) {
@@ -732,7 +732,7 @@ function makeEdgeId(fromId: IdType, toId: IdType): string {
 type EdgesRecord = Record<string, Edge>;
 type LineageNodesRecord = Record<string, LineageNode>;
 type NodesInCombinedNode = Record<string, string[]>;
-type VisNodesRecord = Record<string, VisGraphNode | VisGraphCombinedNode>;
+type VisNodesRecord = Record<string, VisGraphCombinedNode | VisGraphNode>;
 
 /**
  * Create an edge between fromId -> toId when dir === Child.
@@ -988,7 +988,7 @@ export interface LineageNodeCollection {
     queryName: string;
 }
 
-export function isAliquotNode(node: LineageNodeCollection | LineageNode): boolean {
+export function isAliquotNode(node: LineageNode | LineageNodeCollection): boolean {
     return node.materialLineageType === 'Aliquot';
 }
 
@@ -1151,7 +1151,7 @@ function groupingBoundary(
     grouping: LineageGroupingOptions,
     depth: number,
     dir: LINEAGE_DIRECTIONS,
-    depthSets: Array<Record<string, string>>
+    depthSets: Record<string, string>[]
 ): boolean {
     if (grouping) {
         // Nearest only examines the first parent and child generations (depth = 1) from seed
@@ -1208,7 +1208,7 @@ function level(depth: number, dir: LINEAGE_DIRECTIONS, combined: boolean): numbe
  * level, however, after further walking the graph it could be that this node needs to be moved to a different level
  * given a parent/child at a higher/lower depth. See Issue 51425.
  */
-function reprocessLevel(visNode: VisGraphNode | VisGraphCombinedNode, dir: LINEAGE_DIRECTIONS, depth: number): void {
+function reprocessLevel(visNode: VisGraphCombinedNode | VisGraphNode, dir: LINEAGE_DIRECTIONS, depth: number): void {
     if (!visNode) return;
 
     const currentLevel = visNode.level;
@@ -1263,7 +1263,7 @@ function processNodes(
     nodesInCombinedNode: NodesInCombinedNode,
     depth = 0,
     processed: Record<string, boolean> = {},
-    depthSets: Array<Record<string, string>> = []
+    depthSets: Record<string, string>[] = []
 ): void {
     if (processed[lsid] === true) {
         // We have already seen this node, however, this now might be at a greater depth so reprocess the level
@@ -1469,7 +1469,7 @@ export function generate(result: LineageResult, options?: LineageOptions): VisGr
     const { edges, nodes } = generateNodesAndEdges(result, options);
 
     return new VisGraphOptions({
-        nodes: new DataSet<VisGraphNode | VisGraphCombinedNode>(Object.values(nodes)),
+        nodes: new DataSet<VisGraphCombinedNode | VisGraphNode>(Object.values(nodes)),
         edges: new DataSet<Edge>(Object.values(edges)),
 
         // vis.js options described in detail here: https://visjs.github.io/vis-network/docs/network/

--- a/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
@@ -18,7 +18,7 @@ export interface LineageDetailProps {
     item: Experiment.LineageItemBase;
 }
 
-const LineageDetailImpl: FC<LineageDetailProps & InjectedQueryModels> = memo(props => {
+const LineageDetailImpl: FC<InjectedQueryModels & LineageDetailProps> = memo(props => {
     const { queryModels } = props;
     if (queryModels.model.isLoading) return <LoadingSpinner />;
     if (queryModels.model.hasLoadErrors) return <Alert>{queryModels.model.loadErrors[0]}</Alert>;
@@ -33,10 +33,10 @@ const LineageDetailImpl: FC<LineageDetailProps & InjectedQueryModels> = memo(pro
 
     return (
         <DetailPanel
-            tableCls="detail-component--table__auto"
+            detailRenderer={_resolveDetailRenderer}
             model={queryModels.model}
             queryColumns={detailColumns}
-            detailRenderer={_resolveDetailRenderer}
+            tableCls="detail-component--table__auto"
         />
     );
 });
@@ -60,7 +60,7 @@ export const LineageDetail: FC<LineageDetailProps> = memo(({ item }) => {
     );
 
     // providing "key" to allow for reload on lsid change
-    return <LineageDetailWithQueryModels key={item.lsid} autoLoad queryConfigs={queryConfigs} item={item} />;
+    return <LineageDetailWithQueryModels autoLoad item={item} key={item.lsid} queryConfigs={queryConfigs} />;
 });
 LineageDetail.displayName = 'LineageDetail';
 
@@ -73,17 +73,19 @@ export const CustomPropertiesRenderer: FC<RendererProps> = memo(({ data }) => {
     return (
         <table className="lineage-detail-prop-table" data-testid="custom-properties-table">
             <tbody>
-                {data?.map(row => {
-                    const fieldKey = row.get('fieldKey');
-                    const name = fieldKey.substring(fieldKey.indexOf('#') + 1);
+                {data
+                    ?.map(row => {
+                        const fieldKey = row.get('fieldKey');
+                        const name = fieldKey.substring(fieldKey.indexOf('#') + 1);
 
-                    return (
-                        <tr key={fieldKey} className="lineage-detail-prop-row">
-                            <td className="lineage-detail-prop-cell">{name}</td>
-                            <td className="lineage-detail-prop-cell">{row.get('value')}</td>
-                        </tr>
-                    );
-                }).toArray()}
+                        return (
+                            <tr className="lineage-detail-prop-row" key={fieldKey}>
+                                <td className="lineage-detail-prop-cell">{name}</td>
+                                <td className="lineage-detail-prop-cell">{row.get('value')}</td>
+                            </tr>
+                        );
+                    })
+                    .toArray()}
             </tbody>
         </table>
     );

--- a/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageDetail.tsx
@@ -49,7 +49,7 @@ export const LineageDetail: FC<LineageDetailProps> = memo(({ item }) => {
         () => ({
             model: {
                 baseFilters: item.pkFilters.map(pkFilter => Filter.create(pkFilter.fieldKey, pkFilter.value)),
-                containerPath: item.container,
+                containerPath: item.containerPath,
                 // Issue 45028: Display details view columns in lineage
                 schemaQuery: new SchemaQuery(item.schemaName, item.queryName, ViewInfo.DETAIL_NAME),
                 // Must specify '*' columns be requested to resolve "properties" columns

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -10,9 +10,9 @@ import { LineageSummary } from '../LineageSummary';
 import {
     createLineageNodeCollections,
     isAliquotNode,
-    LineageNodeCollectionByType,
     LineageIOWithMetadata,
     LineageNode,
+    LineageNodeCollectionByType,
 } from '../models';
 import { LineageOptions } from '../types';
 
@@ -148,10 +148,10 @@ export class ClusterNodeDetail extends PureComponent<ClusterNodeDetailProps> {
                     );
                     return (
                         <DetailsListNodes
-                            key={groupName}
-                            title={groupDisplayName}
-                            nodes={nodesByType[groupName]}
                             highlightNode={highlightNode}
+                            key={groupName}
+                            nodes={nodesByType[groupName]}
+                            title={groupDisplayName}
                         />
                     );
                 })}
@@ -192,7 +192,7 @@ const RunStepNodeDetail: FC<RunStepNodeDetailProps> = memo(props => {
                     <DetailsListLineageIO item={step} />
                 </Tab>
                 {hasProvenanceModule && (
-                    <Tab eventKey="provenanceMap" title="Provenance Map" className="lineage-run-step-provenance-map">
+                    <Tab className="lineage-run-step-provenance-map" eventKey="provenanceMap" title="Provenance Map">
                         <RunStepProvenanceMap item={step} />
                     </Tab>
                 )}

--- a/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
+++ b/packages/components/src/internal/components/lineage/node/LineageNodeDetail.tsx
@@ -75,7 +75,7 @@ export class LineageNodeDetail extends PureComponent<LineageNodeDetailProps, Lin
                 <LineageDetail item={node} />
                 <LineageSummary
                     {...lineageOptions}
-                    containerPath={node.container}
+                    containerPath={node.containerPath}
                     highlightNode={highlightNode}
                     key={node.lsid}
                     lsid={node.lsid}


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53449](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53449) by updating the lineage UI to resolve lineage items by `containerPath` rather than `container` (entityId). With this the container filter is resolved correctly based on application configuration so that lookup values in lineage details display as expected.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/201
- https://github.com/LabKey/labkey-ui-components/pull/1880
- https://github.com/LabKey/platform/pull/7166
- https://github.com/LabKey/limsModules/pull/1769

#### Changes
- Bump `@labkey/api`
- Refer to `item.containerPath` instead of `item.container` in lineage details.
