### PR TITLE
GitHub Issue 974: Lookup data type incorrectly shown in app assay designer

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.3-fb-assayLookupType974.1",
+  "version": "7.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.3-fb-assayLookupType974.1",
+      "version": "7.21.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.3-fb-assayLookupType974.0",
+  "version": "7.21.3-fb-assayLookupType974.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.3-fb-assayLookupType974.0",
+      "version": "7.21.3-fb-assayLookupType974.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.3",
+  "version": "7.21.3-fb-assayLookupType974.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.3",
+      "version": "7.21.3-fb-assayLookupType974.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.3",
+  "version": "7.21.3-fb-assayLookupType974.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.3-fb-assayLookupType974.1",
+  "version": "7.21.4",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.3-fb-assayLookupType974.0",
+  "version": "7.21.3-fb-assayLookupType974.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue #974: ...
+
 ### version 7.21.3
 *Released*: 12 March 2026
 - GitHub Issue #790: Sample check-in and discard should not allow amount/unit input for differing units

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,9 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-- GitHub Issue #974: ...
+- GitHub Issue #974: Lookup Data Type shown in Assay Designer for app, even when premium module is not present
+  - AssayDesignerPanels to pass appPropertiesOnly to AssayDomainForm
+  - add new domainFormDisplayOptions.showAdvancedSettingsForApp for assay designer case
 
 ### version 7.21.3
 *Released*: 12 March 2026

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.21.4
+*Released*: 6 April 2026
 - GitHub Issue #974: Lookup Data Type shown in Assay Designer for app, even when premium module is not present
   - AssayDesignerPanels to pass appPropertiesOnly to AssayDomainForm
   - add new domainFormDisplayOptions.showAdvancedSettingsForApp for assay designer case

--- a/packages/components/src/internal/components/domainproperties/DomainRow.tsx
+++ b/packages/components/src/internal/components/domainproperties/DomainRow.tsx
@@ -395,7 +395,10 @@ export class DomainRow extends React.PureComponent<DomainRowProps, DomainRowStat
         const draggableId = createFormInputId('domaindrag', domainIndex, index);
         // Use undefined instead of false to allow for css to handle the highlight color for hover
         const highlighted = dragging ? true : isDragDisabled ? false : undefined;
