### PR TITLE
GitHub Issue 848: Add the ability to reset TOTP settings in the apps

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.0",
+  "version": "7.29.5-fb-totpReset.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.29.5-fb-totpReset.0",
+      "version": "7.29.5-fb-totpReset.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.2",
+  "version": "7.29.5-fb-totpReset.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.29.5-fb-totpReset.2",
+      "version": "7.29.5-fb-totpReset.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.1",
+  "version": "7.29.5-fb-totpReset.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.29.5-fb-totpReset.1",
+      "version": "7.29.5-fb-totpReset.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.4",
+  "version": "7.29.5-fb-totpReset.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.29.4",
+      "version": "7.29.5-fb-totpReset.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.3",
+  "version": "7.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.29.5-fb-totpReset.3",
+      "version": "7.30.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.3",
+  "version": "7.30.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.4",
+  "version": "7.29.5-fb-totpReset.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.1",
+  "version": "7.29.5-fb-totpReset.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.0",
+  "version": "7.29.5-fb-totpReset.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.29.5-fb-totpReset.2",
+  "version": "7.29.5-fb-totpReset.3",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.X
+*Released*: X April 2026
+- GitHub Issue 848: Add the ability to reset TOTP settings in the apps
+
 ### version 7.29.4
 *Released*: 9 April 2026
 - GitHub Issue 954: Add error for duplicate values for parent inputs

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 7.X
-*Released*: X April 2026
+### version 7.30.0
+*Released*: 17 April 2026
 - GitHub Issue 848: Add the ability to reset TOTP settings in the apps
 
 ### version 7.29.4

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactNode, useCallback, useEffect, useState } from 'react';
 import { Map } from 'immutable';
 import { getServerContext, Utils } from '@labkey/api';
 
@@ -25,7 +25,9 @@ import { getRolesByUniqueName } from '../permissions/actions';
 
 import { AppLink } from '../../url/AppLink';
 
+import { hasTotpSettings } from './actions';
 import { UserResetPasswordConfirmModal } from './UserResetPasswordConfirmModal';
+import { UserResetTotpSettingsConfirmModal } from './UserResetTotpSettingsConfirmModal';
 import { UserDeleteConfirmModal } from './UserDeleteConfirmModal';
 import { UserActivateChangeConfirmModal } from './UserActivateChangeConfirmModal';
 import { ADMIN_KEY } from '../../app/constants';
@@ -83,130 +85,123 @@ interface Props {
     userId: number;
 }
 
