### PR TITLE
Sample amount/units polish

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.5",
+  "version": "6.70.6-fb-amountValidation.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.5",
+      "version": "6.70.6-fb-amountValidation.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.8-fb-amountValidation.2",
+  "version": "6.70.8-fb-amountValidation.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.8-fb-amountValidation.2",
+      "version": "6.70.8-fb-amountValidation.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.3",
+  "version": "6.70.9-fb-amountValidation.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.9-fb-amountValidation.3",
+      "version": "6.70.9-fb-amountValidation.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.8",
+  "version": "6.70.9-fb-amountValidation.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.8",
+      "version": "6.70.9-fb-amountValidation.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.8-fb-amountValidation.1",
+  "version": "6.70.8-fb-amountValidation.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.8-fb-amountValidation.1",
+      "version": "6.70.8-fb-amountValidation.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.1",
+  "version": "6.70.9-fb-amountValidation.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.9-fb-amountValidation.1",
+      "version": "6.70.9-fb-amountValidation.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.2",
+  "version": "6.70.9-fb-amountValidation.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.9-fb-amountValidation.2",
+      "version": "6.70.9-fb-amountValidation.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.71.0",
+  "version": "6.71.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.71.0",
+      "version": "6.71.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.4",
+  "version": "6.70.9-fb-amountValidation.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.9-fb-amountValidation.4",
+      "version": "6.70.9-fb-amountValidation.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.7",
+  "version": "6.70.8-fb-amountValidation.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.7",
+      "version": "6.70.8-fb-amountValidation.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.2",
+  "version": "6.70.9-fb-amountValidation.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.8-fb-amountValidation.2",
+  "version": "6.70.8-fb-amountValidation.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.5",
+  "version": "6.70.6-fb-amountValidation.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.3",
+  "version": "6.70.9-fb-amountValidation.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.4",
+  "version": "6.70.9-fb-amountValidation.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.8-fb-amountValidation.1",
+  "version": "6.70.8-fb-amountValidation.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.9-fb-amountValidation.1",
+  "version": "6.70.9-fb-amountValidation.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.8",
+  "version": "6.70.9-fb-amountValidation.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,8 +3,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ###  version 6.X
 *Released*: X November 2025
-- Disallow negative sample amounts
-    - Update `getValidatedEditableGridValue` to check for negative amount values
+- Sample Amount/Units polish
+  - Disallow negative sample amounts: Update `getValidatedEditableGridValue` to check for negative amount values
+  - Added `AmountUnitInput` to show amount/units input side-by-side on bulk add/edit
 
 ###  version 6.70.7
 *Released*: 18 November 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version 6.X
+*Released*: X November 2025
+- Disallow negative sample amounts
+    - Update `getValidatedEditableGridValue` to check for negative amount values
+
 ###  version 6.70.5
 *Released*: 13 November 2025
 - Issue 54186: App actions for picklists and assay run delete don't get TransactionAuditEvent

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -471,10 +471,10 @@ import {
     DOMAIN_FIELD_REQUIRED,
     DOMAIN_FIELD_TYPE,
     DOMAIN_RANGE_VALIDATOR,
+    NON_NEGATIVE_NUMBER_CONCEPT_URI,
     RANGE_URIS,
     SAMPLE_TYPE_CONCEPT_URI,
     STORAGE_UNIQUE_ID_CONCEPT_URI,
-    NON_NEGATIVE_NUMBER_CONCEPT_URI,
 } from './internal/components/domainproperties/constants';
 import { ExpandableContainer } from './internal/components/ExpandableContainer';
 import { Principal, SecurityAssignment, SecurityPolicy, SecurityRole } from './internal/components/permissions/models';
