### PR TITLE
Copy folder access settings when copying freezers and assay designs - GitHub 284 and 305

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.5.2-fb-copyFolderSettings.0",
+  "version": "7.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.5.2-fb-copyFolderSettings.0",
+      "version": "7.6.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.5.1",
+  "version": "7.5.2-fb-copyFolderSettings.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.5.1",
+      "version": "7.5.2-fb-copyFolderSettings.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.5.1",
+  "version": "7.5.2-fb-copyFolderSettings.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.5.2-fb-copyFolderSettings.0",
+  "version": "7.6.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.6.0
+*Released*: 29 December 2025
 - Copy folder access settings when copying freezers and assay designs
   - GitHub Issue #284: Freezer copy
   - GitHub Issue #305: Assay design copy

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Copy folder access settings when copying freezers and assay designs
+  - GitHub Issue #284: Freezer copy
+  - GitHub Issue #305: Assay design copy
+
 ### version 7.5.1
 *Released*: 24 December 2025
 - Add `displaySelectedOptions` prop and respect setting when passing `selectedOptions` to the underlying `SelectInput`

--- a/packages/components/src/internal/components/domainproperties/DataTypeFoldersPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeFoldersPanel.tsx
@@ -31,7 +31,7 @@ interface OwnProps {
 }
 
 // export for jest testing
