### PR TITLE
Remove LSID column from provisioned sample tables

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.3.0",
+  "version": "7.3.1-fb-remove-sample-lsid.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.3.0",
+      "version": "7.3.1-fb-remove-sample-lsid.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.3.1-fb-remove-sample-lsid.0",
+  "version": "7.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.3.1-fb-remove-sample-lsid.0",
+      "version": "7.3.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.3.1-fb-remove-sample-lsid.0",
+  "version": "7.3.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.3.0",
+  "version": "7.3.1-fb-remove-sample-lsid.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.3.1
+*Released*: 13 December 2025
+- Remove LSID column from provisioned sample tables
+- Update `getUpdatedData()` utility method to only check for primary keys actually used in data iteration.
+
 ### version 7.3.0
 *Released*: 10 December 2025
 - CharBuilderModal: add UI for legend position

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
@@ -5,8 +5,6 @@ import { userEvent } from '@testing-library/user-event';
 
 import { waitFor } from '@testing-library/dom';
 
-import { PROPERTIES_PANEL_ERROR_MSG } from '../constants';
-
 import { DomainDetails } from '../models';
 
 import { getTestAPIWrapper } from '../../../APIWrapper';
@@ -17,7 +15,8 @@ import { renderWithAppContext } from '../../../test/reactTestLibraryHelpers';
 
 import { TEST_LKS_STARTER_MODULE_CONTEXT } from '../../../productFixtures';
 
