### PR TITLE
Registry: auditing of provisional entities

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.23.3",
+  "version": "7.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.23.3",
+      "version": "7.23.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.23.3",
+  "version": "7.23.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.23.4
+*Released*: 22 March 2026
+- Set query and registry audit events to `hasTransactionId=true`
+
 ### version 7.23.3
 *Released*: 19 March 2026
 - GitHub Issue 942: Add error for duplicate values for MVTC fields

--- a/packages/components/src/internal/components/auditlog/constants.ts
+++ b/packages/components/src/internal/components/auditlog/constants.ts
@@ -20,6 +20,7 @@ export const DOMAIN_PROPERTY_AUDIT_QUERY: AuditQuery = {
 };
 export const QUERY_UPDATE_AUDIT_QUERY: AuditQuery = {
     hasDetail: true,
+    hasTransactionId: true,
     label: 'Query Update Events',
     value: 'QueryUpdateAuditEvent',
 };
@@ -97,7 +98,11 @@ export const SOURCE_AUDIT_QUERY: AuditQuery = {
 
 export const NOTEBOOK_AUDIT_QUERY: AuditQuery = { label: 'Notebook Events', value: 'LabBookEvent' };
 export const NOTEBOOK_REVIEW_AUDIT_QUERY: AuditQuery = { label: 'Notebook Review Events', value: 'NotebookEvent' };
-export const REGISTRY_AUDIT_QUERY: AuditQuery = { label: 'Registry Events', value: 'RegistryEvent' };
+export const REGISTRY_AUDIT_QUERY: AuditQuery = {
+    hasTransactionId: true,
+    label: 'Registry Events',
+    value: 'RegistryEvent',
+};
 export const REPORT_AUDIT_QUERY: AuditQuery = { label: 'Report Events', value: 'ReportEvent' };
 
 export const FILE_SYSTEM_AUDIT_QUERY: AuditQuery = {


### PR DESCRIPTION
#### Rationale
This introduces audit events for provisional entities (currently NS and PS).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1954
- https://github.com/LabKey/labkey-ui-premium/pull/907
- https://github.com/LabKey/limsModules/pull/2038
- https://github.com/LabKey/testAutomation/pull/2917

#### Changes
- Set query and registry audit events to `hasTransactionId: true`. This allows for them to appear on the transaction detail page as a tab.
