### PR TITLE
Issue 1084: Add Storage Terminal Location to Sample Finder fields

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.0",
+  "version": "7.38.1-terminalLocationInSF.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.38.0",
+      "version": "7.38.1-terminalLocationInSF.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.2-terminalLocationInSF.1",
+  "version": "7.38.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.38.2-terminalLocationInSF.1",
+      "version": "7.38.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.2-terminalLocationInSF.0",
+  "version": "7.38.2-terminalLocationInSF.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.38.2-terminalLocationInSF.0",
+      "version": "7.38.2-terminalLocationInSF.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.0",
+  "version": "7.38.1-terminalLocationInSF.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.2-terminalLocationInSF.0",
+  "version": "7.38.2-terminalLocationInSF.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.38.2-terminalLocationInSF.1",
+  "version": "7.38.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.38.2
+*Released*: 27 May 2026
 - Update `getDefaultVisibleColumns` to remove columns that metadata eliminates from views
 
 ### version 7.38.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- Update `getDefaultVisibleColumns` to remove columns that metadata eliminates from views
+
 ### version 7.38.0
 *Released*: 21 May 2026
 - Accessibility improvements for app pages: Keyboard Interactions

--- a/packages/components/src/internal/components/entities/constants.ts
+++ b/packages/components/src/internal/components/entities/constants.ts
@@ -141,7 +141,7 @@ export const SampleTypeDataType: EntityDataType = {
     supportsCrossTypeImport: true,
     folderConfigurableDataType: 'SampleType',
     labelColorCol: 'labelcolor',
-    extraFinderFields: ['storagepositionnumber'],
+    extraFinderFields: ['storagepositionnumber', 'storageterminallocation'],
 };
 
 export const SampleParentDataType = {

--- a/packages/components/src/internal/query/api.ts
+++ b/packages/components/src/internal/query/api.ts
@@ -182,7 +182,10 @@ export function getDefaultVisibleColumns(options: GetQueryDetailsOptions): Promi
                 const rawColumnMap = response.columns;
                 Object.keys(rawColumnMap).forEach(fieldKey => {
                     const rawColumn = rawColumnMap[fieldKey];
-                    columns.push(applyColumnMetadata(schemaQuery, rawColumn));
+                    const updatedColumn = applyColumnMetadata(schemaQuery, rawColumn);
+                    if (!updatedColumn.removeFromViews) {
+                        columns.push(updatedColumn);
+                    }
                 });
                 resolve(columns);
             }),


### PR DESCRIPTION
#### Rationale
Issue [1084](https://github.com/LabKey/internal-issues/issues/1084) - We added Storage Terminal Location as a possible fiel in our grids and now also want to add it as a possible field for filtering in Sample Finder

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2222
- https://github.com/LabKey/labkey-ui-premium/pull/957

#### Changes
- Update `getDefaultVisibleColumns` to remove columns that metadata eliminates from views
