### PR TITLE
Update @labkey/api

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.26.3",
+  "version": "7.26.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.26.3",
+      "version": "7.26.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.0",
+        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",
@@ -3746,9 +3746,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.0.tgz",
-      "integrity": "sha512-1fiVQOP5UXvj1JW0LyJDtu3N8bgP95D9f7E+23w7BapabIT2xCvBj4YGRQZCvgSbW6pa+fH2Ayw542OFDWwfvA==",
+      "version": "1.50.1-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
+        "@labkey/api": "1.51.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",
@@ -3746,9 +3746,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.1-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
+      "version": "1.51.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.0.tgz",
+      "integrity": "sha512-pyYXCNbFF3HZQ8KVapcwBl/7cHlVDz0ysPlCRBUQ9czX6s2yLwiho0OWkBd9MpbGVkqGFihbTUsUAU+Y5rz5Pw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.50.1-fb-package-updates-0326.0",
+    "@labkey/api": "1.51.0",
     "@testing-library/dom": "~10.4.1",
     "@testing-library/jest-dom": "~6.9.1",
     "@testing-library/react": "~16.3.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.50.0",
+    "@labkey/api": "1.50.1-fb-package-updates-0326.0",
     "@testing-library/dom": "~10.4.1",
     "@testing-library/jest-dom": "~6.9.1",
     "@testing-library/react": "~16.3.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.26.3",
+  "version": "7.26.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.26.4
+*Released*: 31 March 2026
+- Update `@labkey/api` dependency
+
 ### version 7.26.3
 *Released*: 31 March 2026
 - GitHub Issue 811: App permissions page shows deactivated users in group members list


### PR DESCRIPTION
#### Rationale
Bump `@labkey/api` dependency to the latest version.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/212
- https://github.com/LabKey/labkey-ui-components/pull/1968
- https://github.com/LabKey/labkey-ui-premium/pull/921
- https://github.com/LabKey/limsModules/pull/2077
- https://github.com/LabKey/platform/pull/7533

#### Changes
- Bump `@labkey/api`
