### PR TITLE
Improve readability of identifying fields

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.26.4",
+  "version": "7.26.5-fb-select-field-css.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.26.4",
+      "version": "7.26.5-fb-select-field-css.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.26.5-fb-select-field-css.0",
+  "version": "7.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.26.5-fb-select-field-css.0",
+      "version": "7.27.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.26.4",
+  "version": "7.26.5-fb-select-field-css.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.26.5-fb-select-field-css.0",
+  "version": "7.27.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.27.0
+*Released*: 1 April 2026
+- GitHub Issue 985: Update styling of `SelectInput` for identifying fields
+
 ### version 7.26.4
 *Released*: 31 March 2026
 - Update `@labkey/api` dependency

--- a/packages/components/src/theme/fields.scss
+++ b/packages/components/src/theme/fields.scss
@@ -170,6 +170,11 @@
     color: #777777
 }
 
+// GitHub Issue 985: Improve readability of identifying fields
+.select-input__option--is-selected .identifying_field_label {
+    color: #FFFFFF;
+}
+
 .folder-field_archived-tag {
     display: inline;
 


### PR DESCRIPTION
#### Rationale
This addresses [#985](https://github.com/LabKey/internal-issues/issues/985) by adjusting the styling for selected identifying fields in the react select dropdown.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1966
- https://github.com/LabKey/limsModules/pull/2071

#### Changes
- Override text color to white when identifying field is selected
