### PR TITLE
GitHub Issue 710: Include columns set as Identifying Fields within the 'Search for Samples' grid when adding samples to a storage location

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1",
+  "version": "7.21.1-fb-addStorageSearchSamples710.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.1",
+      "version": "7.21.1-fb-addStorageSearchSamples710.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-addStorageSearchSamples710.1",
+  "version": "7.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.1-fb-addStorageSearchSamples710.1",
+      "version": "7.21.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-addStorageSearchSamples710.0",
+  "version": "7.21.1-fb-addStorageSearchSamples710.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.1-fb-addStorageSearchSamples710.0",
+      "version": "7.21.1-fb-addStorageSearchSamples710.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-addStorageSearchSamples710.0",
+  "version": "7.21.1-fb-addStorageSearchSamples710.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1",
+  "version": "7.21.1-fb-addStorageSearchSamples710.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.1-fb-addStorageSearchSamples710.1",
+  "version": "7.21.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 7.21.TBD
-*Released*: TBD March 2026
+### version 7.21.2
+*Released*: 11 March 2026
 - GitHub Issue 710: Include columns set as Identifying Fields within the 'Search for Samples' grid when adding samples to a storage location
   - update saveGridView() to take hidden prop (default false)
   - saveSettingsToLocalStorage() fix for checking model.useSavedSettings === SavedSettings.none

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,12 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.21.TBD
+*Released*: TBD March 2026
+- GitHub Issue 710: Include columns set as Identifying Fields within the 'Search for Samples' grid when adding samples to a storage location
+  - update saveGridView() to take hidden prop (default false)
+  - saveSettingsToLocalStorage() fix for checking model.useSavedSettings === SavedSettings.none
+
 ### version 7.21.1
 *Released*: 4 March 2026
 - GitHub Issue 829: Sample type with lookup to list with text primary key where the value contains a comma doesn't map to lookup

--- a/packages/components/src/internal/ViewInfo.ts
+++ b/packages/components/src/internal/ViewInfo.ts
@@ -97,6 +97,7 @@ export class ViewInfo {
     static UPDATE_NAME = '~~UPDATE~~';
     static SAMPLE_FINDER_VIEW_NAME = '~~samplefinder~~';
     static IDENTIFYING_FIELDS_VIEW_NAME = '~~identifyingfields~~';
+    static UNASSIGNED_SAMPLES_VIEW_NAME = '~~unassignedsamples~~';
     // TODO seems like this should not be in the generic model, but we'll need a good way
     //  to define the override detail name.
     static BIO_DETAIL_NAME = 'BiologicsDetails';

--- a/packages/components/src/internal/actions.ts
+++ b/packages/components/src/internal/actions.ts
@@ -613,14 +613,15 @@ export function saveGridView(
     replace: boolean,
     session: boolean,
     inherit: boolean,
-    shared: boolean
+    shared: boolean,
+    hidden = false
 ): Promise<void> {
     return new Promise((resolve, reject) => {
         Query.saveQueryViews({
             schemaName: schemaQuery.schemaName,
             queryName: schemaQuery.queryName,
             containerPath,
-            views: [{ ...ViewInfo.serialize(viewInfo), replace, session, inherit, shared, hidden: false }],
+            views: [{ ...ViewInfo.serialize(viewInfo), replace, session, inherit, shared, hidden }],
             success: () => {
                 invalidateQueryDetailsCache(schemaQuery, containerPath);
                 resolve();

--- a/packages/components/src/internal/query/APIWrapper.ts
+++ b/packages/components/src/internal/query/APIWrapper.ts
@@ -125,7 +125,8 @@ export interface QueryAPIWrapper {
         replace: boolean,
         session: boolean,
         inherit: boolean,
-        shared: boolean
+        shared: boolean,
+        hidden?: boolean
     ) => Promise<void>;
     saveRows: (options: SaveRowsOptions) => Promise<Query.SaveRowsResponse>;
     saveRowsByContainer: (options: SaveRowsOptions, containerField?: string) => Promise<Query.SaveRowsResponse>;

--- a/packages/components/src/public/QueryModel/QueryModel.ts
+++ b/packages/components/src/public/QueryModel/QueryModel.ts
@@ -1288,7 +1288,7 @@ const UNIQUE_ERROR =
 
 export function saveSettingsToLocalStorage(model: QueryModel): void {
     // Don't serialize anything to localStorage if we're not supposed to use saved settings
-    if (!model.useSavedSettings) {
+    if (!model.useSavedSettings || model.useSavedSettings === SavedSettings.none) {
         return;
     }
 


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/710

On the add samples to storage modal, there is an option for Search for Samples where the user selects a sample type and sees a grid of samples to be selected and added to the box. This grid was just showing some base sample fields (amount, units, created, folder). This PR updates that grid so that it also includes the sample type specific identifying fields.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1949
- https://github.com/LabKey/labkey-ui-premium/pull/904
- https://github.com/LabKey/limsModules/pull/2030

#### Changes
- update saveGridView() to take hidden prop (default false)
- saveSettingsToLocalStorage() fix for checking model.useSavedSettings === SavedSettings.none
