### PR TITLE
withQueryModels: cancel stale requests

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.0",
+  "version": "7.13.2-fb-cancel-requests-54041.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.13.2-fb-cancel-requests-54041.0",
+      "version": "7.13.2-fb-cancel-requests-54041.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.5",
+  "version": "7.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.13.2-fb-cancel-requests-54041.5",
+      "version": "7.14.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.1",
+  "version": "7.13.2-fb-cancel-requests-54041.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.13.2-fb-cancel-requests-54041.1",
+      "version": "7.13.2-fb-cancel-requests-54041.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.1",
+  "version": "7.13.2-fb-cancel-requests-54041.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.13.1",
+      "version": "7.13.2-fb-cancel-requests-54041.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.3",
+  "version": "7.13.2-fb-cancel-requests-54041.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.13.2-fb-cancel-requests-54041.3",
+      "version": "7.13.2-fb-cancel-requests-54041.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.4",
+  "version": "7.13.2-fb-cancel-requests-54041.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.13.2-fb-cancel-requests-54041.4",
+      "version": "7.13.2-fb-cancel-requests-54041.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.2",
+  "version": "7.13.2-fb-cancel-requests-54041.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.13.2-fb-cancel-requests-54041.2",
+      "version": "7.13.2-fb-cancel-requests-54041.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.5",
+  "version": "7.14.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.1",
+  "version": "7.13.2-fb-cancel-requests-54041.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.0",
+  "version": "7.13.2-fb-cancel-requests-54041.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.1",
+  "version": "7.13.2-fb-cancel-requests-54041.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.3",
+  "version": "7.13.2-fb-cancel-requests-54041.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.2",
+  "version": "7.13.2-fb-cancel-requests-54041.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.13.2-fb-cancel-requests-54041.4",
+  "version": "7.13.2-fb-cancel-requests-54041.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,13 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.14.0
+*Released*: 30 January 2026
+- Update `withQueryModels` to track and cancel requests for `loadRows`, `loadSelections` and `loadTotalCount`
+- Add `RequestHandler` handling for `selectRows` and `selectRowsDeprecated`
+- Skip error logging when request is aborted
+- Update a few endpoint wrappers to use `request()`
+
 ### version 7.13.1
 *Released*: 26 January 2026
 - Merge from release26.1-SNAPSHOT to develop

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -38,9 +38,8 @@ import {
 } from './constants';
 import { DataViewInfo } from './DataViewInfo';
 
-import { handleRequestFailure } from './request';
+import { request, RequestHandler } from './request';
 import { resolveErrorMessage } from './util/messaging';
-import { buildURL } from './url/AppURL';
 
 import { ViewInfo } from './ViewInfo';
 import { createGridModelId } from './models';
@@ -56,21 +55,11 @@ export function selectAll(
     queryParameters?: Record<string, any>,
     containerFilter?: Query.ContainerFilter
 ): Promise<SelectResponse> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL('query', 'selectAll.api', undefined, {
-                container: containerPath,
-            }),
-            method: 'POST',
-            params: buildQueryParams(key, schemaQuery, filterArray, queryParameters, containerPath, containerFilter),
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(
-                reject,
-                `Problem in selecting all items in the grid ${key} ${schemaQuery.schemaName} ${schemaQuery.queryName}`
-            ),
-        });
+    return request<SelectResponse>({
+        url: ActionURL.buildURL('query', 'selectAll.api', containerPath),
+        method: 'POST',
+        params: buildQueryParams(key, schemaQuery, filterArray, queryParameters, containerPath, containerFilter),
+        errorLogMsg: `Problem in selecting all items in the grid ${key} ${schemaQuery.schemaName} ${schemaQuery.queryName}`,
     });
 }
 
@@ -274,7 +263,8 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
         }
     });
 
-    let controller, action;
+    let action: string;
+    let controller: string;
     if (type === EXPORT_TYPES.CSV || type === EXPORT_TYPES.TSV || type === EXPORT_TYPES.LABEL_TEMPLATE) {
         controller = 'query';
         action = 'exportRowsTsv.post';
@@ -298,7 +288,7 @@ export function exportRows(type: EXPORT_TYPES, exportParams: Record<string, any>
 
     form.append('formDataEncoded', 'true');
     Ajax.request({
-        url: buildURL(controller, action, undefined, { container: containerPath, returnUrl: false }),
+        url: ActionURL.buildURL(controller, action, containerPath),
         method: 'POST',
         form,
         downloadFile: true,
@@ -380,29 +370,24 @@ export function getSelected(
     filterArray?: Filter.IFilter[],
     containerPath?: string,
     queryParameters?: Record<string, any>,
-    containerFilter?: Query.ContainerFilter
+    containerFilter?: Query.ContainerFilter,
+    requestHandler?: RequestHandler
 ): Promise<GetSelectedResponse> {
-    if (useSnapshotSelection) return getSnapshotSelections(key, containerPath);
+    if (useSnapshotSelection) return getSnapshotSelections(key, containerPath, requestHandler);
 
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL('query', 'getSelected.api', undefined, {
-                container: containerPath,
-            }),
-            method: 'POST',
-            jsonData: getFilteredQueryParams(
-                key,
-                schemaQuery,
-                filterArray,
-                queryParameters,
-                containerPath,
-                containerFilter
-            ),
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to get selected.'),
-        });
+    return request({
+        url: ActionURL.buildURL('query', 'getSelected.api', containerPath),
+        method: 'POST',
+        jsonData: getFilteredQueryParams(
+            key,
+            schemaQuery,
+            filterArray,
+            queryParameters,
+            containerPath,
+            containerFilter
+        ),
+        errorLogMsg: 'Failed to get selected.',
+        requestHandler,
     });
 }
 
@@ -452,26 +437,18 @@ export type ClearSelectedOptions = {
 };
 
 export function clearSelected(options: ClearSelectedOptions): Promise<SelectResponse> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: ActionURL.buildURL('query', 'clearSelected.api', options.containerPath),
-            method: 'POST',
-            jsonData: getFilteredQueryParams(
-                options.selectionKey,
-                options.schemaQuery,
-                options.filters,
-                options.queryParameters,
-                options.containerPath,
-                options.containerFilter
-            ),
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(
-                reject,
-                `Problem clearing the selection ${options.selectionKey} ${options.schemaQuery?.schemaName} ${options.schemaQuery?.queryName}`
-            ),
-        });
+    return request<SelectResponse>({
+        url: ActionURL.buildURL('query', 'clearSelected.api', options.containerPath),
+        method: 'POST',
+        jsonData: getFilteredQueryParams(
+            options.selectionKey,
+            options.schemaQuery,
+            options.filters,
+            options.queryParameters,
+            options.containerPath,
+            options.containerFilter
+        ),
+        errorLogMsg: `Problem clearing the selection ${options.selectionKey} ${options.schemaQuery?.schemaName} ${options.schemaQuery?.queryName}`,
     });
 }
 