-interface State {
-    loading: boolean;
-    policy?: SecurityPolicy;
-    rolesByUniqueName?: Map<string, SecurityRole>;
-    showDialog: string;
-    userProperties: Record<string, any>;
-}
+export const UserDetailsPanel: FC<Props> = props => {
+    const {
+        allowDelete = true,
+        allowResetPassword = true,
+        api = getDefaultAPIWrapper().security,
+        container,
+        currentUser,
+        displayName,
+        isSelf,
+        onUsersStateChangeComplete,
+        policy,
+        rolesByUniqueName,
+        rootPolicy,
+        showGroupListLinks = true,
+        showPermissionListLinks = true,
+        toggleDetailsModal,
+        userId,
+    } = props;
 
-export class UserDetailsPanel extends React.PureComponent<Props, State> {
-    static defaultProps = {
-        allowDelete: true,
-        allowResetPassword: true,
-        api: getDefaultAPIWrapper().security,
-        showGroupListLinks: true,
-        showPermissionListLinks: true,
-    };
+    const [loading, setLoading] = useState<boolean>(false);
+    const [policyState, setPolicyState] = useState<SecurityPolicy | undefined>(undefined);
+    const [rolesByUniqueNameState, setRolesByUniqueNameState] = useState<Map<string, SecurityRole> | undefined>(
+        undefined
+    );
+    const [showDialog, setShowDialog] = useState<string | undefined>(undefined);
+    const [showResetTotp, setShowResetTotp] = useState<boolean>(false);
+    const [userProperties, setUserProperties] = useState<Record<string, any> | undefined>(undefined);
 
-    constructor(props: Props) {
-        super(props);
-
-        this.state = {
-            loading: false,
-            policy: undefined,
-            rolesByUniqueName: undefined,
-            showDialog: undefined,
-            userProperties: undefined,
-        };
-    }
-
-    componentDidMount(): void {
-        this.loadUserDetails();
-        this.loadPolicyAndRoles();
-    }
-
-    componentDidUpdate(prevProps: Readonly<Props>): void {
-        if (this.props.userId !== prevProps.userId) {
-            this.loadUserDetails();
-        }
-    }
-
-    loadPolicyAndRoles = async (): Promise<void> => {
-        const { policy, rolesByUniqueName, container, currentUser, api } = this.props;
-
+    const loadPolicyAndRoles = useCallback(async () => {
         if (currentUser.isAdmin && !policy && !rolesByUniqueName && container) {
             try {
                 const policy_ = await api.fetchPolicy(container.id);
                 const roles = await api.fetchRoles();
-                this.setState({ policy: policy_, rolesByUniqueName: getRolesByUniqueName(roles) });
+                setPolicyState(policy_);
+                setRolesByUniqueNameState(getRolesByUniqueName(roles));
             } catch (e) {
                 console.error(e);
             }
         }
-    };
+    }, [api, container, currentUser.isAdmin, policy, rolesByUniqueName]);
 
-    loadUserDetails = async (): Promise<void> => {
-        const { userId, isSelf, api, displayName } = this.props;
-
+    const loadUserDetails = useCallback(async () => {
         if (!userId) {
-            this.setState({ userProperties: undefined });
+            setUserProperties(undefined);
+            setShowResetTotp(false);
             return;
         }
 
-        this.setState({ loading: true });
+        setLoading(true);
 
         try {
             if (isSelf) {
                 const response = await api.getUserProperties(userId);
-                this.setState({ userProperties: response.props });
+                setUserProperties(response.props);
             } else {
                 const response = await api.getUserPropertiesForOther(userId);
                 if (!Utils.isEmptyObj(response)) {
-                    this.setState({ userProperties: response });
+                    setUserProperties(response);
                 } else {
-                    this.setState({ userProperties: { UserId: userId, DisplayName: displayName } });
+                    setUserProperties({ UserId: userId, DisplayName: displayName });
                 }
             }
         } catch (e) {
-            this.setState({ userProperties: undefined });
+            setUserProperties(undefined);
         }
 
-        this.setState({ loading: false });
-    };
-
-    toggleDialog = (name: string): void => {
-        this.setState({ showDialog: name });
-    };
-
-    closeDialog = (): void => {
-        this.toggleDialog(undefined);
-    };
-
-    toggleResetDialog = (): void => {
-        this.toggleDialog('reset');
-    };
-
-    toggleDeleteDialog = (): void => {
-        this.toggleDialog('delete');
-    };
-
-    toggleActivateDialog = (): void => {
-        this.toggleDialog('reactivate');
-    };
-
-    toggleDeactivateDialog = (): void => {
-        this.toggleDialog('deactivate');
-    };
-
-    onUsersStateChangeComplete = (response: any, isDelete: boolean = false): void => {
-        this.toggleDialog(undefined); // close dialog
-        if (!isDelete) {
-            this.loadUserDetails(); // reload to pickup new user state
+        if (currentUser.isRootAdmin) {
+            try {
+                setShowResetTotp(await hasTotpSettings(userId));
+            } catch (e) {
+                setShowResetTotp(false);
+            }
         }
 
-        this.props.onUsersStateChangeComplete?.(response, isDelete);
-    };
+        setLoading(false);
+    }, [api, currentUser.isRootAdmin, displayName, isSelf, userId]);
 
-    onUserDeleteComplete = (response: any) => {
-        this.onUsersStateChangeComplete(response, true);
-    };
+    useEffect(() => {
+        loadUserDetails();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [userId]);
 
-    renderButtons() {
-        const { allowDelete, allowResetPassword } = this.props;
-        const { userProperties } = this.state;
+    useEffect(() => {
+        loadPolicyAndRoles();
+    }, [loadPolicyAndRoles]);
 
+    const toggleDialog = useCallback((name?: string) => {
+        setShowDialog(name);
+    }, []);
+
+    const closeDialog = useCallback(() => toggleDialog(undefined), [toggleDialog]);
+    const toggleResetDialog = useCallback(() => toggleDialog('reset'), [toggleDialog]);
+    const toggleResetTotpDialog = useCallback(() => toggleDialog('resetTotp'), [toggleDialog]);
+    const toggleDeleteDialog = useCallback(() => toggleDialog('delete'), [toggleDialog]);
+    const toggleActivateDialog = useCallback(() => toggleDialog('reactivate'), [toggleDialog]);
+    const toggleDeactivateDialog = useCallback(() => toggleDialog('deactivate'), [toggleDialog]);
+
+    const handleUsersStateChangeComplete = useCallback(
+        (response: any, isDelete: boolean = false): void => {
+            toggleDialog(undefined); // close dialog
+            if (!isDelete) {
+                loadUserDetails(); // reload to pickup new user state
+            }
+
+            onUsersStateChangeComplete?.(response, isDelete);
+        },
+        [loadUserDetails, onUsersStateChangeComplete, toggleDialog]
+    );
+
+    const onUserDeleteComplete = useCallback(
+        (response: any) => {
+            handleUsersStateChangeComplete(response, true);
+        },
+        [handleUsersStateChangeComplete]
+    );
+
+    const renderButtons = (): React.ReactNode => {
         if (!userProperties) return null;
 
         const isActive = caseInsensitive(userProperties, 'active');
@@ -215,15 +210,20 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
             <>
                 <hr className="principal-hr" />
                 {allowResetPassword && isActive && (
-                    <button className="btn btn-default" onClick={this.toggleResetDialog} type="button">
+                    <button className="btn btn-default" onClick={toggleResetDialog} type="button">
                         Reset Password
+                    </button>
+                )}
+                {showResetTotp && isActive && (
+                    <button className="btn btn-default" style={{ marginLeft: '10px' }} onClick={toggleResetTotpDialog} type="button">
+                        Reset TOTP Settings
                     </button>
                 )}
                 {allowDelete && (
                     <button
                         className="pull-right btn btn-default"
                         style={{ marginLeft: '10px' }}
-                        onClick={this.toggleDeleteDialog}
+                        onClick={toggleDeleteDialog}
                         type="button"
                     >
                         Delete
@@ -232,27 +232,16 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
                 <button
                     className="pull-right btn btn-default"
                     style={{ marginLeft: '10px' }}
-                    onClick={isActive ? this.toggleDeactivateDialog : this.toggleActivateDialog}
+                    onClick={isActive ? toggleDeactivateDialog : toggleActivateDialog}
                     type="button"
                 >
                     {isActive ? 'Deactivate' : 'Reactivate'}
                 </button>
             </>
         );
-    }
+    };
 
-    renderBody() {
-        const {
-            showGroupListLinks,
-            showPermissionListLinks,
-            currentUser,
-            policy,
-            rolesByUniqueName,
-            rootPolicy,
-            userId,
-        } = this.props;
-        const { loading, userProperties } = this.state;
-
+    const renderBody = (): React.ReactNode => {
         if (loading) {
             return <LoadingSpinner />;
         }
@@ -282,8 +271,8 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
 
                     <EffectiveRolesList
                         currentUser={currentUser}
-                        policy={policy ?? this.state.policy}
-                        rolesByUniqueName={rolesByUniqueName ?? this.state.rolesByUniqueName}
+                        policy={policy ?? policyState}
+                        rolesByUniqueName={rolesByUniqueName ?? rolesByUniqueNameState}
                         rootPolicy={rootPolicy}
                         showLinks={showPermissionListLinks}
                         userId={userId}
@@ -294,18 +283,17 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
         }
 
         return <div>No user selected.</div>;
-    }
+    };
 
-    renderHeader() {
-        const { loading, userProperties } = this.state;
+    const renderHeader = (): React.ReactNode => {
         if (loading || !userProperties) return 'User Details';
 
-        const displayName = caseInsensitive(userProperties, 'displayName');
+        const displayName_ = caseInsensitive(userProperties, 'displayName');
         const active = caseInsensitive(userProperties, 'active');
 
         return (
             <>
-                <span>{displayName}</span>
+                <span>{displayName_}</span>
                 {active !== undefined && (
                     <span
                         className={classNames('margin-left status-pill', {
@@ -318,74 +306,76 @@ export class UserDetailsPanel extends React.PureComponent<Props, State> {
                 )}
             </>
         );
-    }
+    };
 
-    render() {
-        const { userId, allowDelete, allowResetPassword, toggleDetailsModal, onUsersStateChangeComplete } = this.props;
-        const { showDialog, userProperties } = this.state;
-        const { user, project } = getServerContext();
-        const isSelf = userId === user.id;
+    const { user, project } = getServerContext();
+    const isSelfCtx = userId === user.id;
 
-        if (toggleDetailsModal) {
-            let footer: ReactNode;
-            if (user.isAdmin) {
-                // We do not currently support user management in sub folders, so we create the management URL for the project
-                // container.
-                const manageUrl = AppURL.create(ADMIN_KEY, 'users')
-                    .addParams({ usersView: 'all', 'all.UserId~eq': userId })
-                    .setContainerPath(project.path);
+    if (toggleDetailsModal) {
+        let footer: ReactNode;
+        if (user.isAdmin) {
+            // We do not currently support user management in sub folders, so we create the management URL for the project
+            // container.
+            const manageUrl = AppURL.create(ADMIN_KEY, 'users')
+                .addParams({ usersView: 'all', 'all.UserId~eq': userId })
+                .setContainerPath(project.path);
 
-                footer = (
-                    <AppLink className="pull-right btn btn-default" to={manageUrl}>
-                        Manage
-                    </AppLink>
-                );
-            }
-
-            return (
-                <Modal
-                    onCancel={toggleDetailsModal}
-                    className="user-detail-modal"
-                    footer={footer}
-                    title={this.renderHeader()}
-                >
-                    {this.renderBody()}
-                </Modal>
+            footer = (
+                <AppLink className="pull-right btn btn-default" to={manageUrl}>
+                    Manage
+                </AppLink>
             );
         }
 
         return (
-            <div className="panel panel-default user-details-panel">
-                <div className="panel-heading">{this.renderHeader()}</div>
-                <div className="panel-body">
-                    {this.renderBody()}
-                    {!isSelf && onUsersStateChangeComplete && this.renderButtons()}
-                    {allowResetPassword && showDialog === 'reset' && (
-                        <UserResetPasswordConfirmModal
-                            email={caseInsensitive(userProperties, 'email')}
-                            userId={caseInsensitive(userProperties, 'userId')}
-                            hasLogin={Utils.isString(caseInsensitive(userProperties, 'lastLogin'))}
-                            onComplete={this.onUsersStateChangeComplete}
-                            onCancel={this.closeDialog}
-                        />
-                    )}
-                    {(showDialog === 'reactivate' || showDialog === 'deactivate') && (
-                        <UserActivateChangeConfirmModal
-                            userIds={[userId]}
-                            reactivate={showDialog === 'reactivate'}
-                            onComplete={this.onUsersStateChangeComplete}
-                            onCancel={this.closeDialog}
-                        />
-                    )}
-                    {allowDelete && showDialog === 'delete' && (
-                        <UserDeleteConfirmModal
-                            userIds={[userId]}
-                            onComplete={this.onUserDeleteComplete}
-                            onCancel={this.closeDialog}
-                        />
-                    )}
-                </div>
-            </div>
+            <Modal onCancel={toggleDetailsModal} className="user-detail-modal" footer={footer} title={renderHeader()}>
+                {renderBody()}
+            </Modal>
         );
     }
-}
+
+    return (
+        <div className="panel panel-default user-details-panel">
+            <div className="panel-heading">{renderHeader()}</div>
+            <div className="panel-body">
+                {renderBody()}
+                {!isSelfCtx && onUsersStateChangeComplete && renderButtons()}
+                {allowResetPassword && showDialog === 'reset' && (
+                    <UserResetPasswordConfirmModal
+                        email={caseInsensitive(userProperties, 'email')}
+                        userId={caseInsensitive(userProperties, 'userId')}
+                        hasLogin={Utils.isString(caseInsensitive(userProperties, 'lastLogin'))}
+                        onComplete={handleUsersStateChangeComplete}
+                        onCancel={closeDialog}
+                    />
+                )}
+                {showDialog === 'resetTotp' && (
+                    <UserResetTotpSettingsConfirmModal
+                        email={caseInsensitive(userProperties, 'email')}
+                        displayName={caseInsensitive(userProperties, 'displayName')}
+                        userId={caseInsensitive(userProperties, 'userId')}
+                        onComplete={handleUsersStateChangeComplete}
+                        onCancel={closeDialog}
+                    />
+                )}
+                {(showDialog === 'reactivate' || showDialog === 'deactivate') && (
+                    <UserActivateChangeConfirmModal
+                        userIds={[userId]}
+                        reactivate={showDialog === 'reactivate'}
+                        onComplete={handleUsersStateChangeComplete}
+                        onCancel={closeDialog}
+                    />
+                )}
+                {allowDelete && showDialog === 'delete' && (
+                    <UserDeleteConfirmModal
+                        userIds={[userId]}
+                        onComplete={onUserDeleteComplete}
+                        onCancel={closeDialog}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};
+
+UserDetailsPanel.displayName = 'UserDetailsPanel';

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -183,7 +183,7 @@ export const UserDetailsPanel: FC<Props> = props => {
     const toggleDeactivateDialog = useCallback(() => toggleDialog('deactivate'), [toggleDialog]);
 
     const handleUsersStateChangeComplete = useCallback(
-        (response: any, isDelete: boolean = false): void => {
+        (response: any, isDelete = false): void => {
             toggleDialog(undefined); // close dialog
             if (!isDelete) {
                 loadUserDetails(); // reload to pickup new user state
@@ -215,15 +215,20 @@ export const UserDetailsPanel: FC<Props> = props => {
                     </button>
                 )}
                 {showResetTotp && isActive && (
-                    <button className="btn btn-default" style={{ marginLeft: '10px' }} onClick={toggleResetTotpDialog} type="button">
+                    <button
+                        className="btn btn-default"
+                        onClick={toggleResetTotpDialog}
+                        style={{ marginLeft: '10px' }}
+                        type="button"
+                    >
                         Reset TOTP Settings
                     </button>
                 )}
                 {allowDelete && (
                     <button
                         className="pull-right btn btn-default"
-                        style={{ marginLeft: '10px' }}
                         onClick={toggleDeleteDialog}
+                        style={{ marginLeft: '10px' }}
                         type="button"
                     >
                         Delete
@@ -231,8 +236,8 @@ export const UserDetailsPanel: FC<Props> = props => {
                 )}
                 <button
                     className="pull-right btn btn-default"
-                    style={{ marginLeft: '10px' }}
                     onClick={isActive ? toggleDeactivateDialog : toggleActivateDialog}
+                    style={{ marginLeft: '10px' }}
                     type="button"
                 >
                     {isActive ? 'Deactivate' : 'Reactivate'}
@@ -328,7 +333,7 @@ export const UserDetailsPanel: FC<Props> = props => {
         }
 
         return (
-            <Modal onCancel={toggleDetailsModal} className="user-detail-modal" footer={footer} title={renderHeader()}>
+            <Modal className="user-detail-modal" footer={footer} onCancel={toggleDetailsModal} title={renderHeader()}>
                 {renderBody()}
             </Modal>
         );
@@ -343,34 +348,34 @@ export const UserDetailsPanel: FC<Props> = props => {
                 {allowResetPassword && showDialog === 'reset' && (
                     <UserResetPasswordConfirmModal
                         email={caseInsensitive(userProperties, 'email')}
-                        userId={caseInsensitive(userProperties, 'userId')}
                         hasLogin={Utils.isString(caseInsensitive(userProperties, 'lastLogin'))}
-                        onComplete={handleUsersStateChangeComplete}
                         onCancel={closeDialog}
+                        onComplete={handleUsersStateChangeComplete}
+                        userId={caseInsensitive(userProperties, 'userId')}
                     />
                 )}
                 {showDialog === 'resetTotp' && (
                     <UserResetTotpSettingsConfirmModal
-                        email={caseInsensitive(userProperties, 'email')}
                         displayName={caseInsensitive(userProperties, 'displayName')}
-                        userId={caseInsensitive(userProperties, 'userId')}
-                        onComplete={handleUsersStateChangeComplete}
+                        email={caseInsensitive(userProperties, 'email')}
                         onCancel={closeDialog}
+                        onComplete={handleUsersStateChangeComplete}
+                        userId={caseInsensitive(userProperties, 'userId')}
                     />
                 )}
                 {(showDialog === 'reactivate' || showDialog === 'deactivate') && (
                     <UserActivateChangeConfirmModal
-                        userIds={[userId]}
-                        reactivate={showDialog === 'reactivate'}
-                        onComplete={handleUsersStateChangeComplete}
                         onCancel={closeDialog}
+                        onComplete={handleUsersStateChangeComplete}
+                        reactivate={showDialog === 'reactivate'}
+                        userIds={[userId]}
                     />
                 )}
                 {allowDelete && showDialog === 'delete' && (
                     <UserDeleteConfirmModal
-                        userIds={[userId]}
-                        onComplete={onUserDeleteComplete}
                         onCancel={closeDialog}
+                        onComplete={onUserDeleteComplete}
+                        userIds={[userId]}
                     />
                 )}
             </div>

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.test.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.test.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+
+import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 
 import { UserResetPasswordConfirmModal, UserResetPasswordConfirmModalProps } from './UserResetPasswordConfirmModal';
 
@@ -32,7 +33,7 @@ describe('UserResetPasswordConfirmModal', () => {
     };
 
     test('with login', () => {
-        render(<UserResetPasswordConfirmModal {...DEFAULT_PROPS} />);
+        renderWithAppContext(<UserResetPasswordConfirmModal {...DEFAULT_PROPS} />);
 
         expect(document.querySelector('.modal-title').innerHTML).toEqual('Reset Password?');
         expect(document.querySelector('.modal-body').innerHTML).toContain(
@@ -44,7 +45,7 @@ describe('UserResetPasswordConfirmModal', () => {
     });
 
     test('without login', () => {
-        render(<UserResetPasswordConfirmModal {...DEFAULT_PROPS} hasLogin={false} />);
+        renderWithAppContext(<UserResetPasswordConfirmModal {...DEFAULT_PROPS} hasLogin={false} />);
 
         expect(document.querySelector('.modal-body').innerHTML).toContain('You are about to send');
         expect(document.querySelectorAll('.btn')).toHaveLength(2);
@@ -55,13 +56,13 @@ describe('UserResetPasswordConfirmModal', () => {
     test('with error', async () => {
         const errorMsg = 'Test Error';
         const resetPasswordApi = jest.fn().mockRejectedValue(errorMsg);
-        render(
+        renderWithAppContext(
             <UserResetPasswordConfirmModal {...DEFAULT_PROPS} hasLogin={false} resetPasswordApi={resetPasswordApi} />
         );
 
         await userEvent.click(document.querySelector('.btn-success'));
 
         expect(resetPasswordApi).toHaveBeenCalledWith(DEFAULT_PROPS.userId);
-        expect(screen.getByText(errorMsg)).toBeInTheDocument();
+        expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
     });
 });

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
@@ -5,6 +5,7 @@ import { Modal } from '../../Modal';
 import { Alert } from '../base/Alert';
 
 import { resetPassword, ResetPasswordResponse } from './actions';
+import { useNotificationsContext } from '../notifications/NotificationsContext';
 
 export interface UserResetPasswordConfirmModalProps {
     email: string;
@@ -17,7 +18,7 @@ export interface UserResetPasswordConfirmModalProps {
 
 export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProps> = memo(props => {
     const { email, userId, hasLogin, onCancel, onComplete, resetPasswordApi = resetPassword } = props;
-    const [error, setError] = useState<string>();
+    const { createNotification } = useNotificationsContext();
     const [submitting, setSubmitting] = useState<boolean>(false);
 
     const onConfirm = useCallback(async () => {
@@ -27,7 +28,12 @@ export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProp
             const response = await resetPasswordApi(userId);
             onComplete({ email, ...response });
         } catch (e) {
-            setError(resolveErrorMessage(e, 'user', 'users', 'update') ?? 'Failed to reset password');
+            const error = resolveErrorMessage(e, 'user', 'users', 'reset') ?? 'Failed to reset Password.';
+            onCancel();
+            createNotification(
+                { alertClass: 'danger', message: error },
+                true
+            );
         } finally {
             setSubmitting(false);
         }
@@ -53,7 +59,6 @@ export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProp
                 </p>
             )}
             <p>Do you want to proceed?</p>
-            {error && <Alert>{error}</Alert>}
         </Modal>
     );
 });

--- a/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetPasswordConfirmModal.tsx
@@ -30,10 +30,7 @@ export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProp
         } catch (e) {
             const error = resolveErrorMessage(e, 'user', 'users', 'reset') ?? 'Failed to reset Password.';
             onCancel();
-            createNotification(
-                { alertClass: 'danger', message: error },
-                true
-            );
+            createNotification({ alertClass: 'danger', message: error }, true);
         } finally {
             setSubmitting(false);
         }
@@ -41,11 +38,11 @@ export const UserResetPasswordConfirmModal: FC<UserResetPasswordConfirmModalProp
 
     return (
         <Modal
-            title="Reset Password?"
-            onConfirm={onConfirm}
-            onCancel={onCancel}
             confirmText="Yes, Reset Password"
             isConfirming={submitting}
+            onCancel={onCancel}
+            onConfirm={onConfirm}
+            title="Reset Password?"
         >
             {hasLogin ? (
                 <p>

--- a/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.test.tsx
+++ b/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+
+import { renderWithAppContext } from '../../test/reactTestLibraryHelpers';
 
 import {
     UserResetTotpSettingsConfirmModal,
@@ -21,7 +22,7 @@ describe('UserResetTotpSettingsConfirmModal', () => {
     };
 
     test('renders confirmation dialog', () => {
-        render(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} />);
+        renderWithAppContext(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} />);
 
         expect(document.querySelector('.modal-title').innerHTML).toEqual('Reset TOTP Settings?');
         expect(document.querySelector('.modal-body').innerHTML).toContain(
@@ -34,7 +35,7 @@ describe('UserResetTotpSettingsConfirmModal', () => {
     });
 
     test('calls resetTotpSettingsApi on confirm', async () => {
-        render(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} />);
+        renderWithAppContext(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} />);
 
         await userEvent.click(document.querySelector('.btn-success'));
 
@@ -45,11 +46,11 @@ describe('UserResetTotpSettingsConfirmModal', () => {
     test('with error', async () => {
         const errorMsg = 'Test Error';
         const resetTotpSettingsApi = jest.fn().mockRejectedValue(errorMsg);
-        render(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} resetTotpSettingsApi={resetTotpSettingsApi} />);
+        renderWithAppContext(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} resetTotpSettingsApi={resetTotpSettingsApi} />);
 
         await userEvent.click(document.querySelector('.btn-success'));
 
         expect(resetTotpSettingsApi).toHaveBeenCalledWith(DEFAULT_PROPS.userId);
-        expect(screen.getByText(errorMsg)).toBeInTheDocument();
+        expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
     });
 });

--- a/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.test.tsx
+++ b/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import {
+    UserResetTotpSettingsConfirmModal,
+    UserResetTotpSettingsConfirmModalProps,
+} from './UserResetTotpSettingsConfirmModal';
+
+describe('UserResetTotpSettingsConfirmModal', () => {
+    const email = 'jest@localhost.test';
+    const displayName = 'Jest User';
+    const userId = 5002;
+    const DEFAULT_PROPS: UserResetTotpSettingsConfirmModalProps = {
+        email,
+        displayName,
+        onCancel: jest.fn(),
+        onComplete: jest.fn(),
+        resetTotpSettingsApi: jest.fn().mockResolvedValue({ userId, resetTotpSettings: true }),
+        userId,
+    };
+
+    test('renders confirmation dialog', () => {
+        render(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} />);
+
+        expect(document.querySelector('.modal-title').innerHTML).toEqual('Reset TOTP Settings?');
+        expect(document.querySelector('.modal-body').innerHTML).toContain(
+            'Are you sure you want to reset the TOTP settings for'
+        );
+        expect(document.querySelector('.modal-body').innerHTML).toContain(displayName);
+        expect(document.querySelectorAll('.btn')).toHaveLength(2);
+        expect(document.querySelectorAll('.btn-success')).toHaveLength(1);
+        expect(document.querySelector('.btn-success').hasAttribute('disabled')).toBe(false);
+    });
+
+    test('calls resetTotpSettingsApi on confirm', async () => {
+        render(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} />);
+
+        await userEvent.click(document.querySelector('.btn-success'));
+
+        expect(DEFAULT_PROPS.resetTotpSettingsApi).toHaveBeenCalledWith(userId);
+        expect(DEFAULT_PROPS.onComplete).toHaveBeenCalled();
+    });
+
+    test('with error', async () => {
+        const errorMsg = 'Test Error';
+        const resetTotpSettingsApi = jest.fn().mockRejectedValue(errorMsg);
+        render(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} resetTotpSettingsApi={resetTotpSettingsApi} />);
+
+        await userEvent.click(document.querySelector('.btn-success'));
+
+        expect(resetTotpSettingsApi).toHaveBeenCalledWith(DEFAULT_PROPS.userId);
+        expect(screen.getByText(errorMsg)).toBeInTheDocument();
+    });
+});

--- a/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.test.tsx
+++ b/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.test.tsx
@@ -46,7 +46,9 @@ describe('UserResetTotpSettingsConfirmModal', () => {
     test('with error', async () => {
         const errorMsg = 'Test Error';
         const resetTotpSettingsApi = jest.fn().mockRejectedValue(errorMsg);
-        renderWithAppContext(<UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} resetTotpSettingsApi={resetTotpSettingsApi} />);
+        renderWithAppContext(
+            <UserResetTotpSettingsConfirmModal {...DEFAULT_PROPS} resetTotpSettingsApi={resetTotpSettingsApi} />
+        );
 
         await userEvent.click(document.querySelector('.btn-success'));
 

--- a/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.tsx
@@ -2,9 +2,9 @@ import React, { FC, memo, useCallback, useState } from 'react';
 
 import { resolveErrorMessage } from '../../util/messaging';
 import { Modal } from '../../Modal';
-import { Alert } from '../base/Alert';
 
 import { ResetTotpResponse, resetTotpSettings } from './actions';
+import { useNotificationsContext } from '../notifications/NotificationsContext';
 
 export interface UserResetTotpSettingsConfirmModalProps {
     email: string;
@@ -17,8 +17,8 @@ export interface UserResetTotpSettingsConfirmModalProps {
 
 export const UserResetTotpSettingsConfirmModal: FC<UserResetTotpSettingsConfirmModalProps> = memo(props => {
     const { email, displayName, userId, onCancel, onComplete, resetTotpSettingsApi = resetTotpSettings } = props;
-    const [error, setError] = useState<string>();
     const [submitting, setSubmitting] = useState<boolean>(false);
+    const { createNotification } = useNotificationsContext();
 
     const onConfirm = useCallback(async () => {
         setSubmitting(true);
@@ -27,7 +27,12 @@ export const UserResetTotpSettingsConfirmModal: FC<UserResetTotpSettingsConfirmM
             const resp = await resetTotpSettingsApi(userId);
             onComplete({email, ...resp});
         } catch (e) {
-            setError(resolveErrorMessage(e, 'user', 'users', 'update') ?? 'Failed to reset TOTP settings');
+            const error = resolveErrorMessage(e, 'user', 'users', 'update') ?? 'Failed to reset TOTP settings';
+            onCancel();
+            createNotification(
+                { alertClass: 'danger', message: error },
+                true
+            );
         } finally {
             setSubmitting(false);
         }
@@ -42,7 +47,6 @@ export const UserResetTotpSettingsConfirmModal: FC<UserResetTotpSettingsConfirmM
             isConfirming={submitting}
         >
             <p>Are you sure you want to reset the TOTP settings for <b>{displayName}</b>?</p>
-            {error && <Alert>{error}</Alert>}
         </Modal>
     );
 });

--- a/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.tsx
@@ -7,8 +7,8 @@ import { ResetTotpResponse, resetTotpSettings } from './actions';
 import { useNotificationsContext } from '../notifications/NotificationsContext';
 
 export interface UserResetTotpSettingsConfirmModalProps {
-    email: string;
     displayName: string;
+    email: string;
     onCancel: () => void;
     onComplete: (response: ResetTotpResponse) => void;
     resetTotpSettingsApi?: (userId: number) => Promise<ResetTotpResponse>;
@@ -25,14 +25,11 @@ export const UserResetTotpSettingsConfirmModal: FC<UserResetTotpSettingsConfirmM
 
         try {
             const resp = await resetTotpSettingsApi(userId);
-            onComplete({email, ...resp});
+            onComplete({ email, ...resp });
         } catch (e) {
             const error = resolveErrorMessage(e, 'user', 'users', 'update') ?? 'Failed to reset TOTP settings';
             onCancel();
-            createNotification(
-                { alertClass: 'danger', message: error },
-                true
-            );
+            createNotification({ alertClass: 'danger', message: error }, true);
         } finally {
             setSubmitting(false);
         }
@@ -40,13 +37,15 @@ export const UserResetTotpSettingsConfirmModal: FC<UserResetTotpSettingsConfirmM
 
     return (
         <Modal
-            title="Reset TOTP Settings?"
-            onConfirm={onConfirm}
-            onCancel={onCancel}
             confirmText="Yes, Reset TOTP Settings"
             isConfirming={submitting}
+            onCancel={onCancel}
+            onConfirm={onConfirm}
+            title="Reset TOTP Settings?"
         >
-            <p>Are you sure you want to reset the TOTP settings for <b>{displayName}</b>?</p>
+            <p>
+                Are you sure you want to reset the TOTP settings for <b>{displayName}</b>?
+            </p>
         </Modal>
     );
 });

--- a/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.tsx
+++ b/packages/components/src/internal/components/user/UserResetTotpSettingsConfirmModal.tsx
@@ -1,0 +1,50 @@
+import React, { FC, memo, useCallback, useState } from 'react';
+
+import { resolveErrorMessage } from '../../util/messaging';
+import { Modal } from '../../Modal';
+import { Alert } from '../base/Alert';
+
+import { ResetTotpResponse, resetTotpSettings } from './actions';
+
+export interface UserResetTotpSettingsConfirmModalProps {
+    email: string;
+    displayName: string;
+    onCancel: () => void;
+    onComplete: (response: ResetTotpResponse) => void;
+    resetTotpSettingsApi?: (userId: number) => Promise<ResetTotpResponse>;
+    userId: number;
+}
+
+export const UserResetTotpSettingsConfirmModal: FC<UserResetTotpSettingsConfirmModalProps> = memo(props => {
+    const { email, displayName, userId, onCancel, onComplete, resetTotpSettingsApi = resetTotpSettings } = props;
+    const [error, setError] = useState<string>();
+    const [submitting, setSubmitting] = useState<boolean>(false);
+
+    const onConfirm = useCallback(async () => {
+        setSubmitting(true);
+
+        try {
+            const resp = await resetTotpSettingsApi(userId);
+            onComplete({email, ...resp});
+        } catch (e) {
+            setError(resolveErrorMessage(e, 'user', 'users', 'update') ?? 'Failed to reset TOTP settings');
+        } finally {
+            setSubmitting(false);
+        }
+    }, [email, userId, onComplete, resetTotpSettingsApi]);
+
+    return (
+        <Modal
+            title="Reset TOTP Settings?"
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            confirmText="Yes, Reset TOTP Settings"
+            isConfirming={submitting}
+        >
+            <p>Are you sure you want to reset the TOTP settings for <b>{displayName}</b>?</p>
+            {error && <Alert>{error}</Alert>}
+        </Modal>
+    );
+});
+
+UserResetTotpSettingsConfirmModal.displayName = 'UserResetTotpSettingsConfirmModal';

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -148,7 +148,7 @@ export function resetPassword(userId: number): Promise<ResetPasswordResponse> {
             url: buildURL('security', 'adminResetPassword.api'),
             method: 'POST',
             params: { userId },
-            success: ((resp) => {
+            success: resp => {
                 // workaround to detect failed reset since AdminResetPasswordAction uses special getFailView response
                 if (resp?.responseText?.indexOf('Password Reset Failed') > -1) {
                     reject('Failed to reset password.');
@@ -156,7 +156,7 @@ export function resetPassword(userId: number): Promise<ResetPasswordResponse> {
                 }
 
                 resolve({ userId, resetPassword: true });
-            }),
+            },
             failure: Utils.getCallbackWrapper(error => {
                 console.error('Failed to reset password.', error);
                 reject(error);
@@ -186,7 +186,7 @@ export async function resetTotpSettings(userId: number): Promise<ResetTotpRespon
     const response = await request<{ success: boolean }>({
         url: buildURL('totp', 'resetTotpSettingsApi.api'),
         method: 'POST',
-        params: {userId},
+        params: { userId },
     });
 
     if (!response.success) {
@@ -195,5 +195,5 @@ export async function resetTotpSettings(userId: number): Promise<ResetTotpRespon
         throw new Error(errorLogMsg);
     }
 
-    return {userId, resetTotpSettings: true};
+    return { userId, resetTotpSettings: true };
 }

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -1,6 +1,7 @@
 import { OrderedMap } from 'immutable';
 import { Ajax, Utils } from '@labkey/api';
 
+import { request } from '../../request';
 import { buildURL } from '../../url/AppURL';
 import { User } from '../base/models/User';
 import { caseInsensitive } from '../../util/utils';
@@ -8,6 +9,7 @@ import { caseInsensitive } from '../../util/utils';
 import { formatDate, parseDate } from '../../util/Date';
 
 import { ChangePasswordModel } from './models';
+import { hasModule } from '../../app/utils';
 
 export function getUserProperties(userId: number): Promise<any> {
     return new Promise((resolve, reject) => {
@@ -155,4 +157,37 @@ export function resetPassword(userId: number): Promise<ResetPasswordResponse> {
             }),
         });
     });
+}
+
+export async function hasTotpSettings(userId: number): Promise<boolean> {
+    if (!hasModule('mfa')) {
+        return false;
+    }
+
+    const response = await request<{ hasTotpSettings: boolean }>({
+        url: buildURL('totp', 'hasTotpSettings.api', { userId }),
+    });
+    return response.hasTotpSettings;
+}
+
+export type ResetTotpResponse = {
+    email?: string;
+    resetTotpSettings: boolean;
+    userId: number;
+};
+
+export async function resetTotpSettings(userId: number): Promise<ResetTotpResponse> {
+    const response = await request<{ success: boolean }>({
+        url: buildURL('totp', 'resetTotpSettingsApi.api'),
+        method: 'POST',
+        params: {userId},
+    });
+
+    if (!response.success) {
+        const errorLogMsg = `Unable to reset TOTP settings for user: ${userId}`;
+        console.error(errorLogMsg, response);
+        throw new Error(errorLogMsg);
+    }
+
+    return {userId, resetTotpSettings: true};
 }

--- a/packages/components/src/internal/components/user/actions.ts
+++ b/packages/components/src/internal/components/user/actions.ts
@@ -148,7 +148,13 @@ export function resetPassword(userId: number): Promise<ResetPasswordResponse> {
             url: buildURL('security', 'adminResetPassword.api'),
             method: 'POST',
             params: { userId },
-            success: Utils.getCallbackWrapper(() => {
+            success: ((resp) => {
+                // workaround to detect failed reset since AdminResetPasswordAction uses special getFailView response
+                if (resp?.responseText?.indexOf('Password Reset Failed') > -1) {
+                    reject('Failed to reset password.');
+                    return;
+                }
+
                 resolve({ userId, resetPassword: true });
             }),
             failure: Utils.getCallbackWrapper(error => {


### PR DESCRIPTION
#### Rationale
Issue [link](https://github.com/LabKey/internal-issues/issues/848)
This PR add the ability for app admins to reset a user's TOTP (Time-based One-Time Password) settings from the user management panel.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1981
- https://github.com/LabKey/labkey-ui-premium/pull/935
- https://github.com/LabKey/testAutomation/pull/2949
- https://github.com/LabKey/premiumModules/pull/513
- https://github.com/LabKey/limsModules/pull/2114

#### Changes
- refactored UserDetailsPanel from class to FC
- new UserResetTotpSettingsConfirmModal
- api actions for get/reset TOTP settings

