### PR TITLE
GitHub 764: Editable grid border display issue on very small screens

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.12.1",
+  "version": "7.12.1-fb-smallScreenGridBorder764.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.12.1",
+      "version": "7.12.1-fb-smallScreenGridBorder764.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.12.0",
+  "version": "7.12.1-fb-smallScreenGridBorder764.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.12.0",
+      "version": "7.12.1-fb-smallScreenGridBorder764.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.12.1-fb-smallScreenGridBorder764.1",
+  "version": "7.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.12.1-fb-smallScreenGridBorder764.1",
+      "version": "7.12.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.12.1-fb-smallScreenGridBorder764.1",
+  "version": "7.12.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.12.1",
+  "version": "7.12.1-fb-smallScreenGridBorder764.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.12.0",
+  "version": "7.12.1-fb-smallScreenGridBorder764.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.12.2
+*Released*: 19 January 2026
 - GitHub Issue 764: Editable grid border display issue on very small screens
   - override default bootstrap table-responsive style for xs scren table border
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue 764: Editable grid border display issue on very small screens
+  - override default bootstrap table-responsive style for xs scren table border
+
 ### version 7.12.0
 *Released*: 7 January 2026
 - Lineage: add "restricted" property

--- a/packages/components/src/theme/app/overrides.scss
+++ b/packages/components/src/theme/app/overrides.scss
@@ -80,3 +80,14 @@ body {
   padding-left: 5px;
   padding-right: 5px;
 }
+
+// _table.scss (GitHub Issue 764)
+.table-responsive {
+    @media screen and (max-width: $screen-xs-max) {
+        border: unset;
+    }
+
+    > .table-bordered {
+        border: 1px solid $table-border-color;
+    }
+}


### PR DESCRIPTION
#### Rationale
[#764](https://github.com/LabKey/internal-issues/issues/764) Editable grid border display issue on very small screens

The default bootstrap table-responsive style for xs screen was causing rendering to look off when viewing the Editable Grid in the app. This PR overrides that default border style to match the border style when not on a small screen.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1922

#### Changes
- override default bootstrap table-responsive style for xs screen table border
