### PR TITLE
Issue 54186: App actions are missing TransactionAuditEvent

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.4",
+  "version": "6.70.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.4",
+      "version": "6.70.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.3",
+  "version": "6.70.4-fb-issue54186.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.3",
+      "version": "6.70.4-fb-issue54186.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.5-fb-issue54186.1",
+  "version": "6.70.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.3",
+  "version": "6.70.4-fb-issue54186.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version 6.X
+*Released*: X November 2025
+- Issue 54186: App actions for picklists and assay run delete don't get TransactionAuditEvent
+  - Add 'auditBehavior' to insertRows, updateRows, deleteRows usages so app actions get TransactionAuditEvent
+
 ### version 6.70.2
 *Released*: 6 November 2025
 - GridPanel

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PermissionTypes, Security, User } from '@labkey/api';
+import { AuditBehaviorTypes, PermissionTypes, Security, User } from '@labkey/api';
 import { useCallback, useEffect, useState } from 'react';
 
 import { updateRows } from '../../query/api';
@@ -127,5 +127,6 @@ export function updateRowFieldValue(model: QueryModel, name: string, value: any)
             },
         ],
         containerPath: model.containerPath,
+        auditBehavior: AuditBehaviorTypes.DETAILED,
     });
 }

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -1,4 +1,4 @@
-import { Domain, Filter, Query } from '@labkey/api';
+import { AuditBehaviorTypes, Domain, Filter, Query } from '@labkey/api';
 
 import { List } from 'immutable';
 
@@ -220,7 +220,11 @@ export async function addSamplesToPicklist(listName: string, sampleIds: number[]
     const schemaQuery = new SchemaQuery(SCHEMAS.PICKLIST_TABLES.SCHEMA, listName);
 
     if (rows.size > 0) {
-        return await insertRows({ schemaQuery, rows });
+        return await insertRows({
+            schemaQuery,
+            rows,
+            auditBehavior: AuditBehaviorTypes.DETAILED,
+        });
     }
 
     return new QueryCommandResponse({

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -1,6 +1,8 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { List } from 'immutable';
 
+import { AuditBehaviorTypes } from '@labkey/api';
+
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { Alert } from '../base/Alert';
 import { LockIcon } from '../base/LockIcon';
@@ -157,6 +159,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
                     rows: [stateToSave],
                     containerPath: container?.path,
+                    auditBehavior: AuditBehaviorTypes.DETAILED,
                 })
                 .then(() => {
                     onActionComplete(stateToSave.label);
@@ -171,6 +174,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
                     rows: List([stateToSave]),
                     containerPath: container?.path,
+                    auditBehavior: AuditBehaviorTypes.DETAILED,
                 })
                 .then(() => {
                     onActionComplete(stateToSave.label);
@@ -192,6 +196,7 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
                     containerPath: container?.path,
                     rows: [updatedState],
+                    auditBehavior: AuditBehaviorTypes.DETAILED,
                 })
                 .then(() => {
                     onActionComplete(undefined, true);


### PR DESCRIPTION
#### Rationale
Wiring up TransactionAuditEvent for more areas in app

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1890
- https://github.com/LabKey/labkey-ui-premium/pull/849
- https://github.com/LabKey/platform/pull/7201
- https://github.com/LabKey/limsModules/pull/1790

#### Changes
- Add 'auditBehavior' to insertRows, updateRows, deleteRows usages so app actions get TransactionAuditEvent