### PR TITLE
Add/update links for the GitHub issues in /kanban/issues

### DIFF
--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -243,7 +243,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
     showDefaultValues = () => {
         const { field, showDefaultValueSettings } = this.props;
 
-        // GitHub Issue #783: we don't yet support default values in the App
+        // GitHub Issue #298: we don't yet support default values in the App
         if (isApp()) return false;
 
         // some domains just don't support default values

--- a/packages/components/src/internal/components/domainproperties/models.test.ts
+++ b/packages/components/src/internal/components/domainproperties/models.test.ts
@@ -1458,7 +1458,7 @@ describe('resolveBaseProperties', () => {
         expect(field.rangeURI).toBe(SAMPLE_TYPE.rangeURI);
         expect(field.required).toBe(true);
 
-        // GitHub Issue 787 (https://github.com/LabKey/kanban/issues/787)
+        // GitHub Issue #656
         field = DomainField.resolveBaseProperties({ name: 'SampleId', required: false });
         expect(field.dataType).toBe(SAMPLE_TYPE);
         expect(field.conceptURI).toBe(SAMPLE_TYPE.conceptURI);

--- a/packages/components/src/internal/components/domainproperties/models.test.ts
+++ b/packages/components/src/internal/components/domainproperties/models.test.ts
@@ -1458,7 +1458,7 @@ describe('resolveBaseProperties', () => {
         expect(field.rangeURI).toBe(SAMPLE_TYPE.rangeURI);
         expect(field.required).toBe(true);
 
-        // GitHub Issue 787
+        // GitHub Issue 787 (https://github.com/LabKey/kanban/issues/787)
         field = DomainField.resolveBaseProperties({ name: 'SampleId', required: false });
         expect(field.dataType).toBe(SAMPLE_TYPE);
         expect(field.conceptURI).toBe(SAMPLE_TYPE.conceptURI);

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1181,7 +1181,7 @@ export class DomainField
                 field.dataType = SAMPLE_TYPE;
                 field.conceptURI = SAMPLE_TYPE.conceptURI;
                 field.rangeURI = SAMPLE_TYPE.rangeURI;
-                field.required = !!(raw.required ?? true); // GitHub Issue 787 (https://github.com/LabKey/kanban/issues/787)
+                field.required = !!(raw.required ?? true); // GitHub Issue #656
             }
         }
 

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -1181,7 +1181,7 @@ export class DomainField
                 field.dataType = SAMPLE_TYPE;
                 field.conceptURI = SAMPLE_TYPE.conceptURI;
                 field.rangeURI = SAMPLE_TYPE.rangeURI;
-                field.required = !!(raw.required ?? true); // GitHub Issue 787
+                field.required = !!(raw.required ?? true); // GitHub Issue 787 (https://github.com/LabKey/kanban/issues/787)
             }
         }
 

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -378,7 +378,7 @@ export function createSessionAssayRunSummaryQuery(sampleIds: number[]): Promise<
         assayRunsQuery = 'AssayRunsPerSampleChildFolder';
     }
 
-    // GitHub Issue 748: need to account for the case with no sampleIds
+    // GitHub Issue 748: need to account for the case with no sampleIds (https://github.com/LabKey/kanban/issues/748)
     let whereClause = 'WHERE RowId IN (' + sampleIds.join(',') + ')\n';
     if (sampleIds.length === 0) {
         whereClause = 'WHERE 1 = 0\n'; // add where clause that will always result in zero rows

--- a/packages/components/src/internal/components/samples/actions.ts
+++ b/packages/components/src/internal/components/samples/actions.ts
@@ -378,7 +378,7 @@ export function createSessionAssayRunSummaryQuery(sampleIds: number[]): Promise<
         assayRunsQuery = 'AssayRunsPerSampleChildFolder';
     }
 
-    // GitHub Issue 748: need to account for the case with no sampleIds (https://github.com/LabKey/kanban/issues/748)
+    // GitHub Issue #643: need to account for the case with no sampleIds
     let whereClause = 'WHERE RowId IN (' + sampleIds.join(',') + ')\n';
     if (sampleIds.length === 0) {
         whereClause = 'WHERE 1 = 0\n'; // add where clause that will always result in zero rows


### PR DESCRIPTION
#### Rationale
GitHub issues are now being created in the internal-issues project. This PR adds links to those that remain in the kanban project and updates a couple of issue numbers that were migrated.
