### PR TITLE
GitHub Issue #598: Wrap text for long file names in various app locations

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.33.1",
+  "version": "7.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.33.1",
+      "version": "7.33.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.33.0",
+  "version": "7.33.0-fb-longFileName.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.33.0",
+      "version": "7.33.0-fb-longFileName.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.33.0",
+  "version": "7.33.0-fb-longFileName.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.33.1",
+  "version": "7.33.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue #598: Wrap text for long file names in various app locations
+
 ### version 7.33.0
 *Released*: 24 April 2026
 - Workflow UI updates

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.33.2
+*Released*: 29 April 2026
 - GitHub Issue #598: Wrap text for long file names in various app locations
 
 ### version 7.33.1

--- a/packages/components/src/internal/Modal.tsx
+++ b/packages/components/src/internal/Modal.tsx
@@ -60,7 +60,7 @@ export const ModalHeader: FC<ModalHeaderProps> = ({ title, onCancel }) => {
                     <span className="sr-only">Close</span>
                 </button>
             )}
-            {title && <h4 className="modal-title">{title}</h4>}
+            {title && <h4 className="modal-title text__wrap">{title}</h4>}
         </div>
     );
 };

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -217,7 +217,7 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
         if (file || typeof data === 'string') {
             body = (
                 <div
-                    className={classNames('attached-file__inline-container', { 'file-upload__is-hover': isHover })}
+                    className={classNames('attached-file__inline-container text__wrap', { 'file-upload__is-hover': isHover })}
                     onDragEnter={this.onDrag}
                     onDragLeave={this.onDragLeave}
                     onDragOver={this.onDrag}

--- a/packages/components/src/theme/announcements.scss
+++ b/packages/components/src/theme/announcements.scss
@@ -165,6 +165,7 @@ $editor-padding-horizontal: 15px;
 }
 .thread-attachment {
     padding: 6px;
+    word-break: break-all;
 }
 .thread-attachment-icon {
     font-size: 20px;

--- a/packages/components/src/theme/fileupload.scss
+++ b/packages/components/src/theme/fileupload.scss
@@ -107,6 +107,7 @@
 .attached-file__container {
   margin-top: 5px;
   position: relative;
+  word-break: break-all;
 }
 
 .attached-file__inline-container {


### PR DESCRIPTION
#### Rationale
[#598](https://github.com/LabKey/internal-issues/issues/598) App long file names display weirdly in a few places (LabKey Issue: 52943)

  This PR fixes LabKey Issue 52943 / GitHub Issue #598, where long file names overflow their containers in several app UI locations. The changes add CSS word-break or word-wrap rules — either via direct SCSS rules or the  
  existing text__wrap utility class — to four locations: the thread attachment display, modal titles, the inline file input display, and the file attachment container. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1989
- https://github.com/LabKey/labkey-ui-premium/pull/940
- https://github.com/LabKey/limsModules/pull/2147

#### Changes
- add usages of text__wrap and word-break
