### PR TITLE
GitHub Issue #1012: Update resolveDuplicatesAsName() regex to handle nested parentheses in key/value

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.4",
+  "version": "7.21.4-fb-boxNameUnique1012.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.4",
+      "version": "7.21.4-fb-boxNameUnique1012.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.4-fb-boxNameUnique1012.0",
+  "version": "7.21.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.21.4-fb-boxNameUnique1012.0",
+      "version": "7.21.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.4",
+  "version": "7.21.4-fb-boxNameUnique1012.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.21.4-fb-boxNameUnique1012.0",
+  "version": "7.21.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.21.5
+*Released*: 23 April 2026
 - GitHub Issue #1012: Update resolveDuplicatesAsName() regex to handle nested parentheses in key/value
 
 ### version 7.21.4

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue #1012: Update resolveDuplicatesAsName() regex to handle nested parentheses in key/value
+
 ### version 7.21.4
 *Released*: 6 April 2026
 - GitHub Issue #974: Lookup Data Type shown in Assay Designer for app, even when premium module is not present

--- a/packages/components/src/internal/util/messaging.test.ts
+++ b/packages/components/src/internal/util/messaging.test.ts
@@ -2,6 +2,7 @@ import {
     getPermissionRestrictionMessage,
     lookupValidationErrorMessage,
     makePresentParticiple,
+    resolveDuplicatesAsName,
     resolveErrorMessage,
 } from './messaging';
 
@@ -397,5 +398,148 @@ describe('lookupValidationErrorMessage', () => {
         expect(lookupValidationErrorMessage('beep,', false, 'vw')).toEqual(
             'vw is no longer a valid value. Data may have been moved or deleted.'
         );
+    });
+});
+
+describe('resolveDuplicatesAsName', () => {
+    describe('no key match', () => {
+        const noMatchMsg = 'Violation of UNIQUE KEY constraint "AK_Material"';
+
+        test('requires literal period after "already exists"', () => {
+            // The escaped \. means a trailing non-period character no longer matches
+            expect(resolveDuplicatesAsName('Key (name)=(foo) already existsX', 'samples')).toBe(
+                'There was a problem creating your samples. Check the existing samples for possible duplicates and make sure any referenced samples are still valid.'
+            );
+        });
+
+        test('defaults noun to data and verb to creating', () => {
+            expect(resolveDuplicatesAsName(noMatchMsg, undefined)).toBe(
+                'There was a problem creating your data. Check the existing data for possible duplicates and make sure any referenced data are still valid.'
+            );
+        });
+
+        test('uses noun when no nounPlural', () => {
+            expect(resolveDuplicatesAsName(noMatchMsg, 'samples')).toBe(
+                'There was a problem creating your samples. Check the existing samples for possible duplicates and make sure any referenced samples are still valid.'
+            );
+        });
+
+        test('uses nounPlural over noun', () => {
+            expect(resolveDuplicatesAsName(noMatchMsg, 'sample', 'samples')).toBe(
+                'There was a problem creating your samples. Check the existing samples for possible duplicates and make sure any referenced samples are still valid.'
+            );
+        });
+
+        test('uses verbPresParticiple when provided', () => {
+            expect(resolveDuplicatesAsName(noMatchMsg, 'samples', undefined, 'updating')).toBe(
+                'There was a problem updating your samples. Check the existing samples for possible duplicates and make sure any referenced samples are still valid.'
+            );
+        });
+
+        test('uses nounPlural and verbPresParticiple together', () => {
+            expect(resolveDuplicatesAsName(noMatchMsg, 'sample', 'samples', 'updating')).toBe(
+                'There was a problem updating your samples. Check the existing samples for possible duplicates and make sure any referenced samples are still valid.'
+            );
+        });
+    });
+
+    describe('value containing closing paren', () => {
+        test('.*? backtracks to include ) in value to complete the match', () => {
+            // .*? is non-greedy but will backtrack through ) if needed to satisfy the full pattern
+            expect(resolveDuplicatesAsName('Key (classid, name)=(46, foo)bar) already exists.', 'sources')).toBe(
+                "There was a problem creating your sources. Duplicate name 'foo)bar' found."
+            );
+        });
+    });
+
+    describe('key containing nested paren', () => {
+        test('.*? backtracks to capture full key field list including )', () => {
+            expect(
+                resolveDuplicatesAsName('Detail: Key (lower(name::text))=(box_large) already exists.', 'samples')
+            ).toBe("There was a problem creating your samples. Duplicate name 'box_large' found.");
+        });
+    });
+
+    describe('single-field key', () => {
+        test('extracts name', () => {
+            expect(resolveDuplicatesAsName('Key (name)=(PtoC2-0) already exists.', 'samples')).toBe(
+                "There was a problem creating your samples. Duplicate name 'PtoC2-0' found."
+            );
+        });
+
+        test('name with commas', () => {
+            expect(resolveDuplicatesAsName('Key (name)=(WC-1,2,204) already exists.', 'samples')).toBe(
+                "There was a problem creating your samples. Duplicate name 'WC-1,2,204' found."
+            );
+        });
+    });
+
+    describe('two-field key', () => {
+        test('extracts last field as name', () => {
+            expect(resolveDuplicatesAsName('Key (classid, name)=(46, L-40) already exists.', 'sources')).toBe(
+                "There was a problem creating your sources. Duplicate name 'L-40' found."
+            );
+        });
+
+        test('name with commas', () => {
+            expect(resolveDuplicatesAsName('Key (classid, name)=(46, L-40,1) already exists.', 'sources')).toBe(
+                "There was a problem creating your sources. Duplicate name 'L-40,1' found."
+            );
+        });
+
+        test('name with commas and spaces', () => {
+            expect(resolveDuplicatesAsName('Key (classid, name)=(46, L-40, 1) already exists.', 'sources')).toBe(
+                "There was a problem creating your sources. Duplicate name 'L-40, 1' found."
+            );
+        });
+    });
+
+    describe('three-field key', () => {
+        test('extracts last field as name', () => {
+            expect(
+                resolveDuplicatesAsName(
+                    'Key (container, cpastype, name)=(uuid, lsid, B1-247) already exists.',
+                    'samples'
+                )
+            ).toBe("There was a problem creating your samples. Duplicate name 'B1-247' found.");
+        });
+
+        test('name with commas only', () => {
+            expect(
+                resolveDuplicatesAsName(
+                    'Key (container, cpastype, name)=(uuid, lsid, WC-1,2,204) already exists.',
+                    'samples'
+                )
+            ).toBe("There was a problem creating your samples. Duplicate name 'WC-1,2,204' found.");
+        });
+
+        test('name with commas and spaces', () => {
+            expect(
+                resolveDuplicatesAsName(
+                    'Key (container, cpastype, name)=(uuid, lsid, WC-1, 2,204) already exists.',
+                    'samples'
+                )
+            ).toBe("There was a problem creating your samples. Duplicate name 'WC-1, 2,204' found.");
+        });
+    });
+
+    describe('optional params with key match', () => {
+        test('uses nounPlural over noun', () => {
+            expect(resolveDuplicatesAsName('Key (name)=(foo) already exists.', 'sample', 'samples')).toBe(
+                "There was a problem creating your samples. Duplicate name 'foo' found."
+            );
+        });
+
+        test('uses verbPresParticiple', () => {
+            expect(resolveDuplicatesAsName('Key (name)=(foo) already exists.', 'samples', undefined, 'updating')).toBe(
+                "There was a problem updating your samples. Duplicate name 'foo' found."
+            );
+        });
+
+        test('uses nounPlural and verbPresParticiple together', () => {
+            expect(resolveDuplicatesAsName('Key (name)=(foo) already exists.', 'sample', 'samples', 'updating')).toBe(
+                "There was a problem updating your samples. Duplicate name 'foo' found."
+            );
+        });
     });
 });