@@ -490,7 +467,7 @@ export function clearSelected(options: ClearSelectedOptions): Promise<SelectResp
 export function setSelected(
     key: string,
     checked: boolean,
-    ids: string[] | string,
+    ids: string | string[],
     containerPath?: string,
     validateIds?: boolean,
     schemaName?: string,
@@ -498,47 +475,35 @@ export function setSelected(
     filters?: Filter.IFilter[],
     queryParameters?: Record<string, any>
 ): Promise<SelectResponse> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL('query', 'setSelected.api', undefined, {
-                container: containerPath,
-            }),
-            method: 'POST',
-            jsonData: {
-                id: ids,
-                key,
-                checked,
-                validateIds,
-                schemaName,
-                queryName,
-                filterList: filters,
-                queryParameters,
-            },
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to set selection.'),
-        });
+    return request<SelectResponse>({
+        url: ActionURL.buildURL('query', 'setSelected.api', containerPath),
+        method: 'POST',
+        jsonData: {
+            id: ids,
+            key,
+            checked,
+            validateIds,
+            schemaName,
+            queryName,
+            filterList: filters,
+            queryParameters,
+        },
+        errorLogMsg: 'Failed to set selection.',
     });
 }
 
 export type ReplaceSelectedOptions = {
     containerPath?: string;
-    id: string[] | string;
+    id: string | string[];
     selectionKey: string;
 };
 
 export function replaceSelected(options: ReplaceSelectedOptions): Promise<SelectResponse> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: ActionURL.buildURL('query', 'replaceSelected.api', options.containerPath),
-            method: 'POST',
-            jsonData: { key: options.selectionKey, id: options.id },
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to replace selection.'),
-        });
+    return request<SelectResponse>({
+        url: ActionURL.buildURL('query', 'replaceSelected.api', options.containerPath),
+        method: 'POST',
+        jsonData: { key: options.selectionKey, id: options.id },
+        errorLogMsg: 'Failed to replace selection.',
     });
 }
 
@@ -551,24 +516,14 @@ export function replaceSelected(options: ReplaceSelectedOptions): Promise<Select
  */
 export function setSnapshotSelections(
     key: string,
-    ids: string[] | string | number[],
+    ids: number[] | string | string[],
     containerPath?: string
 ): Promise<SelectResponse> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL('query', 'setSnapshotSelection.api', undefined, {
-                container: containerPath,
-            }),
-            method: 'POST',
-            jsonData: {
-                key,
-                id: ids,
-            },
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to set snapshot selection.'),
-        });
+    return request<SelectResponse>({
+        url: ActionURL.buildURL('query', 'setSnapshotSelection.api', containerPath),
+        method: 'POST',
+        jsonData: { key, id: ids },
+        errorLogMsg: 'Failed to set snapshot selection.',
     });
 }
 
