### PR TITLE
Fix assay result edit with plate well lookup

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.5",
+  "version": "6.70.6-fb-excludePlateForIdentifyingFields.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.70.5",
+      "version": "6.70.6-fb-excludePlateForIdentifyingFields.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.70.5",
+  "version": "6.70.6-fb-excludePlateForIdentifyingFields.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version 6.X
+*Released*: X November 2025
+- Exclude plate well column lookup for identifying fields determination
+
 ###  version 6.70.5
 *Released*: 13 November 2025
 - Issue 54186: App actions for picklists and assay run delete don't get TransactionAuditEvent

--- a/packages/components/src/internal/AssayDefinitionModel.ts
+++ b/packages/components/src/internal/AssayDefinitionModel.ts
@@ -301,7 +301,7 @@ export class AssayDefinitionModel extends ImmutableRecord({
         sampleIds?: number[] | string[]
     ): Promise<QueryInfo> {
         const sampleResultColumnData = this.getSampleColInResults();
-        if (sampleResultColumnData) {
+        if (sampleResultColumnData && sampleResultColumnData.isSampleLookup() /*skip plate well column*/) {
             if (sampleResultColumnData.isSingleSampleTypeLookup())
                 return api.query.getQueryDetails(sampleResultColumnData.lookup.schemaQuery);
             else if (sampleIds?.length > 0) {

--- a/packages/components/src/internal/components/entities/actions.ts
+++ b/packages/components/src/internal/components/entities/actions.ts
@@ -1327,8 +1327,8 @@ export function getSingleSampleTypeQueryInfo(sampleIds: number[] | string[]): Pr
         })
             .then(result => {
                 const sampleTypes = result.values;
-                if (sampleTypes.length > 1) {
-                    resolve(null); // multiple sample types found
+                if (sampleTypes.length !== 1) {
+                    resolve(null);
                     return;
                 }
                 const sampleTypeSQ = new SchemaQuery(SCHEMAS.SAMPLE_SETS.SCHEMA, sampleTypes[0]);


### PR DESCRIPTION
#### Rationale
When determining if a assay has a result sample lookup column for identifying fields, plate well lookup column(welllsid) should be excluded. 

[PlateAssayImportTest](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_NightlyBiologicsPostgres/3738970?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests.biologics.plates&class=PlateAssayImportTest)
Unable to edit assay results from editable grid
Error from 'query-getQueryDetails' with no query name specified

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1896
- https://github.com/LabKey/limsModules/pull/1807
- https://github.com/LabKey/labkey-ui-components/pull/1889
- https://github.com/LabKey/labkey-ui-premium/pull/852

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
