### PR TITLE
Update FEEZER_ITEM_SAMPLE_MAPPER to return undefined if not matched

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.1",
+  "version": "7.28.2-workflowURLs.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.28.1",
+      "version": "7.28.2-workflowURLs.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.2-workflowURLs.0",
+  "version": "7.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.28.2-workflowURLs.0",
+      "version": "7.28.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.1",
+  "version": "7.28.2-workflowURLs.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.2-workflowURLs.0",
+  "version": "7.28.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.28.2
+*Released*: 7 April 2026
 - Update `FEEZER_ITEM_SAMPLE_MAPPER` to return undefined if not matched, for consistency with other mappers
 
 ### version 7.28.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Update `FEEZER_ITEM_SAMPLE_MAPPER` to return undefined if not matched, for consistency with other mappers
+
 ### version 7.28.1
 *Released*: 3 April 2026
 - GitHub Issue 613: Use "Status" instead of "SampleState" in error messaging.

--- a/packages/components/src/internal/url/URLResolver.ts
+++ b/packages/components/src/internal/url/URLResolver.ts
@@ -479,7 +479,7 @@ export const FREEZER_ITEM_SAMPLE_MAPPER = new ActionMapper('query', 'executeQuer
             }
         }
     }
-    return false;
+    return undefined;
 });
 
 // This mapper overrides the URL provided for the core.ProjectManagement query.


### PR DESCRIPTION
#### Rationale
For consistency with other URL mappers that map the `query.executeQuery` action, we'll return `undefined` instead of `false`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/926

#### Changes
- Update `FREEZER_ITEM_SAMPLE_MAPPER` return value in the absence of a url.