-        const showAdvancedSettingsButton = expanded && !isFieldFullyLocked(field.lockType) && !appPropertiesOnly;
+        const showAdvancedSettingsButton =
+            expanded &&
+            !isFieldFullyLocked(field.lockType) &&
+            (!appPropertiesOnly || domainFormDisplayOptions?.showAdvancedSettingsForApp); // GitHub Issue #974
 
         return (
             <Draggable

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -39,8 +39,10 @@ import { FilterCriteriaContext } from './FilterCriteriaContext';
 const PROPERTIES_PANEL_INDEX = 0;
 const DOMAIN_PANEL_INDEX = 1;
 
-interface AssayDomainFormProps
-    extends Omit<InjectedBaseDomainDesignerProps, 'onFinish' | 'setSubmitting' | 'submitting'> {
+interface AssayDomainFormProps extends Omit<
+    InjectedBaseDomainDesignerProps,
+    'onFinish' | 'setSubmitting' | 'submitting'
+> {
     api: DomainPropertiesAPIWrapper;
     appDomainHeaders: Map<string, HeaderRenderer>;
     appPropertiesOnly?: boolean;

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -108,6 +108,7 @@ const AssayDomainForm: FC<AssayDomainFormProps> = memo(props => {
         return {
             ...domainFormDisplayOptions,
             domainKindDisplayName: 'assay design',
+            showAdvancedSettingsForApp: true, // GitHub Issue #974: show Advanced Settings button for domain rows even when appPropertiesOnly=true
             hideFilePropertyType,
             hideInferFromFile,
             showFilterCriteria: isResultsDomain && protocolModel.plateMetadata,

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -43,10 +43,10 @@ interface AssayDomainFormProps
     extends Omit<InjectedBaseDomainDesignerProps, 'onFinish' | 'setSubmitting' | 'submitting'> {
     api: DomainPropertiesAPIWrapper;
     appDomainHeaders: Map<string, HeaderRenderer>;
+    appPropertiesOnly?: boolean;
     domain: DomainDesign;
     domainFormDisplayOptions: IDomainFormDisplayOptions;
     headerPrefix: string;
-    hideAdvancedProperties?: boolean;
     index: number;
     onDomainChange: (
         index: number,
@@ -67,7 +67,7 @@ const AssayDomainForm: FC<AssayDomainFormProps> = memo(props => {
         domainFormDisplayOptions,
         firstState,
         headerPrefix,
-        hideAdvancedProperties,
+        appPropertiesOnly,
         index,
         onDomainChange,
         onTogglePanel,
@@ -125,7 +125,7 @@ const AssayDomainForm: FC<AssayDomainFormProps> = memo(props => {
         <DomainForm
             api={api}
             appDomainHeaderRenderer={appDomainHeaderRenderer}
-            appPropertiesOnly={hideAdvancedProperties}
+            appPropertiesOnly={appPropertiesOnly}
             controlledCollapse
             domain={domain}
             domainFormDisplayOptions={displayOptions}
@@ -450,6 +450,7 @@ export class AssayDesignerPanelsImpl extends React.PureComponent<Props, State> {
                             <AssayDomainForm
                                 api={api}
                                 appDomainHeaders={appDomainHeaders}
+                                appPropertiesOnly={appPropertiesOnly}
                                 currentPanelIndex={currentPanelIndex}
                                 domain={domain}
                                 domainFormDisplayOptions={domainFormDisplayOptions}

--- a/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
+++ b/packages/components/src/internal/components/domainproperties/assay/AssayDesignerPanels.tsx
@@ -108,7 +108,6 @@ const AssayDomainForm: FC<AssayDomainFormProps> = memo(props => {
         return {
             ...domainFormDisplayOptions,
             domainKindDisplayName: 'assay design',
-            showAdvancedSettingsForApp: true, // GitHub Issue #974: show Advanced Settings button for domain rows even when appPropertiesOnly=true
             hideFilePropertyType,
             hideInferFromFile,
             showFilterCriteria: isResultsDomain && protocolModel.plateMetadata,

--- a/packages/components/src/internal/components/domainproperties/models.tsx
+++ b/packages/components/src/internal/components/domainproperties/models.tsx
@@ -2248,6 +2248,7 @@ export interface IDomainFormDisplayOptions {
     isDragDisabled?: boolean;
     phiLevelDisabled?: boolean;
     retainReservedFields?: boolean;
+    showAdvancedSettingsForApp?: boolean;
     showFilterCriteria?: boolean;
     showScannableOption?: boolean;
     textChoiceLockedForDomain?: boolean;

--- a/packages/components/src/internal/components/forms/model.ts
+++ b/packages/components/src/internal/components/forms/model.ts
@@ -129,8 +129,10 @@ export function formatSavedResults(
 
     const { key, orderedModels } = result;
     const models = fromJS(result.models[key]);
-    const orderedResults = orderedModels[key]
-        .reduce((ordered, k) => ordered.set(k, models.get(k)), OrderedMap<string, any>());
+    const orderedResults = orderedModels[key].reduce(
+        (ordered, k) => ordered.set(k, models.get(k)),
+        OrderedMap<string, any>()
+    );
 
     return formatResults(model, orderedResults, token);
 }


### PR DESCRIPTION
#### Rationale
[#974](https://github.com/LabKey/internal-issues/issues/974): LKSM: Lookup Data Type shown in Assay Designer

This PR fixes GitHub Issue #974, where the Lookup data type was incorrectly shown in the app assay designer even when the premium module was not present. The root cause was that AssayDesignerPanelsImpl was never actually
   forwarding its appPropertiesOnly prop down to AssayDomainForm, so DomainForm always received undefined (falsy) for that prop — making it behave as if the app-property filter was off. The fix corrects the prop
  forwarding, renames an intermediary prop for clarity, and adds a new showAdvancedSettingsForApp escape hatch that allows a downstream consumer (ui-premium) to re-enable the advanced settings button even in app mode.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1971
- https://github.com/LabKey/labkey-ui-premium/pull/927
- https://github.com/LabKey/platform/pull/7544
- https://github.com/LabKey/limsModules/pull/2088

#### Changes
- AssayDesignerPanels to pass appPropertiesOnly to AssayDomainForm
- add new domainFormDisplayOptions.showAdvancedSettingsForApp for assay designer case