### PR TITLE
Expose Grid View Audit event in apps

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.1",
+  "version": "7.20.2-fb-customViewAuditFK.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.20.1",
+      "version": "7.20.2-fb-customViewAuditFK.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.2",
+  "version": "7.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.20.2",
+      "version": "7.20.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.1",
+  "version": "7.20.2-fb-customViewAuditFK.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.X
+*Released*: X February 2026
+- GitHub Issue 465: Add auditing capabilities for grid views
+- GitHub Issue 840: Increase text choice options from 200 to 500
+
 ### version 7.20.1
 *Released*: 20 February 2026
 - GitHub Issue 830: Assay design add transform script webdav path doesn't resolve from subfolder

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -39,6 +39,10 @@ export const INVENTORY_AUDIT_QUERY: AuditQuery = {
     value: 'InventoryAuditEvent',
 };
 export const LIST_AUDIT_QUERY: AuditQuery = { hasTransactionId: true, label: 'List Events', value: 'ListAuditEvent' };
+export const GRID_VIEW_AUDIT_EVENT: AuditQuery = {
+    label: 'Grid View Events',
+    value: 'GridViewAuditEvent',
+};
 export const GROUP_AUDIT_QUERY: AuditQuery = {
     containerFilter: Query.ContainerFilter.allFolders,
     label: 'Roles and Assignment Events',
@@ -129,6 +133,7 @@ export const COMMON_AUDIT_QUERIES: AuditQuery[] = [
     DOMAIN_AUDIT_QUERY,
     DOMAIN_PROPERTY_AUDIT_QUERY,
     FILE_SYSTEM_AUDIT_QUERY,
+    GRID_VIEW_AUDIT_EVENT,
     GROUP_AUDIT_QUERY,
     INVENTORY_AUDIT_QUERY,
     LIST_AUDIT_QUERY,

--- a/packages/components/src/internal/components/auditlog/utils.test.ts
+++ b/packages/components/src/internal/components/auditlog/utils.test.ts
@@ -30,18 +30,18 @@ import {
 describe('getAuditQueries', () => {
     test('LKS starter', () => {
         const auditQueries = getAuditQueries(TEST_LKS_STARTER_MODULE_CONTEXT);
-        expect(auditQueries.length).toBe(14);
+        expect(auditQueries.length).toBe(15);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === ASSAY_RESULT_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(12);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(13);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBe(-1);
         expect(auditQueries.findIndex(entry => entry === SOURCE_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
     });
 
     test('LKSM starter', () => {
         const auditQueries = getAuditQueries(TEST_LKSM_STARTER_MODULE_CONTEXT);
-        expect(auditQueries.length).toBe(12);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(10);
+        expect(auditQueries.length).toBe(13);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(11);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBe(-1);
         expect(auditQueries.findIndex(entry => entry === ASSAY_RESULT_AUDIT_QUERY)).toBe(-1);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBe(-1);
@@ -50,8 +50,8 @@ describe('getAuditQueries', () => {
 
     test('LKSM professional', () => {
         const auditQueries = getAuditQueries(TEST_LKSM_PROFESSIONAL_MODULE_CONTEXT);
-        expect(auditQueries.length).toBe(17);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(15);
+        expect(auditQueries.length).toBe(18);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(16);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === SOURCE_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
@@ -78,8 +78,8 @@ describe('getAuditQueries', () => {
             },
         };
         const auditQueries = getAuditQueries(moduleContext);
-        expect(auditQueries.length).toBe(18);
-        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(16);
+        expect(auditQueries.length).toBe(19);
+        expect(auditQueries.findIndex(entry => entry === INVENTORY_AUDIT_QUERY)).toBe(17);
         expect(auditQueries.findIndex(entry => entry === ASSAY_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === ASSAY_RESULT_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);
         expect(auditQueries.findIndex(entry => entry === WORKFLOW_AUDIT_QUERY)).toBeGreaterThanOrEqual(0);

--- a/packages/components/src/internal/components/domainproperties/TextChoiceAddValuesModal.test.tsx
+++ b/packages/components/src/internal/components/domainproperties/TextChoiceAddValuesModal.test.tsx
@@ -32,13 +32,13 @@ describe('TextChoiceAddValuesModal', () => {
     test('default props', () => {
         render(<TextChoiceAddValuesModal {...DEFAULT_PROPS} />);
         validate();
-        validateCounterText('400 values', '0 new values');
+        validateCounterText('500 values', '0 new values');
     });
 
     test('initialValueCount', () => {
         render(<TextChoiceAddValuesModal {...DEFAULT_PROPS} initialValueCount={70} />);
         validate();
-        validateCounterText('330 values', '0 new values');
+        validateCounterText('430 values', '0 new values');
     });
 
     test('fieldName', () => {
@@ -50,19 +50,19 @@ describe('TextChoiceAddValuesModal', () => {
         render(<TextChoiceAddValuesModal {...DEFAULT_PROPS} />);
         validate();
         expect(document.querySelector('.btn-success').hasAttribute('disabled')).toBeTruthy();
-        validateCounterText('400 values', '0 new values');
+        validateCounterText('500 values', '0 new values');
 
         await userEvent.type(document.querySelector('textarea'), 'a');
         validate();
         expect(document.querySelector('.btn-success').hasAttribute('disabled')).toBeFalsy();
-        validateCounterText('400 values', '1 new value');
+        validateCounterText('500 values', '1 new value');
 
         // empty rows and duplicates (after trim) should be removed
         await userEvent.clear(document.querySelector('textarea'));
         await userEvent.type(document.querySelector('textarea'), 'a\n\na\na \n a\nb');
         validate();
         expect(document.querySelector('.btn-success').hasAttribute('disabled')).toBeFalsy();
-        validateCounterText('400 values', '2 new values');
+        validateCounterText('500 values', '2 new values');
     });
 
     test('success button disabled after max reached', async () => {

--- a/packages/components/src/internal/components/domainproperties/constants.ts
+++ b/packages/components/src/internal/components/domainproperties/constants.ts
@@ -232,7 +232,7 @@ export const DERIVATION_DATA_SCOPES = {
     ALL: 'All',
 };
 
-export const MAX_VALID_TEXT_CHOICES = 400;
+export const MAX_VALID_TEXT_CHOICES = 500;
 
 export const LOOKUP_VALIDATOR_VALUES = { type: 'Lookup', name: 'Lookup Validator' };
 


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1941
- https://github.com/LabKey/limsModules/pull/2002

#### Changes
- GitHub Issue 465: Add auditing capabilities for grid views and expose new audit event in app
- GitHub Issue 840: Increase text choice options from 200 to 500 (not 400)