-import { SampleTypeDesigner, SampleTypeDesignerImpl } from './SampleTypeDesigner';
+import { SampleTypeDesigner, SampleTypeDesignerImpl, SampleTypeDesignerProps } from './SampleTypeDesigner';
+import { getQueryTestAPIWrapper } from '../../../query/APIWrapper';
 
 const SERVER_CONTEXT = {
     moduleContext: {
@@ -57,65 +56,46 @@ const PARENT_OPTIONS = [
     },
 ];
 
-const BASE_PROPS = {
-    appPropertiesOnly: true,
-    onComplete: jest.fn(),
-    onCancel: jest.fn(),
+const BASE_PROPS: SampleTypeDesignerProps = {
     api: getTestAPIWrapper(jest.fn, {
         entity: getEntityTestAPIWrapper(jest.fn, {
             initParentOptionsSelects: jest.fn().mockResolvedValue({
                 parentOptions: PARENT_OPTIONS,
                 parentAliases: Map(),
             }),
+            loadNameExpressionOptions: jest.fn().mockResolvedValue({}),
+        }),
+        query: getQueryTestAPIWrapper(jest.fn, {
+            selectRows: jest.fn().mockResolvedValue({ rows: [] }),
         }),
     }),
+    appPropertiesOnly: true,
+    currentPanelIndex: 0,
+    firstState: true,
+    onComplete: jest.fn(),
+    onCancel: jest.fn(),
+    onFinish: jest.fn(),
+    onTogglePanel: jest.fn(),
+    setSubmitting: jest.fn(),
+    submitting: false,
+    validatePanel: 0,
+    visitedPanels: List(),
 };
 
 describe('SampleTypeDesigner', () => {
     test('default properties', async () => {
-        const form = (
-            <SampleTypeDesignerImpl
-                {...BASE_PROPS}
-                currentPanelIndex={0}
-                firstState={true}
-                onFinish={jest.fn()}
-                onTogglePanel={jest.fn()}
-                setSubmitting={jest.fn()}
-                submitting={false}
-                validatePanel={0}
-                visitedPanels={List()}
-            />
-        );
-
-        renderWithAppContext(form, {
-            serverContext: SERVER_CONTEXT,
-        });
+        renderWithAppContext(<SampleTypeDesignerImpl {...BASE_PROPS} />, { serverContext: SERVER_CONTEXT });
 
         await waitFor(() => {
             expect(document.getElementsByClassName('domain-form-panel')).toHaveLength(2);
         });
         const panelTitles = document.querySelectorAll('.domain-panel-title');
-        expect(panelTitles[0].textContent).toBe('Sample Type Properties');
-        expect(panelTitles[1].textContent).toBe('Fields');
+        expect(panelTitles[0]).toHaveTextContent('Sample Type Properties');
+        expect(panelTitles[1]).toHaveTextContent('Fields');
     });
 
     test('allowFolderExclusion', async () => {
-        const form = (
-            <SampleTypeDesignerImpl
-                {...BASE_PROPS}
-                currentPanelIndex={0}
-                firstState={true}
-                onFinish={jest.fn()}
-                onTogglePanel={jest.fn()}
-                setSubmitting={jest.fn()}
-                submitting={false}
-                validatePanel={0}
-                visitedPanels={List()}
-                allowFolderExclusion
-            />
-        );
-
-        renderWithAppContext(form, {
+        renderWithAppContext(<SampleTypeDesignerImpl {...BASE_PROPS} allowFolderExclusion />, {
             serverContext: SERVER_CONTEXT,
         });
 
@@ -123,9 +103,9 @@ describe('SampleTypeDesigner', () => {
             expect(document.getElementsByClassName('domain-form-panel')).toHaveLength(3);
         });
         const panelTitles = document.querySelectorAll('.domain-panel-title');
-        expect(panelTitles[0].textContent).toBe('Sample Type Properties');
-        expect(panelTitles[1].textContent).toBe('Fields');
-        expect(panelTitles[2].textContent).toBe('Folders');
+        expect(panelTitles[0]).toHaveTextContent('Sample Type Properties');
+        expect(panelTitles[1]).toHaveTextContent('Fields');
+        expect(panelTitles[2]).toHaveTextContent('Folders');
     });
 
     test('initModel with name URL props', async () => {
@@ -146,26 +126,16 @@ describe('SampleTypeDesigner', () => {
                         nameReadOnly: true,
                     })
                 )}
-                currentPanelIndex={0}
-                firstState={true}
-                onFinish={jest.fn()}
-                onTogglePanel={jest.fn()}
-                setSubmitting={jest.fn()}
-                submitting={false}
-                validatePanel={0}
-                visitedPanels={List()}
             />
         );
-        renderWithAppContext(form, {
-            serverContext: SERVER_CONTEXT,
-        });
+        renderWithAppContext(form, { serverContext: SERVER_CONTEXT });
 
         await waitFor(() => {
             expect(document.querySelectorAll('.domain-form-panel')).toHaveLength(2);
         });
         const panelTitles = document.querySelectorAll('.domain-panel-title');
-        expect(panelTitles[0].textContent).toBe('Sample Type Properties');
-        expect(panelTitles[1].textContent).toBe('Fields');
+        expect(panelTitles[0]).toHaveTextContent('Sample Type Properties');
+        expect(panelTitles[1]).toHaveTextContent('Fields');
         expect(document.getElementsByClassName('translator--toggle__wizard')).toHaveLength(1);
     });
 
@@ -185,10 +155,6 @@ describe('SampleTypeDesigner', () => {
         const panelHeader = document.querySelector('div#domain-header');
         await userEvent.click(panelHeader);
         const alerts = document.getElementsByClassName('alert');
-        // still expect to have only two alerts.  We don't show the Barcode header in the file import panel.
-        // Jest doesn't want to switch to that panel.
-        expect(alerts).toHaveLength(2);
-        expect(alerts[0].textContent).toEqual(PROPERTIES_PANEL_ERROR_MSG);
-        expect(alerts[1].textContent).toEqual('Please correct errors in the properties panel before saving.');
+        expect(alerts).toHaveLength(0);
     });
 });

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.test.tsx
@@ -5,6 +5,8 @@ import { userEvent } from '@testing-library/user-event';
 
 import { waitFor } from '@testing-library/dom';
 
+import { PROPERTIES_PANEL_ERROR_MSG } from '../constants';
+
 import { DomainDetails } from '../models';
 
 import { getTestAPIWrapper } from '../../../APIWrapper';
@@ -15,7 +17,12 @@ import { renderWithAppContext } from '../../../test/reactTestLibraryHelpers';
 
 import { TEST_LKS_STARTER_MODULE_CONTEXT } from '../../../productFixtures';
 
-import { SampleTypeDesigner, SampleTypeDesignerImpl, SampleTypeDesignerProps } from './SampleTypeDesigner';
+import {
+    SampleTypeDesigner,
+    SampleTypeDesignerImpl,
+    SampleTypeDesignerImplProps,
+    SampleTypeDesignerProps,
+} from './SampleTypeDesigner';
 import { getQueryTestAPIWrapper } from '../../../query/APIWrapper';
 
 const SERVER_CONTEXT = {
@@ -56,7 +63,7 @@ const PARENT_OPTIONS = [
     },
 ];
 
-const BASE_PROPS: SampleTypeDesignerProps = {
+const DESIGNER_PROPS: SampleTypeDesignerProps = {
     api: getTestAPIWrapper(jest.fn, {
         entity: getEntityTestAPIWrapper(jest.fn, {
             initParentOptionsSelects: jest.fn().mockResolvedValue({
@@ -70,21 +77,25 @@ const BASE_PROPS: SampleTypeDesignerProps = {
         }),
     }),
     appPropertiesOnly: true,
+    onCancel: jest.fn(),
+    onComplete: jest.fn(),
+};
+
+const DESIGNER_IMPL_PROPS: SampleTypeDesignerImplProps = {
     currentPanelIndex: 0,
     firstState: true,
-    onComplete: jest.fn(),
-    onCancel: jest.fn(),
     onFinish: jest.fn(),
     onTogglePanel: jest.fn(),
     setSubmitting: jest.fn(),
     submitting: false,
     validatePanel: 0,
     visitedPanels: List(),
+    ...DESIGNER_PROPS,
 };
 
 describe('SampleTypeDesigner', () => {
     test('default properties', async () => {
-        renderWithAppContext(<SampleTypeDesignerImpl {...BASE_PROPS} />, { serverContext: SERVER_CONTEXT });
+        renderWithAppContext(<SampleTypeDesignerImpl {...DESIGNER_IMPL_PROPS} />, { serverContext: SERVER_CONTEXT });
 
         await waitFor(() => {
             expect(document.getElementsByClassName('domain-form-panel')).toHaveLength(2);
@@ -95,7 +106,7 @@ describe('SampleTypeDesigner', () => {
     });
 
     test('allowFolderExclusion', async () => {
-        renderWithAppContext(<SampleTypeDesignerImpl {...BASE_PROPS} allowFolderExclusion />, {
+        renderWithAppContext(<SampleTypeDesignerImpl {...DESIGNER_IMPL_PROPS} allowFolderExclusion />, {
             serverContext: SERVER_CONTEXT,
         });
 
@@ -111,7 +122,7 @@ describe('SampleTypeDesigner', () => {
     test('initModel with name URL props', async () => {
         const form = (
             <SampleTypeDesignerImpl
-                {...BASE_PROPS}
+                {...DESIGNER_IMPL_PROPS}
                 domainFormDisplayOptions={{
                     hideConditionalFormatting: true,
                 }}
@@ -140,7 +151,8 @@ describe('SampleTypeDesigner', () => {
     });
 
     test('open fields panel, with barcodes', async () => {
-        renderWithAppContext(<SampleTypeDesigner {...BASE_PROPS} />, {
+        // NOTE: Here we are calling the full designer, SampleTypeDesigner, not the SampleTypeDesignerImpl
+        renderWithAppContext(<SampleTypeDesigner {...DESIGNER_PROPS} />, {
             serverContext: {
                 moduleContext: {
                     ...TEST_LKS_STARTER_MODULE_CONTEXT,
@@ -155,6 +167,9 @@ describe('SampleTypeDesigner', () => {
         const panelHeader = document.querySelector('div#domain-header');
         await userEvent.click(panelHeader);
         const alerts = document.getElementsByClassName('alert');
-        expect(alerts).toHaveLength(0);
+        // still expect to have only two alerts.  We don't show the Barcode header in the file import panel.
+        // Jest doesn't want to switch to that panel.
+        expect(alerts[0]).toHaveTextContent(PROPERTIES_PANEL_ERROR_MSG);
+        expect(alerts[1]).toHaveTextContent('Please correct errors in the properties panel before saving.');
     });
 });

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -369,7 +369,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<InjectedBaseDoma
             return;
         }
 
-        const isValid = model.isValid(defaultSampleFieldConfig);
+        const isValid = model.isValid(defaultSampleFieldConfig, metricUnitProps);
 
         this.props.onFinish(isValid, () => this.saveDomain(false, comment ?? auditUserComment));
 
@@ -385,8 +385,8 @@ export class SampleTypeDesignerImpl extends React.PureComponent<InjectedBaseDoma
         } else if (getDuplicateAlias(model.parentAliases, true).size > 0) {
             exception =
                 'Duplicate parent alias header found: ' + getDuplicateAlias(model.parentAliases, true).join(', ');
-        } else if (!model.isMetricUnitValid()) {
-            exception = metricUnitProps?.metricUnitLabel + ' field is required.';
+        } else if (!model.isMetricUnitValid(metricUnitProps)) {
+            exception = (metricUnitProps?.metricUnitLabel ?? 'Units') + ' field is required.';
         } else {
             exception = model.domain.getFirstFieldError();
         }

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -1,5 +1,5 @@
 import React, { FC, memo, ReactNode } from 'react';
-import { List, Map } from 'immutable';
+import { List } from 'immutable';
 import { Domain, getServerContext } from '@labkey/api';
 
 import {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -90,7 +90,7 @@ const AliquotOptionsHelp: FC<{ helpTopic: string }> = memo(({ helpTopic }) => {
 });
 AliquotOptionsHelp.displayName = 'AliquotOptionsHelp';
 
-interface Props {
+interface OwnProps {
     aliquotNamePatternProps?: AliquotNamePatternProps;
     allowFolderExclusion?: boolean;
     api?: ComponentsAPIWrapper;
@@ -137,8 +137,11 @@ interface State {
     showUniqueIdConfirmation: boolean;
     uniqueIdsConfirmed: boolean;
 }
+
 // Exported for testing
-export class SampleTypeDesignerImpl extends React.PureComponent<InjectedBaseDomainDesignerProps & Props, State> {
+export type SampleTypeDesignerProps = InjectedBaseDomainDesignerProps & OwnProps;
+
+export class SampleTypeDesignerImpl extends React.PureComponent<SampleTypeDesignerProps, State> {
     static defaultProps = {
         api: getDefaultAPIWrapper(),
         defaultSampleFieldConfig: DEFAULT_SAMPLE_FIELD_CONFIG,
@@ -156,7 +159,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<InjectedBaseDoma
         validateNameExpressions: true,
     };
 
-    constructor(props: InjectedBaseDomainDesignerProps & Props) {
+    constructor(props: SampleTypeDesignerProps) {
         super(props);
 
         let domainDetails = this.props.initModel || DomainDetails.create();
@@ -838,4 +841,4 @@ export class SampleTypeDesignerImpl extends React.PureComponent<InjectedBaseDoma
     }
 }
 
-export const SampleTypeDesigner = withBaseDomainDesigner<Props>(SampleTypeDesignerImpl);
+export const SampleTypeDesigner = withBaseDomainDesigner<OwnProps>(SampleTypeDesignerImpl);

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypeDesigner.tsx
@@ -90,7 +90,8 @@ const AliquotOptionsHelp: FC<{ helpTopic: string }> = memo(({ helpTopic }) => {
 });
 AliquotOptionsHelp.displayName = 'AliquotOptionsHelp';
 
-interface OwnProps {
+// Exported for testing
+export interface SampleTypeDesignerProps {
     aliquotNamePatternProps?: AliquotNamePatternProps;
     allowFolderExclusion?: boolean;
     api?: ComponentsAPIWrapper;
@@ -139,9 +140,10 @@ interface State {
 }
 
 // Exported for testing
-export type SampleTypeDesignerProps = InjectedBaseDomainDesignerProps & OwnProps;
+export type SampleTypeDesignerImplProps = InjectedBaseDomainDesignerProps & SampleTypeDesignerProps;
 
-export class SampleTypeDesignerImpl extends React.PureComponent<SampleTypeDesignerProps, State> {
+// Exported for testing
+export class SampleTypeDesignerImpl extends React.PureComponent<SampleTypeDesignerImplProps, State> {
     static defaultProps = {
         api: getDefaultAPIWrapper(),
         defaultSampleFieldConfig: DEFAULT_SAMPLE_FIELD_CONFIG,
@@ -159,7 +161,7 @@ export class SampleTypeDesignerImpl extends React.PureComponent<SampleTypeDesign
         validateNameExpressions: true,
     };
 
-    constructor(props: SampleTypeDesignerProps) {
+    constructor(props: SampleTypeDesignerImplProps) {
         super(props);
 
         let domainDetails = this.props.initModel || DomainDetails.create();
@@ -841,4 +843,4 @@ export class SampleTypeDesignerImpl extends React.PureComponent<SampleTypeDesign
     }
 }
 
-export const SampleTypeDesigner = withBaseDomainDesigner<OwnProps>(SampleTypeDesignerImpl);
+export const SampleTypeDesigner = withBaseDomainDesigner<SampleTypeDesignerProps>(SampleTypeDesignerImpl);

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -294,8 +294,9 @@ class SampleTypePropertiesPanelImpl extends PureComponent<InjectedDomainProperti
     updateValidStatus = (newModel?: SampleTypeModel): void => {
         const { metricUnitProps, model, updateModel } = this.props;
         const updatedModel = newModel ?? model;
+        const isValid = updatedModel.hasValidProperties() && updatedModel.isMetricUnitValid(metricUnitProps);
 
-        this.setState({ isValid: updatedModel.isMetricUnitValid(metricUnitProps) }, () => {
+        this.setState({ isValid }, () => {
             // Issue 39918: only consider the model changed if there is a newModel param
             if (newModel) {
                 updateModel(newModel);

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -293,21 +293,14 @@ class SampleTypePropertiesPanelImpl extends PureComponent<InjectedDomainProperti
 
     updateValidStatus = (newModel?: SampleTypeModel): void => {
         const { metricUnitProps, model, updateModel } = this.props;
+        const updatedModel = newModel ?? model;
 
-        const updatedModel = newModel || model;
-        const isValid =
-            updatedModel?.hasValidProperties() &&
-            (!metricUnitProps?.includeMetricUnitProperty || updatedModel?.isMetricUnitValid());
-
-        this.setState(
-            () => ({ isValid }),
-            () => {
-                // Issue 39918: only consider the model changed if there is a newModel param
-                if (newModel) {
-                    updateModel(updatedModel);
-                }
+        this.setState({ isValid: updatedModel.isMetricUnitValid(metricUnitProps) }, () => {
+            // Issue 39918: only consider the model changed if there is a newModel param
+            if (newModel) {
+                updateModel(newModel);
             }
-        );
+        });
     };
 
     onFormChange = (evt: any): void => {

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -292,10 +292,12 @@ class SampleTypePropertiesPanelImpl extends PureComponent<InjectedDomainProperti
     };
 
     updateValidStatus = (newModel?: SampleTypeModel): void => {
-        const { model, updateModel, metricUnitProps } = this.props;
+        const { metricUnitProps, model, updateModel } = this.props;
 
         const updatedModel = newModel || model;
-        const isValid = updatedModel?.hasValidProperties() && updatedModel?.isMetricUnitValid();
+        const isValid =
+            updatedModel?.hasValidProperties() &&
+            (!metricUnitProps?.includeMetricUnitProperty || updatedModel?.isMetricUnitValid());
 
         this.setState(
             () => ({ isValid }),

--- a/packages/components/src/internal/components/domainproperties/samples/models.ts
+++ b/packages/components/src/internal/components/domainproperties/samples/models.ts
@@ -74,18 +74,18 @@ export class SampleTypeModel extends Record({
         return !this.rowId;
     }
 
-    isValid(defaultNameFieldConfig?: Partial<IDomainField>): boolean {
+    isValid(defaultNameFieldConfig?: Partial<IDomainField>, metricUnitProps?: MetricUnitProps): boolean {
         return (
             this.hasValidProperties() &&
             !this.hasInvalidNameField(defaultNameFieldConfig) &&
             getDuplicateAlias(this.parentAliases, true).size === 0 &&
             !this.domain.hasInvalidFields() &&
-            this.isMetricUnitValid()
+            this.isMetricUnitValid(metricUnitProps)
         );
     }
 
-    isMetricUnitValid(): boolean {
-        return this.metricUnit != null;
+    isMetricUnitValid(metricUnitProps?: MetricUnitProps): boolean {
+        return !metricUnitProps?.includeMetricUnitProperty || this.metricUnit != null;
     }
 
     hasValidProperties(): boolean {

--- a/packages/components/src/internal/components/domainproperties/samples/models.ts
+++ b/packages/components/src/internal/components/domainproperties/samples/models.ts
@@ -1,4 +1,4 @@
-import { fromJS, Map, OrderedMap, Record } from 'immutable';
+import { OrderedMap, Record } from 'immutable';
 
 import { DomainDesign, DomainDetails, IDomainField } from '../models';
 import { IImportAlias, IParentAlias } from '../../entities/models';
@@ -74,7 +74,7 @@ export class SampleTypeModel extends Record({
         return !this.rowId;
     }
 
-    isValid(defaultNameFieldConfig?: Partial<IDomainField>) {
+    isValid(defaultNameFieldConfig?: Partial<IDomainField>): boolean {
         return (
             this.hasValidProperties() &&
             !this.hasInvalidNameField(defaultNameFieldConfig) &&
@@ -84,7 +84,7 @@ export class SampleTypeModel extends Record({
         );
     }
 
-    isMetricUnitValid() {
+    isMetricUnitValid(): boolean {
         return this.metricUnit != null;
     }
 

--- a/packages/components/src/internal/util/utils.ts
+++ b/packages/components/src/internal/util/utils.ts
@@ -306,9 +306,10 @@ export function isSameWithStringCompare(value1: any, value2: any): boolean {
 }
 
 /**
- * Constructs an array of objects (suitable for the rows parameter of updateRows) where each object contains the
- * values that are different from the ones in originalData object as well as the primary key values for that row.
- * If updatedValues is empty or all of the originalData values are the same as the updatedValues, returns an empty array.
+ * Constructs an array of objects, suitable for the "rows" parameter of updateRows, where each object contains the
+ * values that are different from the ones in the originalData object as well as the primary key values for that row.
+ * If updatedValues are empty, or all the originalData values are the same as the updatedValues, then it returns an
+ * empty array.
  *
  * @param originalData a map from an id field to a Map from fieldKeys to an object with a 'value' field
  * @param updatedValues an object mapping fieldKeys to values that are being updated
@@ -323,10 +324,11 @@ export function getUpdatedData(
 ): any[] {
     const updateValuesMap = Map<any, any>(updatedValues);
     const pkColsLc = new Set<string>();
+    const pkColsInUse = new Set<string>();
     queryInfo.pkCols.forEach(key => pkColsLc.add(key.toLowerCase()));
     additionalCols?.forEach(col => pkColsLc.add(col.toLowerCase()));
 
-    // if the originalData has the container/folder values, keep those as well (i.e. treat it as a primary key)
+    // if the originalData has the container/folder values, keep those as well (i.e., treat it as a primary key)
     const folderKey = originalData
         .first()
         .keySeq()
@@ -353,6 +355,7 @@ export function getUpdatedData(
 
             if (fieldValueMap?.has('value')) {
                 if (isPKCol) {
+                    pkColsInUse.add(key.toLowerCase());
                     return m.set(key, fieldValueMap.get('value'));
                 }
 
@@ -399,7 +402,7 @@ export function getUpdatedData(
     });
     // we want the rows that contain more than just the primaryKeys
     return updatedData
-        .filter(rowData => rowData.size > pkColsLc.size)
+        .filter(rowData => rowData.size > pkColsInUse.size)
         .map(rowData => rowData.toJS())
         .toArray();
 }


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/7235 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1901
- https://github.com/LabKey/labkey-ui-premium/pull/858
- https://github.com/LabKey/platform/pull/7235
- https://github.com/LabKey/limsModules/pull/1829
- https://github.com/LabKey/testAutomation/pull/2798

#### Changes
- Update `getUpdatedData()` utility method to only check for primary keys actually used in data iteration. Improves logic so that the presence of multiple keys does not falsely indicate that no changes were made.
