### PR TITLE
GitHub Issue #734: App narrow screen display can cut off error message for field editor pages

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.1",
+  "version": "7.20.1-fb-appPagePadding.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.20.1",
+      "version": "7.20.1-fb-appPagePadding.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.3",
+  "version": "7.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.20.3",
+      "version": "7.20.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.1",
+  "version": "7.20.1-fb-appPagePadding.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.3",
+  "version": "7.20.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD February 2026
+### version 7.20.4
+*Released*: 25 February 2026
 - GitHub Issue #734: App narrow screen display can cut off error message for field editor pages
   - inline-comment footer can take up to 125px on small screens so increase bottom padding for .app-page
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD February 2026
+- GitHub Issue #734: App narrow screen display can cut off error message for field editor pages
+  - inline-comment footer can take up to 125px on small screens so increase bottom padding for .app-page
+
 ### version 7.20.1
 *Released*: 20 February 2026
 - GitHub Issue 830: Assay design add transform script webdav path doesn't resolve from subfolder

--- a/packages/components/src/theme/app/app.scss
+++ b/packages/components/src/theme/app/app.scss
@@ -21,7 +21,14 @@
 
 .app-page {
     padding-top: 20px;
-    padding-bottom: 80px;
+
+    // GitHub Issue #734: inline-comment footer can take up to 125px on small screens
+    @media (max-width: 774px) {
+        padding-bottom: 130px;
+    }
+    @media (min-width: 775px) {
+        padding-bottom: 80px;
+    }
 }
 
 .page-header {


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/734

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1939
- https://github.com/LabKey/limsModules/pull/1999

#### Changes
- inline-comment footer can take up to 125px on small screens so increase bottom padding for .app-page
