### PR TITLE
Issue 868: Add more nouns for count units

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.1",
+  "version": "7.28.2-moreCountUnits.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.28.1",
+      "version": "7.28.2-moreCountUnits.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.2-moreCountUnits.1",
+  "version": "7.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.28.2-moreCountUnits.1",
+      "version": "7.29.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.2-moreCountUnits.0",
+  "version": "7.28.2-moreCountUnits.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.28.2-moreCountUnits.0",
+      "version": "7.28.2-moreCountUnits.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.0",
+  "version": "7.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.29.0",
+      "version": "7.29.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.0",
+  "version": "7.29.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.2-moreCountUnits.0",
+  "version": "7.28.2-moreCountUnits.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.1",
+  "version": "7.28.2-moreCountUnits.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.28.2-moreCountUnits.1",
+  "version": "7.29.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue 868: Add more nouns for count units
+
 ### version 7.28.1
 *Released*: 3 April 2026
 - GitHub Issue 613: Use "Status" instead of "SampleState" in error messaging.

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.29.0
+*Released*: 7 April 2026
 - GitHub Issue 868: Add more nouns for count units
 
 ### version 7.28.1

--- a/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
+++ b/packages/components/src/internal/components/domainproperties/samples/SampleTypePropertiesPanel.tsx
@@ -53,9 +53,11 @@ import {
     getMeasurementUnit,
     getMetricUnitOptions,
     getMetricUnitOptionsFromKind,
+    MEASUREMENT_UNITS,
     UNITS_KIND,
 } from '../../../util/measurement';
 import { Alert } from '../../base/Alert';
+import { makeCommaSeparatedString } from '../../../util/utils';
 
 const PROPERTIES_HEADER_ID = 'sample-type-properties-hdr';
 const ALIQUOT_HELP_LINK = getHelpLink('aliquotIDs');
@@ -94,7 +96,7 @@ export const UnitKinds: Record<UNITS_KIND, UnitKindType> = {
         value: UNITS_KIND.COUNT,
         label: 'Other',
         hideSubSelect: true,
-        msg: "Amounts can be entered as bottles, blocks, boxes, cells, kits, packs, pieces, slides, tests, or unit and won't be converted.",
+        msg: "Amounts can be entered as " +  makeCommaSeparatedString(MEASUREMENT_UNITS.unit.altLabels, ', or ') + " and won't be converted",
     },
 };
 

--- a/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
+++ b/packages/components/src/internal/components/forms/input/AmountUnitInput.tsx
@@ -11,6 +11,7 @@ import { FormsyInput } from './FormsyReactComponents';
 import { Operation } from '../../../../public/QueryColumn';
 import { STORED_AMOUNT_FIELDS } from '../../samples/constants';
 import { Alert } from '../../base/Alert';
+import { LOOKUP_DEFAULT_SIZE } from '../../../constants';
 
 export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
     const {
@@ -102,6 +103,7 @@ export const AmountUnitInput: FC<InputRendererProps> = memo(props => {
                     id={id}
                     inputClass={''}
                     name={unitCol.fieldKey}
+                    maxRows={LOOKUP_DEFAULT_SIZE}
                     onQSChange={onSelectChange}
                     placeholder="Select or type to search..."
                     queryFilters={queryFilter}

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -134,9 +134,9 @@ describe('MetricUnit utils', () => {
             ])
         );
 
-        expect(getMetricUnitOptions(null).length).toBe(18);
-        expect(getMetricUnitOptions('').length).toBe(18);
-        expect(getMetricUnitOptions('bad').length).toBe(18);
+        expect(getMetricUnitOptions(null).length).toBe(22);
+        expect(getMetricUnitOptions('').length).toBe(22);
+        expect(getMetricUnitOptions('bad').length).toBe(22);
     });
 
     test('getMetricUnitOptions with filterFn', () => {
@@ -209,9 +209,9 @@ describe('MetricUnit utils', () => {
         ]);
 
         // include all options when no unitTypeStr or an invalid unitTypeStr is provided
-        expect(getAltUnitKeys(null).length).toBe(18);
-        expect(getAltUnitKeys('').length).toBe(18);
-        expect(getAltUnitKeys('bad').length).toBe(18);
+        expect(getAltUnitKeys(null).length).toBe(22);
+        expect(getAltUnitKeys('').length).toBe(22);
+        expect(getAltUnitKeys('bad').length).toBe(22);
     });
 
     test('getMeasurementUnit', () => {

--- a/packages/components/src/internal/util/measurement.test.ts
+++ b/packages/components/src/internal/util/measurement.test.ts
@@ -197,11 +197,15 @@ describe('MetricUnit utils', () => {
             'boxes',
             'cells',
             'kits',
+            'organisms',
             'packs',
             'pieces',
             'slides',
+            'syringes',
             'tests',
+            'tubes',
             'unit',
+            'vials',
         ]);
 
         // include all options when no unitTypeStr or an invalid unitTypeStr is provided

--- a/packages/components/src/internal/util/measurement.ts
+++ b/packages/components/src/internal/util/measurement.ts
@@ -181,7 +181,7 @@ export const MEASUREMENT_UNITS: Record<string, MeasurementUnit> = {
         kind: UNITS_KIND.COUNT,
         ratio: 1,
         displayPrecision: 2,
-        altLabels: ['blocks', 'bottles', 'boxes', 'cells', 'kits', 'packs', 'pieces', 'slides', 'tests', 'unit'],
+        altLabels: ['blocks', 'bottles', 'boxes', 'cells', 'kits', 'organisms', 'packs', 'pieces', 'slides', 'syringes', 'tests', 'tubes', 'unit', 'vials'],
     },
 };
 


### PR DESCRIPTION
#### Rationale
Issue [868](https://github.com/LabKey/internal-issues/issues/868): Different nouns for different labs.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2935
- https://github.com/LabKey/platform/pull/7551
- https://github.com/LabKey/limsModules/pull/2094

#### Changes
- Add more count unit options.
