### PR TITLE
GridColumn to only apply displayWidth to multiLine columns

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.72.0",
+  "version": "6.72.0-displayWidthMultiLine.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.72.0",
+      "version": "6.72.0-displayWidthMultiLine.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.72.0-displayWidthMultiLine.0",
+  "version": "6.72.0-displayWidthMultiLine.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.72.0-displayWidthMultiLine.0",
+      "version": "6.72.0-displayWidthMultiLine.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "6.72.0-displayWidthMultiLine.1",
+  "version": "6.72.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "6.72.0-displayWidthMultiLine.1",
+      "version": "6.72.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.72.0-displayWidthMultiLine.0",
+  "version": "6.72.0-displayWidthMultiLine.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.72.0-displayWidthMultiLine.1",
+  "version": "6.72.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "6.72.0",
+  "version": "6.72.0-displayWidthMultiLine.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ###  version TBD
 *Released*: TBD November 2025
-- GridColumn to only apply displayWidth to multiLine columns (see changes from v6.71.0)
+- QueryColumn to only apply displayWidth for multiLine columns
 
 ###  version 6.72.0
 *Released*: 20 November 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-###  version TBD
-*Released*: TBD November 2025
+###  version 6.72.1
+*Released*: 25 November 2025
 - QueryColumn to only apply displayWidth for multiLine columns
 
 ###  version 6.72.0

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+###  version TBD
+*Released*: TBD November 2025
+- GridColumn to only apply displayWidth to multiLine columns (see changes from v6.71.0)
+
 ###  version 6.72.0
 *Released*: 20 November 2025
 - Default to detailed audit behavior

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -37,9 +37,6 @@ function processColumns(columns: List<any>): List<GridColumn> {
                 });
             }
 
-            // only apply the displayWidth, if avaialble, to multiLine text columns
-            const _displayWidth = c.rangeURI?.endsWith('multiLine') ? c.displayWidth : undefined;
-
             return new GridColumn({
                 align: c.align,
                 cell: c.cell,
@@ -51,7 +48,7 @@ function processColumns(columns: List<any>): List<GridColumn> {
                 raw: c,
                 tableCell: c.tableCell,
                 title: c.title || c.caption,
-                width: c.width || _displayWidth,
+                width: c.width,
             });
         })
         .toList();

--- a/packages/components/src/internal/components/base/Grid.tsx
+++ b/packages/components/src/internal/components/base/Grid.tsx
@@ -37,6 +37,9 @@ function processColumns(columns: List<any>): List<GridColumn> {
                 });
             }
 
+            // only apply the displayWidth, if avaialble, to multiLine text columns
+            const _displayWidth = c.rangeURI?.endsWith('multiLine') ? c.displayWidth : undefined;
+
             return new GridColumn({
                 align: c.align,
                 cell: c.cell,
@@ -48,7 +51,7 @@ function processColumns(columns: List<any>): List<GridColumn> {
                 raw: c,
                 tableCell: c.tableCell,
                 title: c.title || c.caption,
-                width: c.width || c.displayWidth,
+                width: c.width || _displayWidth,
             });
         })
         .toList();

--- a/packages/components/src/public/IQueryColumn.ts
+++ b/packages/components/src/public/IQueryColumn.ts
@@ -18,6 +18,7 @@ export interface IQueryColumn {
     displayField?: string;
     displayFieldJsonType?: string;
     displayFieldSqlType?: string;
+    displayWidth: number | string;
     // excludeFromShifting: boolean;
     // ext: any;
     facetingBehaviorType: string;

--- a/packages/components/src/public/QueryColumn.ts
+++ b/packages/components/src/public/QueryColumn.ts
@@ -205,6 +205,11 @@ export class QueryColumn implements IQueryColumn {
         if (rawColumn && rawColumn.lookup !== undefined) {
             Object.assign(this, { lookup: new QueryLookup(rawColumn.lookup) });
         }
+
+        // only apply the displayWidth, if available, to multiLine text columns for now
+        if (rawColumn?.displayWidth && this.width === undefined && this.rangeURI?.endsWith('multiLine')) {
+            Object.assign(this, { width: rawColumn.displayWidth });
+        }
     }
 
     static ANCESTORS_PREFIX = 'Ancestors';


### PR DESCRIPTION
#### Rationale
Previous related PR started using the displayWidth from the QueryColumn in the GridColumn for the width. However, this was passing through null and empty string values from the server which meant that the default width for the GridColumn wasn't being set. This PR fixes that but also scopes down this change so that the non-empty displayWidth only applies to multiLine text columns (we can reassess having this apply to other columns at a later date).

#### Related Pull Requests
- Previous: https://github.com/LabKey/labkey-ui-components/pull/1888
- https://github.com/LabKey/labkey-ui-components/pull/1900
- https://github.com/LabKey/limsModules/pull/1812
- https://github.com/LabKey/platform/pull/7225

#### Changes
- GridColumn to only apply displayWidth to multiLine columns
