### PR TITLE
Always use container relative URLs

### DIFF
--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -17,9 +17,6 @@ module.exports = {
                     timeFormat: "HH:mm"
                 }
             },
-            experimental: {
-                containerRelativeURL: true,
-            },
             project: {
                 rootId: 'ROOTID'
             },

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.2-fb-container-first-clients.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",
@@ -3845,9 +3845,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.2-fb-container-first-clients.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
-      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.46.2-fb-container-first-clients.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",
@@ -3845,9 +3845,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.46.2-fb-container-first-clients.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
+      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.1",
+  "version": "7.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.20.1",
+      "version": "7.20.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.20.1",
+  "version": "7.20.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.46.2-fb-container-first-clients.1",
+    "@labkey/api": "1.47.0",
     "@testing-library/dom": "~10.4.1",
     "@testing-library/jest-dom": "~6.9.1",
     "@testing-library/react": "~16.3.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.46.1",
+    "@labkey/api": "1.46.2-fb-container-first-clients.1",
     "@testing-library/dom": "~10.4.1",
     "@testing-library/jest-dom": "~6.9.1",
     "@testing-library/react": "~16.3.2",

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.20.2
+*Released*: 24 February 2026
+- Bump @labkey/api dependency
+
 ### version 7.20.1
 *Released*: 20 February 2026
 - GitHub Issue 830: Assay design add transform script webdav path doesn't resolve from subfolder

--- a/packages/components/src/internal/url/AppURL.test.ts
+++ b/packages/components/src/internal/url/AppURL.test.ts
@@ -9,10 +9,6 @@ describe('AppURL', () => {
         LABKEY = {
             ...LABKEY,
             devMode: true,
-            experimental: {
-                ...LABKEY.experimental,
-                containerRelativeURL: true,
-            },
             moduleContext: {
                 ...LABKEY.moduleContext,
                 // Force isSampleManagerEnabled to be true


### PR DESCRIPTION
#### Rationale
Container Relative URLs are no longer an experimental feature, and are always enabled. This PR updates the api-js dependency and removes all references to the containerRelativeURL experimental feature flag.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/207
* https://github.com/LabKey/labkey-ui-components/pull/1942
* https://github.com/LabKey/labkey-ui-premium/pull/898
* https://github.com/LabKey/platform/pull/7451
* https://github.com/LabKey/limsModules/pull/2005

#### Changes
- Bump api-js
- Remove references to containerRelativeURL
