### PR TITLE
GitHub Issue 790: Sample check-in and discard should not allow amount/unit input for differing units

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-checkInUnits790.1",
+  "version": "7.21.1-fb-checkInUnits790.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.1-fb-checkInUnits790.1",
+      "version": "7.21.1-fb-checkInUnits790.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-checkInUnits790.0",
+  "version": "7.21.1-fb-checkInUnits790.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.1-fb-checkInUnits790.0",
+      "version": "7.21.1-fb-checkInUnits790.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1",
+  "version": "7.21.1-fb-checkInUnits790.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.1",
+      "version": "7.21.1-fb-checkInUnits790.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.0",
+  "version": "7.21.0-fb-checkInUnits790.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.0",
+      "version": "7.21.0-fb-checkInUnits790.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.2",
+  "version": "7.21.2-fb-checkInUnits790.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.2",
+      "version": "7.21.2-fb-checkInUnits790.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.2-fb-checkInUnits790.0",
+  "version": "7.21.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.2-fb-checkInUnits790.0",
+      "version": "7.21.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.2",
+  "version": "7.21.2-fb-checkInUnits790.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1",
+  "version": "7.21.1-fb-checkInUnits790.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-checkInUnits790.1",
+  "version": "7.21.1-fb-checkInUnits790.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.2-fb-checkInUnits790.0",
+  "version": "7.21.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.0",
+  "version": "7.21.0-fb-checkInUnits790.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-checkInUnits790.0",
+  "version": "7.21.1-fb-checkInUnits790.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.21.TBD
+*Released*: TBD
+- GitHub Issue #790: Update areUnitsCompatible to account for different "Count" unit labels
+
 ### version 7.21.0
 *Released*: 26 February 2026
 - Package updates

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 7.21.TBD
-*Released*: TBD
+### version 7.21.3
+*Released*: 12 March 2026
 - GitHub Issue #790: Sample check-in and discard should not allow amount/unit input for differing units
   - Update areUnitsCompatible to account for different "Count" unit labels
   - getMetricUnitOptions() to allow optional filterFn parameter for the "Count" unit case

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version 7.21.TBD
 *Released*: TBD
