### PR TITLE
Issue 613: Use "Status" instead of "SampleState" in error messaging

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.1-statusMessaging.0",
+  "version": "7.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.28.1-statusMessaging.0",
+      "version": "7.28.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.0",
+  "version": "7.28.1-statusMessaging.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.28.0",
+      "version": "7.28.1-statusMessaging.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.1-statusMessaging.0",
+  "version": "7.28.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.0",
+  "version": "7.28.1-statusMessaging.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.28.1
+*Released*: 3 April 2026
+- GitHub Issue 613: Use "Status" instead of "SampleState" in error messaging.
+
 ### version 7.28.0
 *Released*: 2 April 2026
 - GitHub Issue 916: Editable grid copy/paste issue with special characters

--- a/packages/components/src/internal/util/messaging.test.ts
+++ b/packages/components/src/internal/util/messaging.test.ts
@@ -331,6 +331,15 @@ describe('resolveErrorMessage', () => {
             'Unable to create a unique constraint for field cloningsite because duplicate values already exists in the data.'
         );
     });
+
+    test('invalid SampleState value', () => {
+        const error = {
+            exception: "Value 'Testing' not found for field SampleState in the current context."
+        }
+        expect(resolveErrorMessage(error)).toBe(
+            "Value 'Testing' not found for field Status in the current context."
+        );
+    })
 });
 
 describe('getPermissionRestrictionMessage', () => {

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -211,6 +211,8 @@ export function resolveErrorMessage(
             return noun + ' cannot be blank.';
         } else if (noun === 'job' && errorMsg.indexOf('when it contains rows with blank values') > -1) {
             return errorMsg.replace('it contains rows with blank values', 'there are already jobs using this template');
+        } else if (errorMsg.indexOf('found for field SampleState')) { // GH Issue 613
+            return errorMsg.replace('SampleState', 'Status');
         }
     }
     return errorMsg;


### PR DESCRIPTION
#### Rationale
[Issue 613](https://github.com/LabKey/internal-issues/issues/613) Users don't know anything about "SampleState" since we use "Status" as the label in the UI

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2089

#### Changes
- Update `resolveErrorMessage` to translate from "SampleState" to "Status"