-export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPanelCollapseProps> = memo(props => {
+export const DataTypeFoldersPanelImpl: FC<InjectedDomainPropertiesPanelCollapseProps & OwnProps> = memo(props => {
     const {
         collapsed,
         togglePanel,
@@ -146,19 +146,19 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
 
     return (
         <BasePropertiesPanel
-            headerId="domain-folders-hdr"
-            title="Folders"
             collapsed={collapsed}
             controlledCollapse={controlledCollapse}
+            headerId="domain-folders-hdr"
             isValid
             panelStatus={collapsed && isValid ? 'COMPLETE' : isValid ? 'INPROGRESS' : 'TODO'}
-            updateValidStatus={updateValidStatus}
+            title="Folders"
             todoIconHelpMsg={
                 'This section defines which folders use this ' +
                 entityDataType.typeNounSingular.toLowerCase() +
                 '. You may want to review.'
             }
             togglePanel={togglePanel}
+            updateValidStatus={updateValidStatus}
         >
             <div className="bottom-padding">
                 Select which folders can use this {entityDataType.typeNounSingular.toLowerCase()}.
@@ -177,17 +177,17 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                     {!relatedFolderConfigurableDataType && (
                         <div className="col-xs-12 bottom-padding">
                             <DataTypeSelector
-                                entityDataType={entityDataType}
                                 allDataCounts={allDataCounts}
                                 allDataTypes={childFolders}
-                                updateUncheckedTypes={updateExcludedFolders}
-                                uncheckedEntitiesDB={excludedContainerIdsDB}
-                                dataTypeLabel="folders"
-                                noHeader
                                 columns={2}
+                                dataTypeLabel="folders"
+                                entityDataType={entityDataType}
                                 inactiveSectionLabel="Archived Folders"
                                 isNewEntity={isNewEntity}
+                                noHeader
                                 showUncheckedWarning={!!dataTypeRowId}
+                                uncheckedEntitiesDB={excludedContainerIdsDB}
+                                updateUncheckedTypes={updateExcludedFolders}
                             />
                         </div>
                     )}
@@ -195,29 +195,29 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                         <>
                             <div className="col-xs-6 bottom-padding">
                                 <DataTypeSelector
-                                    entityDataType={entityDataType}
                                     allDataCounts={allDataCounts}
                                     allDataTypes={childFolders}
-                                    updateUncheckedTypes={updateExcludedFolders}
-                                    uncheckedEntitiesDB={excludedContainerIdsDB}
                                     dataTypeLabel="Include in Folders"
+                                    entityDataType={entityDataType}
                                     inactiveSectionLabel="Archived Folders"
                                     isNewEntity={isNewEntity}
                                     showUncheckedWarning={!!dataTypeRowId}
+                                    uncheckedEntitiesDB={excludedContainerIdsDB}
+                                    updateUncheckedTypes={updateExcludedFolders}
                                 />
                             </div>
                             <div className="col-xs-6 bottom-padding">
                                 <DataTypeSelector
+                                    allDataTypes={allContainers}
+                                    dataTypeLabel={relatedDataTypeLabel}
                                     dataTypePrefix="Dashboard"
                                     entityDataType={entityDataType}
-                                    allDataTypes={allContainers}
-                                    updateUncheckedTypes={updateRelatedExcludedFolders}
-                                    uncheckedEntitiesDB={relatedExcludedContainerIdsDB}
                                     hiddenEntities={excludedContainerIds}
-                                    dataTypeLabel={relatedDataTypeLabel}
                                     inactiveSectionLabel="Archived Folders"
                                     isNewEntity={isNewEntity}
                                     showUncheckedWarning={false}
+                                    uncheckedEntitiesDB={relatedExcludedContainerIdsDB}
+                                    updateUncheckedTypes={updateRelatedExcludedFolders}
                                 />
                             </div>
                         </>

--- a/packages/components/src/internal/components/domainproperties/DataTypeFoldersPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/DataTypeFoldersPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from './DomainPropertiesPanelCollapse';
 
 interface OwnProps {
+    dataTypeCopyId?: number; // RowId for the data type being copied, if applicable
     dataTypeName?: string;
     dataTypeRowId?: number;
     entityDataType: EntityDataType;
@@ -35,6 +36,7 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
         collapsed,
         togglePanel,
         controlledCollapse,
+        dataTypeCopyId,
         dataTypeRowId,
         dataTypeName,
         onUpdateExcludedFolders,
@@ -53,6 +55,8 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
     const [excludedContainerIdsDB, setExcludedContainerIdsDB] = useState<string[]>();
     const [excludedContainerIds, setExcludedContainerIds] = useState<string[]>();
     const [relatedExcludedContainerIdsDB, setRelatedExcludedContainerIdsDB] = useState<string[]>();
+    const copy = !!dataTypeCopyId && !dataTypeRowId;
+    const isNewEntity = !dataTypeRowId && !copy;
 
     useEffect(
         () => {
@@ -62,6 +66,7 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
 
                 try {
                     const containers = await api.folder.getContainers(container, moduleContext, true, true, true);
+                    const dataTypeRowId_ = copy ? dataTypeCopyId : dataTypeRowId;
 
                     const allContainers_ = containers.map(container_ => {
                         return {
@@ -77,10 +82,13 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
 
                     const excludedContainerIds_ = await api.folder.getDataTypeExcludedContainers(
                         entityDataType.folderConfigurableDataType,
-                        dataTypeRowId
+                        dataTypeRowId_
                     );
                     setExcludedContainerIdsDB(excludedContainerIds_);
                     setExcludedContainerIds(excludedContainerIds_);
+                    if (copy) {
+                        onUpdateExcludedFolders(entityDataType.folderConfigurableDataType, excludedContainerIds_);
+                    }
 
                     const allDataCounts_ = await api.query.getDataTypeFolderDataCount(
                         entityDataType,
@@ -178,7 +186,7 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                                 noHeader
                                 columns={2}
                                 inactiveSectionLabel="Archived Folders"
-                                isNewEntity={!dataTypeRowId}
+                                isNewEntity={isNewEntity}
                                 showUncheckedWarning={!!dataTypeRowId}
                             />
                         </div>
@@ -194,7 +202,7 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                                     uncheckedEntitiesDB={excludedContainerIdsDB}
                                     dataTypeLabel="Include in Folders"
                                     inactiveSectionLabel="Archived Folders"
-                                    isNewEntity={!dataTypeRowId}
+                                    isNewEntity={isNewEntity}
                                     showUncheckedWarning={!!dataTypeRowId}
                                 />
                             </div>
@@ -208,7 +216,7 @@ export const DataTypeFoldersPanelImpl: FC<OwnProps & InjectedDomainPropertiesPan
                                     hiddenEntities={excludedContainerIds}
                                     dataTypeLabel={relatedDataTypeLabel}
                                     inactiveSectionLabel="Archived Folders"
-                                    isNewEntity={!dataTypeRowId}
+                                    isNewEntity={isNewEntity}
                                     showUncheckedWarning={false}
                                 />
                             </div>

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -163,6 +163,7 @@ export interface AssayDesignerPanelsProps {
     hideAdvancedProperties?: boolean;
     hideEmptyBatchDomain?: boolean;
     initModel: AssayProtocolModel;
+    initProtocolId?: number; // used for copy assay design since initModel will not have the protocolId in that case
     onCancel: () => void;
     onChange?: (model: AssayProtocolModel) => void;
     onComplete: (model: AssayProtocolModel) => void;
@@ -392,6 +393,7 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
             appPropertiesOnly,
             hideAdvancedProperties,
             initModel,
+            initProtocolId,
             domainFormDisplayOptions,
             currentPanelIndex,
             validatePanel,
@@ -475,6 +477,7 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                 {appPropertiesOnly && allowFolderExclusion && (
                     <DataTypeFoldersPanel
                         controlledCollapse
+                        dataTypeCopyId={initProtocolId}
                         dataTypeName={protocolModel?.name}
                         dataTypeRowId={protocolModel?.protocolId}
                         entityDataType={AssayRunDataType}


### PR DESCRIPTION
#### Rationale
[#284](https://github.com/LabKey/internal-issues/issues/284) Copy folder access settings when copying a freezer (LabKey Issue: 52603)
[#305](https://github.com/LabKey/internal-issues/issues/305) Copying an assay design doesn't copy the folders in which it's enabled (LabKey Issue: 53641)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1912
- https://github.com/LabKey/labkey-ui-premium/pull/873
- https://github.com/LabKey/limsModules/pull/1875

#### Changes
- Assay design initProtocolId prop to track the assay design protocolId being copied
- DataTypeFoldersPanel dataTypeCopyId prop
