### PR TITLE
GitHub Issue 897: Study dataset should not allow multivalue text choice as a third key

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.0",
+  "version": "7.22.0-fb-mvtcMVFK.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.0",
+      "version": "7.22.0-fb-mvtcMVFK.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.22.0",
+  "version": "7.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.22.0",
+      "version": "7.22.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.0",
+  "version": "7.22.0-fb-mvtcMVFK.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.22.1-fb-mvtcMVFK.1",
+  "version": "7.22.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.X
+*Released*: X March 2026
+- GitHub Issue 897: Study dataset should not allow multivalue text choice as a third key
+
 ### version 7.21.0
 *Released*: 26 February 2026
 - Package updates

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 7.X
-*Released*: X March 2026
+### version 7.22.1
+*Released*: 6 March 2026
 - GitHub Issue 897: Study dataset should not allow multivalue text choice as a third key
 
 ### version 7.22.0

--- a/packages/components/src/internal/components/domainproperties/dataset/actions.test.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/actions.test.ts
@@ -1,0 +1,90 @@
+import { DomainDesign } from '../models';
+import { CALCULATED_CONCEPT_URI, MULTI_CHOICE_RANGE_URI } from '../constants';
+
+import { TIME_KEY_FIELD_DISPLAY, TIME_KEY_FIELD_KEY, VISIT_TIMEPOINT_TYPE } from './constants';
+import { getAdditionalKeyFields } from './actions';
+
+describe('getAdditionalKeyFields', () => {
+    test('includes time key field for date-based study', () => {
+        const domain = DomainDesign.create({});
+        const result = getAdditionalKeyFields(domain, 'DATE');
+
+        expect(result.size).toBe(1);
+        expect(result.get(0)).toEqual({ value: TIME_KEY_FIELD_KEY, label: TIME_KEY_FIELD_DISPLAY });
+    });
+
+    test('excludes time key field for visit-based study', () => {
+        const domain = DomainDesign.create({});
+        const result = getAdditionalKeyFields(domain, VISIT_TIMEPOINT_TYPE);
+
+        expect(result.size).toBe(0);
+    });
+
+    test('includes regular fields', () => {
+        const domain = DomainDesign.create({
+            fields: [
+                { name: 'Field1', rangeURI: 'int' },
+                { name: 'Field2', rangeURI: 'string' },
+            ],
+        });
+        const result = getAdditionalKeyFields(domain, VISIT_TIMEPOINT_TYPE);
+
+        expect(result.size).toBe(2);
+        expect(result.get(0)).toEqual({ value: 'Field1', label: 'Field1' });
+        expect(result.get(1)).toEqual({ value: 'Field2', label: 'Field2' });
+    });
+
+    test('excludes calculated fields', () => {
+        const domain = DomainDesign.create({
+            fields: [
+                { name: 'Regular', rangeURI: 'int' },
+                { name: 'Calculated', rangeURI: 'int', conceptURI: CALCULATED_CONCEPT_URI },
+            ],
+        });
+        const result = getAdditionalKeyFields(domain, VISIT_TIMEPOINT_TYPE);
+
+        expect(result.size).toBe(1);
+        expect(result.get(0)).toEqual({ value: 'Regular', label: 'Regular' });
+    });
+
+    test('excludes multi-choice fields', () => {
+        const domain = DomainDesign.create({
+            fields: [
+                { name: 'Regular', rangeURI: 'int' },
+                { name: 'MultiChoice', rangeURI: MULTI_CHOICE_RANGE_URI },
+            ],
+        });
+        const result = getAdditionalKeyFields(domain, VISIT_TIMEPOINT_TYPE);
+
+        expect(result.size).toBe(1);
+        expect(result.get(0)).toEqual({ value: 'Regular', label: 'Regular' });
+    });
+
+    test('includes time key field before domain fields for non-visit study', () => {
+        const domain = DomainDesign.create({
+            fields: [{ name: 'Field1', rangeURI: 'int' }],
+        });
+        const result = getAdditionalKeyFields(domain, 'Timepoints');
+
+        expect(result.size).toBe(2);
+        expect(result.get(0)).toEqual({ value: TIME_KEY_FIELD_KEY, label: TIME_KEY_FIELD_DISPLAY });
+        expect(result.get(1)).toEqual({ value: 'Field1', label: 'Field1' });
+    });
+
+    test('filters out both calculated and multi-choice fields while keeping regular fields', () => {
+        const domain = DomainDesign.create({
+            fields: [
+                { name: 'Regular1', rangeURI: 'int' },
+                { name: 'Calculated', rangeURI: 'int', conceptURI: CALCULATED_CONCEPT_URI },
+                { name: 'Regular2', rangeURI: 'string' },
+                { name: 'MultiChoice', rangeURI: MULTI_CHOICE_RANGE_URI },
+            ],
+        });
+        const result = getAdditionalKeyFields(domain, 'Timepoints');
+
+        expect(result.size).toBe(3);
+        expect(result.get(0)).toEqual({ value: TIME_KEY_FIELD_KEY, label: TIME_KEY_FIELD_DISPLAY });
+        expect(result.get(1)).toEqual({ value: 'Regular1', label: 'Regular1' });
+        expect(result.get(2)).toEqual({ value: 'Regular2', label: 'Regular2' });
+    });
+});

--- a/packages/components/src/internal/components/domainproperties/dataset/actions.ts
+++ b/packages/components/src/internal/components/domainproperties/dataset/actions.ts
@@ -79,7 +79,7 @@ export function getAdditionalKeyFields(domain: DomainDesign, timepointType: stri
     }
 
     domain.fields
-        .filter(field => !field.isCalculatedField())
+        .filter(field => !field.isCalculatedField() && !field.isMultiChoiceField())
         .map(field => {
             additionalKeyFields = additionalKeyFields.push({ value: field.name, label: field.name });
         });


### PR DESCRIPTION
#### Rationale
GitHub Issue [897](https://github.com/LabKey/internal-issues/issues/897)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1948
- https://github.com/LabKey/platform/pull/7474

#### Changes
- remove mvtc fields from allowed 3rd key for study dataset