--- a/packages/components/src/internal/util/messaging.tsx
+++ b/packages/components/src/internal/util/messaging.tsx
@@ -42,7 +42,8 @@ function trimExceptionPrefix(exceptionMessage: string, message: string): string 
     return message.substring(startIndex + exceptionMessage.length).trim();
 }
 
-function resolveDuplicatesAsName(
+// export for jest testing
+export function resolveDuplicatesAsName(
     errorMsg: string,
     noun: string,
     nounPlural?: string,
@@ -51,7 +52,7 @@ function resolveDuplicatesAsName(
     // N.B. Issues 48050 and 48209: only for Postgres since the error message from SQL server doesn't provide a
     // reasonable way to parse a multi-field key in the face of names that may contain commas and spaces. Seems
     // better to show a generic message instead of an incorrectly parsed name.
-    const keyMatch = errorMsg.match(/Key \(([^)]+)\)=\(([^)]+)\) already exists./);
+    const keyMatch = errorMsg.match(/Key \((.*?)\)=\((.*?)\) already exists\./);
     let name;
     if (keyMatch) {
         const numParts = keyMatch[1].split(', ').length;
@@ -72,8 +73,8 @@ function resolveDuplicatesAsName(
     if (name) {
         retMsg += ` Duplicate name '${name}' found.`;
     } else {
-        retMsg += ` Check the existing ${nounPlural || noun} for possible duplicates and make sure any referenced ${
-            nounPlural || noun
+        retMsg += ` Check the existing ${nounPlural || noun || 'data'} for possible duplicates and make sure any referenced ${
+            nounPlural || noun || 'data'
         } are still valid.`;
     }
     return retMsg;


### PR DESCRIPTION
#### Rationale
[#1012](https://github.com/LabKey/internal-issues/issues/1012) LKSM: Provide an admin-defined setting to limit all terminal storage locations to have unique names

  This PR updates the resolveDuplicatesAsName() function to correctly parse PostgreSQL unique-constraint violation messages when the key expression contains nested parentheses (e.g., lower(name::text)). The old [^)]+ character  
  class stopped at the first ), failing to capture function-call expressions in index definitions. It also fixes an unescaped . in the regex and adds a || 'data' fallback to the else branch for when both noun and nounPlural are 
  undefined.  

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2125

#### Changes
- Update resolveDuplicatesAsName() regex to handle nested parentheses in key/value
