### PR TITLE
Add justfiles

### DIFF
--- a/packages/build/justfile
+++ b/packages/build/justfile
@@ -1,0 +1,121 @@
+# Note: this justfile should work for anyone using MacOS, however with some work we can probably get it to also work on
+# Windows if we use the [unix] and [windows] attributes on the commands that execute shell scripts:
+#   https://just.systems/man/en/attributes.html#enabling-and-disabling-recipes180
+
+[private]
+default:
+    just --list
+
+currentBranch := `git branch --show-current`
+branchAsTag := replace(currentBranch, '_', '-')
+packageName := '@labkey/build'
+
+# We trim the trailing / from our environment variables so we can treat them consistently with our other paths
+# We quote the paths from our environment variables so these variables will work even if the paths contains spaces
+labkey := quote(trim_end_match(env('LABKEY_HOME'), '/'))
+components := quote(trim_end_match(env('LABKEY_UI_COMPONENTS_HOME'), '/'))
+premium := quote(trim_end_match(env('LABKEY_UI_PREMIUM_HOME'), '/'))
+distPath := 'node_modules' / packageName / 'webpack'
+sourceDist := components / 'packages/build/webpack/'
+modules := labkey / 'server/modules'
+premiumModules := modules / 'premiumModules'
+platform := modules / 'platform'
+core := platform / 'core'
+experiment := platform / 'experiment'
+assay := platform / 'assay'
+pipeline := platform / 'pipeline'
+lims := modules / 'limsModules'
+biologics := lims / 'biologics'
+sampleManagement := lims / 'sampleManagement'
+inventory := lims / 'inventory'
+labbook := lims / 'labbook'
+puppeteer := lims / 'puppeteer'
+
+# Note: these are not all of the locations that we use @labkey/build, however they are the most common places that we
+# want to keep up to date.
+platformModules := core + ' ' + experiment + ' ' + assay + ' ' + pipeline
+appModules := premium + ' ' + biologics + ' ' + inventory + ' ' + sampleManagement
+modulesToBump := appModules + ' ' + labbook + ' ' + ' ' + puppeteer + ' ' + platformModules
+
+# Note: this is just a common subset of locations where we would want to copy a locally built package, in order to test
+# before we publish a version. You may want to add more locations (e.g. core, assay)
+copyLocations := append('/' + distPath, appModules)
+
+# Copies built package to NODE_MODULES directory for every module listed in copyLocations
+copy:
+    #!/usr/bin/env zsh
+    set -euo pipefail
+    for module in {{ copyLocations }}; do
+        echo '{{ GREEN }}'Copying built package to '{{CYAN}}'$module'{{ NORMAL }}'
+        rsync -ra {{ sourceDist }} $module
+    done
+
+# Bumps version to a prerelease version based on the current branch name
+preVersion:
+    @echo {{ GREEN }}Bumping prerelease version with preid='{{CYAN}}'{{ branchAsTag }}{{ NORMAL }}
+    npm version prerelease --preid {{ branchAsTag }} --no-git-tag-version
+
+# Publishes the current version with the current branch name as a tag
+publishPreVersion:
+    @echo {{ GREEN }}Publishing prerelease package{{ NORMAL }}
+    @npm publish --tag {{ branchAsTag }}
+
+[private]
+sleep:
+    @echo {{ GREEN }}"Sleeping so artifactory doesn't return 404"{{ NORMAL }}
+    @sleep 6
+
+# Lists the modules in the 'modulesToBump' variable
+listModules:
+    #!/usr/bin/env zsh
+    set -euo pipefail
+    for module in {{ modulesToBump }}; do
+        echo $module
+    done
+
+# Stored as a string because we want to execute this when scripts are run, not when the justfile is evaluated, so we
+# always have the most up to date version.
+
+currentVersionImport := quote("require('./package.json').version")
+
+# Bumps the @labkey/build package to the current version in every module listed in the modules variable
+_bump modules:
+    #!/usr/bin/env zsh
+    set -euo pipefail
+    v=$(node -p -e {{ currentVersionImport }})
+    echo Bumping {{ packageName }} to '{{CYAN}}'$v
+    for module in {{ modules }}; do
+        pushd $module
+        echo '{{ GREEN }}'Bumping {{ packageName }} in '{{CYAN}}'$(pwd)'{{ NORMAL }}'
+        npm install --legacy-peer-deps --save-exact {{ packageName }}@$v
+        popd
+    done
+
+# Bumps the @labkey/build package to the current version in every module listed in the 'modulesToBump' variable
+bump: (_bump modulesToBump)
+
+# Bumps the @labkey/build package to the current version in every module listed in the 'appModules' variable
+bumpApps: (_bump appModules)
+
+# Bumps the version to a prerelease version based on the current branch name, publishes the version, and bumps it in every module listed in 'modulesToBump'
+release: preVersion publishPreVersion sleep bump
+
+# Bumps the version to a prerelease version based on the current branch name, publishes the version, and bumps it in every module listed in 'appModules'
+releaseApps: preVersion publishPreVersion sleep bumpApps
+
+# Bumps the major version
+major:
+    @npm version major --no-git-tag-version
+
+# Bumps the minor version
+minor:
+    @npm version major --no-git-tag-version
+
+# Bumps the patch version
+patch:
+    @npm version patch --no-git-tag-version
+
+# Publishes the current version, must be a production version
+publish:
+    @echo {{ GREEN }}Publishing release version{{ NORMAL }}
+    @npm publish

