### PR TITLE
Issue 53983: Sort fields by caption

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.2",
+  "version": "6.68.3-fb-sort-modal-columns.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.68.2",
+      "version": "6.68.3-fb-sort-modal-columns.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.3-fb-sort-modal-columns.0",
+  "version": "6.68.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.68.3-fb-sort-modal-columns.0",
+      "version": "6.68.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.2",
+  "version": "6.68.3-fb-sort-modal-columns.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.3-fb-sort-modal-columns.0",
+  "version": "6.68.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version 6.68.3
+*Released*: 4 November 2025
+- Issue 53983: Sort fields by caption
+- Issue 53927: Adjust column view layout to wrap
+
 ###  version 6.68.2
 *Released*: 3 November 2025
 - SVGChart: render curve fit statistics when available

--- a/packages/components/src/internal/components/ColumnSelectionModal.test.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.test.tsx
@@ -10,9 +10,9 @@ import { wrapDraggable } from '../test/testHelpers';
 
 import {
     ColumnChoice,
-    ColumnChoiceProps,
     ColumnChoiceGroup,
     ColumnChoiceGroupProps,
+    ColumnChoiceProps,
     ColumnInView,
     ColumnInViewProps,
     ColumnSelectionModal,
@@ -52,7 +52,7 @@ describe('ColumnSelectionModal', () => {
 
         test('isInView', () => {
             render(<ColumnChoice {...defaultProps()} isInView />);
-            expect(document.querySelector('.field-caption').textContent).toBe('Test Column');
+            expect(document.querySelector('.field-caption')).toHaveTextContent('Test Column');
             expect(document.querySelectorAll('.fa-check')).toHaveLength(1);
             expect(document.querySelectorAll('.fa-plus')).toHaveLength(0);
             expect(document.querySelectorAll('.field-expand-icon')).toHaveLength(1);
@@ -62,7 +62,7 @@ describe('ColumnSelectionModal', () => {
 
         test('not isInView', () => {
             render(<ColumnChoice {...defaultProps()} isInView={false} />);
-            expect(document.querySelector('.field-caption').textContent).toBe('Test Column');
+            expect(document.querySelector('.field-caption')).toHaveTextContent('Test Column');
             expect(document.querySelectorAll('.fa-check')).toHaveLength(0);
             expect(document.querySelectorAll('.fa-plus')).toHaveLength(1);
             expect(document.querySelectorAll('.field-expand-icon')).toHaveLength(1);
@@ -72,7 +72,7 @@ describe('ColumnSelectionModal', () => {
 
         test('lookup, collapsed', () => {
             render(<ColumnChoice {...defaultProps()} column={QUERY_COL_LOOKUP} isInView={false} />);
-            expect(document.querySelector('.field-caption').textContent).toBe('Test Column');
+            expect(document.querySelector('.field-caption')).toHaveTextContent('Test Column');
             expect(document.querySelectorAll('.fa-check')).toHaveLength(0);
             expect(document.querySelectorAll('.fa-plus')).toHaveLength(1);
             expect(document.querySelectorAll('.field-expand-icon')).toHaveLength(3);
@@ -82,7 +82,7 @@ describe('ColumnSelectionModal', () => {
 
         test('lookup, expanded', () => {
             render(<ColumnChoice {...defaultProps()} column={QUERY_COL_LOOKUP} isExpanded isInView={false} />);
-            expect(document.querySelector('.field-caption').textContent).toBe('Test Column');
+            expect(document.querySelector('.field-caption')).toHaveTextContent('Test Column');
             expect(document.querySelectorAll('.fa-check')).toHaveLength(0);
             expect(document.querySelectorAll('.fa-plus')).toHaveLength(1);
             expect(document.querySelectorAll('.field-expand-icon')).toHaveLength(3);
@@ -116,7 +116,7 @@ describe('ColumnSelectionModal', () => {
         }
 
         function validate(column: QueryColumn, deleteDisabled: boolean): void {
-            expect(document.querySelector('.field-caption span').textContent).toBe(column.caption);
+            expect(document.querySelector('.field-caption span')).toHaveTextContent(column.caption);
             const removeIcon = document.querySelector('.fa-times');
             if (deleteDisabled) {
                 expect(removeIcon).toBeFalsy();
@@ -184,7 +184,7 @@ describe('ColumnSelectionModal', () => {
     describe('FieldLabelDisplay', () => {
         test('not lookup', () => {
             render(<FieldLabelDisplay column={QUERY_COL} includeFieldKey />);
-            expect(document.querySelector('.field-caption span').textContent).toBe(QUERY_COL.caption);
+            expect(document.querySelector('.field-caption span')).toHaveTextContent(QUERY_COL.caption);
             expect(document.querySelectorAll('.overlay-trigger')).toHaveLength(1);
             expect(document.querySelectorAll('input')).toHaveLength(0);
         });
@@ -266,8 +266,8 @@ describe('ColumnSelectionModal', () => {
                 <ColumnChoiceGroup
                     {...defaultProps()}
                     column={QUERY_COL_LOOKUP}
-                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: new QueryInfo({}) }}
                     columnsInView={[QUERY_COL_LOOKUP]}
+                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: new QueryInfo({}) }}
                 />
             );
             validate(true, true);
@@ -279,8 +279,8 @@ describe('ColumnSelectionModal', () => {
                 <ColumnChoiceGroup
                     {...defaultProps()}
                     column={QUERY_COL_LOOKUP}
-                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
                     columnsInView={[QUERY_COL_LOOKUP]}
+                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
                 />
             );
             validate(true, true, true);
@@ -292,8 +292,8 @@ describe('ColumnSelectionModal', () => {
                 <ColumnChoiceGroup
                     {...defaultProps()}
                     column={QUERY_COL_LOOKUP}
-                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
                     columnsInView={[QUERY_COL_LOOKUP, QUERY_COL]}
+                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
                 />
             );
             validate(true, true, true);
@@ -321,8 +321,8 @@ describe('ColumnSelectionModal', () => {
                 <ColumnChoiceGroup
                     {...defaultProps()}
                     column={QUERY_COL_LOOKUP}
-                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
                     columnsInView={[QUERY_COL_LOOKUP, colHidden]}
+                    expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
                     showAllColumns
                 />
             );
@@ -336,9 +336,9 @@ describe('ColumnSelectionModal', () => {
                 <ColumnChoiceGroup
                     {...defaultProps()}
                     column={QUERY_COL_LOOKUP}
+                    columnsInView={[QUERY_COL_LOOKUP]}
                     expandedColumnFilter={jest.fn().mockImplementation(c => !c.removeFromViews)}
                     expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
-                    columnsInView={[QUERY_COL_LOOKUP]}
                 />
             );
             validate(true, true);
@@ -376,14 +376,66 @@ describe('ColumnSelectionModal', () => {
                 <ColumnChoiceGroup
                     {...defaultProps()}
                     column={QUERY_COL_LOOKUP}
+                    columnsInView={[QUERY_COL_LOOKUP]}
                     expandedColumnFilter={jest.fn().mockImplementation(c => !c.isJunctionLookup())}
                     expandedColumns={{ [QUERY_COL_LOOKUP.index]: queryInfo }}
-                    columnsInView={[QUERY_COL_LOOKUP]}
                     showAllColumns
                 />
             );
             validate(true, true, true);
             expect(document.querySelectorAll('.list-group-item')).toHaveLength(2);
+        });
+
+        // Issue 53983
+        test('Expanded lookup child fields are sorted by caption', () => {
+            const parent = new QueryColumn({
+                caption: 'Parent',
+                name: 'parent',
+                fieldKey: 'parent',
+                fieldKeyArray: ['parent'],
+                fieldKeyPath: 'parent',
+                selectable: true,
+                lookup: new QueryLookup({}),
+            });
+            const childZ = new QueryColumn({
+                caption: 'zeta',
+                name: 'z',
+                fieldKey: 'z',
+                fieldKeyArray: ['z'],
+                fieldKeyPath: 'parent/z',
+                selectable: true,
+            });
+            const childA = new QueryColumn({
+                caption: 'Alpha',
+                name: 'a',
+                fieldKey: 'a',
+                fieldKeyArray: ['a'],
+                fieldKeyPath: 'parent/a',
+                selectable: true,
+            });
+
+            const expandedInfo = new QueryInfo({
+                columns: new ExtendedMap({
+                    [childZ.fieldKey]: childZ,
+                    [childA.fieldKey]: childA,
+                }),
+            });
+
+            render(
+                <ColumnChoiceGroup
+                    {...defaultProps()}
+                    column={parent}
+                    expandedColumns={{ [parent.index]: expandedInfo }}
+                    showAllColumns
+                />
+            );
+
+            // Expect list to contain parent followed by children sorted by caption: Alpha, zeta
+            const items = Array.from(document.querySelectorAll('.list-group-item .field-caption')).map(el =>
+                el.textContent.trim()
+            );
+
+            expect(items).toEqual(['Parent', 'Alpha', 'zeta']);
         });
     });
 
@@ -404,8 +456,8 @@ describe('ColumnSelectionModal', () => {
             expect(titles).toHaveLength(2);
 
             expect(document.querySelectorAll('.list-group-item')).toHaveLength(2);
-            expect(titles[0].textContent).toContain('Available Fields');
-            expect(titles[1].textContent).toContain('Selected Fields');
+            expect(titles[0]).toHaveTextContent('Available Fields');
+            expect(titles[1]).toHaveTextContent('Selected Fields');
             expect(document.querySelector('.field-modal__footer')).toBeFalsy();
         });
 
@@ -431,6 +483,61 @@ describe('ColumnSelectionModal', () => {
 
             // verify useEffect initialization of selectedIndex, selectedColumns
             expect(document.querySelectorAll('.list-group-item.active')).toHaveLength(1);
+        });
+
+        // Issue 53983
+        test('Available Fields list is sorted by caption', () => {
+            const colB = new QueryColumn({
+                caption: 'b Beta',
+                name: 'b',
+                fieldKey: 'b',
+                fieldKeyArray: ['b'],
+                fieldKeyPath: 'b',
+                selectable: true,
+            });
+            const colA = new QueryColumn({
+                caption: 'A Alpha',
+                name: 'a',
+                fieldKey: 'a',
+                fieldKeyArray: ['a'],
+                fieldKeyPath: 'a',
+                selectable: true,
+            });
+            const col10 = new QueryColumn({
+                caption: 'Item 10',
+                name: 'item10',
+                fieldKey: 'item10',
+                fieldKeyArray: ['item10'],
+                fieldKeyPath: 'item10',
+                selectable: true,
+            });
+            const col2 = new QueryColumn({
+                caption: 'Item 2',
+                name: 'item2',
+                fieldKey: 'item2',
+                fieldKeyArray: ['item2'],
+                fieldKeyPath: 'item2',
+                selectable: true,
+            });
+
+            const queryInfo = new QueryInfo({
+                columns: new ExtendedMap({
+                    [colB.fieldKey]: colB,
+                    [colA.fieldKey]: colA,
+                    [col10.fieldKey]: col10,
+                    [col2.fieldKey]: col2,
+                }),
+            });
+
+            render(<ColumnSelectionModal {...defaultProps()} queryInfo={queryInfo} />);
+
+            // Available Fields (left column)
+            const availableFields = document.querySelector('.field-modal__col-content');
+            const captions = [...availableFields.querySelectorAll('.list-group-item .field-caption')].map(
+                el => el.textContent?.trim() ?? ''
+            );
+
+            expect(captions).toEqual(['A Alpha', 'b Beta', 'Item 2', 'Item 10']);
         });
     });
 });

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -63,13 +63,13 @@ export const FieldLabelDisplay: FC<FieldLabelDisplayProps> = memo(props => {
         return (
             <input
                 autoFocus
-                placeholder={undefined}
                 className="form-control"
                 defaultValue={title}
+                maxLength={MAX_LABEL_LENGTH}
                 onBlur={onBlur}
                 onChange={onChange}
+                placeholder={undefined}
                 type="text"
-                maxLength={MAX_LABEL_LENGTH}
             />
         );
     }
@@ -136,11 +136,10 @@ export const ColumnChoice: FC<ColumnChoiceProps> = memo(props => {
     );
 
     return (
-        <div className="list-group-item flex" key={column.index} data-fieldkey={column.fieldKeyPath}>
+        <div className="list-group-item flex" data-fieldkey={column.fieldKeyPath} key={column.index}>
             {supportsExpand && (
                 <>
                     {parentFieldKeys.map((parent, index) => (
-                        // eslint-disable-next-line react/no-array-index-key
                         <div className="field-expand-icon" key={`${column.index}|${index}`} />
                     ))}
                     <div className="field-expand-icon">
@@ -162,11 +161,11 @@ export const ColumnChoice: FC<ColumnChoiceProps> = memo(props => {
             {!isInView && column.selectable && (
                 <div
                     className={'pull-right view-field__action ' + (disabledMsg ? ' disabled ' : '')}
-                    title={disabled ? undefined : 'Add this field to the view.'}
                     onClick={disabled ? undefined : _onAddColumn}
                     onMouseEnter={onMouseEnter}
                     onMouseLeave={onMouseLeave}
                     ref={targetRef}
+                    title={disabled ? undefined : 'Add this field to the view.'}
                 >
                     <i className="fa fa-plus" />
                     {show && createPortal(popover, portalEl)}
@@ -224,16 +223,16 @@ export const ColumnChoiceGroup: FC<ColumnChoiceGroupProps> = memo(props => {
                     .map(fkCol => (
                         <ColumnChoiceGroup
                             column={fkCol}
-                            disabledMsg={disabledMsg}
-                            key={fkCol.index}
-                            isInView={isColumnInView(fkCol)}
-                            onAddColumn={onAddColumn}
-                            isExpanded={!!expandedColumns[fkCol.index]}
-                            onExpandColumn={onExpandColumn}
-                            expandedColumnFilter={expandedColumnFilter}
-                            onCollapseColumn={onCollapseColumn}
-                            expandedColumns={expandedColumns}
                             columnsInView={columnsInView}
+                            disabledMsg={disabledMsg}
+                            expandedColumnFilter={expandedColumnFilter}
+                            expandedColumns={expandedColumns}
+                            isExpanded={!!expandedColumns[fkCol.index]}
+                            isInView={isColumnInView(fkCol)}
+                            key={fkCol.index}
+                            onAddColumn={onAddColumn}
+                            onCollapseColumn={onCollapseColumn}
+                            onExpandColumn={onExpandColumn}
                             showAllColumns={showAllColumns}
                         />
                     ))}
@@ -294,7 +293,7 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
     }, [onEditTitle]);
 
     return (
-        <Draggable key={key} draggableId={key} index={index} isDragDisabled={isDragDisabled}>
+        <Draggable draggableId={key} index={index} isDragDisabled={isDragDisabled} key={key}>
             {(dragProvided, snapshot) => (
                 <div
                     className={classNames('list-group-item flex draggable', { active: selected && !editing })}
@@ -308,8 +307,8 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
                     </div>
                     <FieldLabelDisplay
                         column={column}
-                        includeFieldKey
                         editing={editing}
+                        includeFieldKey
                         onEditComplete={_onUpdateTitle}
                     />
                     {!editing && (
@@ -317,17 +316,17 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
                             {allowEditLabel && (
                                 <span
                                     className="edit-inline-field__toggle"
-                                    title="Edit the field's label for this view."
                                     onClick={_onEditTitle}
+                                    title="Edit the field's label for this view."
                                 >
-                                    <i id={'select-' + index} className="fa fa-pencil" />
+                                    <i className="fa fa-pencil" id={'select-' + index} />
                                 </span>
                             )}
                             {!disableDelete && (
                                 <span
                                     className="view-field__action clickable"
-                                    title="Remove this field from the view."
                                     onClick={_onRemoveColumn}
+                                    title="Remove this field from the view."
                                 >
                                     <i className="fa fa-times" />
                                 </span>
@@ -343,7 +342,7 @@ export const ColumnInView: FC<ColumnInViewProps> = memo(props => {
 
 ColumnInView.displayName = 'ColumnInView';
 
-export interface ColumnSelectionModalProps extends Omit<ModalProps, 'canConfirm' | 'onConfirm' | 'cancelText'> {
+export interface ColumnSelectionModalProps extends Omit<ModalProps, 'cancelText' | 'canConfirm' | 'onConfirm'> {
     allowEditLabel?: boolean;
     allowEmptySelection?: boolean;
     allowShowAll?: boolean;
@@ -531,28 +530,28 @@ export const ColumnSelectionModal: FC<ColumnSelectionModalProps> = memo(props =>
             {isLoaded && (
                 <div className="field-modal__container row">
                     <div className="col-xs-12 col-sm-6 field-modal__col-2">
-                        <div key="title" className="field-modal__col-title">
+                        <div className="field-modal__col-title" key="title">
                             {leftColumnTitle}
                         </div>
-                        <div key="field-list" className="list-group field-modal__col-content">
+                        <div className="list-group field-modal__col-content" key="field-list">
                             {availableColumns.map(column => (
                                 <ColumnChoiceGroup
                                     column={column}
-                                    key={column.index}
-                                    onAddColumn={onAddColumn}
-                                    onExpandColumn={onExpand ? onExpandColumn : undefined}
-                                    onCollapseColumn={onCollapseColumn}
+                                    columnsInView={selectedColumns}
+                                    disabledMsg={disabledMsg}
                                     expandedColumnFilter={expandedColumnFilter}
                                     expandedColumns={expandedColumns}
-                                    columnsInView={selectedColumns}
+                                    key={column.index}
+                                    onAddColumn={onAddColumn}
+                                    onCollapseColumn={onCollapseColumn}
+                                    onExpandColumn={onExpand ? onExpandColumn : undefined}
                                     showAllColumns={showAllColumns}
-                                    disabledMsg={disabledMsg}
                                 />
                             ))}
                         </div>
                         {allowShowAll && (
-                            <div key="toggleAll" className="field-modal__footer">
-                                <input type="checkbox" checked={showAllColumns} onChange={onToggleShowAll} />
+                            <div className="field-modal__footer" key="toggleAll">
+                                <input checked={showAllColumns} onChange={onToggleShowAll} type="checkbox" />
                                 &nbsp;Show all system and user-defined fields
                             </div>
                         )}
@@ -578,16 +577,16 @@ export const ColumnSelectionModal: FC<ColumnSelectionModalProps> = memo(props =>
                                         {selectedColumns.map((column, index) => (
                                             <ColumnInView
                                                 allowEditLabel={allowEditLabel}
-                                                disableDelete={fixedFieldKeys?.indexOf(column.fieldKey) >= 0}
-                                                key={column.index}
                                                 column={column}
+                                                disableDelete={fixedFieldKeys?.indexOf(column.fieldKey) >= 0}
                                                 index={index}
                                                 isDragDisabled={editingColumnTitle}
-                                                onRemoveColumn={onRemoveColumn}
-                                                selected={selectedIndex === index}
+                                                key={column.index}
                                                 onClick={onSelectField}
                                                 onEditTitle={onEditTitle}
+                                                onRemoveColumn={onRemoveColumn}
                                                 onUpdateTitle={onUpdateTitle}
+                                                selected={selectedIndex === index}
                                             />
                                         ))}
                                         {dropProvided.placeholder}

--- a/packages/components/src/internal/components/ColumnSelectionModal.tsx
+++ b/packages/components/src/internal/components/ColumnSelectionModal.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 
 import { QueryColumn } from '../../public/QueryColumn';
 import { QueryInfo } from '../../public/QueryInfo';
+import { naturalSortByProperty } from '../../public/sort';
 
 import { Modal, ModalProps } from '../Modal';
 
@@ -219,6 +220,7 @@ export const ColumnChoiceGroup: FC<ColumnChoiceGroupProps> = memo(props => {
             {isLookupExpanded &&
                 expandedColumns[column.index].columns.valueArray
                     .filter(fkCol => expandedColumnFilter?.(fkCol, showAllColumns) ?? true)
+                    .sort(naturalSortByProperty('caption')) // Issue 53983: Sort fields by caption
                     .map(fkCol => (
                         <ColumnChoiceGroup
                             column={fkCol}
@@ -506,7 +508,8 @@ export const ColumnSelectionModal: FC<ColumnSelectionModalProps> = memo(props =>
         if (!isLoaded || !queryInfo) return [];
         return queryInfo.columns.valueArray
             .filter(c => expandedColumnFilter?.(c, showAllColumns) ?? true)
-            .filter(c => c.fieldKeyArray.length === 1); // at the top level don't include lookup fields
+            .filter(c => c.fieldKeyArray.length === 1) // at the top level don't include lookup fields
+            .sort(naturalSortByProperty('caption')); // Issue 53983: Sort fields by caption
     }, [expandedColumnFilter, isLoaded, queryInfo, showAllColumns]);
 
     const disabledMsg = useMemo<string>(() => {

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -9,6 +9,7 @@ import { ChoicesListItem } from '../base/ChoicesListItem';
 
 import { QueryColumn } from '../../../public/QueryColumn';
 import { QueryInfo } from '../../../public/QueryInfo';
+import { naturalSortByProperty } from '../../../public/sort';
 
 import { NOT_ANY_FILTER_TYPE } from '../../url/NotAnyFilterType';
 
@@ -146,7 +147,7 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
         setActiveField(undefined);
         if (!queryInfo) return;
 
-        let validFields;
+        let validFields: QueryColumn[];
         if (fields) validFields = fields;
         else {
             const qFields = skipDefaultViewCheck
@@ -157,6 +158,11 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                     field.filterable &&
                     (!validFilterField || validFilterField(field, queryInfo, entityDataType?.exprColumnsWithSubSelect))
             );
+        }
+
+        // Issue 53983: Sort fields by caption
+        if (validFields) {
+            validFields = validFields.sort(naturalSortByProperty('caption'));
         }
 
         setQueryFields(validFields);

--- a/packages/components/src/internal/components/search/QueryFilterPanel.tsx
+++ b/packages/components/src/internal/components/search/QueryFilterPanel.tsx
@@ -41,7 +41,7 @@ interface Props {
     entityDataType?: EntityDataType;
     fieldKey?: string;
     fields?: QueryColumn[];
-    filters: { [key: string]: FieldFilter[] };
+    filters: Record<string, FieldFilter[]>;
     fullWidth?: boolean;
     hasNotInQueryFilter?: boolean;
     hasNotInQueryFilterLabel?: string;
@@ -245,11 +245,11 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                         {entityDataType?.supportHasNoValueInQuery && (
                             <div className="form-check list-group-item">
                                 <input
+                                    checked={hasNotInQueryFilter}
                                     className="form-check-input filter-faceted__checkbox"
-                                    type="checkbox"
                                     name="field-value-nodata-check"
                                     onChange={event => onHasNoValueInQueryChange(event.target.checked)}
-                                    checked={hasNotInQueryFilter}
+                                    type="checkbox"
                                 />
                                 <div className="filter-modal__fields-col-nodata-msg">
                                     {hasNotInQueryFilterLabel ?? 'Without data from this type'}
@@ -267,14 +267,14 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                 return (
                                     <ChoicesListItem
                                         active={currFieldKey === activeFieldKey}
-                                        index={index}
-                                        key={field.fieldKeyPath}
-                                        label={<span data-fieldkey={field.fieldKeyPath}>{caption}</span>}
-                                        onSelect={() => onFieldClick(field)}
                                         componentRight={
                                             hasFilters(field) && <span className="pull-right field-modal__field_dot" />
                                         }
                                         disabled={hasNotInQueryFilter}
+                                        index={index}
+                                        key={field.fieldKeyPath}
+                                        label={<span data-fieldkey={field.fieldKeyPath}>{caption}</span>}
+                                        onSelect={() => onFieldClick(field)}
                                     />
                                 );
                             })}
@@ -297,15 +297,15 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                 {activeTab === FieldFilterTabs.Filter && (
                                     <FilterExpressionView
                                         allowRelativeDateFilter={allowRelativeDateFilter}
-                                        key={activeFieldKey}
+                                        disabled={hasNotInQueryFilter}
                                         field={activeField}
                                         fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
-                                        onFieldFilterUpdate={(newFilters, index) =>
-                                            onFilterUpdate(activeField, newFilters, index)
-                                        }
-                                        disabled={hasNotInQueryFilter}
                                         includeAllAncestorFilter={
                                             isAncestor && activeField?.fieldKey.toLowerCase() === 'name'
+                                        }
+                                        key={activeFieldKey}
+                                        onFieldFilterUpdate={(newFilters, index) =>
+                                            onFilterUpdate(activeField, newFilters, index)
                                         }
                                     />
                                 )}
@@ -316,6 +316,14 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                         Find values for {activeField.caption}
                                     </div>
                                     <FilterFacetedSelector
+                                        canBeBlank={!activeField?.required && !activeField.nameExpression}
+                                        disabled={hasNotInQueryFilter}
+                                        fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
+                                        fieldKey={activeFieldKey}
+                                        key={activeFieldKey}
+                                        onFieldFilterUpdate={(newFilters, index) =>
+                                            onFilterUpdate(activeField, newFilters, index)
+                                        }
                                         selectDistinctOptions={{
                                             ...selectDistinctOptions,
                                             column: activeFieldKey,
@@ -324,14 +332,6 @@ export const QueryFilterPanel: FC<Props> = memo(props => {
                                             viewName,
                                             filterArray: fieldDistinctValueFilters,
                                         }}
-                                        fieldFilters={currentFieldFilters?.map(filter => filter.filter)}
-                                        fieldKey={activeFieldKey}
-                                        canBeBlank={!activeField?.required && !activeField.nameExpression}
-                                        key={activeFieldKey}
-                                        onFieldFilterUpdate={(newFilters, index) =>
-                                            onFilterUpdate(activeField, newFilters, index)
-                                        }
-                                        disabled={hasNotInQueryFilter}
                                     />
                                 </Tab>
                             )}

--- a/packages/components/src/theme/filter.scss
+++ b/packages/components/src/theme/filter.scss
@@ -25,6 +25,10 @@
     .list-group-item .field-caption {
         flex: 1;
         cursor: default;
+
+        // Issue 53927: Prevent clipping/overlap with field caption
+        overflow: hidden;
+        word-wrap: break-word;
     }
 
     .list-group-item .field-expand-icon {


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53983](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53983) by sorting columns in the `ColumnSelectionModal` by their caption. This sorting will now be done in:

1. Customize (grid) view
2. Identifying fields
3. Customize well metadata

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1775

#### Changes
- Naturally sort columns by caption in `ColumnSelectionModal`
- Address [Issue 53927](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53927) by updating column caption layout.
- Add regression tests