@@ -577,55 +532,40 @@ export function setSnapshotSelections(
  * Get the snapshot selections for a grid
  * @param key the selection key for the grid
  * @param containerPath optional path to the container for this grid.  Default is the current container path
+ * @param requestHandler optional request handler to use for the request
  */
-export function getSnapshotSelections(key: string, containerPath?: string): Promise<GetSelectedResponse> {
-    return new Promise((resolve, reject) => {
-        return Ajax.request({
-            url: buildURL('query', 'getSnapshotSelection.api', undefined, {
-                container: containerPath,
-            }),
-            method: 'POST',
-            jsonData: {
-                key,
-            },
-            success: Utils.getCallbackWrapper(response => {
-                resolve(response);
-            }),
-            failure: handleRequestFailure(reject, 'Failed to get snapshot selection.'),
-        });
+export function getSnapshotSelections(
+    key: string,
+    containerPath?: string,
+    requestHandler?: RequestHandler
+): Promise<GetSelectedResponse> {
+    return request<GetSelectedResponse>({
+        url: ActionURL.buildURL('query', 'getSnapshotSelection.api', containerPath),
+        method: 'POST',
+        jsonData: { key },
+        errorLogMsg: 'Failed to get snapshot selection.',
+        requestHandler,
     });
 }
 
-export function fetchCharts(schemaQuery: SchemaQuery, containerPath?: string): Promise<DataViewInfo[]> {
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: buildURL(
-                'reports',
-                'getReportInfos.api',
-                {
-                    schemaName: schemaQuery.schemaName,
-                    queryName: schemaQuery.queryName,
-                },
-                {
-                    container: containerPath,
-                }
-            ),
-            success: Utils.getCallbackWrapper((response: any) => {
-                if (response && response.success) {
-                    resolve(response.reports.map(report => new DataViewInfo(report)));
-                } else {
-                    reject({
-                        error:
-                            'Unable to get report info for schema/query: ' +
-                            schemaQuery.schemaName +
-                            '/' +
-                            schemaQuery.queryName,
-                    });
-                }
-            }),
-            failure: handleRequestFailure(reject),
-        });
+export async function fetchCharts(schemaQuery: SchemaQuery, containerPath?: string): Promise<DataViewInfo[]> {
+    const { queryName, schemaName } = schemaQuery;
+    const errorLogMsg = `Unable to get report info for schema/query: ${schemaName}/${queryName}`;
+
+    // TODO: Improve typings
+    const response = await request<any>({
+        url: ActionURL.buildURL('reports', 'getReportInfos.api', containerPath, {
+            schemaName,
+            queryName,
+        }),
+        errorLogMsg,
     });
+
+    if (!response.success) {
+        throw new Error(errorLogMsg);
+    }
+
+    return response.reports.map(report => new DataViewInfo(report));
 }
 
 /**
@@ -644,7 +584,7 @@ export function incrementClientSideMetricCount(featureArea: string, metricName: 
     }
 
     Ajax.request({
-        url: buildURL('core', 'incrementClientSideMetricCount.api'),
+        url: ActionURL.buildURL('core', 'incrementClientSideMetricCount.api'),
         method: 'POST',
         jsonData: {
             featureArea,
@@ -829,9 +769,7 @@ export function renameGridView(
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         Ajax.request({
-            url: buildURL('query', 'renameQueryView.api', undefined, {
-                container: containerPath,
-            }),
+            url: ActionURL.buildURL('query', 'renameQueryView.api', containerPath),
             method: 'POST',
             jsonData: {
                 schemaName: schemaQuery.schemaName,

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -16,7 +16,7 @@
 import { fromJS, List } from 'immutable';
 import { ActionURL, Ajax, Filter, getServerContext, Query, Utils } from '@labkey/api';
 
-import { resolveKey, SchemaQuery } from '../public/SchemaQuery';
+import { SchemaQuery } from '../public/SchemaQuery';
 
 import { Actions } from '../public/QueryModel/withQueryModels';
 
@@ -63,34 +63,33 @@ export function selectAll(
     });
 }
 
-export function getGridIdsFromTransactionId(
+export async function getGridIdsFromTransactionId(
     transactionAuditId: number | string,
     dataType: string,
     containerPath?: string
 ): Promise<string[]> {
-    if (!transactionAuditId) {
-        return;
-    }
-    const failureMsg = 'There was a problem retrieving the ' + dataType + ' from the last action.';
-    return new Promise((resolve, reject) => {
-        Ajax.request({
-            url: ActionURL.buildURL('audit', 'getTransactionRowIds.api'),
-            params: { transactionAuditId, dataType, containerFilter: getContainerFilterForFolder(containerPath) },
-            success: Utils.getCallbackWrapper(response => {
-                if (response.success) {
-                    // The server returns numbers, so we coerce to string; If we don't it can lead to bugs (and has).
-                    resolve(response.rowIds.map((rowId: number) => rowId.toString()));
-                } else {
-                    console.error(failureMsg + ' (transactionAuditId = ' + transactionAuditId + ')', response);
-                    reject(failureMsg);
-                }
-            }),
-            failure: Utils.getCallbackWrapper(error => {
-                console.error(failureMsg + ' (transactionAuditId = ' + transactionAuditId + ')', error);
-                reject(failureMsg);
-            }),
-        });
+    if (!transactionAuditId) return;
+
+    const failureMsg = `There was a problem retrieving the ${dataType} from the last action.`;
+    const errorLogMsg = `${failureMsg} (transactionAuditId = ${transactionAuditId})`;
+
+    const response = await request<{ rowIds: number[]; success: boolean }>({
+        url: ActionURL.buildURL('audit', 'getTransactionRowIds.api'),
+        params: {
+            containerFilter: getContainerFilterForFolder(containerPath),
+            dataType,
+            transactionAuditId,
+        },
+        errorLogMsg,
     });
+
+    if (!response.success) {
+        console.error(errorLogMsg, response);
+        throw new Error(failureMsg);
+    }
+
+    // The server returns numbers, so we coerce to string; If we don't, it can lead to bugs (and has).
+    return response.rowIds.map(rowId => rowId.toString());
 }
 
 export async function selectGridIdsFromTransactionId(
@@ -404,7 +403,7 @@ export async function getSelectedDataDeprecated(
     viewName?: string,
     keyColumn = 'RowId'
 ): Promise<GridResponse> {
-    const { models, orderedModels } = await selectRowsDeprecated({
+    const { key, models, orderedModels } = await selectRowsDeprecated({
         schemaName,
         queryName,
         viewName,
@@ -415,11 +414,9 @@ export async function getSelectedDataDeprecated(
         offset: 0,
     });
 
-    const dataKey = resolveKey(schemaName, queryName);
-
     return {
-        data: fromJS(models[dataKey]),
-        dataIds: List(orderedModels[dataKey]),
+        data: fromJS(models[key]),
+        dataIds: orderedModels[key],
     };
 }
 
@@ -552,8 +549,7 @@ export async function fetchCharts(schemaQuery: SchemaQuery, containerPath?: stri
     const { queryName, schemaName } = schemaQuery;
     const errorLogMsg = `Unable to get report info for schema/query: ${schemaName}/${queryName}`;
 
-    // TODO: Improve typings
-    const response = await request<any>({
+    const response = await request<{ reports: Partial<DataViewInfo[]>; success: boolean }>({
         url: ActionURL.buildURL('reports', 'getReportInfos.api', containerPath, {
             schemaName,
             queryName,
@@ -562,6 +558,7 @@ export async function fetchCharts(schemaQuery: SchemaQuery, containerPath?: stri
     });
 
     if (!response.success) {
+        console.error(errorLogMsg, response);
         throw new Error(errorLogMsg);
     }
 

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -465,28 +465,28 @@ export interface ISelectRowsResult {
     rowCount: number;
 }
 
-export type SelectRowsDeprecatedOptions = Omit<
-    Query.SelectRowsOptions,
-    'failure' | 'method' | 'requiredVersion' | 'scope' | 'success'
->;
+export interface SelectRowsDeprecatedOptions
+    extends Omit<Query.SelectRowsOptions, 'failure' | 'method' | 'requiredVersion' | 'scope' | 'success'> {
+    requestHandler?: RequestHandler;
+}
 
 /**
  * @deprecated use selectRows() or executeSql() instead.
  * Fetches an API response and normalizes the result JSON according to schema.
  * This makes every API response have the same shape, regardless of how nested it was.
  */
-export async function selectRowsDeprecated(options: SelectRowsDeprecatedOptions): Promise<ISelectRowsResult> {
+export async function selectRowsDeprecated(options_: SelectRowsDeprecatedOptions): Promise<ISelectRowsResult> {
+    const { requestHandler, ...options } = options_;
     const schemaQuery = new SchemaQuery(options.schemaName, options.queryName, options.viewName);
 
     const columns = options.columns ? options.columns : '*';
     const [queryInfo, response] = await Promise.all([
         getQueryDetails(options),
         new Promise<Query.Response>((resolve, reject) => {
-            Query.selectRows({
+            const request_ = Query.selectRows({
                 ...options,
                 requiredVersion: 17.1,
                 method: 'POST',
-                // put on this another parameter!
                 columns,
                 containerFilter: options.containerFilter ?? getContainerFilter(options.containerPath),
                 includeMetadata: isSelectRowMetadataRequired(options.includeMetadata, columns),
@@ -495,7 +495,9 @@ export async function selectRowsDeprecated(options: SelectRowsDeprecatedOptions)
                     resolve(response_);
                 },
                 failure: (data, request) => {
-                    console.error('There was a problem retrieving the data', data);
+                    if (request.status !== 0) {
+                        console.error('There was a problem retrieving the data', data);
+                    }
                     reject({
                         exceptionClass: data.exceptionClass,
                         message: data.exception,
@@ -504,6 +506,7 @@ export async function selectRowsDeprecated(options: SelectRowsDeprecatedOptions)
                     });
                 },
             });
+            requestHandler?.(request_);
         }),
     ]);
 

--- a/packages/components/src/internal/query/selectRows.ts
+++ b/packages/components/src/internal/query/selectRows.ts
@@ -5,12 +5,14 @@ import { QueryInfo } from '../../public/QueryInfo';
 import { URLResolver } from '../url/URLResolver';
 
 import { getContainerFilter, getQueryDetails, isSelectRowMetadataRequired } from './api';
+import { RequestHandler } from '../request';
 
 export interface SelectRowsOptions
     extends Omit<
         Query.SelectRowsOptions,
         'failure' | 'queryName' | 'requiredVersion' | 'schemaName' | 'scope' | 'success'
     > {
+    requestHandler?: RequestHandler;
     schemaQuery: SchemaQuery;
 }
 
@@ -37,6 +39,7 @@ export async function selectRows(options: SelectRowsOptions): Promise<SelectRows
         includeMetadata,
         includeTotalCount = false, // default to false to improve performance
         method = 'POST',
+        requestHandler,
         schemaQuery,
         ...selectRowsOptions
     } = options;
@@ -46,7 +49,7 @@ export async function selectRows(options: SelectRowsOptions): Promise<SelectRows
     const [queryInfo, response] = await Promise.all([
         getQueryDetails({ containerPath: options.containerPath, schemaQuery }),
         new Promise<Query.Response>((resolve, reject) => {
-            Query.selectRows({
+            const request_ = Query.selectRows({
                 ...selectRowsOptions,
                 columns,
                 containerFilter,
@@ -61,7 +64,9 @@ export async function selectRows(options: SelectRowsOptions): Promise<SelectRows
                     resolve(response_);
                 },
                 failure: (data, request) => {
-                    console.error('There was a problem retrieving the data', data);
+                    if (request.status !== 0) {
+                        console.error('There was a problem retrieving the data', data);
+                    }
                     reject({
                         exceptionClass: data.exceptionClass,
                         message: data.exception,
@@ -70,6 +75,7 @@ export async function selectRows(options: SelectRowsOptions): Promise<SelectRows
                     });
                 },
             });
+            requestHandler?.(request_);
         }),
     ]);
 

--- a/packages/components/src/internal/request.ts
+++ b/packages/components/src/internal/request.ts
@@ -22,7 +22,7 @@ export function handleRequestFailure(reject: (error: any) => void, logMsg?: stri
         (error, response) => {
             // Appends the response's status code to the error object
             const errorWithStatus = { ...error, status: response?.status };
-            if (logMsg) {
+            if (logMsg && errorWithStatus.status !== 0) {
                 console.error(logMsg, errorWithStatus);
             }
             reject(errorWithStatus);

--- a/packages/components/src/public/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/public/QueryModel/QueryModelLoader.ts
@@ -13,6 +13,7 @@ import { isRReportsEnabled } from '../../internal/app/utils';
 import { DataViewInfoTypes, VISUALIZATION_REPORTS } from '../../internal/constants';
 
 import { DataViewInfo, IDataViewInfo } from '../../internal/DataViewInfo';
+import { RequestHandler } from '../../internal/request';
 import { getQueryColumnRenderers } from '../../internal/global';
 import { getQueryDetails, selectRowsDeprecated } from '../../internal/query/api';
 import { DefaultRenderer } from '../../internal/renderers/DefaultRenderer';
@@ -77,7 +78,7 @@ export interface QueryModelLoader {
      * Loads the current page of rows for the specified model.
      * @param model: QueryModel
      */
-    loadRows: (model: QueryModel) => Promise<RowsResponse>;
+    loadRows: (model: QueryModel, requestHandler?: RequestHandler) => Promise<RowsResponse>;
 
     /**
      * Loads the selected RowIds (or PK values) for the specified model.
@@ -118,13 +119,14 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
         });
         return queryInfo.mutate({ columns: bindColumnRenderers(queryInfo.columns) });
     },
-    async loadRows(model) {
+    async loadRows(model, requestHandler) {
         const result = await selectRowsDeprecated({
             ...model.loadRowsConfig,
             schemaName: model.schemaName,
             queryName: model.queryName,
             includeTotalCount: false, // if requesting to includeTotalCount, it will be loaded separately via loadTotalCount
             includeStyle: true, // Issue 49100
+            requestHandler,
         });
         const { key, models, orderedModels, rowCount, messages } = result;
 

--- a/packages/components/src/public/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/public/QueryModel/QueryModelLoader.ts
@@ -84,7 +84,7 @@ export interface QueryModelLoader {
      * Loads the selected RowIds (or PK values) for the specified model.
      * @param model: QueryModel
      */
-    loadSelections: (model: QueryModel) => Promise<Set<string>>;
+    loadSelections: (model: QueryModel, requestHandler?: RequestHandler) => Promise<Set<string>>;
 
     /**
      * Replaces the currently selected items with the given set of selections.
@@ -158,7 +158,7 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
             });
         }
     },
-    async loadSelections(model) {
+    async loadSelections(model, requestHandler) {
         const { containerFilter, selectionKey, schemaQuery, filters, queryParameters, selectionContainerPath } = model;
         const result = await getSelected(
             selectionKey,
@@ -167,7 +167,8 @@ export const DefaultQueryModelLoader: QueryModelLoader = {
             filters,
             selectionContainerPath,
             queryParameters,
-            containerFilter
+            containerFilter,
+            requestHandler
         );
         return new Set(result?.selected ?? []);
     },

--- a/packages/components/src/public/QueryModel/QueryModelLoader.ts
+++ b/packages/components/src/public/QueryModel/QueryModelLoader.ts
@@ -52,7 +52,7 @@ export interface RowsResponse {
     orderedRows: string[];
     rowCount: number;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rows: { [key: string]: any };
+    rows: Record<string, any>;
 }
 
 export interface QueryModelLoader {

--- a/packages/components/src/public/QueryModel/withQueryModels.test.ts
+++ b/packages/components/src/public/QueryModel/withQueryModels.test.ts
@@ -1,0 +1,87 @@
+import { RequestManager } from './withQueryModels';
+
+describe('RequestManager', () => {
+    let manager: RequestManager;
+    let mockXHR: any;
+
+    beforeEach(() => {
+        manager = new RequestManager();
+        mockXHR = () => ({
+            abort: jest.fn(),
+            addEventListener: jest.fn(),
+        });
+    });
+
+    const ID = 'some|model|id|123';
+    const REQUEST_TYPE = 'someLoadAction';
+
+    it('should abort an existing request when a new one of the same type starts', () => {
+        const handler = manager.getRequestHandler(ID, REQUEST_TYPE);
+        const req1 = mockXHR();
+        const req2 = mockXHR();
+
+        handler(req1);
+        handler(req2);
+
+        expect(req1.abort).toHaveBeenCalledTimes(1);
+        expect(manager._requests[ID][REQUEST_TYPE]).toBe(req2);
+    });
+
+    it('should clean up references on loadend', () => {
+        const handler = manager.getRequestHandler(ID, REQUEST_TYPE);
+        const req = mockXHR();
+
+        let cleanup: () => void;
+        req.addEventListener.mockImplementation((event: string, cb: () => void) => {
+            if (event === 'loadend') cleanup = cb;
+        });
+
+        handler(req);
+        expect(manager._requests[ID]).toBeDefined();
+
+        // Simulate the request finishing
+        cleanup();
+
+        expect(manager._requests[ID]).toBeUndefined();
+    });
+
+    it('should not delete a new request if an old request finishes', () => {
+        const handler = manager.getRequestHandler(ID, REQUEST_TYPE);
+
+        const req1 = mockXHR();
+        let cleanup: () => void;
+        req1.addEventListener.mockImplementation((event: string, cb: () => void) => {
+            if (event === 'loadend') cleanup = cb;
+        });
+
+        handler(req1);
+
+        const req2 = mockXHR();
+        handler(req2);
+
+        // Simulate request 1 finally finishing its 'loadend' event
+        cleanup();
+
+        // Validate request 2 is still there
+        expect(manager._requests[ID][REQUEST_TYPE]).toBe(req2);
+    });
+
+    it('should handle requests object mutation during abort', () => {
+        const manager = new RequestManager();
+        const handler = manager.getRequestHandler(ID, REQUEST_TYPE);
+        const req1 = mockXHR();
+        handler(req1);
+
+        // Mock abort() so that the moment we try to start Req 2,
+        // the manager deletes the whole ID entry (simulating a concurrent loadend cleanup).
+        req1.abort.mockImplementation(() => {
+            delete manager._requests[ID];
+        });
+
+        const req2 = mockXHR();
+
+        // The manager should have correctly re-attached the ID to the state
+        expect(() => handler(req2)).not.toThrow();
+        expect(manager._requests[ID][REQUEST_TYPE]).toBe(req2);
+    });
+});

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -278,8 +278,9 @@ function applySavedSettings(id: string, model: QueryModel): QueryModel {
 // N.B. This is similar to useRequestHandler() but we cannot use a hook here, so we have to use class
 // variables instead. Additionally, we cannot make use of React.createRef() since that returns an immutable
 // reference unlike React.useRef() which is mutable.
-class RequestManager {
-    private _requests: Record<string, Record<string, undefined | XMLHttpRequest>> = {};
+// Exported for unit tests
+export class RequestManager {
+    _requests: Record<string, Record<string, undefined | XMLHttpRequest>> = {};
 
     public cancelAllRequests = (): void => {
         Object.values(this._requests).forEach(allReq => {
@@ -292,22 +293,28 @@ class RequestManager {
 
     public getRequestHandler(id: string, requestType: string): RequestHandler {
         return request => {
-            if (!this._requests.hasOwnProperty(id)) {
-                this._requests[id] = {};
+            const bucket = this._requests[id] || (this._requests[id] = {});
+
+            // Abort in-flight request
+            bucket[requestType]?.abort();
+
+            // If the bucket was detached during the abort() call,
+            // then re-attach it before assigning the new request.
+            if (this._requests[id] !== bucket) {
+                this._requests[id] = bucket;
             }
 
-            // Abort and replace existing request of this type
-            this._requests[id][requestType]?.abort();
-            this._requests[id][requestType] = request;
+            bucket[requestType] = request;
 
             // Remove the request once the request has completed
             request.addEventListener(
                 'loadend',
                 () => {
-                    if (this._requests[id]?.[requestType] === request) {
-                        delete this._requests[id][requestType];
+                    const bucket_ = this._requests[id];
+                    if (bucket_?.[requestType] === request) {
+                        delete bucket_[requestType];
 
-                        if (Object.keys(this._requests[id]).length === 0) {
+                        if (Object.keys(bucket_).length === 0) {
                             delete this._requests[id];
                         }
                     }

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -19,6 +19,7 @@ import { incrementClientSideMetricCount } from '../../internal/actions';
 
 import { filterArraysEqual, getSelectRowCountColumnsStr, sortArraysEqual } from './utils';
 import { DefaultQueryModelLoader, QueryModelLoader } from './QueryModelLoader';
+import { RequestHandler } from '../../internal/request';
 import {
     getSettingsFromLocalStorage,
     GridMessage,
@@ -309,6 +310,39 @@ export function withQueryModels<Props>(
     };
 
     class ComponentWithQueryModels extends PureComponent<WrappedProps, State> {
+        // N.B. This is very similar to useRequestHandler() but we cannot use a hook here so we have to use class
+        // variables instead. Additionally, we cannot make use of React.createRef() since that returns an immutable
+        // reference unlike React.useRef() which is mutable.
+
+        // TODO: Not married to this structure, just first thoughts on coalescing requests by model.
+        private _requests: Record<string, Record<string, undefined | XMLHttpRequest>> = {};
+
+        private cancelAllRequests = (): void => {
+            Object.values(this._requests).forEach(allReq => {
+                Object.values(allReq).forEach(req => {
+                    req?.abort();
+                });
+            });
+            this._requests = {};
+        };
+
+        private getRequestHandler =
+            (id: string, requestType: string): RequestHandler =>
+            request => {
+                if (!this._requests.hasOwnProperty(id)) {
+                    this._requests[id] = {};
+                }
+
+                this._requests[id][requestType]?.abort();
+                this._requests[id][requestType] = request;
+            };
+
+        private resetRequestHandler = (id: string, requestType: string): void => {
+            if (this._requests[id] !== undefined) {
+                this._requests[id][requestType] = undefined;
+            }
+        };
+
         static defaultProps;
 
         constructor(props: WrappedProps) {
@@ -412,6 +446,10 @@ export function withQueryModels<Props>(
                         }
                     });
             }
+        }
+
+        componentWillUnmount(): void {
+            this.cancelAllRequests();
         }
 
         actions: Actions;
@@ -736,7 +774,9 @@ export function withQueryModels<Props>(
             );
 
             try {
-                const result = await loadRows(this.state.queryModels[id]);
+                const requestType = 'loadRows';
+                const result = await loadRows(this.state.queryModels[id], this.getRequestHandler(id, requestType));
+                this.resetRequestHandler(id, requestType);
                 const { messages, rows, orderedRows, rowCount } = result;
 
                 this.setState(
@@ -753,6 +793,7 @@ export function withQueryModels<Props>(
                     () => this.maybeLoad(id, false, false, loadSelections, false, selectionsForReplace)
                 );
             } catch (error) {
+                if (error?.status === 0) return;
                 let viewDoesNotExist = false;
                 this.setState(
                     produce<State>((draft: WritableDraft<State>) => {
@@ -845,6 +886,8 @@ export function withQueryModels<Props>(
                     loadRowsConfig.filterArray,
                     queryInfo?.getPkCols()
                 );
+
+                const requestType = 'loadTotalCount';
                 const { rowCount } = await selectRows({
                     ...loadRowsConfig,
                     columns,
@@ -855,7 +898,9 @@ export function withQueryModels<Props>(
                     maxRows: 1,
                     offset: 0,
                     sort: undefined,
+                    requestHandler: this.getRequestHandler(id, requestType),
                 });
+                this.resetRequestHandler(id, requestType);
 
                 this.setState(
                     produce<State>((draft: WritableDraft<State>) => {
@@ -866,6 +911,7 @@ export function withQueryModels<Props>(
                     })
                 );
             } catch (error) {
+                if (error?.status === 0) return;
                 this.setState(
                     produce<State>((draft: WritableDraft<State>) => {
                         const model = draft.queryModels[id];
@@ -946,6 +992,9 @@ export function withQueryModels<Props>(
             reloadTotalCount = false,
             selectionsForReplace?: string[]
         ): void => {
+            // TODO: Consider how to incorporate stale request handling.
+            //   Feels like we should never be cancelling query info loading -- just to keep it simple. Already cached, etc.
+            //   Definitely want to cancel loading selections. Need to make sure caller is requeuing the load.
             if (loadQueryInfo) {
                 // Postpone loading any rows or selections if we're loading the QueryInfo.
                 this.loadQueryInfo(id, loadRows, loadSelections);

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -310,7 +310,7 @@ export function withQueryModels<Props>(
     };
 
     class ComponentWithQueryModels extends PureComponent<WrappedProps, State> {
-        // N.B. This is very similar to useRequestHandler() but we cannot use a hook here so we have to use class
+        // N.B. This is very similar to useRequestHandler() but we cannot use a hook here, so we have to use class
         // variables instead. Additionally, we cannot make use of React.createRef() since that returns an immutable
         // reference unlike React.useRef() which is mutable.
 
@@ -538,7 +538,12 @@ export function withQueryModels<Props>(
             );
 
             try {
-                const selections = await loadSelections(this.state.queryModels[id]);
+                const requestType = 'loadSelections';
+                const selections = await loadSelections(
+                    this.state.queryModels[id],
+                    this.getRequestHandler(id, requestType)
+                );
+                this.resetRequestHandler(id, requestType);
 
                 this.setState(
                     produce<State>((draft: WritableDraft<State>) => {

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -572,6 +572,7 @@ export function withQueryModels<Props>(
                     })
                 );
             } catch (error) {
+                if (error?.status === 0) return;
                 this.setSelectionsError(id, error, 'loading');
             }
         };
@@ -797,11 +798,15 @@ export function withQueryModels<Props>(
             );
 
             try {
-                const requestType = 'loadRows';
-                const result = await loadRows(
-                    this.state.queryModels[id],
-                    this.requestManager.getRequestHandler(id, requestType)
-                );
+                // If we have selectionsForReplace, then skip request cancellation optimization
+                let requestHandler: RequestHandler | undefined;
+                if (!selectionsForReplace) {
+                    // Key requests as loadRows|<loadSelections> so loadSelection is respected
+                    const requestType = ['loadRows', loadSelections].join('|');
+                    requestHandler = this.requestManager.getRequestHandler(id, requestType);
+                }
+
+                const result = await loadRows(this.state.queryModels[id], requestHandler);
                 const { messages, rows, orderedRows, rowCount } = result;
 
                 this.setState(

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -275,6 +275,49 @@ function applySavedSettings(id: string, model: QueryModel): QueryModel {
     return model;
 }
 
+// N.B. This is similar to useRequestHandler() but we cannot use a hook here, so we have to use class
+// variables instead. Additionally, we cannot make use of React.createRef() since that returns an immutable
+// reference unlike React.useRef() which is mutable.
+class RequestManager {
+    private _requests: Record<string, Record<string, undefined | XMLHttpRequest>> = {};
+
+    public cancelAllRequests = (): void => {
+        Object.values(this._requests).forEach(allReq => {
+            Object.values(allReq).forEach(req => {
+                req?.abort();
+            });
+        });
+        this._requests = {};
+    };
+
+    public getRequestHandler(id: string, requestType: string): RequestHandler {
+        return request => {
+            if (!this._requests.hasOwnProperty(id)) {
+                this._requests[id] = {};
+            }
+
+            // Abort and replace existing request of this type
+            this._requests[id][requestType]?.abort();
+            this._requests[id][requestType] = request;
+
+            // Remove the request once the request has completed
+            request.addEventListener(
+                'loadend',
+                () => {
+                    if (this._requests[id]?.[requestType] === request) {
+                        delete this._requests[id][requestType];
+
+                        if (Object.keys(this._requests[id]).length === 0) {
+                            delete this._requests[id];
+                        }
+                    }
+                },
+                { once: true }
+            );
+        };
+    }
+}
+
 /**
  * A wrapper for LabKey selectRows API. For in-depth documentation and examples see components/docs/QueryModel.md.
  * @param ComponentToWrap A component that implements generic Props and InjectedQueryModels.
@@ -310,40 +353,9 @@ export function withQueryModels<Props>(
     };
 
     class ComponentWithQueryModels extends PureComponent<WrappedProps, State> {
-        // N.B. This is very similar to useRequestHandler() but we cannot use a hook here, so we have to use class
-        // variables instead. Additionally, we cannot make use of React.createRef() since that returns an immutable
-        // reference unlike React.useRef() which is mutable.
-
-        // TODO: Not married to this structure, just first thoughts on coalescing requests by model.
-        private _requests: Record<string, Record<string, undefined | XMLHttpRequest>> = {};
-
-        private cancelAllRequests = (): void => {
-            Object.values(this._requests).forEach(allReq => {
-                Object.values(allReq).forEach(req => {
-                    req?.abort();
-                });
-            });
-            this._requests = {};
-        };
-
-        private getRequestHandler =
-            (id: string, requestType: string): RequestHandler =>
-            request => {
-                if (!this._requests.hasOwnProperty(id)) {
-                    this._requests[id] = {};
-                }
-
-                this._requests[id][requestType]?.abort();
-                this._requests[id][requestType] = request;
-            };
-
-        private resetRequestHandler = (id: string, requestType: string): void => {
-            if (this._requests[id] !== undefined) {
-                this._requests[id][requestType] = undefined;
-            }
-        };
-
         static defaultProps;
+
+        private requestManager = new RequestManager();
 
         constructor(props: WrappedProps) {
             super(props);
@@ -449,7 +461,7 @@ export function withQueryModels<Props>(
         }
 
         componentWillUnmount(): void {
-            this.cancelAllRequests();
+            this.requestManager.cancelAllRequests();
         }
 
         actions: Actions;
@@ -541,9 +553,8 @@ export function withQueryModels<Props>(
                 const requestType = 'loadSelections';
                 const selections = await loadSelections(
                     this.state.queryModels[id],
-                    this.getRequestHandler(id, requestType)
+                    this.requestManager.getRequestHandler(id, requestType)
                 );
-                this.resetRequestHandler(id, requestType);
 
                 this.setState(
                     produce<State>((draft: WritableDraft<State>) => {
@@ -780,8 +791,10 @@ export function withQueryModels<Props>(
 
             try {
                 const requestType = 'loadRows';
-                const result = await loadRows(this.state.queryModels[id], this.getRequestHandler(id, requestType));
-                this.resetRequestHandler(id, requestType);
+                const result = await loadRows(
+                    this.state.queryModels[id],
+                    this.requestManager.getRequestHandler(id, requestType)
+                );
                 const { messages, rows, orderedRows, rowCount } = result;
 
                 this.setState(
@@ -903,9 +916,8 @@ export function withQueryModels<Props>(
                     maxRows: 1,
                     offset: 0,
                     sort: undefined,
-                    requestHandler: this.getRequestHandler(id, requestType),
+                    requestHandler: this.requestManager.getRequestHandler(id, requestType),
                 });
-                this.resetRequestHandler(id, requestType);
 
                 this.setState(
                     produce<State>((draft: WritableDraft<State>) => {
@@ -997,9 +1009,6 @@ export function withQueryModels<Props>(
             reloadTotalCount = false,
             selectionsForReplace?: string[]
         ): void => {
-            // TODO: Consider how to incorporate stale request handling.
-            //   Feels like we should never be cancelling query info loading -- just to keep it simple. Already cached, etc.
-            //   Definitely want to cancel loading selections. Need to make sure caller is requeuing the load.
             if (loadQueryInfo) {
                 // Postpone loading any rows or selections if we're loading the QueryInfo.
                 this.loadQueryInfo(id, loadRows, loadSelections);

--- a/packages/components/src/public/QueryModel/withQueryModels.tsx
+++ b/packages/components/src/public/QueryModel/withQueryModels.tsx
@@ -557,10 +557,9 @@ export function withQueryModels<Props>(
             );
 
             try {
-                const requestType = 'loadSelections';
                 const selections = await loadSelections(
                     this.state.queryModels[id],
-                    this.requestManager.getRequestHandler(id, requestType)
+                    this.requestManager.getRequestHandler(id, 'loadSelections')
                 );
 
                 this.setState(
@@ -801,9 +800,7 @@ export function withQueryModels<Props>(
                 // If we have selectionsForReplace, then skip request cancellation optimization
                 let requestHandler: RequestHandler | undefined;
                 if (!selectionsForReplace) {
-                    // Key requests as loadRows|<loadSelections> so loadSelection is respected
-                    const requestType = ['loadRows', loadSelections].join('|');
-                    requestHandler = this.requestManager.getRequestHandler(id, requestType);
+                    requestHandler = this.requestManager.getRequestHandler(id, 'loadRows');
                 }
 
                 const result = await loadRows(this.state.queryModels[id], requestHandler);
@@ -917,7 +914,6 @@ export function withQueryModels<Props>(
                     queryInfo?.getPkCols()
                 );
 
-                const requestType = 'loadTotalCount';
                 const { rowCount } = await selectRows({
                     ...loadRowsConfig,
                     columns,
@@ -928,7 +924,7 @@ export function withQueryModels<Props>(
                     maxRows: 1,
                     offset: 0,
                     sort: undefined,
-                    requestHandler: this.requestManager.getRequestHandler(id, requestType),
+                    requestHandler: this.requestManager.getRequestHandler(id, 'loadTotalCount'),
                 });
 
                 this.setState(


### PR DESCRIPTION
#### Rationale
This adds request tracking and cancelling in `withQueryModels` for a few of the most common data loading requests. This seeks to address [#455](https://github.com/LabKey/internal-issues/issues/455).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1929
- https://github.com/LabKey/labkey-ui-premium/pull/888
- https://github.com/LabKey/limsModules/pull/1953
- https://github.com/LabKey/platform/pull/7366

#### Changes
- Update `withQueryModels` to track and cancel requests for `loadRows`, `loadSelections` and `loadTotalCount`
- Add `RequestHandler` handling for `selectRows` and `selectRowsDeprecated`
- Skip error logging when request is aborted
- Update a few endpoint wrappers to use `request()`