--- a/packages/components/justfile
+++ b/packages/components/justfile
@@ -1,0 +1,130 @@
+# Note: this justfile should work for anyone using MacOS, however with some work we can probably get it to also work on
+# Windows if we use the [unix] and [windows] attributes on the commands that execute shell scripts:
+#   https://just.systems/man/en/attributes.html#enabling-and-disabling-recipes180
+
+[private]
+default:
+    just --list
+
+currentBranch := `git branch --show-current`
+branchAsTag := replace(currentBranch, '_', '-')
+packageName := '@labkey/components'
+
+# We trim the trailing / from our environment variables so we can treat them consistently with our other paths
+# We quote the paths from our environment variables so these variables will work even if the paths contains spaces
+labkey := quote(trim_end_match(env('LABKEY_HOME'), '/'))
+components := quote(trim_end_match(env('LABKEY_UI_COMPONENTS_HOME'), '/'))
+premium := quote(trim_end_match(env('LABKEY_UI_PREMIUM_HOME'), '/'))
+distPath := 'node_modules' / packageName / 'dist'
+sourceDist := components / 'packages/components/dist/'
+modules := labkey / 'server/modules'
+platform := modules / 'platform'
+core := platform / 'core'
+experiment := platform / 'experiment'
+assay := platform / 'assay'
+pipeline := platform / 'pipeline'
+lims := modules / 'limsModules'
+biologics := lims / 'biologics'
+sampleManagement := lims / 'sampleManagement'
+inventory := lims / 'inventory'
+labbook := lims / 'labbook'
+puppeteer := lims / 'puppeteer'
+
+# Note: these are not all of the locations that we use @labkey/components, however they are the most common places that
+# we want to keep up to date.
+platformModules := core + ' ' + experiment + ' ' + assay + ' ' + pipeline
+appModules := premium + ' ' + biologics + ' ' + inventory + ' ' + sampleManagement
+modulesToBump := appModules + ' ' + labbook + ' ' + ' ' + puppeteer + ' ' + platformModules
+
+# Note: this is just a common subset of locations where we would want to copy a locally built package, in order to test
+# before we publish a version. You may want to add more locations (e.g. core, assay)
+copyLocations := append('/' + distPath, appModules)
+
+# Builds the package
+build:
+    @npm run build
+
+# Copies built package to NODE_MODULES directory for every module listed in copyLocations
+copy:
+    #!/usr/bin/env zsh
+    set -euo pipefail
+    for module in {{ copyLocations }}; do
+        echo '{{ GREEN }}'Copying built package to '{{CYAN}}'$module'{{ NORMAL }}'
+        rsync -ra {{ sourceDist }} $module
+    done
+
+# Builds the package and copies it to NODE_MODULES for every module listed in the 'copyLocations' variable
+bc: build copy
+
+# Bumps version to a prerelease version based on the current branch name
+preVersion:
+    @echo {{ GREEN }}Bumping prerelease version with preid='{{CYAN}}'{{ branchAsTag }}{{ NORMAL }}
+    npm version prerelease --preid {{ branchAsTag }} --no-git-tag-version
+
+# Publishes the current version with the current branch name as a tag
+publishPreVersion:
+    @echo {{ GREEN }}Publishing prerelease package{{ NORMAL }}
+    npm publish --tag {{ branchAsTag }}
+
+[private]
+sleep:
+    @echo {{ GREEN }}"Sleeping so artifactory doesn't return 404"{{ NORMAL }}
+    @sleep 6
+
+# Lists the modules in the 'modulesToBump' variable
+listModules:
+    #!/usr/bin/env zsh
+    set -euo pipefail
+    for module in {{ modulesToBump }}; do
+        echo $module
+    done
+
+# Stored as a string because we want to execute this when scripts are run, not when the justfile is evaluated, so we
+# always have the most up to date version.
+
+currentVersionImport := quote("require('./package.json').version")
+
+# lists the current package version
+version:
+    @echo $(node -p -e {{ currentVersionImport }})
+
+# Bumps the @labkey/components package to the current version in every module listed in the modules variable
+_bump modules:
+    #!/usr/bin/env zsh
+    set -euo pipefail
+    v=$(node -p -e {{ currentVersionImport }})
+    echo '{{ GREEN }}'Bumping {{ packageName }} to '{{CYAN}}'$v'{{ NORMAL }}'
+    for module in {{ modules }}; do
+        pushd $module
+        echo '{{ GREEN }}'Bumping {{ packageName }} in '{{CYAN}}'$(pwd)'{{ NORMAL }}'
+        npm install --legacy-peer-deps --save-exact {{ packageName }}@$v
+        popd
+    done
+
+# Bumps the @labkey/components package to the current version in every module listed in the 'modulesToBump' variable
+bump: (_bump modulesToBump)
+
+# Bumps the @labkey/components package to the current version in every module listed in the 'appModules' variable
+bumpApps: (_bump appModules)
+
+# Bumps the version to a prerelease version based on the current branch name, publishes the version, and bumps it in every module listed in 'modulesToBump'
+release: preVersion publishPreVersion sleep bump
+
+# Bumps the version to a prerelease version based on the current branch name, publishes the version, and bumps it in every module listed in 'appModules'
+releaseApps: preVersion publishPreVersion sleep bumpApps
+
+# Bumps the major version
+major:
+    npm version major --no-git-tag-version
+
+# Bumps the minor version
+minor:
+    npm version major --no-git-tag-version
+
+# Bumps the patch version
+patch:
+    npm version patch --no-git-tag-version
+
+# Publishes the current version, must be a production version
+publish:
+    npm publish

