### PR TITLE
GitHub Issue 111: Query metadata editor indicates all fields as "New Field"

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.3",
+  "version": "6.68.3-queryMetadata111.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.68.3",
+      "version": "6.68.3-queryMetadata111.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.3-queryMetadata111.0",
+  "version": "6.68.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.68.3-queryMetadata111.0",
+      "version": "6.68.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.3-queryMetadata111.0",
+  "version": "6.68.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.68.3",
+  "version": "6.68.3-queryMetadata111.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version TBD
+*Released*: TBD November 2025
+- GitHub Issue 111: Query metadata editor indicates all fields as "New Field"
+  - use the field.lockExistingField property to determine if field is new or existing
+
 ###  version 6.68.3
 *Released*: 4 November 2025
 - Issue 53983: Sort fields by caption

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-###  version TBD
-*Released*: TBD November 2025
+###  version 6.68.4
+*Released*: 18 November 2025
 - GitHub Issue 111: Query metadata editor indicates all fields as "New Field"
   - use the field.lockExistingField property to determine if field is new or existing
 

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -140,6 +140,7 @@ const DomainFormToolbar: FC<DomainFormToolbarProps> = memo(props => {
         (event: ChangeEvent<HTMLInputElement>) => onSearch(event.target.value),
         [onSearch]
     );
+
     return (
         <div className="row domain-field-toolbar">
             <div className="col-xs-4">
@@ -151,15 +152,16 @@ const DomainFormToolbar: FC<DomainFormToolbarProps> = memo(props => {
                         onClick={onAddField}
                     />
                 )}
-                <ActionButton
-                    containerClass="container--toolbar-button"
-                    buttonClass="domain-toolbar-delete-btn"
-                    onClick={onBulkDeleteClick}
-                    disabled={visibleSelection.size === 0}
-                >
-                    <i className="fa fa-trash domain-toolbar-export-btn-icon" /> Delete
-                </ActionButton>
-
+                {!domainFormDisplayOptions?.hideAddFieldsButton && (
+                    <ActionButton
+                        containerClass="container--toolbar-button"
+                        buttonClass="domain-toolbar-delete-btn"
+                        onClick={onBulkDeleteClick}
+                        disabled={visibleSelection.size === 0}
+                    >
+                        <i className="fa fa-trash domain-toolbar-export-btn-icon" /> Delete
+                    </ActionButton>
+                )}
                 {shouldShowImportExport && (
                     <ActionButton
                         containerClass="container--toolbar-button"
@@ -1386,6 +1388,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                     {showToolbar && (
                                         <DomainFormToolbar
                                             disableExport={disableExport}
+                                            domainFormDisplayOptions={domainFormDisplayOptions}
                                             domainIndex={domainIndex}
                                             fields={fields}
                                             onAddField={this.onAddField}

--- a/packages/components/src/internal/components/domainproperties/models.test.ts
+++ b/packages/components/src/internal/components/domainproperties/models.test.ts
@@ -1136,7 +1136,8 @@ describe('DomainField', () => {
         );
     });
 
-    test('getDetailsTextArray, queryMetadata editor', () => { // Issue 54226
+    test('getDetailsTextArray, queryMetadata editor', () => {
+        // Issue 54226
         const field = DomainField.create({ propertyId: -1, name: 'test', lockExistingField: true });
         expect(field.getDetailsArray().join('')).toBe('');
     });

--- a/packages/components/src/internal/components/domainproperties/models.test.ts
+++ b/packages/components/src/internal/components/domainproperties/models.test.ts
@@ -1136,6 +1136,11 @@ describe('DomainField', () => {
         );
     });
 
+    test('getDetailsTextArray, queryMetadata editor', () => { // Issue 54226
+        const field = DomainField.create({ propertyId: -1, name: 'test', lockExistingField: true });
+        expect(field.getDetailsArray().join('')).toBe('');
+    });
+
     test('serialize, name trim', () => {
         expect(DomainField.serialize(DomainField.create({})).name).toBe(undefined);
         expect(DomainField.serialize(DomainField.create({ name: '' })).name).toBe('');

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1407,7 +1407,8 @@ export class DomainField
         const details = [];
         let period = '';
 
-        if (this.isNew()) {
+        // Issue 54226: queryMetadata editor uses lockExistingField to mark existing fields
+        if (this.isNew() && !this.lockExistingField) {
             details.push('New Field');
             period = '. ';
         } else if (this.updatedField) {


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/111

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7208

#### Changes
- use the field.lockExistingField property to determine if field is new or existing
- fix DomainFormToolbar to accept/use domainFormDisplayOptions props