-- GitHub Issue #790: Update areUnitsCompatible to account for different "Count" unit labels
+- GitHub Issue #790: Sample check-in and discard should not allow amount/unit input for differing units
+  - Update areUnitsCompatible to account for different "Count" unit labels
+  - getMetricUnitOptions() to allow optional filterFn parameter for the "Count" unit case
 
 ### version 7.21.1
 *Released*: 4 March 2026

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -863,6 +863,7 @@ import {
     getMetricUnitOptions,
     MEASUREMENT_UNITS,
     UnitModel,
+    UNITS_KIND,
 } from './internal/util/measurement';
 import { DELIMITER, DETAIL_TABLE_CLASSES } from './internal/components/forms/constants';
 import {
@@ -1531,6 +1532,7 @@ export {
     MAX_EDITABLE_GRID_ROWS,
     MAX_SELECTION_ACTION_ROWS,
     MEASUREMENT_UNITS,
+    UNITS_KIND,
     MemberType,
     MenuDivider,
     MenuHeader,

--- a/packages/components/src/internal/components/samples/StorageAmountInput.tsx
+++ b/packages/components/src/internal/components/samples/StorageAmountInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useMemo, useState } from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 
 import { Alert } from '../base/Alert';
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
@@ -8,7 +8,6 @@ import {
     getMetricUnitOptions,
     isMeasurementUnitIgnoreCase,
     UnitModel,
-    UNITS_KIND,
 } from '../../util/measurement';
 import { getInvalidSampleAmountMessage } from '../../util/utils';
 
@@ -17,6 +16,7 @@ interface Props {
     className?: string;
     inputName?: string;
     label: string;
+    metricUnitsFilterFn?: (option: { label: string; value: string }) => boolean;
     model: UnitModel;
     preferredUnit: string;
     tipText?: string;
@@ -24,10 +24,18 @@ interface Props {
 }
 
 export const StorageAmountInput: FC<Props> = memo(props => {
-    const { className, model, preferredUnit, inputName, label, tipText, amountChangedHandler, unitsChangedHandler } =
-        props;
+    const {
+        className,
+        model,
+        preferredUnit,
+        inputName,
+        label,
+        tipText,
+        amountChangedHandler,
+        unitsChangedHandler,
+        metricUnitsFilterFn,
+    } = props;
     const [amountInput, setAmountInput] = useState<string>(model?.value?.toString() || '');
-    const _preferredUnit = useMemo(() => new UnitModel(undefined, preferredUnit), [preferredUnit]);
 
     const unitText = model?.unit?.label || model.unitStr;
     let preferredUnitMessage;
@@ -51,13 +59,7 @@ export const StorageAmountInput: FC<Props> = memo(props => {
     } else {
         // IFF preferred units nor provided or are a supported type, then show possible conversions
 
-        // GitHub Issue #790: for Count units, only show the preferred unit as an option in the UI
-        const optionFilter =
-            _preferredUnit.unit?.kind === UNITS_KIND.COUNT
-                ? (option: { label: string; value: string }) => option.value === preferredUnit
-                : undefined;
-        const options = getMetricUnitOptions(preferredUnit, false, optionFilter);
-
+        const options = getMetricUnitOptions(preferredUnit, false, metricUnitsFilterFn);
         unitDisplay = (
             <SelectInput
                 containerClass="checkin-unit-select-container"

--- a/packages/components/src/internal/components/samples/StorageAmountInput.tsx
+++ b/packages/components/src/internal/components/samples/StorageAmountInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useState } from 'react';
+import React, { FC, memo, useCallback, useMemo, useState } from 'react';
 
 import { Alert } from '../base/Alert';
 import { SelectInput, SelectInputOption } from '../forms/input/SelectInput';
@@ -8,6 +8,7 @@ import {
     getMetricUnitOptions,
     isMeasurementUnitIgnoreCase,
     UnitModel,
+    UNITS_KIND,
 } from '../../util/measurement';
 import { getInvalidSampleAmountMessage } from '../../util/utils';
 
@@ -25,8 +26,8 @@ interface Props {
 export const StorageAmountInput: FC<Props> = memo(props => {
     const { className, model, preferredUnit, inputName, label, tipText, amountChangedHandler, unitsChangedHandler } =
         props;
-
     const [amountInput, setAmountInput] = useState<string>(model?.value?.toString() || '');
+    const _preferredUnit = useMemo(() => new UnitModel(undefined, preferredUnit), [preferredUnit]);
 
     const unitText = model?.unit?.label || model.unitStr;
     let preferredUnitMessage;
@@ -49,6 +50,14 @@ export const StorageAmountInput: FC<Props> = memo(props => {
         );
     } else {
         // IFF preferred units nor provided or are a supported type, then show possible conversions
+
+        // GitHub Issue #790: for Count units, only show the preferred unit as an option in the UI
+        const optionFilter =
+            _preferredUnit.unit?.kind === UNITS_KIND.COUNT
+                ? (option: { label: string; value: string }) => option.value === preferredUnit
+                : undefined;
+        const options = getMetricUnitOptions(preferredUnit, false, optionFilter);
+
         unitDisplay = (
             <SelectInput
                 containerClass="checkin-unit-select-container"
@@ -57,7 +66,7 @@ export const StorageAmountInput: FC<Props> = memo(props => {
                 onChange={(name, formValue, option: SelectInputOption) => {
                     unitsChangedHandler(formValue === undefined && option ? option.id : formValue);
                 }}
-                options={getMetricUnitOptions(preferredUnit)}
+                options={options}
                 value={model.unit?.label}
             />
         );

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -139,6 +139,49 @@ describe('MetricUnit utils', () => {
         expect(getMetricUnitOptions('bad').length).toBe(18);
     });
 
+    test('getMetricUnitOptions with filterFn', () => {
+        let options = getMetricUnitOptions('kg', false);
+        expect(options).toEqual([
+            { label: 'g', value: 'g' },
+            { label: 'mg', value: 'mg' },
+            { label: 'kg', value: 'kg' },
+            { label: 'ug', value: 'ug' },
+            { label: 'ng', value: 'ng' },
+        ]);
+
+        let filterFn = option => option.value !== 'mg';
+        options = getMetricUnitOptions('kg', false, filterFn);
+        expect(options).toEqual([
+            { label: 'g', value: 'g' },
+            { label: 'kg', value: 'kg' },
+            { label: 'ug', value: 'ug' },
+            { label: 'ng', value: 'ng' },
+        ]);
+
+        filterFn = option => option.value === 'mg';
+        options = getMetricUnitOptions('kg', false, filterFn);
+        expect(options).toEqual([{ label: 'mg', value: 'mg' }]);
+
+        filterFn = option => option.value === 'mg';
+        options = getMetricUnitOptions('mg', false, filterFn);
+        expect(options).toEqual([{ label: 'mg', value: 'mg' }]);
+
+        // incompatible units
+        filterFn = option => option.value === 'mg';
+        options = getMetricUnitOptions('mL', false, filterFn);
+        expect(options).toEqual([]);
+
+        // no unit
+        filterFn = option => option.value === 'mg';
+        options = getMetricUnitOptions(undefined, false, filterFn);
+        expect(options).toEqual([{ label: 'mg', value: 'mg' }]);
+
+        // bogus unit will be treated as no unit
+        filterFn = option => option.value === 'mg';
+        options = getMetricUnitOptions('bogus', false, filterFn);
+        expect(options).toEqual([{ label: 'mg', value: 'mg' }]);
+    });
+
     test('getAltUnitKeys', () => {
         const expectedUlOptions = ['mL', 'uL', 'L'];
         expect(getAltUnitKeys('uL')).toEqual(expectedUlOptions);

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -234,4 +234,13 @@ describe('areUnitsCompatible', () => {
         expect(areUnitsCompatible('mL', 'bogus')).toBeFalsy();
         expect(areUnitsCompatible('kg', 'bogus')).toBeFalsy();
     });
+
+    test('comparison of Count units with different labels but same kind', () => {
+        expect(areUnitsCompatible('count', 'count')).toBeTruthy();
+        expect(areUnitsCompatible('blocks', 'blocks')).toBeTruthy();
+        expect(areUnitsCompatible('boxes', 'cells')).toBeFalsy();
+        expect(areUnitsCompatible('kits', 'packs')).toBeFalsy();
+        expect(areUnitsCompatible('pieces', 'unit')).toBeFalsy();
+        expect(areUnitsCompatible('unit', 'unit')).toBeTruthy();
+    });
 });

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -281,9 +281,16 @@ describe('areUnitsCompatible', () => {
     test('comparison of Count units with different labels but same kind', () => {
         expect(areUnitsCompatible('count', 'count')).toBeTruthy();
         expect(areUnitsCompatible('blocks', 'blocks')).toBeTruthy();
-        expect(areUnitsCompatible('boxes', 'cells')).toBeFalsy();
-        expect(areUnitsCompatible('kits', 'packs')).toBeFalsy();
-        expect(areUnitsCompatible('pieces', 'unit')).toBeFalsy();
+        expect(areUnitsCompatible('boxes', 'cells')).toBeTruthy();
+        expect(areUnitsCompatible('kits', 'packs')).toBeTruthy();
+        expect(areUnitsCompatible('pieces', 'unit')).toBeTruthy();
         expect(areUnitsCompatible('unit', 'unit')).toBeTruthy();
+
+        expect(areUnitsCompatible('count', 'count', true)).toBeTruthy();
+        expect(areUnitsCompatible('blocks', 'blocks', true)).toBeTruthy();
+        expect(areUnitsCompatible('boxes', 'cells', true)).toBeFalsy();
+        expect(areUnitsCompatible('kits', 'packs', true)).toBeFalsy();
+        expect(areUnitsCompatible('pieces', 'unit', true)).toBeFalsy();
+        expect(areUnitsCompatible('unit', 'unit', true)).toBeTruthy();
     });
 });

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -204,7 +204,7 @@ export function getMeasurementUnit(unitStr: string): MeasurementUnit | null {
     return null;
 }
 
-export function areUnitsCompatible(unitAStr: string, unitBStr: string): boolean {
+export function areUnitsCompatible(unitAStr: string, unitBStr: string, compareCountUnitLabels = false): boolean {
     if (unitAStr == unitBStr) {
         return true;
     }
@@ -225,9 +225,10 @@ export function areUnitsCompatible(unitAStr: string, unitBStr: string): boolean 
 
     // GitHub Issue #790: for "Count" kind, the specific label must also match
     const matchingKinds = unitA.kind === unitB.kind;
-    if (matchingKinds && unitA.kind === UNITS_KIND.COUNT) {
+    if (compareCountUnitLabels && matchingKinds && unitA.kind === UNITS_KIND.COUNT) {
         return unitA.label === unitB.label;
     }
+
     return matchingKinds;
 }
 

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -222,7 +222,13 @@ export function areUnitsCompatible(unitAStr: string, unitBStr: string): boolean 
     if (!unitA || !unitB) {
         return false;
     }
-    return unitA.kind === unitB.kind;
+
+    // GitHub Issue #790: for "Count" kind, the specific label must also match
+    const matchingKinds = unitA.kind === unitB.kind;
+    if (matchingKinds && unitA.kind === UNITS_KIND.COUNT) {
+        return unitA.label === unitB.label;
+    }
+    return matchingKinds;
 }
 
 export function getMetricUnitOptions(metricUnit?: string, showLongLabel?: boolean): { label: string; value: string }[] {

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -231,7 +231,11 @@ export function areUnitsCompatible(unitAStr: string, unitBStr: string): boolean 
     return matchingKinds;
 }
 
-export function getMetricUnitOptions(metricUnit?: string, showLongLabel?: boolean): { label: string; value: string }[] {
+export function getMetricUnitOptions(
+    metricUnit?: string,
+    showLongLabel?: boolean,
+    filterFn?: (option: { label: string; value: string }) => boolean
+): { label: string; value: string }[] {
     const unit = getMeasurementUnit(metricUnit);
 
     const options = [];
@@ -254,6 +258,12 @@ export function getMetricUnitOptions(metricUnit?: string, showLongLabel?: boolea
             }
         }
     }
+
+    // apply additional filter if provided
+    if (filterFn) {
+        return options.filter(filterFn);
+    }
+
     return options;
 }
 


### PR DESCRIPTION
#### Rationale
GitHub Issue [790](https://github.com/LabKey/internal-issues/issues/790): Checking samples in from the same sample type but with differing units sometimes doesn't display proper warning

When a sample type allows for "any" units, the options for the "Count" unit kind include multiple labels. The check in and discard modals are currently checking for matching unit kinds when seeing if it should show the input to set the amount/unit or decrement the amount unit for the selected samples. In the case of the "Count" unit kind, we also want to make sure that the samples have matching unit labels (i.e. it doesn't make sense for a sample with N cells and another samples with N bottles to show an input to decrement them by N "something").

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1947
- https://github.com/LabKey/labkey-ui-premium/pull/903
- https://github.com/LabKey/limsModules/pull/2024

#### Changes
- update areUnitsCompatible to account for different "Count" unit labels