--- a/packages/components/justfile
+++ b/packages/components/justfile
@@ -119,7 +119,7 @@ major:
 
 # Bumps the minor version
 minor:
-    npm version major --no-git-tag-version
+    npm version minor --no-git-tag-version
 
 # Bumps the patch version
 patch:
@@ -128,3 +128,6 @@ patch:
 # Publishes the current version, must be a production version
 publish:
     npm publish
+
+pb: publish sleep bump
+pba: publish sleep bumpApps


### PR DESCRIPTION
#### Rationale
This PR adds a justfile to the components and build package directories. These justfiles automate building, releasing, and bumping the packages.

#### Example Usage
First you will need to install `just`, to do this run `brew install just`

The justfiles use the environment variables that we already use for LabKey server, ui-components, and ui-premium to ensure that it is operating in the correct folders, so no further setup should be required as long as you have the following environment variables already set: `LABKEY_HOME`, `LABKEY_UI_COMPONENTS_HOME`, and `LABKEY_UI_PREMIUM_HOME`

While working on a branch if you want publish a prerelease version so you can test your changes on TeamCity run the following command:
```
just release
```

This will do the following:
1. Bump the package to a prerelease version using your current branch name as the prerelease ID e.g. if you have a branch name `fb_my_special_branch` it will bump the version to `6.70.1-fb-my-special-branch.0`
    - All underscores in branch names are converted to dashes to be compatible with NPM naming requirements
3. Publish the package, using your current branch as the tag name e.g. `fb_my_special_branch` will be used as the tag: `fb-my-special-branch`
4. For every directory in the `modulesToBump` variable (core, experiment, assay, pipeline, ui-premium, biologics, inventory, sampleManagement, labbook, puppeteer) it will `cd` into the directory, and bump the `@labkey/components` version to the prerelease version via `npm install`
    - If you would like to only bump the package version in our apps (including ui-premium) run `just releaseApps` instead 

When it comes time to merge your changes you can do the following:
1. Run `just major`, `just minor`, or `just patch` to bump to the appropriate version
2. Commit the changes to package.json and package-lock.json
3. Run `just publish` to publish the version

If you wish to test your changes locally, but without publishing a version (e.g. you want to test your changes with selenium locally) you can run `just bc`, which will build the package and manually copy it to the app locations. You'll then need to run `npm run build` at each location you want to build with your package.


#### Caveats
These justfiles will only work on MacOS and Linux, however, it is possible to create justfiles that are compatible with both Windows and Unix systems, so we could update these to work across all operating systems we want to support. I do not currently have access to a Windows machine, so I cannot test this. In theory you may be able to run these justfiles under cygwin and have them work. Windows users could also run these justfiles under WSL which should work as-is.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1887
- https://github.com/LabKey/labkey-ui-premium/pull/844

#### Changes
- Add components/justfile
- Add build/justfile
