### PR TITLE
Allow users to utilize quotation marks for exact search within the apps

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.18.0",
+  "version": "7.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.18.0",
+      "version": "7.18.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.18.0",
+  "version": "7.18.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.18.1
+*Released*: 17 February 2026
+- Allow users to use quotation marks for exact search within the apps
+
 ### version 7.18.0
 *Released*: 17 February 2026
 - Update `FilterStatus` to optionally include an "Add Filter" button

--- a/packages/components/src/internal/components/search/utils.test.ts
+++ b/packages/components/src/internal/components/search/utils.test.ts
@@ -1603,7 +1603,7 @@ describe('decodeErrorMessage', () => {
 describe('escapeSearchQuery', () => {
     test('empty values', () => {
         expect(escapeSearchQuery(undefined)).toBeUndefined();
-        expect(null).toBeNull();
+        expect(escapeSearchQuery(null)).toBeNull();
         expect(escapeSearchQuery('')).toEqual('');
     });
     test('escapes special characters', () => {
@@ -1626,14 +1626,50 @@ describe('escapeSearchQuery', () => {
     test('handles quotes well', () => {
         expect(escapeSearchQuery('"Fresh" and "Flowers"', false)).toEqual('"Fresh" and "Flowers"');
         expect(escapeSearchQuery('Fl"ower', true)).toEqual('Fl\\"ower OR Fl\\"ower*');
+        expect(escapeSearchQuery('Fl"ower', false)).toEqual('Fl"ower');
         expect(escapeSearchQuery('D_"fee{-e>4_b4"', false)).toEqual('D_"fee\\{\\-e>4_b4"');
         expect(escapeSearchQuery('D_"fee{-e>4_b4"', true)).toEqual(
             'D_\\"fee\\{\\-e>4_b4\\" OR D_\\"fee\\{\\-e>4_b4\\"*'
         );
     });
     test('trims', () => {
+        expect(escapeSearchQuery('   ', true)).toEqual('');
+        expect(escapeSearchQuery('   ', false)).toEqual('');
         expect(escapeSearchQuery('   test  &&    sp"ace    ', true)).toEqual(
             'test  \\&&    sp\\"ace OR test  \\&&    sp\\"ace*'
         );
+    });
+    describe('retains start/end quoting', () => {
+        test('when escapeQuotes is true', () => {
+            const escapeQuotes = true;
+            expect(escapeSearchQuery('"', escapeQuotes)).toEqual('\\" OR \\"*');
+            expect(escapeSearchQuery('""', escapeQuotes)).toEqual('""');
+            expect(escapeSearchQuery('"test"', escapeQuotes)).toEqual('"test"');
+            expect(escapeSearchQuery('"te"st"', escapeQuotes)).toEqual('"te\\"st"');
+            expect(escapeSearchQuery('"test', escapeQuotes)).toEqual('\\"test OR \\"test*');
+            expect(escapeSearchQuery('test"', escapeQuotes)).toEqual('test\\" OR test\\"*');
+            expect(escapeSearchQuery('no quotes', escapeQuotes)).toEqual('no quotes OR no quotes*');
+            expect(escapeSearchQuery('"""', escapeQuotes)).toEqual('"\\""');
+            expect(escapeSearchQuery('"a"b"c"', escapeQuotes)).toEqual('"a\\"b\\"c"');
+            expect(escapeSearchQuery('a "b" c', escapeQuotes)).toEqual('a \\"b\\" c OR a \\"b\\" c*');
+            expect(escapeSearchQuery('"te+st"', escapeQuotes)).toEqual('"te\\+st"');
+            expect(escapeSearchQuery('"(a) [b]"', escapeQuotes)).toEqual('"\\(a\\) \\[b\\]"');
+            expect(escapeSearchQuery('"   "', escapeQuotes)).toEqual('"   "');
+        });
+        test('when escapeQuotes is false', () => {
+            const escapeQuotes = false;
+            expect(escapeSearchQuery('"', escapeQuotes)).toEqual('"');
+            expect(escapeSearchQuery('""', escapeQuotes)).toEqual('""');
+            expect(escapeSearchQuery('"test"', escapeQuotes)).toEqual('"test"');
+            expect(escapeSearchQuery('"te"st"', escapeQuotes)).toEqual('"te"st"');
+            expect(escapeSearchQuery('"test', escapeQuotes)).toEqual('"test');
+            expect(escapeSearchQuery('test"', escapeQuotes)).toEqual('test"');
+            expect(escapeSearchQuery('no quotes', escapeQuotes)).toEqual('no quotes OR no quotes*');
+            expect(escapeSearchQuery('"""', escapeQuotes)).toEqual('"""');
+            expect(escapeSearchQuery('a "b" c', escapeQuotes)).toEqual('a "b" c');
+            expect(escapeSearchQuery('"te+st"', escapeQuotes)).toEqual('"te\\+st"');
+            expect(escapeSearchQuery('"(a) [b]"', escapeQuotes)).toEqual('"\\(a\\) \\[b\\]"');
+            expect(escapeSearchQuery('"   "', escapeQuotes)).toEqual('"   "');
+        });
     });
 });

--- a/packages/components/src/internal/components/search/utils.ts
+++ b/packages/components/src/internal/components/search/utils.ts
@@ -699,28 +699,55 @@ export const decodeErrorMessage = (msg: string): string => {
     return decodedMsg;
 };
 
-// Double quotes (") can be used as part of the Lucene syntax to specify exact matches. For usages
-// that don't allow more than one word or any Lucene operators, use escapeQuotes=true, in order
-// to treat the quote character as a special character to be found during searching. Note that
-// the current implementation does not try to match quote pairs to determine which could be escaped and which not.
+// Matches: && || + - ! ( ) { } [ ] ^ ~ * ? : \
+const LUCENE_SPECIAL_CHARS = /&&|\|\||[+\-!(){}\[\]^~*?:\\]/g;
+// Matches: "
+const DOUBLE_QUOTE = /"/g;
+
+/**
+ * Sanitizes and prepares a search string for safe execution in a Lucene-based search engine.
+ * Automatically escapes special characters and appends a wildcard clause for prefix matching
+ * unless an exact phrase match is requested.
+ *
+ * See:
+ * - Issue 51645: Ending a notebook or template name with ':' throws an error when using application-wide search
+ * - Issue 52082: Global searching for Notebook names fails with special characters
+ * - GH Issue #700: Allow users to use quotation marks for exact search within the apps
+ *
+ * @param q - The raw search query string.
+ * @param escapeQuotes - Determines how quote characters (`"`) are handled. Defaults to `false`
+ * (preserves all quotes). If `true`, internal quotes are escaped as literal characters, but outer
+ * wrapping quotes (e.g., `"exact match"`) are retained to preserve exact phrase functionality.
+ * @returns The sanitized and formatted Lucene query string.
+ * * @example
+ * escapeSearchQuery('hello:world');      // => 'hello\:world OR hello\:world*'
+ * escapeSearchQuery('"exact match"');    // => '"exact match"'
+ * escapeSearchQuery('Fl"ower', true);    // => 'Fl\"ower OR Fl\"ower*'
+ */
 export function escapeSearchQuery(q: string, escapeQuotes = false): string {
-    if (q) {
-        const hasQuotes = q.indexOf('"') > -1;
+    if (!q) return q;
 
-        // Escape special lucene characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \
-        // https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters
-        q = q.trim().replace(/&&|\|\||[+\-!(){}\[\]^~*?:\\]/g, m => `\\${m}`);
+    const trimmed = q.trim();
+    if (!trimmed) return trimmed;
 
-        if (escapeQuotes) {
-            q = q.replace(/"/g, '\\"');
-        }
+    let query = trimmed;
+    const hasQuotes = query.includes('"');
+    const startsAndEndsWithQuotes = hasQuotes && query.length > 1 && query.startsWith('"') && query.endsWith('"');
 
-        // Append an additional wildcard search clause to include prefix matching
-        // Example: "M-" will result in a query of "M\- OR M\-*"
-        if (!hasQuotes || escapeQuotes) {
-            q = [q, `${q}*`].join(' OR ');
+    query = query.replace(LUCENE_SPECIAL_CHARS, '\\$&');
+
+    if (escapeQuotes) {
+        if (startsAndEndsWithQuotes) {
+            const innerQ = query.substring(1, query.length - 1);
+            query = `"${innerQ.replace(DOUBLE_QUOTE, '\\"')}"`;
+        } else {
+            query = query.replace(DOUBLE_QUOTE, '\\"');
         }
     }
 
-    return q;
+    if (!hasQuotes || (escapeQuotes && !startsAndEndsWithQuotes)) {
+        query = `${query} OR ${query}*`;
+    }
+
+    return query;
 }


### PR DESCRIPTION
#### Rationale
Add the capability requested with [#700](https://github.com/LabKey/internal-issues/issues/700) to be able to perform exact searches by using quotation marks to start and end a search query within the apps.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1983

#### Changes
- Check for query string that starts and ends with `"` character
- If `escapeQuotes=true` then escape all quotes inside start/end quotes
- Extract regex to constants
- Use token matching rather than processor function
- Update description with ticket references and examples
- Add unit tests
