### PR TITLE
GitHub Issue 495: Do less capitalization of user-provided names

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.2-lessCapitalization.1",
+  "version": "7.7.2-lessCapitalization.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.7.2-lessCapitalization.1",
+      "version": "7.7.2-lessCapitalization.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.3-lessCapitalization.2",
+  "version": "7.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.7.3-lessCapitalization.2",
+      "version": "7.7.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.0",
+  "version": "7.7.1-lessCapitalization.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.7.0",
+      "version": "7.7.1-lessCapitalization.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.2-lessCapitalization.0",
+  "version": "7.7.2-lessCapitalization.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.7.2-lessCapitalization.0",
+      "version": "7.7.2-lessCapitalization.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.3-lessCapitalization.2",
+  "version": "7.7.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.0",
+  "version": "7.7.1-lessCapitalization.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.2-lessCapitalization.0",
+  "version": "7.7.2-lessCapitalization.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.7.2-lessCapitalization.1",
+  "version": "7.7.2-lessCapitalization.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- [GitHub Issue #495](https://github.com/LabKey/internal-issues/issues/495) Remove some gratuitous capitalization of types and field names
+
 ### version 7.7.1
 *Released*: 29 December 2025
 - [GitHub Issue 734](https://github.com/LabKey/internal-issues/issues/734) Update sizing of comment input box for better display in narrow screens

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-- [GitHub Issue #495](https://github.com/LabKey/internal-issues/issues/495) Remove some gratuitous capitalization of types and field names
+- [GitHub Issue #495](https://github.com/LabKey/internal-issues/issues/495) Remove some gratuitous capitalization of field names in audit event details
 
 ### version 7.7.1
 *Released*: 29 December 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-- [GitHub Issue #495](https://github.com/LabKey/internal-issues/issues/495) Remove some gratuitous capitalization of field names in audit event details
+- [GitHub Issue #495](https://github.com/LabKey/internal-issues/issues/495)
+ - Remove some gratuitous capitalization of field names in audit event details
+ - When generating a column label for an added parent column in the editable grid, don't capitalize query name
 
 ### version 7.7.1
 *Released*: 29 December 2025

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,11 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.7.3
+*Released*: 31 December 2025
 - [GitHub Issue #495](https://github.com/LabKey/internal-issues/issues/495)
  - Remove some gratuitous capitalization of field names in audit event details
- - When generating a column label for an added parent column in the editable grid, don't capitalize query name
+ - When generating a column label for an added parent column in the editable grid, don't capitalize the query name
 
 ### version 7.7.2
 *Released*: 30 December 2025

--- a/packages/components/src/internal/components/auditlog/AuditDetails.tsx
+++ b/packages/components/src/internal/components/auditlog/AuditDetails.tsx
@@ -95,7 +95,7 @@ export class AuditDetails extends Component<Props> {
             <div className="row margin-bottom" key={field}>
                 <div className="left-padding right-padding">
                     <span className="audit-detail-row-label right-padding">
-                        {capitalizeFirstChar(field)}
+                        {field}
                         {!!providedVals.length && (
                             <LabelHelpTip
                                 iconComponent={<i className="original-value-icon fa fa-info-circle left-padding" />}

--- a/packages/components/src/internal/components/entities/models.test.ts
+++ b/packages/components/src/internal/components/entities/models.test.ts
@@ -27,19 +27,19 @@ describe('EntityParentType', () => {
             'Display Column',
             SCHEMAS.DATA_CLASSES.SCHEMA
         );
-        expect(col.caption).toBe('Dataclass Parents');
+        expect(col.caption).toBe('dataclass Parents');
 
         col = EntityParentType.create({ schema: SCHEMAS.DATA_CLASSES.SCHEMA, query: 'dataclass' }).generateColumn(
             'Display Column',
             SCHEMAS.SAMPLE_SETS.SCHEMA
         );
-        expect(col.caption).toBe('Dataclass');
+        expect(col.caption).toBe('dataclass');
 
         col = EntityParentType.create({ schema: SCHEMAS.SAMPLE_SETS.SCHEMA, query: 'sampletype' }).generateColumn(
             'Display Column',
             SCHEMAS.SAMPLE_SETS.SCHEMA
         );
-        expect(col.caption).toBe('Sampletype Parents');
+        expect(col.caption).toBe('sampletype Parents');
 
         col = EntityParentType.create({
             schema: SCHEMAS.SAMPLE_SETS.SCHEMA,

--- a/packages/components/src/internal/components/entities/models.ts
+++ b/packages/components/src/internal/components/entities/models.ts
@@ -23,7 +23,7 @@ import { ExtendedMap } from '../../../public/ExtendedMap';
 import { decodePart, encodePart, SchemaQuery } from '../../../public/SchemaQuery';
 import { IEntityDetails } from '../domainproperties/entities/models';
 import { SelectInputOption } from '../forms/input/SelectInput';
-import { capitalizeFirstChar, caseInsensitive, generateId } from '../../util/utils';
+import { caseInsensitive, generateId } from '../../util/utils';
 import { QueryColumn, QueryLookup } from '../../../public/QueryColumn';
 import { SCHEMAS } from '../../schemas';
 import { EntityCreationType } from '../samples/models';
@@ -107,7 +107,7 @@ export class EntityParentType extends Record({
     }
 
     generateColumn(displayColumn: string, targetSchema: string): QueryColumn {
-        const label_ = this.label ?? capitalizeFirstChar(this.query);
+        const label_ = this.label ?? this.query;
         const parentColName = this.generateFieldKey();
 
         // Issue 40233: SM app allows for two types of parents, sources and samples, and its confusing if both use


### PR DESCRIPTION
#### Rationale
Issue [495](https://github.com/LabKey/internal-issues/issues/495) We sometimes capitalize the names of types and field names when it is not necessary. This includes, but may not be limited to, the parent type names when adding lineage in an editable grid and the names of fields in audit event details. This PR removes the gratuitous capitalization. 

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1880

#### Changes
- Update `AuditDetails.tsx` to remove capitalization of field name
- Update `EntityParentType.generateFieldKey` to remove capitalization of the query name