@@ -1536,6 +1536,7 @@ export {
     NavigationBar,
     NO_UPDATES_MESSAGE,
     NoLinkRenderer,
+    NON_NEGATIVE_NUMBER_CONCEPT_URI,
     NOT_ANY_FILTER_TYPE,
     NOT_IN_EXP_DESCENDANTS_OF_FILTER_TYPE,
     Notifications,
@@ -1679,7 +1680,6 @@ export {
     SplitButton,
     splitDateTimeFormat,
     STORAGE_UNIQUE_ID_CONCEPT_URI,
-    NON_NEGATIVE_NUMBER_CONCEPT_URI,
     StorageAmountInput,
     StorageStatusRenderer,
     STORED_AMOUNT_FIELDS,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -474,6 +474,7 @@ import {
     RANGE_URIS,
     SAMPLE_TYPE_CONCEPT_URI,
     STORAGE_UNIQUE_ID_CONCEPT_URI,
+    NON_NEGATIVE_NUMBER_CONCEPT_URI,
 } from './internal/components/domainproperties/constants';
 import { ExpandableContainer } from './internal/components/ExpandableContainer';
 import { Principal, SecurityAssignment, SecurityPolicy, SecurityRole } from './internal/components/permissions/models';
@@ -1678,6 +1679,7 @@ export {
     SplitButton,
     splitDateTimeFormat,
     STORAGE_UNIQUE_ID_CONCEPT_URI,
+    NON_NEGATIVE_NUMBER_CONCEPT_URI,
     StorageAmountInput,
     StorageStatusRenderer,
     STORED_AMOUNT_FIELDS,

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -248,6 +248,8 @@ export interface DomainFormProps extends PropsWithChildren {
     systemFields?: SystemField[];
     todoIconHelpMsg?: string;
     validate?: boolean;
+    // Map of grouped system fields, that should be enabled/disabled together
+    groupedSystemFields?: Record<string, string[]>;
 }
 
 interface State {
@@ -701,8 +703,12 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
     };
 
     onSystemFieldEnable = (field: string, enable: boolean): void => {
-        const { domain } = this.props;
-        this.onDomainChange(handleSystemFieldUpdates(domain, field, enable));
+        const { domain, groupedSystemFields } = this.props;
+        let updatedDomain = handleSystemFieldUpdates(domain, field, enable);
+        groupedSystemFields?.[field.toLowerCase()]?.forEach(groupedField => {
+            updatedDomain = handleSystemFieldUpdates(updatedDomain, groupedField, enable);
+        });
+        this.onDomainChange(updatedDomain);
     };
 
     onFieldsChange = (changes: List<IFieldChange>, index: number, expand: boolean, skipDirtyCheck = false): void => {

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -145,27 +145,27 @@ const DomainFormToolbar: FC<DomainFormToolbarProps> = memo(props => {
             <div className="col-xs-4">
                 {!domainFormDisplayOptions?.hideAddFieldsButton && (
                     <AddEntityButton
-                        entity="Field"
-                        containerClass="container--toolbar-button"
                         buttonClass="domain-toolbar-add-btn"
+                        containerClass="container--toolbar-button"
+                        entity="Field"
                         onClick={onAddField}
                     />
                 )}
                 <ActionButton
-                    containerClass="container--toolbar-button"
                     buttonClass="domain-toolbar-delete-btn"
-                    onClick={onBulkDeleteClick}
+                    containerClass="container--toolbar-button"
                     disabled={visibleSelection.size === 0}
+                    onClick={onBulkDeleteClick}
                 >
                     <i className="fa fa-trash domain-toolbar-export-btn-icon" /> Delete
                 </ActionButton>
 
                 {shouldShowImportExport && (
                     <ActionButton
-                        containerClass="container--toolbar-button"
                         buttonClass="domain-toolbar-export-btn"
-                        onClick={onExportFields}
+                        containerClass="container--toolbar-button"
                         disabled={disableExport}
+                        onClick={onExportFields}
                     >
                         <i className="fa fa-download domain-toolbar-export-btn-icon" /> Export
                     </ActionButton>
@@ -175,26 +175,26 @@ const DomainFormToolbar: FC<DomainFormToolbarProps> = memo(props => {
                 <div className="pull-right domain-field-toolbar-right-aligned">
                     {!valueIsEmpty(search) && (
                         <span className="domain-search-text">
-                            Showing {fields.filter(f => f.visible).size} of {fields.size} {' '}
-                            field{fields.size > 1 ? 's' : ''}.
+                            Showing {fields.filter(f => f.visible).size} of {fields.size} field
+                            {fields.size > 1 ? 's' : ''}.
                         </span>
                     )}
                     <input
-                        id={'domain-search-name-' + domainIndex}
                         className="form-control domain-search-input"
-                        type="text"
-                        placeholder="Search Fields"
+                        id={'domain-search-name-' + domainIndex}
                         onChange={onSearchChange}
+                        placeholder="Search Fields"
+                        type="text"
                     />
 
                     <div className="domain-toolbar-toggle-summary">
                         <span>Mode: </span>
                         <ToggleButtons
+                            active={summaryViewMode ? 'Summary' : 'Detail'}
                             className=""
                             first="Summary"
-                            second="Detail"
-                            active={summaryViewMode ? 'Summary' : 'Detail'}
                             onClick={onToggleSummaryView}
+                            second="Detail"
                         />
                     </div>
                 </div>
@@ -215,6 +215,8 @@ export interface DomainFormProps extends PropsWithChildren {
     domainFormDisplayOptions?: IDomainFormDisplayOptions;
     domainIndex?: number;
     fieldsAdditionalRenderer?: () => ReactNode;
+    // Map of grouped system fields, that should be enabled/disabled together
+    groupedSystemFields?: Record<string, string[]>;
     headerPrefix?: string; // used as a string to remove from the heading when using the domain.name
     headerTitle?: string;
     helpNoun?: string;
@@ -248,8 +250,6 @@ export interface DomainFormProps extends PropsWithChildren {
     systemFields?: SystemField[];
     todoIconHelpMsg?: string;
     validate?: boolean;
-    // Map of grouped system fields, that should be enabled/disabled together
-    groupedSystemFields?: Record<string, string[]>;
 }
 
 interface State {
@@ -602,10 +602,10 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         if (deletableSelectedFieldsCount === 0) {
             return (
                 <Modal
-                    title="Cannot Delete Required Fields"
-                    onCancel={this.onConfirmBulkCancel}
                     cancelText="Close"
                     confirmClass="btn-danger"
+                    onCancel={this.onConfirmBulkCancel}
+                    title="Cannot Delete Required Fields"
                 >
                     <div>
                         <p> None of the selected fields can be deleted. </p>
@@ -621,11 +621,11 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
 
         return (
             <Modal
-                title="Confirm Delete Selected Fields"
-                onConfirm={this.onBulkDeleteConfirm}
-                onCancel={this.onConfirmBulkCancel}
                 confirmClass="btn-danger"
                 confirmText="Yes, Delete Fields"
+                onCancel={this.onConfirmBulkCancel}
+                onConfirm={this.onBulkDeleteConfirm}
+                title="Confirm Delete Selected Fields"
             >
                 <div>
                     <p>{howManyDeleted} will be deleted.</p>
@@ -927,9 +927,9 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 <div className="row domain-add-field-row">
                     <div className="col-xs-12">
                         <AddEntityButton
-                            entity="Field"
                             buttonClass="domain-form-add-btn"
                             containerClass="pull-right"
+                            entity="Field"
                             onClick={this.onAddField}
                         />
                     </div>
@@ -961,11 +961,11 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         const fieldName = field && field.name && field.name.trim().length > 0 ? <b>{field.name}</b> : 'this field';
         return (
             <Modal
-                title="Confirm Remove Field"
-                onConfirm={() => this.onDeleteConfirm(confirmDeleteRowIndex)}
-                onCancel={this.onConfirmCancel}
                 confirmClass="btn-danger"
                 confirmText="Yes, Remove Field"
+                onCancel={this.onConfirmCancel}
+                onConfirm={() => this.onDeleteConfirm(confirmDeleteRowIndex)}
+                title="Confirm Remove Field"
             >
                 <div>
                     Are you sure you want to remove {fieldName}?{' '}
@@ -1094,11 +1094,11 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 <>
                     <FileAttachmentForm
                         acceptedFormats={acceptedFormats.join(', ')}
-                        showAcceptedFormats
                         allowDirectories={false}
                         allowMultiple={false}
-                        label={label}
+                        fileSpecificCallback={Map({ '.json': this.importFieldsFromJson })}
                         index={index}
+                        label={label}
                         onFileRemoval={this.onFileRemoval}
                         previewGridProps={
                             shouldShowInferFromFile && {
@@ -1108,7 +1108,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                 domainKindName: domain.domainKindName,
                             }
                         }
-                        fileSpecificCallback={Map({ '.json': this.importFieldsFromJson })}
+                        showAcceptedFormats
                     />
                     {shouldShowInferFromFile && this.state.filePreviewMsg && (
                         <Alert bsStyle="info">{this.state.filePreviewMsg}</Alert>
@@ -1203,7 +1203,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
             visibleFieldsCount !== 0 && visibleSelection.size === visibleFieldsCount ? 'Clear All' : 'Clear';
 
         return (
-            <DragDropContext onDragEnd={this.onDragEnd} onBeforeDragStart={this.onBeforeDragStart}>
+            <DragDropContext onBeforeDragStart={this.onBeforeDragStart} onDragEnd={this.onDragEnd}>
                 <div className="domain-field-row domain-row-border-default domain-floating-hdr">
                     <Alert bsStyle="info">{reservedFieldsMsg}</Alert>
                     <div className="row">
@@ -1223,10 +1223,10 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                         <div className="domain-row-handle" />
                         <div className="domain-row-action-section">
                             <CheckboxLK
-                                className="domain-field-check-icon"
-                                name="domain-select-all-checkbox"
-                                id="domain-select-all-checkbox"
                                 checked={selectAll}
+                                className="domain-field-check-icon"
+                                id="domain-select-all-checkbox"
+                                name="domain-select-all-checkbox"
                                 onChange={this.toggleSelectAll}
                             />
                         </div>
@@ -1261,39 +1261,39 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
 
                                         return (
                                             <DomainRow
-                                                ref={ref => {
-                                                    this.refsArray[i] = ref;
-                                                }}
-                                                domainId={domain.domainId}
-                                                helpNoun={helpNoun}
-                                                key={key}
-                                                field={field}
-                                                fieldError={this.getFieldError(domain, i)}
-                                                getDomainFields={this.getDomainFields}
-                                                fieldDetailsInfo={fieldDetails.detailsInfo}
-                                                domainIndex={domainIndex}
-                                                index={i}
-                                                expanded={expandedRowIndex === i}
-                                                onChange={this.onFieldsChange}
-                                                onExpand={this.onFieldExpandToggle}
-                                                onDelete={this.onDeleteField}
-                                                maxPhiLevel={maxPhiLevel}
-                                                dragging={dragId === i}
-                                                availableTypes={availableTypes}
                                                 allowUniqueConstraintProperties={domain.allowUniqueConstraintProperties}
-                                                showDefaultValueSettings={domain.showDefaultValueSettings}
+                                                appPropertiesOnly={appPropertiesOnly}
+                                                availableTypes={availableTypes}
                                                 defaultDefaultValueType={domain.defaultDefaultValueType}
                                                 defaultValueOptions={domain.defaultValueOptions}
-                                                appPropertiesOnly={appPropertiesOnly}
+                                                domainContainerPath={domain.container}
+                                                domainFormDisplayOptions={domainFormDisplayOptions}
+                                                domainId={domain.domainId}
+                                                domainIndex={domainIndex}
+                                                dragging={dragId === i}
+                                                expanded={expandedRowIndex === i}
+                                                field={field}
+                                                fieldDetailsInfo={fieldDetails.detailsInfo}
+                                                fieldError={this.getFieldError(domain, i)}
+                                                getDomainFields={this.getDomainFields}
+                                                helpNoun={helpNoun}
+                                                index={i}
                                                 isDragDisabled={
                                                     !valueIsEmpty(search) ||
                                                     domainFormDisplayOptions.isDragDisabled ||
                                                     field.isCalculatedField()
                                                 }
-                                                domainFormDisplayOptions={domainFormDisplayOptions}
-                                                domainContainerPath={domain.container}
-                                                schemaName={schemaName ?? domain.schemaName}
+                                                key={key}
+                                                maxPhiLevel={maxPhiLevel}
+                                                onChange={this.onFieldsChange}
+                                                onDelete={this.onDeleteField}
+                                                onExpand={this.onFieldExpandToggle}
                                                 queryName={queryName ?? domain.queryName}
+                                                ref={ref => {
+                                                    this.refsArray[i] = ref;
+                                                }}
+                                                schemaName={schemaName ?? domain.schemaName}
+                                                showDefaultValueSettings={domain.showDefaultValueSettings}
                                             />
                                         );
                                     })
@@ -1360,17 +1360,17 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 <div className={getDomainPanelClass(collapsed, controlledCollapse, isApp_)}>
                     {showHeader && (
                         <CollapsiblePanelHeader
-                            id={getDomainPanelHeaderId(domain)}
-                            title={getDomainHeaderName(domain.name, headerTitle, headerPrefix)}
                             collapsed={!(this.isPanelExpanded() && controlledCollapse)}
                             collapsible={collapsible}
                             controlledCollapse={controlledCollapse}
                             headerDetails={headerDetails}
-                            todoIconHelpMsg={todoIconHelpMsg}
-                            panelStatus={panelStatus}
-                            togglePanel={this.togglePanel}
-                            isValid={!hasException}
                             iconHelpMsg={hasException ? domain.domainException.exception : undefined}
+                            id={getDomainPanelHeaderId(domain)}
+                            isValid={!hasException}
+                            panelStatus={panelStatus}
+                            title={getDomainHeaderName(domain.name, headerTitle, headerPrefix)}
+                            todoIconHelpMsg={todoIconHelpMsg}
+                            togglePanel={this.togglePanel}
                         >
                             {children}
                         </CollapsiblePanelHeader>
@@ -1383,8 +1383,8 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                 <>
                                     {systemFields && (
                                         <SystemFields
-                                            fields={systemFields}
                                             disabledSystemFields={domain.disabledSystemFields}
+                                            fields={systemFields}
                                             onSystemFieldEnable={this.onSystemFieldEnable}
                                         />
                                     )}
@@ -1410,7 +1410,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                         <div className={`col-xs-${helpTopic ? 9 : 12}`} />
                                         {helpTopic && (
                                             <div className="col-xs-3">
-                                                <HelpLink topic={helpTopic} className="domain-field-float-right">
+                                                <HelpLink className="domain-field-float-right" topic={helpTopic}>
                                                     Learn more about this tool
                                                 </HelpLink>
                                             </div>
@@ -1457,10 +1457,10 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
 
                             {filePreviewData && !domainFormDisplayOptions?.hideImportData && (
                                 <ImportDataFilePreview
-                                    noun={helpNoun}
-                                    filePreviewData={filePreviewData}
-                                    setFileImportData={setFileImportData}
                                     file={file}
+                                    filePreviewData={filePreviewData}
+                                    noun={helpNoun}
+                                    setFileImportData={setFileImportData}
                                 />
                             )}
                         </div>
@@ -1468,8 +1468,8 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 </div>
                 {hasException && domain.domainException.severity === SEVERITY_LEVEL_ERROR && (
                     <div
-                        onClick={this.togglePanel}
                         className={getDomainAlertClasses(collapsed, controlledCollapse, isApp_)}
+                        onClick={this.togglePanel}
                     >
                         <Alert bsStyle="danger">{domain.domainException.exception}</Alert>
                     </div>

--- a/packages/components/src/internal/components/domainproperties/DomainForm.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainForm.tsx
@@ -146,28 +146,28 @@ const DomainFormToolbar: FC<DomainFormToolbarProps> = memo(props => {
             <div className="col-xs-4">
                 {!domainFormDisplayOptions?.hideAddFieldsButton && (
                     <AddEntityButton
-                        entity="Field"
-                        containerClass="container--toolbar-button"
                         buttonClass="domain-toolbar-add-btn"
+                        containerClass="container--toolbar-button"
+                        entity="Field"
                         onClick={onAddField}
                     />
                 )}
                 {!domainFormDisplayOptions?.hideAddFieldsButton && (
                     <ActionButton
-                        containerClass="container--toolbar-button"
                         buttonClass="domain-toolbar-delete-btn"
-                        onClick={onBulkDeleteClick}
+                        containerClass="container--toolbar-button"
                         disabled={visibleSelection.size === 0}
+                        onClick={onBulkDeleteClick}
                     >
                         <i className="fa fa-trash domain-toolbar-export-btn-icon" /> Delete
                     </ActionButton>
                 )}
                 {shouldShowImportExport && (
                     <ActionButton
-                        containerClass="container--toolbar-button"
                         buttonClass="domain-toolbar-export-btn"
-                        onClick={onExportFields}
+                        containerClass="container--toolbar-button"
                         disabled={disableExport}
+                        onClick={onExportFields}
                     >
                         <i className="fa fa-download domain-toolbar-export-btn-icon" /> Export
                     </ActionButton>
@@ -177,26 +177,26 @@ const DomainFormToolbar: FC<DomainFormToolbarProps> = memo(props => {
                 <div className="pull-right domain-field-toolbar-right-aligned">
                     {!valueIsEmpty(search) && (
                         <span className="domain-search-text">
-                            Showing {fields.filter(f => f.visible).size} of {fields.size} {' '}
-                            field{fields.size > 1 ? 's' : ''}.
+                            Showing {fields.filter(f => f.visible).size} of {fields.size} field
+                            {fields.size > 1 ? 's' : ''}.
                         </span>
                     )}
                     <input
-                        id={'domain-search-name-' + domainIndex}
                         className="form-control domain-search-input"
-                        type="text"
-                        placeholder="Search Fields"
+                        id={'domain-search-name-' + domainIndex}
                         onChange={onSearchChange}
+                        placeholder="Search Fields"
+                        type="text"
                     />
 
                     <div className="domain-toolbar-toggle-summary">
                         <span>Mode: </span>
                         <ToggleButtons
+                            active={summaryViewMode ? 'Summary' : 'Detail'}
                             className=""
                             first="Summary"
-                            second="Detail"
-                            active={summaryViewMode ? 'Summary' : 'Detail'}
                             onClick={onToggleSummaryView}
+                            second="Detail"
                         />
                     </div>
                 </div>
@@ -604,10 +604,10 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         if (deletableSelectedFieldsCount === 0) {
             return (
                 <Modal
-                    title="Cannot Delete Required Fields"
-                    onCancel={this.onConfirmBulkCancel}
                     cancelText="Close"
                     confirmClass="btn-danger"
+                    onCancel={this.onConfirmBulkCancel}
+                    title="Cannot Delete Required Fields"
                 >
                     <div>
                         <p> None of the selected fields can be deleted. </p>
@@ -623,11 +623,11 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
 
         return (
             <Modal
-                title="Confirm Delete Selected Fields"
-                onConfirm={this.onBulkDeleteConfirm}
-                onCancel={this.onConfirmBulkCancel}
                 confirmClass="btn-danger"
                 confirmText="Yes, Delete Fields"
+                onCancel={this.onConfirmBulkCancel}
+                onConfirm={this.onBulkDeleteConfirm}
+                title="Confirm Delete Selected Fields"
             >
                 <div>
                     <p>{howManyDeleted} will be deleted.</p>
@@ -929,9 +929,9 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 <div className="row domain-add-field-row">
                     <div className="col-xs-12">
                         <AddEntityButton
-                            entity="Field"
                             buttonClass="domain-form-add-btn"
                             containerClass="pull-right"
+                            entity="Field"
                             onClick={this.onAddField}
                         />
                     </div>
@@ -963,11 +963,11 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
         const fieldName = field && field.name && field.name.trim().length > 0 ? <b>{field.name}</b> : 'this field';
         return (
             <Modal
-                title="Confirm Remove Field"
-                onConfirm={() => this.onDeleteConfirm(confirmDeleteRowIndex)}
-                onCancel={this.onConfirmCancel}
                 confirmClass="btn-danger"
                 confirmText="Yes, Remove Field"
+                onCancel={this.onConfirmCancel}
+                onConfirm={() => this.onDeleteConfirm(confirmDeleteRowIndex)}
+                title="Confirm Remove Field"
             >
                 <div>
                     Are you sure you want to remove {fieldName}?{' '}
@@ -1096,11 +1096,11 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 <>
                     <FileAttachmentForm
                         acceptedFormats={acceptedFormats.join(', ')}
-                        showAcceptedFormats
                         allowDirectories={false}
                         allowMultiple={false}
-                        label={label}
+                        fileSpecificCallback={Map({ '.json': this.importFieldsFromJson })}
                         index={index}
+                        label={label}
                         onFileRemoval={this.onFileRemoval}
                         previewGridProps={
                             shouldShowInferFromFile && {
@@ -1110,7 +1110,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                 domainKindName: domain.domainKindName,
                             }
                         }
-                        fileSpecificCallback={Map({ '.json': this.importFieldsFromJson })}
+                        showAcceptedFormats
                     />
                     {shouldShowInferFromFile && this.state.filePreviewMsg && (
                         <Alert bsStyle="info">{this.state.filePreviewMsg}</Alert>
@@ -1205,7 +1205,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
             visibleFieldsCount !== 0 && visibleSelection.size === visibleFieldsCount ? 'Clear All' : 'Clear';
 
         return (
-            <DragDropContext onDragEnd={this.onDragEnd} onBeforeDragStart={this.onBeforeDragStart}>
+            <DragDropContext onBeforeDragStart={this.onBeforeDragStart} onDragEnd={this.onDragEnd}>
                 <div className="domain-field-row domain-row-border-default domain-floating-hdr">
                     <Alert bsStyle="info">{reservedFieldsMsg}</Alert>
                     <div className="row">
@@ -1225,10 +1225,10 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                         <div className="domain-row-handle" />
                         <div className="domain-row-action-section">
                             <CheckboxLK
-                                className="domain-field-check-icon"
-                                name="domain-select-all-checkbox"
-                                id="domain-select-all-checkbox"
                                 checked={selectAll}
+                                className="domain-field-check-icon"
+                                id="domain-select-all-checkbox"
+                                name="domain-select-all-checkbox"
                                 onChange={this.toggleSelectAll}
                             />
                         </div>
@@ -1263,39 +1263,39 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
 
                                         return (
                                             <DomainRow
-                                                ref={ref => {
-                                                    this.refsArray[i] = ref;
-                                                }}
-                                                domainId={domain.domainId}
-                                                helpNoun={helpNoun}
-                                                key={key}
-                                                field={field}
-                                                fieldError={this.getFieldError(domain, i)}
-                                                getDomainFields={this.getDomainFields}
-                                                fieldDetailsInfo={fieldDetails.detailsInfo}
-                                                domainIndex={domainIndex}
-                                                index={i}
-                                                expanded={expandedRowIndex === i}
-                                                onChange={this.onFieldsChange}
-                                                onExpand={this.onFieldExpandToggle}
-                                                onDelete={this.onDeleteField}
-                                                maxPhiLevel={maxPhiLevel}
-                                                dragging={dragId === i}
-                                                availableTypes={availableTypes}
                                                 allowUniqueConstraintProperties={domain.allowUniqueConstraintProperties}
-                                                showDefaultValueSettings={domain.showDefaultValueSettings}
+                                                appPropertiesOnly={appPropertiesOnly}
+                                                availableTypes={availableTypes}
                                                 defaultDefaultValueType={domain.defaultDefaultValueType}
                                                 defaultValueOptions={domain.defaultValueOptions}
-                                                appPropertiesOnly={appPropertiesOnly}
+                                                domainContainerPath={domain.container}
+                                                domainFormDisplayOptions={domainFormDisplayOptions}
+                                                domainId={domain.domainId}
+                                                domainIndex={domainIndex}
+                                                dragging={dragId === i}
+                                                expanded={expandedRowIndex === i}
+                                                field={field}
+                                                fieldDetailsInfo={fieldDetails.detailsInfo}
+                                                fieldError={this.getFieldError(domain, i)}
+                                                getDomainFields={this.getDomainFields}
+                                                helpNoun={helpNoun}
+                                                index={i}
                                                 isDragDisabled={
                                                     !valueIsEmpty(search) ||
                                                     domainFormDisplayOptions.isDragDisabled ||
                                                     field.isCalculatedField()
                                                 }
-                                                domainFormDisplayOptions={domainFormDisplayOptions}
-                                                domainContainerPath={domain.container}
-                                                schemaName={schemaName ?? domain.schemaName}
+                                                key={key}
+                                                maxPhiLevel={maxPhiLevel}
+                                                onChange={this.onFieldsChange}
+                                                onDelete={this.onDeleteField}
+                                                onExpand={this.onFieldExpandToggle}
                                                 queryName={queryName ?? domain.queryName}
+                                                ref={ref => {
+                                                    this.refsArray[i] = ref;
+                                                }}
+                                                schemaName={schemaName ?? domain.schemaName}
+                                                showDefaultValueSettings={domain.showDefaultValueSettings}
                                             />
                                         );
                                     })
@@ -1362,17 +1362,17 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 <div className={getDomainPanelClass(collapsed, controlledCollapse, isApp_)}>
                     {showHeader && (
                         <CollapsiblePanelHeader
-                            id={getDomainPanelHeaderId(domain)}
-                            title={getDomainHeaderName(domain.name, headerTitle, headerPrefix)}
                             collapsed={!(this.isPanelExpanded() && controlledCollapse)}
                             collapsible={collapsible}
                             controlledCollapse={controlledCollapse}
                             headerDetails={headerDetails}
-                            todoIconHelpMsg={todoIconHelpMsg}
-                            panelStatus={panelStatus}
-                            togglePanel={this.togglePanel}
-                            isValid={!hasException}
                             iconHelpMsg={hasException ? domain.domainException.exception : undefined}
+                            id={getDomainPanelHeaderId(domain)}
+                            isValid={!hasException}
+                            panelStatus={panelStatus}
+                            title={getDomainHeaderName(domain.name, headerTitle, headerPrefix)}
+                            todoIconHelpMsg={todoIconHelpMsg}
+                            togglePanel={this.togglePanel}
                         >
                             {children}
                         </CollapsiblePanelHeader>
@@ -1385,8 +1385,8 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                 <>
                                     {systemFields && (
                                         <SystemFields
-                                            fields={systemFields}
                                             disabledSystemFields={domain.disabledSystemFields}
+                                            fields={systemFields}
                                             onSystemFieldEnable={this.onSystemFieldEnable}
                                         />
                                     )}
@@ -1413,7 +1413,7 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                                         <div className={`col-xs-${helpTopic ? 9 : 12}`} />
                                         {helpTopic && (
                                             <div className="col-xs-3">
-                                                <HelpLink topic={helpTopic} className="domain-field-float-right">
+                                                <HelpLink className="domain-field-float-right" topic={helpTopic}>
                                                     Learn more about this tool
                                                 </HelpLink>
                                             </div>
@@ -1460,10 +1460,10 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
 
                             {filePreviewData && !domainFormDisplayOptions?.hideImportData && (
                                 <ImportDataFilePreview
-                                    noun={helpNoun}
-                                    filePreviewData={filePreviewData}
-                                    setFileImportData={setFileImportData}
                                     file={file}
+                                    filePreviewData={filePreviewData}
+                                    noun={helpNoun}
+                                    setFileImportData={setFileImportData}
                                 />
                             )}
                         </div>
@@ -1471,8 +1471,8 @@ export class DomainFormImpl extends React.PureComponent<DomainFormProps, State> 
                 </div>
                 {hasException && domain.domainException.severity === SEVERITY_LEVEL_ERROR && (
                     <div
-                        onClick={this.togglePanel}
                         className={getDomainAlertClasses(collapsed, controlledCollapse, isApp_)}
+                        onClick={this.togglePanel}
                     >
                         <Alert bsStyle="danger">{domain.domainException.exception}</Alert>
                     </div>

--- a/packages/components/src/internal/components/domainproperties/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/constants.ts
@@ -158,6 +158,7 @@ export const MODIFIED_TIMESTAMP_CONCEPT_URI = 'http://www.labkey.org/types#modif
 export const SMILES_CONCEPT_URI = 'http://www.labkey.org/exp/xml#smiles';
 export const AUTO_INT_CONCEPT_URI = 'http://www.labkey.org/types#autoInt';
 export const CALCULATED_CONCEPT_URI = 'http://www.labkey.org/exp/xml#calculated';
+export const NON_NEGATIVE_NUMBER_CONCEPT_URI = 'http://www.labkey.org/types#nonNegativeNumber';
 
 export const UNLIMITED_TEXT_LENGTH = 2147483647; // Integer.MAX_VALUE
 export const MAX_TEXT_LENGTH = 4000;

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -29,7 +29,7 @@ import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../../APIWrapper'
 
 import { GENID_SYNTAX_STRING } from '../NameExpressionGenIdBanner';
 
-import { IImportAlias, IParentAlias, IParentOption, FolderConfigurableDataType } from '../../entities/models';
+import { FolderConfigurableDataType, IImportAlias, IParentAlias, IParentOption } from '../../entities/models';
 import { SCHEMAS } from '../../../schemas';
 import {
     getHelpLink,
@@ -115,10 +115,10 @@ interface Props {
     onCancel: () => void;
     onChange?: (model: SampleTypeModel) => void;
     onComplete: (response: DomainDesign) => void;
+    sampleAliasCaption?: string;
     sampleTypeCaption?: string;
     saveBtnText?: string;
     showAliquotOptions?: boolean;
-    sampleAliasCaption?: string;
     showLinkToStudy?: boolean;
     showParentLabelPrefix?: boolean;
     useSeparateDataClassesAliasMenu?: boolean;
@@ -138,7 +138,7 @@ interface State {
     uniqueIdsConfirmed: boolean;
 }
 // Exported for testing
-export class SampleTypeDesignerImpl extends React.PureComponent<Props & InjectedBaseDomainDesignerProps, State> {
+export class SampleTypeDesignerImpl extends React.PureComponent<InjectedBaseDomainDesignerProps & Props, State> {
     static defaultProps = {
         api: getDefaultAPIWrapper(),
         defaultSampleFieldConfig: DEFAULT_SAMPLE_FIELD_CONFIG,
@@ -156,7 +156,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         validateNameExpressions: true,
     };
 
-    constructor(props: Props & InjectedBaseDomainDesignerProps) {
+    constructor(props: InjectedBaseDomainDesignerProps & Props) {
         super(props);
 
         let domainDetails = this.props.initModel || DomainDetails.create();
@@ -550,7 +550,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         if (isCommunityDistribution() || !model.isNew() || model.domain?.fields?.isEmpty()) {
             return null;
         }
-        return <UniqueIdBanner model={this.state.model} isFieldsPanel={true} onAddField={config.onAddField} />;
+        return <UniqueIdBanner isFieldsPanel={true} model={this.state.model} onAddField={config.onAddField} />;
     };
 
     getNumNewUniqueIdFields(): number {
@@ -558,7 +558,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
         return model.domain.fields.filter(field => field.isNew() && field.isUniqueIdField()).count();
     }
 
-    getDomainDetails = (): { [key: string]: any } => {
+    getDomainDetails = (): Record<string, any> => {
         const { model } = this.state;
 
         const {
@@ -683,56 +683,31 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
 
         return (
             <BaseDomainDesigner
-                name={model.name}
-                exception={model.exception}
                 domains={List.of(model.domain)}
+                exception={model.exception}
                 hasValidProperties={model.hasValidProperties()}
-                visitedPanels={visitedPanels}
-                submitting={submitting}
+                name={model.name}
                 onCancel={onCancel}
                 onFinish={this.onFinish}
                 saveBtnText={saveBtnText}
                 showUserComment={isUpdate && appPropertiesOnly}
+                submitting={submitting}
+                visitedPanels={visitedPanels}
             >
                 <SampleTypePropertiesPanel
+                    aliquotNamePatternProps={aliquotNamePatternProps}
                     api={api}
-                    nounSingular={nounSingular}
-                    nounPlural={nounPlural}
-                    nameExpressionInfoUrl={nameExpressionInfoUrl}
-                    nameExpressionPlaceholder={nameExpressionPlaceholder}
+                    appPropertiesOnly={appPropertiesOnly}
+                    controlledCollapse
+                    dataClassAliasCaption={dataClassAliasCaption}
+                    dataClassParentageLabel={dataClassParentageLabel}
+                    dataClassTypeCaption={dataClassTypeCaption}
                     headerText={headerText}
                     helpTopic={helpTopic}
-                    model={model}
-                    parentOptions={parentOptions}
                     includeDataClasses={includeDataClasses}
-                    useSeparateDataClassesAliasMenu={useSeparateDataClassesAliasMenu}
-                    sampleAliasCaption={sampleAliasCaption}
-                    sampleTypeCaption={sampleTypeCaption}
-                    dataClassAliasCaption={dataClassAliasCaption}
-                    dataClassTypeCaption={dataClassTypeCaption}
-                    dataClassParentageLabel={dataClassParentageLabel}
-                    onParentAliasChange={this.parentAliasChange}
-                    onAddParentAlias={this.addParentAlias}
-                    onRemoveParentAlias={this.removeParentAlias}
-                    updateDupeParentAliases={this.updateDupes}
-                    updateModel={this.onFieldChange}
-                    controlledCollapse
                     initCollapsed={currentPanelIndex !== PROPERTIES_PANEL_INDEX}
-                    panelStatus={
-                        model.isNew()
-                            ? getDomainPanelStatus(PROPERTIES_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState)
-                            : 'COMPLETE'
-                    }
-                    validate={validatePanel === PROPERTIES_PANEL_INDEX}
-                    onToggle={this.propertiesToggle}
-                    appPropertiesOnly={appPropertiesOnly}
-                    showLinkToStudy={_showLinkToStudy}
                     metricUnitProps={metricUnitProps}
-                    onAddUniqueIdField={this.onAddUniqueIdField}
-                    aliquotNamePatternProps={aliquotNamePatternProps}
-                    namePreviewsLoading={namePreviewsLoading}
-                    namePreviews={namePreviews}
-                    onNameFieldHover={this.onNameFieldHover}
+                    model={model}
                     nameExpressionGenIdProps={
                         isUpdate && options && hasGenIdInExpression
                             ? {
@@ -745,27 +720,38 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                               }
                             : undefined
                     }
+                    nameExpressionInfoUrl={nameExpressionInfoUrl}
+                    nameExpressionPlaceholder={nameExpressionPlaceholder}
+                    namePreviews={namePreviews}
+                    namePreviewsLoading={namePreviewsLoading}
+                    nounPlural={nounPlural}
+                    nounSingular={nounSingular}
+                    onAddParentAlias={this.addParentAlias}
+                    onAddUniqueIdField={this.onAddUniqueIdField}
+                    onNameFieldHover={this.onNameFieldHover}
+                    onParentAliasChange={this.parentAliasChange}
+                    onRemoveParentAlias={this.removeParentAlias}
+                    onToggle={this.propertiesToggle}
+                    panelStatus={
+                        model.isNew()
+                            ? getDomainPanelStatus(PROPERTIES_PANEL_INDEX, currentPanelIndex, visitedPanels, firstState)
+                            : 'COMPLETE'
+                    }
+                    parentOptions={parentOptions}
+                    sampleAliasCaption={sampleAliasCaption}
+                    sampleTypeCaption={sampleTypeCaption}
+                    showLinkToStudy={_showLinkToStudy}
+                    updateDupeParentAliases={this.updateDupes}
+                    updateModel={this.onFieldChange}
+                    useSeparateDataClassesAliasMenu={useSeparateDataClassesAliasMenu}
+                    validate={validatePanel === PROPERTIES_PANEL_INDEX}
                 />
                 <DomainForm
                     api={api.domain}
-                    key={model.domain.domainId || 0}
                     appDomainHeaderRenderer={this.uniqueIdBannerRenderer}
-                    domainIndex={0}
-                    domain={model.domain}
-                    headerTitle="Fields"
-                    helpTopic={null} // null so that we don't show the "learn more about this tool" link for this domains
-                    controlledCollapse
-                    initCollapsed={currentPanelIndex !== DOMAIN_PANEL_INDEX}
-                    validate={validatePanel === DOMAIN_PANEL_INDEX}
-                    panelStatus={
-                        model.isNew()
-                            ? getDomainPanelStatus(1, currentPanelIndex, visitedPanels, firstState)
-                            : 'COMPLETE'
-                    }
-                    onChange={this.domainChangeHandler}
-                    onToggle={this.formToggle}
                     appPropertiesOnly={appPropertiesOnly}
-                    groupedSystemFields={{storedamount: ['units'], units: ['storedamount']}}
+                    controlledCollapse
+                    domain={model.domain}
                     domainFormDisplayOptions={{
                         ...domainFormDisplayOptions,
                         hideStudyPropertyTypes: !_showLinkToStudy,
@@ -792,47 +778,61 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                                 "Updating a 'Samples Only' field to be 'Samples and Aliquots' will blank out the field values for all aliquots. This action cannot be undone. ",
                         },
                     }}
+                    domainIndex={0}
+                    groupedSystemFields={{ storedamount: ['units'], units: ['storedamount'] }}
+                    headerTitle="Fields"
+                    helpTopic={null} // null so that we don't show the "learn more about this tool" link for this domains
+                    initCollapsed={currentPanelIndex !== DOMAIN_PANEL_INDEX}
+                    key={model.domain.domainId || 0}
                     newFieldConfig={{
                         derivationDataScope: DERIVATION_DATA_SCOPES.PARENT_ONLY,
                     }}
+                    onChange={this.domainChangeHandler}
+                    onToggle={this.formToggle}
+                    panelStatus={
+                        model.isNew()
+                            ? getDomainPanelStatus(1, currentPanelIndex, visitedPanels, firstState)
+                            : 'COMPLETE'
+                    }
                     systemFields={options?.get('systemFields')}
+                    validate={validatePanel === DOMAIN_PANEL_INDEX}
                 />
                 {appPropertiesOnly && allowFolderExclusion && (
                     // appPropertiesOnly check will prevent this panel from showing in LKS and in LKB media types
                     <DataTypeFoldersPanel
                         controlledCollapse
-                        dataTypeRowId={model?.rowId}
                         dataTypeName={model?.name}
+                        dataTypeRowId={model?.rowId}
                         entityDataType={SampleTypeDataType}
-                        relatedFolderConfigurableDataType="DashboardSampleType"
-                        relatedDataTypeLabel="Include in Dashboard Insights graphs"
                         initCollapsed={currentPanelIndex !== FOLDERS_PANEL_INDEX}
                         onToggle={this.foldersToggle}
                         onUpdateExcludedFolders={this.onUpdateExcludedFolders}
+                        relatedDataTypeLabel="Include in Dashboard Insights graphs"
+                        relatedFolderConfigurableDataType="DashboardSampleType"
                     />
                 )}
                 {error && <div className="domain-form-panel">{error && <Alert bsStyle="danger">{error}</Alert>}</div>}
                 {showUniqueIdConfirmation && (
                     <Modal
+                        confirmText="Continue"
+                        onCancel={this.onUniqueIdCancel}
+                        onConfirm={this.onUniqueIdConfirm}
                         title={
                             'Updating ' +
                             SampleTypeDataType.typeNounSingular +
                             ' with Unique ID field' +
                             (numNewUniqueIdFields !== 1 ? 's' : '')
                         }
-                        onCancel={this.onUniqueIdCancel}
-                        onConfirm={this.onUniqueIdConfirm}
-                        confirmText="Continue"
                     >
                         {confirmModalMessage}
                     </Modal>
                 )}
                 <NameExpressionValidationModal
-                    onHide={this.onNameExpressionWarningCancel}
                     onConfirm={this.onNameExpressionWarningConfirm}
-                    warnings={nameExpressionWarnings}
+                    onHide={this.onNameExpressionWarningCancel}
                     previews={namePreviews}
                     show={!!nameExpressionWarnings && !model.exception}
+                    warnings={nameExpressionWarnings}
                 />
             </BaseDomainDesigner>
         );

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -765,6 +765,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<Props & Injected
                     onChange={this.domainChangeHandler}
                     onToggle={this.formToggle}
                     appPropertiesOnly={appPropertiesOnly}
+                    groupedSystemFields={{storedamount: ['units'], units: ['storedamount']}}
                     domainFormDisplayOptions={{
                         ...domainFormDisplayOptions,
                         hideStudyPropertyTypes: !_showLinkToStudy,

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -533,7 +533,7 @@ export class Cell extends React.PureComponent<CellProps, undefined> {
                 .filter(vd => vd && vd.display !== undefined)
                 .reduce((v, vd, i) => v + (i > 0 ? ', ' : '') + vd.display, '');
 
-            const showMenu = (showLookup || !!col.inputRenderer) && (NON_NEGATIVE_NUMBER_CONCEPT_URI !== col?.conceptURI);
+            const showMenu = (showLookup || !!col.inputRenderer) && (NON_NEGATIVE_NUMBER_CONCEPT_URI !== col?.conceptURI /*storedamount has inputRenderer but shouldn't show menu*/);
 
             return (
                 <>

--- a/packages/components/src/internal/components/editable/Cell.tsx
+++ b/packages/components/src/internal/components/editable/Cell.tsx
@@ -44,6 +44,7 @@ import {
 } from './utils';
 import { LookupCell } from './LookupCell';
 import { DateInputCell } from './DateInputCell';
+import { NON_NEGATIVE_NUMBER_CONCEPT_URI } from '../domainproperties/constants';
 
 // CSS Order: top, right, bottom, left
 export type BorderMask = [boolean, boolean, boolean, boolean];
@@ -532,6 +533,8 @@ export class Cell extends React.PureComponent<CellProps, undefined> {
                 .filter(vd => vd && vd.display !== undefined)
                 .reduce((v, vd, i) => v + (i > 0 ? ', ' : '') + vd.display, '');
 
+            const showMenu = (showLookup || !!col.inputRenderer) && (NON_NEGATIVE_NUMBER_CONCEPT_URI !== col?.conceptURI);
+
             return (
                 <>
                     <DisplayCell
@@ -551,7 +554,7 @@ export class Cell extends React.PureComponent<CellProps, undefined> {
                         placeholder={placeholder}
                         selected={selected}
                         selection={selection}
-                        showMenu={showLookup || !!col.inputRenderer}
+                        showMenu={showMenu}
                         targetRef={this.displayEl}
                     />
                     {renderDragHandle && !this.isReadOnly && (

--- a/packages/components/src/internal/components/editable/utils.test.ts
+++ b/packages/components/src/internal/components/editable/utils.test.ts
@@ -3,7 +3,7 @@ import { List, Map } from 'immutable';
 import { QueryInfo } from '../../../public/QueryInfo';
 import { QueryColumn, QueryLookup } from '../../../public/QueryColumn';
 
-import { DATE_RANGE_URI } from '../domainproperties/constants';
+import { DATE_RANGE_URI, NON_NEGATIVE_NUMBER_CONCEPT_URI } from '../domainproperties/constants';
 
 import sampleSetQueryInfoJSON from '../../../test/data/sampleSetAllFieldTypes-getQueryDetails.json';
 
@@ -267,6 +267,38 @@ describe('getValidatedEditableGridValue', () => {
             expect(getValidatedEditableGridValue(value, floatCol)).toStrictEqual({
                 message: {
                     message: 'Invalid decimal',
+                },
+                value,
+            });
+        });
+    });
+
+    test('amount column', () => {
+        const amountCol = new QueryColumn({ jsonType: 'float', conceptURI: NON_NEGATIVE_NUMBER_CONCEPT_URI, caption: 'Amount' });
+
+        const validValues = [null, undefined, '', ' ', 0, 1.1e3, '100', '0.0', 1.11, '1.11', 123.456e2];
+        validValues.forEach(value => {
+            expect(getValidatedEditableGridValue(value, amountCol)).toStrictEqual({
+                message: undefined,
+                value: Utils.isString(value) ? value.trim() : value,
+            });
+        });
+
+        const invalidValues = ['Bogus', true, NaN];
+        invalidValues.forEach(value => {
+            expect(getValidatedEditableGridValue(value, amountCol)).toStrictEqual({
+                message: {
+                    message: 'Invalid decimal',
+                },
+                value,
+            });
+        });
+
+        const invalidNegative = ['-1', '-1.1', -1, -1.1, -1.1e3, -123.456e2];
+        invalidNegative.forEach(value => {
+            expect(getValidatedEditableGridValue(value, amountCol)).toStrictEqual({
+                message: {
+                    message: 'Invalid Amount, must be non-negative',
                 },
                 value,
             });

--- a/packages/components/src/internal/components/editable/utils.test.ts
+++ b/packages/components/src/internal/components/editable/utils.test.ts
@@ -302,7 +302,7 @@ describe('getValidatedEditableGridValue', () => {
         invalidNegative.forEach(value => {
             expect(getValidatedEditableGridValue(value, amountCol)).toStrictEqual({
                 message: {
-                    message: 'Invalid Amount, must be non-negative',
+                    message: 'Amount must be non-negative',
                 },
                 value,
             });

--- a/packages/components/src/internal/components/editable/utils.test.ts
+++ b/packages/components/src/internal/components/editable/utils.test.ts
@@ -274,7 +274,11 @@ describe('getValidatedEditableGridValue', () => {
     });
 
     test('amount column', () => {
-        const amountCol = new QueryColumn({ jsonType: 'float', conceptURI: NON_NEGATIVE_NUMBER_CONCEPT_URI, caption: 'Amount' });
+        const amountCol = new QueryColumn({
+            jsonType: 'float',
+            conceptURI: NON_NEGATIVE_NUMBER_CONCEPT_URI,
+            caption: 'Amount',
+        });
 
         const validValues = [null, undefined, '', ' ', 0, 1.1e3, '100', '0.0', 1.11, '1.11', 123.456e2];
         validValues.forEach(value => {

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -65,7 +65,7 @@ export const getValidatedEditableGridValue = (origValue: any, col: QueryColumn):
         } else if (jsonType === 'float' && !isFloat(value)) {
             message = 'Invalid decimal';
         } else if (NON_NEGATIVE_NUMBER_CONCEPT_URI === col?.conceptURI && Number(value) < 0) {
-            message = 'Invalid ' + col.caption + ', must be non-negative';
+            message = col.caption + ' must be non-negative';
         } else if (jsonType === 'string' && scale) {
             if (value.toString().trim().length > scale)
                 message = value.toString().trim().length + '/' + scale + ' characters';

--- a/packages/components/src/internal/components/editable/utils.ts
+++ b/packages/components/src/internal/components/editable/utils.ts
@@ -20,6 +20,7 @@ import { incrementClientSideMetricCount } from '../../actions';
 
 import { CellMessage } from './models';
 import { CellActions, MODIFICATION_TYPES } from './constants';
+import { NON_NEGATIVE_NUMBER_CONCEPT_URI } from '../domainproperties/constants';
 
 interface ValidatedValue {
     message: CellMessage;
@@ -63,6 +64,8 @@ export const getValidatedEditableGridValue = (origValue: any, col: QueryColumn):
             message = 'Invalid integer';
         } else if (jsonType === 'float' && !isFloat(value)) {
             message = 'Invalid decimal';
+        } else if (NON_NEGATIVE_NUMBER_CONCEPT_URI === col?.conceptURI && Number(value) < 0) {
+            message = 'Invalid ' + col.caption + ', must be non-negative';
         } else if (jsonType === 'string' && scale) {
             if (value.toString().trim().length > scale)
                 message = value.toString().trim().length + '/' + scale + ' characters';

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -223,6 +223,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (ColumnInputRenderer) {
                         return (
                             <ColumnInputRenderer
+                                allColumns={columns}
                                 allowFieldDisable={allowFieldDisable}
                                 col={col}
                                 containerFilter={containerFilter}
@@ -237,7 +238,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 showAsteriskSymbol={showAsteriskSymbol}
                                 showLabel
                                 value={value}
-                                allColumns={columns}
                             />
                         );
                     }

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -238,6 +238,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 showAsteriskSymbol={showAsteriskSymbol}
                                 showLabel
                                 value={value}
+                                queryFilters={queryFilters}
                             />
                         );
                     }

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -234,11 +234,11 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 onAdditionalFormDataChange={onAdditionalFormDataChange}
                                 onSelectChange={this.onSelectChange}
                                 onToggleDisable={this.onToggleDisable}
+                                queryFilters={queryFilters}
                                 renderLabelField={this.renderLabelField}
                                 showAsteriskSymbol={showAsteriskSymbol}
                                 showLabel
                                 value={value}
-                                queryFilters={queryFilters}
                             />
                         );
                     }

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -225,6 +225,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                             <ColumnInputRenderer
                                 allowFieldDisable={allowFieldDisable}
                                 col={col}
+                                containerFilter={containerFilter}
                                 data={fieldValues}
                                 formsy
                                 initiallyDisabled={shouldDisableField}
@@ -236,7 +237,6 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 showAsteriskSymbol={showAsteriskSymbol}
                                 showLabel
                                 value={value}
-                                containerFilter={containerFilter}
                             />
                         );
                     }

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -194,7 +194,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
         // QueryFormInputs to be a rendering factory for the columns that are in the set.
         if (columns) {
             return columns.valueArray
-                .filter(col => filter(col))
+                .filter(col => filter(col) && !col.removeFromFormInput)
                 .map(col => {
                     const { fieldKey, name, required } = col;
                     const shouldDisableField = initiallyDisableFields || disabledFields.contains(name.toLowerCase());
@@ -237,6 +237,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 showAsteriskSymbol={showAsteriskSymbol}
                                 showLabel
                                 value={value}
+                                allColumns={columns}
                             />
                         );
                     }

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -236,6 +236,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 showAsteriskSymbol={showAsteriskSymbol}
                                 showLabel
                                 value={value}
+                                containerFilter={containerFilter}
                             />
                         );
                     }

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -40,7 +40,7 @@ import { UserDetailsRenderer } from '../../../renderers/UserDetailsRenderer';
 import { ExpirationDateColumnRenderer } from '../../../renderers/ExpirationDateColumnRenderer';
 import { getContainerFilterForLookups } from '../../../query/api';
 import { FolderColumnRenderer } from '../../../renderers/FolderColumnRenderer';
-import { FILELINK_RANGE_URI } from '../../domainproperties/constants';
+import { FILELINK_RANGE_URI, NON_NEGATIVE_NUMBER_CONCEPT_URI } from '../../domainproperties/constants';
 import { LOOKUP_DEFAULT_SIZE } from '../../../constants';
 
 export type Renderer = (data: any, row?: any) => ReactNode;
@@ -294,7 +294,7 @@ export function resolveDetailEditRenderer(
         }
         let value = resolveDetailFieldValue(data);
 
-        const ColumnInputRenderer = resolveInputRenderer(col);
+        const ColumnInputRenderer = col.conceptURI === NON_NEGATIVE_NUMBER_CONCEPT_URI ? null /* Use standard forminput for media amount/unit */ : resolveInputRenderer(col);
         if (ColumnInputRenderer) {
             return (
                 <ColumnInputRenderer

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -294,7 +294,10 @@ export function resolveDetailEditRenderer(
         }
         let value = resolveDetailFieldValue(data);
 
-        const ColumnInputRenderer = col.conceptURI === NON_NEGATIVE_NUMBER_CONCEPT_URI ? null /* Use standard forminput for media amount/unit */ : resolveInputRenderer(col);
+        const ColumnInputRenderer =
+            col.conceptURI === NON_NEGATIVE_NUMBER_CONCEPT_URI
+                ? null /* Use standard forminput for media amount/unit */
+                : resolveInputRenderer(col);
         if (ColumnInputRenderer) {
             return (
                 <ColumnInputRenderer

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.test.tsx
@@ -6,16 +6,21 @@ import { QueryColumn } from '../../../../public/QueryColumn';
 import { Formsy } from '../formsy/index';
 
 describe('AmountUnitInput', () => {
-
     const amountCol = { name: 'StoredAmount', caption: 'amount', fieldKey: 'amountKey' };
-    const unitCol = { name: 'Units', caption: 'unit', fieldKey: 'unitKey',
+    const unitCol = {
+        name: 'Units',
+        caption: 'unit',
+        fieldKey: 'unitKey',
         lookup: {
             hasQueryFilters: jest.fn(),
-            displayColumn: new QueryColumn({caption: 'test'})
-        }
+            displayColumn: new QueryColumn({ caption: 'test' }),
+        },
     };
     const data = { StoredAmount: 12.5, Units: 'mg' };
-    const allColumns = new ExtendedMap<string, QueryColumn>({ [amountCol.fieldKey]: amountCol, [unitCol.fieldKey]: unitCol });
+    const allColumns = new ExtendedMap<string, QueryColumn>({
+        [amountCol.fieldKey]: amountCol,
+        [unitCol.fieldKey]: unitCol,
+    });
 
     const CAN_DISABLE: any = {
         allowFieldDisable: true,
@@ -31,12 +36,12 @@ describe('AmountUnitInput', () => {
 
     const DISABLED: any = {
         ...CAN_DISABLE,
-        initiallyDisabled: true
+        initiallyDisabled: true,
     };
 
     const NOT_DISABLABLE: any = {
         ...CAN_DISABLE,
-        allowFieldDisable: false
+        allowFieldDisable: false,
     };
 
     test('returns null when required columns are missing', () => {
@@ -44,16 +49,16 @@ describe('AmountUnitInput', () => {
 
         const someColumns = new ExtendedMap<string, QueryColumn>({ [amountCol.fieldKey]: amountCol });
         const { container } = render(
-            <Formsy className='inner-test'>
+            <Formsy className="inner-test">
                 <AmountUnitInput
+                    allColumns={someColumns}
                     allowFieldDisable={false}
-                    onSelectChange={jest.fn()}
-                    onToggleDisable={jest.fn()}
-                    initiallyDisabled={false}
                     containerFilter={undefined}
                     containerPath={undefined}
-                    allColumns={someColumns}
                     data={{}}
+                    initiallyDisabled={false}
+                    onSelectChange={jest.fn()}
+                    onToggleDisable={jest.fn()}
                     queryFilters={{}}
                 />
             </Formsy>
@@ -64,12 +69,11 @@ describe('AmountUnitInput', () => {
     });
 
     test('with amount and unit column, can disable', () => {
-
         const { container } = render(
             <Formsy>
                 <AmountUnitInput {...CAN_DISABLE} />
             </Formsy>
-            );
+        );
         expect(document.querySelectorAll('.form-group.row')).toHaveLength(1);
         expect(document.querySelectorAll('label')).toHaveLength(2);
         expect(document.querySelectorAll('label')[0].textContent).toBe('Amount and Units ');
@@ -87,11 +91,9 @@ describe('AmountUnitInput', () => {
         expect(inputs[3].getAttribute('name')).toBe('Units::enabled');
         expect(inputs[3].getAttribute('value')).toBe('true');
         expect(inputs[3].getAttribute('type')).toBe('hidden');
-
     });
 
     test('with amount and unit column, can disable and disabled', () => {
-
         const { container } = render(
             <Formsy>
                 <AmountUnitInput {...DISABLED} />
@@ -114,11 +116,9 @@ describe('AmountUnitInput', () => {
         expect(inputs[3].getAttribute('name')).toBe('Units::enabled');
         expect(inputs[3].getAttribute('value')).toBe('false');
         expect(inputs[3].getAttribute('type')).toBe('hidden');
-
     });
 
     test('with amount and unit column, cannot disable', () => {
-
         const { container } = render(
             <Formsy>
                 <AmountUnitInput {...NOT_DISABLABLE} />
@@ -136,4 +136,4 @@ describe('AmountUnitInput', () => {
         expect(inputs[0].getAttribute('name')).toBe('amountKey');
         expect(inputs[1].getAttribute('role')).toBe('combobox');
     });
-})
+});

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AmountUnitInput } from './AmountUnitInput';
+import { ExtendedMap } from '../../../../public/ExtendedMap';
+import { QueryColumn } from '../../../../public/QueryColumn';
+import { Formsy } from '../formsy/index';
+
+describe('AmountUnitInput', () => {
+
+    const amountCol = { name: 'StoredAmount', caption: 'amount', fieldKey: 'amountKey' };
+    const unitCol = { name: 'Units', caption: 'unit', fieldKey: 'unitKey',
+        lookup: {
+            hasQueryFilters: jest.fn(),
+            displayColumn: new QueryColumn({caption: 'test'})
+        }
+    };
+    const data = { StoredAmount: 12.5, Units: 'mg' };
+    const allColumns = new ExtendedMap<string, QueryColumn>({ [amountCol.fieldKey]: amountCol, [unitCol.fieldKey]: unitCol });
+
+    const CAN_DISABLE: any = {
+        allowFieldDisable: true,
+        onSelectChange: jest.fn(),
+        onToggleDisable: jest.fn(),
+        initiallyDisabled: false,
+        containerFilter: undefined,
+        containerPath: undefined,
+        allColumns,
+        data,
+        queryFilters: {},
+    };
+
+    const DISABLED: any = {
+        ...CAN_DISABLE,
+        initiallyDisabled: true
+    };
+
+    const NOT_DISABLABLE: any = {
+        ...CAN_DISABLE,
+        allowFieldDisable: false
+    };
+
+    test('returns null when required columns are missing', () => {
+        // Missing unit column
+
+        const someColumns = new ExtendedMap<string, QueryColumn>({ [amountCol.fieldKey]: amountCol });
+        const { container } = render(
+            <Formsy className='inner-test'>
+                <AmountUnitInput
+                    allowFieldDisable={false}
+                    onSelectChange={jest.fn()}
+                    onToggleDisable={jest.fn()}
+                    initiallyDisabled={false}
+                    containerFilter={undefined}
+                    containerPath={undefined}
+                    allColumns={someColumns}
+                    data={{}}
+                    queryFilters={{}}
+                />
+            </Formsy>
+        );
+
+        // Component should render nothing when unit or amount column can't be found
+        expect(container.querySelector('.inner-test')).toBeEmptyDOMElement();
+    });
+
+    test('with amount and unit column, can disable', () => {
+
+        const { container } = render(
+            <Formsy>
+                <AmountUnitInput {...CAN_DISABLE} />
+            </Formsy>
+            );
+        expect(document.querySelectorAll('.form-group.row')).toHaveLength(1);
+        expect(document.querySelectorAll('label')).toHaveLength(2);
+        expect(document.querySelectorAll('label')[0].textContent).toBe('Amount and Units ');
+        expect(document.querySelectorAll('label')[1].textContent).toBe('');
+        expect(document.querySelectorAll('.fa-toggle-on')).toHaveLength(1);
+        expect(document.querySelectorAll('.fa-toggle-off')).toHaveLength(0);
+        const inputs = document.querySelectorAll('input');
+        expect(inputs).toHaveLength(4);
+        expect(inputs[0].getAttribute('value')).toBe('true');
+        expect(inputs[0].getAttribute('type')).toBe('hidden');
+        expect(inputs[0].getAttribute('name')).toBe('StoredAmount::enabled');
+        expect(inputs[1].getAttribute('value')).toBe('12.5');
+        expect(inputs[1].getAttribute('name')).toBe('amountKey');
+        expect(inputs[2].getAttribute('role')).toBe('combobox');
+        expect(inputs[3].getAttribute('name')).toBe('Units::enabled');
+        expect(inputs[3].getAttribute('value')).toBe('true');
+        expect(inputs[3].getAttribute('type')).toBe('hidden');
+
+    });
+
+    test('with amount and unit column, can disable and disabled', () => {
+
+        const { container } = render(
+            <Formsy>
+                <AmountUnitInput {...DISABLED} />
+            </Formsy>
+        );
+        expect(document.querySelectorAll('.form-group.row')).toHaveLength(1);
+        expect(document.querySelectorAll('label')).toHaveLength(2);
+        expect(document.querySelectorAll('label')[0].textContent).toBe('Amount and Units ');
+        expect(document.querySelectorAll('label')[1].textContent).toBe('');
+        expect(document.querySelectorAll('.fa-toggle-on')).toHaveLength(0);
+        expect(document.querySelectorAll('.fa-toggle-off')).toHaveLength(1);
+        const inputs = document.querySelectorAll('input');
+        expect(inputs).toHaveLength(4);
+        expect(inputs[0].getAttribute('value')).toBe('false');
+        expect(inputs[0].getAttribute('type')).toBe('hidden');
+        expect(inputs[0].getAttribute('name')).toBe('StoredAmount::enabled');
+        expect(inputs[1].getAttribute('value')).toBe('12.5');
+        expect(inputs[1].getAttribute('name')).toBe('amountKey');
+        expect(inputs[2].getAttribute('role')).toBe('combobox');
+        expect(inputs[3].getAttribute('name')).toBe('Units::enabled');
+        expect(inputs[3].getAttribute('value')).toBe('false');
+        expect(inputs[3].getAttribute('type')).toBe('hidden');
+
+    });
+
+    test('with amount and unit column, cannot disable', () => {
+
+        const { container } = render(
+            <Formsy>
+                <AmountUnitInput {...NOT_DISABLABLE} />
+            </Formsy>
+        );
+        expect(document.querySelectorAll('.form-group.row')).toHaveLength(1);
+        expect(document.querySelectorAll('label')).toHaveLength(2);
+        expect(document.querySelectorAll('label')[0].textContent).toBe('Amount and Units ');
+        expect(document.querySelectorAll('label')[1].textContent).toBe('');
+        expect(document.querySelectorAll('.fa-toggle-on')).toHaveLength(0);
+        expect(document.querySelectorAll('.fa-toggle-off')).toHaveLength(0);
+        const inputs = document.querySelectorAll('input');
+        expect(inputs).toHaveLength(2);
+        expect(inputs[0].getAttribute('value')).toBe('12.5');
+        expect(inputs[0].getAttribute('name')).toBe('amountKey');
+        expect(inputs[1].getAttribute('role')).toBe('combobox');
+    });
+})

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -1,0 +1,87 @@
+import React, { FC, memo, useCallback, useState } from 'react';
+
+import { TextInput } from './TextInput';
+import { QuerySelect } from '../QuerySelect';
+import { getContainerFilterForLookups } from '../../../query/api';
+import { FieldLabel } from '../FieldLabel';
+import { InputRendererProps } from './types';
+import { caseInsensitive, generateId } from '../../../util/utils';
+import { FormsyInput } from './FormsyReactComponents';
+
+export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
+    const { allowFieldDisable, onSelectChange,
+        onToggleDisable, initiallyDisabled,
+        containerFilter, containerPath,
+        allColumns, data } = props;
+    const [disabled, setDisabled] = useState<boolean>(initiallyDisabled && allowFieldDisable);
+
+    const id = generateId('selectinput-');
+    const amountCol = allColumns.filter(col => col.name.toLowerCase() === 'storedamount').valueArray?.[0];
+    const unitCol = allColumns.filter(col => col.name.toLowerCase() === 'units').valueArray?.[0];
+    const amountValue = caseInsensitive(data, amountCol.name);
+    const unitValue = caseInsensitive(data, unitCol.name);
+
+    const onToggleChange = useCallback(() => {
+        setDisabled(prevDisabled => {
+            const newDisabled = !prevDisabled;
+            onToggleDisable?.(newDisabled);
+            return newDisabled;
+        });
+    }, [setDisabled]);
+
+    return (
+        <div className="form-group row">
+            <FieldLabel
+                id={id}
+                fieldName={amountCol.name}
+                labelOverlayProps={{
+                    inputId: amountCol.name,
+                    description: 'TODO',
+                    label: "Amount and Units",
+                    isFormsy: false,
+                }}
+                showLabel
+                showToggle={allowFieldDisable}
+                isDisabled={disabled}
+                toggleProps={{
+                    onClick: onToggleChange,
+                }}
+            />
+            <TextInput
+                queryColumn={amountCol}
+                value={amountValue ? String(amountValue) : amountValue}
+                disableInput={disabled}
+                showLabel={false}
+                rowClassName={"col-sm-5 col-xs-6"}
+                elementWrapperClassName=""
+            />
+            <QuerySelect
+                id={id}
+                containerFilter={
+                    unitCol.lookup.containerFilter ??
+                    containerFilter ??
+                    getContainerFilterForLookups()
+                }
+                containerPath={unitCol.lookup.containerPath ?? containerPath}
+                description={unitCol.description}
+                displayColumn={unitCol.lookup.displayColumn}
+                formsy
+                showLabel={false}
+                name={unitCol.fieldKey}
+                onQSChange={onSelectChange}
+                placeholder="Select or type to search..."
+                schemaQuery={unitCol.lookup.schemaQuery}
+                value={unitValue}
+                valueColumn={unitCol.lookup.keyColumn}
+                disableInput={disabled}
+                containerClass={"col-sm-4 col-xs-6"}
+                inputClass={""}
+            />
+            {allowFieldDisable && !disabled && (
+                <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value="true" />
+            )}
+        </div>
+    );
+});
+
+AmountUnitInput.displayName = 'AmountUnitInput';

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -91,7 +91,7 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                 valueColumn={unitCol.lookup.keyColumn}
             />
             {allowFieldDisable && (
-                <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value={disabled ? "false" : "true"} />
+                <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value={disabled ? 'false' : 'true'} />
             )}
         </div>
     );

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -55,7 +55,7 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                 isDisabled={disabled}
                 labelOverlayProps={{
                     inputId: amountCol.name,
-                    description: 'The amount and units of this sample, currently on hand.',
+                    description: 'The amount and units of this sample currently on hand.',
                     label: 'Amount and Units',
                     isFormsy: false,
                 }}

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -49,7 +49,7 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                 isDisabled={disabled}
                 labelOverlayProps={{
                     inputId: amountCol.name,
-                    description: 'TODO',
+                    description: 'The amount of this sample, in the display unit for the sample type, currently on hand.',
                     label: 'Amount and Units',
                     isFormsy: false,
                 }}
@@ -86,8 +86,8 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                 value={unitValue}
                 valueColumn={unitCol.lookup.keyColumn}
             />
-            {allowFieldDisable && !disabled && (
-                <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value="true" />
+            {allowFieldDisable && (
+                <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value={disabled ? "false" : "true"} />
             )}
         </div>
     );

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -41,6 +41,10 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
         });
     }, [setDisabled]);
 
+    if (!amountCol || !unitCol) {
+        return null;
+    }
+
     return (
         <div className="form-group row">
             <FieldLabel
@@ -49,7 +53,7 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                 isDisabled={disabled}
                 labelOverlayProps={{
                     inputId: amountCol.name,
-                    description: 'The amount of this sample, in the display unit for the sample type, currently on hand.',
+                    description: 'The amount and units of this sample, currently on hand.',
                     label: 'Amount and Units',
                     isFormsy: false,
                 }}

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -9,10 +9,16 @@ import { caseInsensitive, generateId } from '../../../util/utils';
 import { FormsyInput } from './FormsyReactComponents';
 
 export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
-    const { allowFieldDisable, onSelectChange,
-        onToggleDisable, initiallyDisabled,
-        containerFilter, containerPath,
-        allColumns, data } = props;
+    const {
+        allowFieldDisable,
+        onSelectChange,
+        onToggleDisable,
+        initiallyDisabled,
+        containerFilter,
+        containerPath,
+        allColumns,
+        data,
+    } = props;
     const [disabled, setDisabled] = useState<boolean>(initiallyDisabled && allowFieldDisable);
 
     const id = generateId('selectinput-');
@@ -32,50 +38,46 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
     return (
         <div className="form-group row">
             <FieldLabel
-                id={id}
                 fieldName={amountCol.name}
+                id={id}
+                isDisabled={disabled}
                 labelOverlayProps={{
                     inputId: amountCol.name,
                     description: 'TODO',
-                    label: "Amount and Units",
+                    label: 'Amount and Units',
                     isFormsy: false,
                 }}
                 showLabel
                 showToggle={allowFieldDisable}
-                isDisabled={disabled}
                 toggleProps={{
                     onClick: onToggleChange,
                 }}
             />
             <TextInput
-                queryColumn={amountCol}
-                value={amountValue ? String(amountValue) : amountValue}
                 disableInput={disabled}
-                showLabel={false}
-                rowClassName={"col-sm-5 col-xs-6"}
                 elementWrapperClassName=""
+                queryColumn={amountCol}
+                rowClassName={'col-sm-5 col-xs-6'}
+                showLabel={false}
+                value={amountValue ? String(amountValue) : amountValue}
             />
             <QuerySelect
-                id={id}
-                containerFilter={
-                    unitCol.lookup.containerFilter ??
-                    containerFilter ??
-                    getContainerFilterForLookups()
-                }
+                containerClass={'col-sm-4 col-xs-6'}
+                containerFilter={unitCol.lookup.containerFilter ?? containerFilter ?? getContainerFilterForLookups()}
                 containerPath={unitCol.lookup.containerPath ?? containerPath}
                 description={unitCol.description}
+                disableInput={disabled}
                 displayColumn={unitCol.lookup.displayColumn}
                 formsy
-                showLabel={false}
+                id={id}
+                inputClass={''}
                 name={unitCol.fieldKey}
                 onQSChange={onSelectChange}
                 placeholder="Select or type to search..."
                 schemaQuery={unitCol.lookup.schemaQuery}
+                showLabel={false}
                 value={unitValue}
                 valueColumn={unitCol.lookup.keyColumn}
-                disableInput={disabled}
-                containerClass={"col-sm-4 col-xs-6"}
-                inputClass={""}
             />
             {allowFieldDisable && !disabled && (
                 <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value="true" />

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo, useCallback, useState } from 'react';
+import { List } from 'immutable';
 
 import { TextInput } from './TextInput';
 import { QuerySelect } from '../QuerySelect';
@@ -7,6 +8,7 @@ import { FieldLabel } from '../FieldLabel';
 import { InputRendererProps } from './types';
 import { caseInsensitive, generateId } from '../../../util/utils';
 import { FormsyInput } from './FormsyReactComponents';
+import { Operation } from '../../../../public/QueryColumn';
 
 export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
     const {
@@ -18,6 +20,7 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
         containerPath,
         allColumns,
         data,
+        queryFilters,
     } = props;
     const [disabled, setDisabled] = useState<boolean>(initiallyDisabled && allowFieldDisable);
 
@@ -26,6 +29,9 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
     const unitCol = allColumns.filter(col => col.name.toLowerCase() === 'units').valueArray?.[0];
     const amountValue = caseInsensitive(data, amountCol.name);
     const unitValue = caseInsensitive(data, unitCol.name);
+    const queryFilter = unitCol.lookup.hasQueryFilters(Operation.insert)
+        ? List(unitCol.lookup.getQueryFilters(Operation.insert))
+        : queryFilters?.[unitCol.fieldKey];
 
     const onToggleChange = useCallback(() => {
         setDisabled(prevDisabled => {
@@ -78,6 +84,7 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                 showLabel={false}
                 value={unitValue}
                 valueColumn={unitCol.lookup.keyColumn}
+                queryFilters={queryFilter}
             />
             {allowFieldDisable && !disabled && (
                 <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value="true" />

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useState } from 'react';
+import React, { FC, memo, useCallback, useMemo, useState } from 'react';
 import { List } from 'immutable';
 
 import { TextInput } from './TextInput';
@@ -9,6 +9,7 @@ import { InputRendererProps } from './types';
 import { caseInsensitive, generateId } from '../../../util/utils';
 import { FormsyInput } from './FormsyReactComponents';
 import { Operation } from '../../../../public/QueryColumn';
+import { STORED_AMOUNT_FIELDS } from '../../samples/constants';
 
 export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
     const {
@@ -24,14 +25,15 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
     } = props;
     const [disabled, setDisabled] = useState<boolean>(initiallyDisabled && allowFieldDisable);
 
-    const id = generateId('selectinput-');
-    const amountCol = allColumns.filter(col => col.name.toLowerCase() === 'storedamount').valueArray?.[0];
-    const unitCol = allColumns.filter(col => col.name.toLowerCase() === 'units').valueArray?.[0];
+    const amountCol = allColumns.find(col => col.name.toLowerCase() === STORED_AMOUNT_FIELDS.AMOUNT.toLowerCase());
+    const unitCol = allColumns.find(col => col.name.toLowerCase() === STORED_AMOUNT_FIELDS.UNITS.toLowerCase());
     const amountValue = caseInsensitive(data, amountCol?.name);
     const unitValue = caseInsensitive(data, unitCol?.name);
     const queryFilter = unitCol?.lookup.hasQueryFilters(Operation.insert)
         ? List(unitCol?.lookup.getQueryFilters(Operation.insert))
         : queryFilters?.[unitCol?.fieldKey];
+
+    const id = useMemo(() => generateId('amount-unit-input-'), []);
 
     const onToggleChange = useCallback(() => {
         setDisabled(prevDisabled => {

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -80,11 +80,11 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                 name={unitCol.fieldKey}
                 onQSChange={onSelectChange}
                 placeholder="Select or type to search..."
+                queryFilters={queryFilter}
                 schemaQuery={unitCol.lookup.schemaQuery}
                 showLabel={false}
                 value={unitValue}
                 valueColumn={unitCol.lookup.keyColumn}
-                queryFilters={queryFilter}
             />
             {allowFieldDisable && !disabled && (
                 <FormsyInput name={unitCol.name + '::enabled'} type="hidden" value="true" />

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -27,11 +27,11 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
     const id = generateId('selectinput-');
     const amountCol = allColumns.filter(col => col.name.toLowerCase() === 'storedamount').valueArray?.[0];
     const unitCol = allColumns.filter(col => col.name.toLowerCase() === 'units').valueArray?.[0];
-    const amountValue = caseInsensitive(data, amountCol.name);
-    const unitValue = caseInsensitive(data, unitCol.name);
-    const queryFilter = unitCol.lookup.hasQueryFilters(Operation.insert)
-        ? List(unitCol.lookup.getQueryFilters(Operation.insert))
-        : queryFilters?.[unitCol.fieldKey];
+    const amountValue = caseInsensitive(data, amountCol?.name);
+    const unitValue = caseInsensitive(data, unitCol?.name);
+    const queryFilter = unitCol?.lookup.hasQueryFilters(Operation.insert)
+        ? List(unitCol?.lookup.getQueryFilters(Operation.insert))
+        : queryFilters?.[unitCol?.fieldKey];
 
     const onToggleChange = useCallback(() => {
         setDisabled(prevDisabled => {

--- a/packages/components/src/internal/components/forms/input/InputRenderFactory.ts
+++ b/packages/components/src/internal/components/forms/input/InputRenderFactory.ts
@@ -6,6 +6,7 @@ import { InputRendererProps } from './types';
 import { AliasGridInput, AliasInput } from './AliasInput';
 import { AppendUnitsInput } from './AppendUnitsInput';
 import { SampleStatusInputRenderer } from './SampleStatusInput';
+import { AmountUnitInput } from './AmountUnitInput';
 
 export type InputRendererComponent = ComponentType<InputRendererProps>;
 export type InputRendererFactory = (col: QueryColumn, isGridInput?: boolean) => InputRendererComponent;
@@ -48,4 +49,5 @@ export function registerInputRenderers(): void {
     registerInputRenderer('ExperimentAlias', AliasGridInput, InputRenderContext.Grid);
     registerInputRenderer('ExperimentAlias', AliasInput, InputRenderContext.Form);
     registerInputRenderer('SampleStatusInput', SampleStatusInputRenderer);
+    registerInputRenderer('AmountUnitInput', AmountUnitInput, InputRenderContext.Form);
 }

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -267,6 +267,7 @@ export interface SelectInputProps {
     valueKey?: string;
     valueRenderer?: any;
     warning?: ReactNode;
+    disableInput?: boolean;
 }
 
 type SelectInputImplProps = SelectInputProps & FormsyInjectedProps<any>;
@@ -686,7 +687,7 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
             id: this.getId(),
             inputId,
             isClearable: clearable,
-            isDisabled: disabled || this.state.isDisabled,
+            isDisabled: disabled || this.state.isDisabled || this.props.disableInput,
             isLoading,
             isMulti: multiple,
             isValidNewOption,

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -145,7 +145,7 @@ export type SelectInputChange = (
 // Copied from @types/react-select/src/Select.d.ts
 export type FilterOption = ((option: SelectInputOption, rawInput: string) => boolean) | null;
 
-function initOptionFromPrimitive(value: string | number, props: SelectInputProps): SelectInputOption {
+function initOptionFromPrimitive(value: number | string, props: SelectInputProps): SelectInputOption {
     const { labelKey = 'label', options, valueKey = 'value' } = props;
     const result = options?.find(o => o[valueKey] === value);
     if (result) return result;
@@ -205,8 +205,8 @@ export interface SelectInputProps {
     autoValue?: boolean;
     backspaceRemovesValue?: boolean;
     cacheOptions?: boolean;
-    clearCacheOnChange?: boolean;
     clearable?: boolean;
+    clearCacheOnChange?: boolean;
     closeMenuOnSelect?: boolean;
     containerClass?: string;
     customStyles?: Record<string, any>;
@@ -216,6 +216,7 @@ export interface SelectInputProps {
     delimiter?: string;
     description?: string;
     disabled?: boolean;
+    disableInput?: boolean;
     filterOption?: FilterOption;
     formatCreateLabel?: (inputValue: string) => ReactNode;
     formatGroupLabel?: (data: any) => ReactNode;
@@ -267,10 +268,9 @@ export interface SelectInputProps {
     valueKey?: string;
     valueRenderer?: any;
     warning?: ReactNode;
-    disableInput?: boolean;
 }
 
-type SelectInputImplProps = SelectInputProps & FormsyInjectedProps<any>;
+type SelectInputImplProps = FormsyInjectedProps<any> & SelectInputProps;
 
 interface State {
     // This state property is used in conjunction with the prop "clearCacheOnChange" which when true
@@ -538,8 +538,9 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
 
                 return (
                     <FieldLabel
-                        id={this.getId()}
                         fieldName={name}
+                        id={this.getId()}
+                        isDisabled={isDisabled}
                         labelOverlayProps={{
                             inputId: name,
                             description: description_,
@@ -552,7 +553,6 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
                         }}
                         showLabel={showLabel}
                         showToggle={allowDisable}
-                        isDisabled={isDisabled}
                         toggleProps={{
                             onClick: toggleDisabledTooltip ? undefined : this.onToggleChange,
                             toolTip: toggleDisabledTooltip,

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -34,6 +34,7 @@ export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputP
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
     showLabel?: boolean;
     startFocused?: boolean;
+    disableInput?: boolean;
 }
 
 interface TextInputState extends DisableableInputState {
@@ -142,7 +143,7 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
                     required={queryColumn.required}
                     {...inputProps}
                     componentRef={this.textInput}
-                    disabled={this.state.isDisabled}
+                    disabled={this.state.isDisabled || this.props.disableInput}
                     help={help}
                     label={this.renderLabel()}
                     labelClassName={showLabel ? labelClassName : 'hide-label'}

--- a/packages/components/src/internal/components/forms/input/TextInput.tsx
+++ b/packages/components/src/internal/components/forms/input/TextInput.tsx
@@ -27,6 +27,7 @@ import { InternalSpacesWarning } from '../InternalSpacesWarning';
 
 export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputProps, 'onChange'> {
     addLabelAsterisk?: boolean;
+    disableInput?: boolean;
     includeSpacesWarning?: boolean;
     isUpdate?: boolean;
     onChange?: (value: any) => void;
@@ -34,7 +35,6 @@ export interface TextInputProps extends DisableableInputProps, Omit<FormsyInputP
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
     showLabel?: boolean;
     startFocused?: boolean;
-    disableInput?: boolean;
 }
 
 interface TextInputState extends DisableableInputState {
@@ -92,12 +92,12 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
 
         return (
             <FieldLabel
-                label={label}
-                showLabel={showLabel}
-                labelOverlayProps={{ isFormsy: true, addLabelAsterisk }}
-                showToggle={allowDisable}
                 column={queryColumn}
                 isDisabled={isDisabled}
+                label={label}
+                labelOverlayProps={{ isFormsy: true, addLabelAsterisk }}
+                showLabel={showLabel}
+                showToggle={allowDisable}
                 toggleProps={{
                     onClick: this.toggleDisabled,
                 }}
@@ -126,7 +126,6 @@ export class TextInput extends DisableableInput<TextInputProps, TextInputState> 
             isUpdate,
             ...inputProps
         } = rest;
-
 
         let help: string;
         // Issue 52367: Don't show the message if we have a name that can be edited

--- a/packages/components/src/internal/components/forms/input/types.ts
+++ b/packages/components/src/internal/components/forms/input/types.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
+import { List } from 'immutable';
 
-import { Query } from '@labkey/api';
+import { Filter, Query } from '@labkey/api';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 
@@ -27,4 +28,5 @@ export interface InputRendererProps {
     showLabel?: boolean;
     value: any;
     values?: any;
+    queryFilters?: Record<string, List<Filter.IFilter>>;
 }

--- a/packages/components/src/internal/components/forms/input/types.ts
+++ b/packages/components/src/internal/components/forms/input/types.ts
@@ -5,6 +5,7 @@ import { Query } from '@labkey/api';
 import { QueryColumn } from '../../../../public/QueryColumn';
 
 import { SelectInputChange, SelectInputProps } from './SelectInput';
+import { ExtendedMap } from '../../../../public/ExtendedMap';
 
 export interface InputRendererProps {
     allowFieldDisable?: boolean;
@@ -25,4 +26,5 @@ export interface InputRendererProps {
     showLabel?: boolean;
     value: any;
     values?: any;
+    allColumns?: ExtendedMap<string, QueryColumn>;
 }

--- a/packages/components/src/internal/components/forms/input/types.ts
+++ b/packages/components/src/internal/components/forms/input/types.ts
@@ -8,6 +8,7 @@ import { SelectInputChange, SelectInputProps } from './SelectInput';
 import { ExtendedMap } from '../../../../public/ExtendedMap';
 
 export interface InputRendererProps {
+    allColumns?: ExtendedMap<string, QueryColumn>;
     allowFieldDisable?: boolean;
     col: QueryColumn;
     containerFilter?: Query.ContainerFilter;
@@ -26,5 +27,4 @@ export interface InputRendererProps {
     showLabel?: boolean;
     value: any;
     values?: any;
-    allColumns?: ExtendedMap<string, QueryColumn>;
 }

--- a/packages/components/src/internal/components/forms/input/types.ts
+++ b/packages/components/src/internal/components/forms/input/types.ts
@@ -22,11 +22,11 @@ export interface InputRendererProps {
     onAdditionalFormDataChange?: (name: string, value: any) => void;
     onSelectChange?: SelectInputChange;
     onToggleDisable?: (disabled: boolean) => void;
+    queryFilters?: Record<string, List<Filter.IFilter>>;
     renderLabelField?: (col: QueryColumn) => ReactNode;
     selectInputProps?: Omit<SelectInputProps, 'onChange'>;
     showAsteriskSymbol?: boolean;
     showLabel?: boolean;
     value: any;
     values?: any;
-    queryFilters?: Record<string, List<Filter.IFilter>>;
 }

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -373,6 +373,10 @@ function applyViewColumns(
 
 export class Renderers {
     static _check(columnMetadata, rawColumn, field, metadata) {
+        const columnValue = columnMetadata[field];
+        if (columnValue)
+            return columnValue;
+
         if (columnMetadata.conceptURI || rawColumn.conceptURI) {
             const concept = metadata.getIn([
                 'concepts',

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -189,6 +189,7 @@ export class QueryColumn implements IQueryColumn {
     declare inputRenderer: string;
     declare sorts: '+' | '-';
     declare removeFromViews: boolean; // strips this column from all ViewInfo definitions
+    declare removeFromFormInput: boolean; // strips this column from QueryFormInputs
     declare units: string;
     declare derivationDataScope: string;
 


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1893
- https://github.com/LabKey/labkey-ui-premium/pull/851
- https://github.com/LabKey/platform/pull/7209
- https://github.com/LabKey/limsModules/pull/1799

#### Changes
  - Disallow negative sample amounts: Update `getValidatedEditableGridValue` to check for negative amount values
  - Added `AmountUnitInput` to show amount/units input side-by-side on bulk add/edit
  - Support enable/disable amount/units fields together in designer 