### PR TITLE
Default to detailed audit behavior

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.71.1",
+  "version": "6.72.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.71.1",
+      "version": "6.72.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.71.1",
+  "version": "6.72.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version 6.72.0
+*Released*: 20 November 2025
+- Default to detailed audit behavior
+
 ###  version 6.71.1
 *Released*: 20 November 2025
 - Sample Amount/Units polish

--- a/packages/components/src/internal/components/entities/EntityMoveModal.tsx
+++ b/packages/components/src/internal/components/entities/EntityMoveModal.tsx
@@ -1,5 +1,4 @@
 import React, { FC, memo, ReactNode, useCallback, useEffect, useState } from 'react';
-import { AuditBehaviorTypes } from '@labkey/api';
 
 import { Progress } from '../base/Progress';
 import { Modal } from '../../Modal';
@@ -12,7 +11,6 @@ import { HelpLink, MOVE_SAMPLES_TOPIC } from '../../util/helpLinks';
 import { isLoading, LoadingState } from '../../../public/LoadingState';
 import { AppURL } from '../../url/AppURL';
 import { ComponentsAPIWrapper, getDefaultAPIWrapper } from '../../APIWrapper';
-import { getPermissionRestrictionMessage } from '../../util/messaging';
 import { EntityDataType, OperationConfirmationData } from './models';
 import { getEntityNoun } from './utils';
 import { EntityMoveConfirmationModal } from './EntityMoveConfirmationModal';
@@ -87,7 +85,6 @@ export const EntityMoveModal: FC<EntityMoveModalProps> = memo(props => {
                     schemaName: schemaQuery.schemaName,
                     queryName: schemaQuery.queryName,
                     rowIds: confirmationData.getActionableIds(),
-                    auditBehavior: AuditBehaviorTypes.DETAILED,
                     auditUserComment,
                 });
                 const updatedUrl = targetAppURL.setContainerPath(targetContainerPath);

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1,4 +1,14 @@
-import { ActionURL, Ajax, Filter, getServerContext, PermissionTypes, Query, Security, Utils } from '@labkey/api';
+import {
+    ActionURL,
+    Ajax,
+    AuditBehaviorTypes,
+    Filter,
+    getServerContext,
+    PermissionTypes,
+    Query,
+    Security,
+    Utils,
+} from '@labkey/api';
 import { List, Map, OrderedMap } from 'immutable';
 
 import { getSelected, getSelectedDataDeprecated } from '../../actions';
