### PR TITLE
GitHub Issue 1021: Sample Finder: Long names truncated in Search cards

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.1-fb-issue1100.0",
+  "version": "7.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.38.1-fb-issue1100.0",
+      "version": "7.38.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.0",
+  "version": "7.38.1-fb-issue1100.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.38.0",
+      "version": "7.38.1-fb-issue1100.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.0",
+  "version": "7.38.1-fb-issue1100.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.1-fb-issue1100.0",
+  "version": "7.38.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.X
+*Released*: X May 2026
+- GitHub Issue 1021: Sample Finder: Long names truncated in Search cards
+
 ### version 7.38.0
 *Released*: 21 May 2026
 - Accessibility improvements for app pages: Keyboard Interactions

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 7.X
-*Released*: X May 2026
+### version 7.38.1
+*Released*: 26 May 2026
 - GitHub Issue 1021: Sample Finder: Long names truncated in Search cards
 
 ### version 7.38.0

--- a/packages/components/src/theme/cards.scss
+++ b/packages/components/src/theme/cards.scss
@@ -185,6 +185,7 @@ $circle-size: 12 * $scale;
             vertical-align: top;
             padding: 10px 0;
             text-transform: uppercase;
+            word-break: break-word;
         }
 
         .filter-display__field-boolean {
@@ -245,7 +246,8 @@ $circle-size: 12 * $scale;
 }
 
 .filter-card__header {
-    height: 59px;
+    min-height: 59px;
+    overflow: hidden;
     color: white;
     padding: 10px 0 10px 20px;
 
@@ -256,6 +258,7 @@ $circle-size: 12 * $scale;
     & .primary-text {
         font-size: 20px;
         line-height: 23px;
+        word-break: break-word;
     }
 
     & .secondary-text {


### PR DESCRIPTION
#### Rationale
Issue [link](https://github.com/LabKey/internal-issues/issues/1021)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2005
- https://github.com/LabKey/platform/pull/7687
- https://github.com/LabKey/limsModules/pull/2216

#### Changes
- use flex card header height