@@ -981,6 +991,7 @@ export function moveEntities(options: MoveEntitiesOptions): Promise<Query.MoveRo
         }
 
         Query.moveRows({
+            auditBehavior: AuditBehaviorTypes.DETAILED,
             ...params,
             auditDetails: getRequestAuditDetail(),
             success: (response: Query.MoveRowsResponse) => {

--- a/packages/components/src/internal/components/forms/actions.ts
+++ b/packages/components/src/internal/components/forms/actions.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AuditBehaviorTypes, PermissionTypes, Security, User } from '@labkey/api';
+import { PermissionTypes, Security, User } from '@labkey/api';
 import { useCallback, useEffect, useState } from 'react';
 
-import { updateRows } from '../../query/api';
+import { QueryCommandResponse, updateRows } from '../../query/api';
 
 import { naturalSortByProperty } from '../../../public/sort';
 
@@ -117,7 +117,10 @@ export function useUsersWithPermissions(
     return { error, loadingState, users };
 }
 
-export function updateRowFieldValue(model: QueryModel, name: string, value: any): Promise<any> {
+/**
+ * @deprecated Use api.query.updateRows instead
+ */
+export function updateRowFieldValue(model: QueryModel, name: string, value: any): Promise<QueryCommandResponse> {
     return updateRows({
         schemaQuery: model.schemaQuery,
         rows: [
@@ -127,6 +130,5 @@ export function updateRowFieldValue(model: QueryModel, name: string, value: any)
             },
         ],
         containerPath: model.containerPath,
-        auditBehavior: AuditBehaviorTypes.DETAILED,
     });
 }

--- a/packages/components/src/internal/components/picklist/actions.ts
+++ b/packages/components/src/internal/components/picklist/actions.ts
@@ -1,4 +1,4 @@
-import { AuditBehaviorTypes, Domain, Filter, Query } from '@labkey/api';
+import { Domain, Filter, Query } from '@labkey/api';
 
 import { List } from 'immutable';
 
@@ -220,11 +220,7 @@ export async function addSamplesToPicklist(listName: string, sampleIds: number[]
     const schemaQuery = new SchemaQuery(SCHEMAS.PICKLIST_TABLES.SCHEMA, listName);
 
     if (rows.size > 0) {
-        return await insertRows({
-            schemaQuery,
-            rows,
-            auditBehavior: AuditBehaviorTypes.DETAILED,
-        });
+        return await insertRows({ rows, schemaQuery });
     }
 
     return new QueryCommandResponse({

--- a/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
+++ b/packages/components/src/internal/components/samples/ManageSampleStatusesPanel.tsx
@@ -1,8 +1,6 @@
 import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { List } from 'immutable';
 
-import { AuditBehaviorTypes } from '@labkey/api';
-
 import { LoadingSpinner } from '../base/LoadingSpinner';
 import { Alert } from '../base/Alert';
 import { LockIcon } from '../base/LockIcon';
@@ -159,7 +157,6 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
                     rows: [stateToSave],
                     containerPath: container?.path,
-                    auditBehavior: AuditBehaviorTypes.DETAILED,
                 })
                 .then(() => {
                     onActionComplete(stateToSave.label);
@@ -174,7 +171,6 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
                     rows: List([stateToSave]),
                     containerPath: container?.path,
-                    auditBehavior: AuditBehaviorTypes.DETAILED,
                 })
                 .then(() => {
                     onActionComplete(stateToSave.label);
@@ -196,7 +192,6 @@ export const SampleStatusDetail: FC<SampleStatusDetailProps> = memo(props => {
                     schemaQuery: SCHEMAS.CORE_TABLES.DATA_STATES,
                     containerPath: container?.path,
                     rows: [updatedState],
-                    auditBehavior: AuditBehaviorTypes.DETAILED,
                 })
                 .then(() => {
                     onActionComplete(undefined, true);

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -374,8 +374,7 @@ function applyViewColumns(
 export class Renderers {
     static _check(columnMetadata, rawColumn, field, metadata) {
         const columnValue = columnMetadata[field];
-        if (columnValue)
-            return columnValue;
+        if (columnValue) return columnValue;
 
         if (columnMetadata.conceptURI || rawColumn.conceptURI) {
             const concept = metadata.getIn([

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -789,12 +789,11 @@ export class QueryCommandResponse {
 }
 
 export function getRequestAuditDetail(editMethod?: EDIT_METHOD): Record<string, string> {
-    const auditDetails = {};
-    if (editMethod) {
-        auditDetails['editMethod'] = editMethod;
-    }
+    const auditDetails: Record<string, string> = {};
+    if (editMethod) auditDetails.editMethod = editMethod;
+
     const requestLocation = window.location.hash;
-    if (requestLocation) auditDetails['requestSource'] = requestLocation;
+    if (requestLocation) auditDetails.requestSource = requestLocation;
 
     return auditDetails;
 }
@@ -804,11 +803,11 @@ export function insertRows(options: InsertRowsOptions): Promise<QueryCommandResp
         const { fillEmptyFields, editMethod, rows, schemaQuery, ...insertRowsOptions } = options;
         const _rows = fillEmptyFields === true ? ensureAllFieldsInAllRows(rows) : rows;
 
-        insertRowsOptions['auditDetails'] = getRequestAuditDetail(editMethod);
-
         Query.insertRows({
+            auditBehavior: AuditBehaviorTypes.DETAILED,
             autoFormFileData: true,
             ...insertRowsOptions,
+            auditDetails: getRequestAuditDetail(editMethod),
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             rows: _rows.toArray(),
@@ -883,7 +882,7 @@ function ensureNullForUndefined(row: Map<string, any>): Map<string, any> {
 }
 
 export interface UpdateRowsOptions
-    extends Omit<Query.QueryRequestOptions, 'queryName' | 'schemaName'>,
+    extends Omit<Query.QueryRequestOptions, 'auditDetails' | 'queryName' | 'schemaName'>,
         QueryRequestOptionsBase {
     schemaQuery: SchemaQuery;
 }
@@ -891,10 +890,11 @@ export interface UpdateRowsOptions
 export function updateRows(options: UpdateRowsOptions): Promise<QueryCommandResponse> {
     return new Promise((resolve, reject) => {
         const { schemaQuery, editMethod, ...updateRowOptions } = options;
-        updateRowOptions['auditDetails'] = getRequestAuditDetail(editMethod);
         Query.updateRows({
+            auditBehavior: AuditBehaviorTypes.DETAILED,
             autoFormFileData: true,
             ...updateRowOptions,
+            auditDetails: getRequestAuditDetail(editMethod),
             queryName: schemaQuery.queryName,
             schemaName: schemaQuery.schemaName,
             skipReselectRows:
@@ -939,7 +939,6 @@ export function updateRowsByContainer(
     if (containerPaths.length < 2) {
         return updateRows({
             containerPath: containerPaths?.[0],
-            auditBehavior: AuditBehaviorTypes.DETAILED,
             auditUserComment,
             rows,
             schemaQuery,
@@ -967,7 +966,7 @@ export function updateRowsByContainer(
 }
 
 export interface DeleteRowsOptions
-    extends Omit<Query.QueryRequestOptions, 'queryName' | 'schemaName'>,
+    extends Omit<Query.QueryRequestOptions, 'auditDetails' | 'queryName' | 'schemaName'>,
         QueryRequestOptionsBase {
     schemaQuery: SchemaQuery;
 }
@@ -975,10 +974,11 @@ export interface DeleteRowsOptions
 export function deleteRows(options: DeleteRowsOptions): Promise<QueryCommandResponse> {
     return new Promise((resolve, reject) => {
         const { schemaQuery, editMethod, ...deleteRowsOptions } = options;
-        deleteRowsOptions['auditDetails'] = getRequestAuditDetail(editMethod);
         Query.deleteRows({
             apiVersion: 13.2,
+            auditBehavior: AuditBehaviorTypes.DETAILED,
             ...deleteRowsOptions,
+            auditDetails: getRequestAuditDetail(editMethod),
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             success: response => {
@@ -1000,15 +1000,23 @@ export function deleteRows(options: DeleteRowsOptions): Promise<QueryCommandResp
     });
 }
 
-export interface SaveRowsOptions extends Omit<Query.SaveRowsOptions, 'failure' | 'success'>, QueryRequestOptionsBase {}
+export interface SaveRowsOptions
+    extends Omit<Query.SaveRowsOptions, 'auditDetails' | 'failure' | 'success'>,
+        QueryRequestOptionsBase {}
 
 export function saveRows(options: SaveRowsOptions): Promise<Query.SaveRowsResponse> {
     return new Promise((resolve, reject) => {
-        const { editMethod, ...saveOptions } = options;
-        saveOptions['auditDetails'] = getRequestAuditDetail(editMethod);
+        const { commands, editMethod, ...saveOptions } = options;
+
+        for (const item of commands) {
+            item.auditBehavior = item.auditBehavior ?? AuditBehaviorTypes.DETAILED;
+        }
+
         Query.saveRows({
             apiVersion: 13.2,
             ...saveOptions,
+            auditDetails: getRequestAuditDetail(editMethod),
+            commands,
             success: response => {
                 resolve(response);
             },
@@ -1166,7 +1174,7 @@ export function importData(config: IImportData): Promise<any> {
     return new Promise((resolve, reject) => {
         const auditDetails = getRequestAuditDetail();
         QueryDOM.importData(
-            Object.assign({auditDetails}, config, {
+            Object.assign({ auditDetails }, config, {
                 success: response => {
                     if (response && response.exception) {
                         reject(response);

--- a/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/EditableDetailPanel.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode, useCallback, useState } from 'react';
 import { fromJS } from 'immutable';
-import { AuditBehaviorTypes, Query } from '@labkey/api';
+import { Query } from '@labkey/api';
 
 import { Formsy } from '../../internal/components/forms/formsy';
 import { DetailPanelHeader } from '../../internal/components/forms/detail/DetailPanelHeader';
@@ -140,7 +140,6 @@ export const EditableDetailPanel: FC<EditableDetailPanelProps> = props => {
 
                 await api.query.updateRows({
                     editMethod: EDIT_METHOD.DETAIL_EDIT,
-                    auditBehavior: AuditBehaviorTypes.DETAILED,
                     containerPath,
                     rows: [updatedValues],
                     schemaQuery: queryInfo.schemaQuery,


### PR DESCRIPTION
#### Rationale
This defaults our API endpoint wrappers to specify `auditBehavior: AuditBehaviorTypes.DETAILED`. This reduces repeated logic and ensures we are consistently auditing at the desired level.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1895
- https://github.com/LabKey/labkey-ui-premium/pull/854
- https://github.com/LabKey/limsModules/pull/1806
- https://github.com/LabKey/platform/pull/7215

#### Changes
- Default API endpoint wrappers to specify `AuditBehaviorTypes.DETAILED`
- Remove all declarations that were stating the `auditBehavior` explicitly for the query endpoint wrappers.
- Update some API wrappers that do not allow override of `auditDetails`.
