### PR TITLE
SecurityAPIWrapper: Add getAuthenticationConfiguration

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.2",
+      "version": "7.43.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.43.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.43.0
+*Released*: 23 June 2026
+- panel.scss: disable margin on h1, h2, etc elements within panel-heading components
+- SecurityAPIWrapper: Add getAuthenticationConfiguration
+
 ### version 7.42.2
 *Released*: 22 June 2026
 - Styling update for user comment on large storage modal

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1893,7 +1893,7 @@ export type {
 } from './internal/components/samples/models';
 export type { SearchHit, SearchOptions } from './internal/components/search/actions';
 export type { EntityFieldFilter } from './internal/components/search/models';
-export type { SecurityAPIWrapper } from './internal/components/security/APIWrapper';
+export type { AuthenticationConfiguration, SecurityAPIWrapper } from './internal/components/security/APIWrapper';
 export type { IDataViewInfo } from './internal/DataViewInfo';
 export type { BSStyle } from './internal/dropdowns';
 export type { MenuSectionItem } from './internal/DropdownSection';

--- a/packages/components/src/internal/components/security/APIWrapper.ts
+++ b/packages/components/src/internal/components/security/APIWrapper.ts
@@ -56,6 +56,16 @@ export interface RemoveGroupMembersResponse {
     removed: number[];
 }
 
+export interface AuthenticationConfiguration {
+    description: string;
+    reauthUrl: string;
+}
+
+interface AuthenticationConfigurationResponse {
+    data: AuthenticationConfiguration;
+    success: boolean;
+}
+
 export interface SecurityAPIWrapper {
     addGroupMembers: (groupId: number, principalIds: number[], projectPath: string) => Promise<AddGroupMembersResponse>;
     createApiKey: (type?: string, description?: string) => Promise<string>;
@@ -78,6 +88,7 @@ export interface SecurityAPIWrapper {
     ) => Promise<SecurityPolicy>;
     fetchRoles: () => Promise<List<SecurityRole>>;
     getAuditLogDate: (filterCol: string, filterVal: number | string) => Promise<string>;
+    getAuthenticationConfiguration: () => Promise<AuthenticationConfiguration>;
     getDeletionSummaries: (containerPath?: string) => Promise<Summary[]>;
     getGroupMemberships: () => Promise<GroupMembership[]>;
     getInheritedContainers: (container: Container) => Promise<string[]>;
@@ -262,6 +273,14 @@ export class ServerSecurityAPIWrapper implements SecurityAPIWrapper {
         return dateRow.formattedValue ?? dateRow.value;
     };
 
+    getAuthenticationConfiguration = async (): Promise<AuthenticationConfiguration> => {
+        const { data } = await request<AuthenticationConfigurationResponse>({
+            url: ActionURL.buildURL('login', 'getAuthenticationConfiguration.api'),
+        });
+
+        return data;
+    };
+
     getDeletionSummaries = async (containerPath?: string): Promise<Summary[]> => {
         const { moduleSummary } = await request<{ moduleSummary: Summary[] }>({
             url: ActionURL.buildURL('core', 'getModuleSummary.api', containerPath),
@@ -443,6 +462,7 @@ export function getSecurityTestAPIWrapper(
         fetchPolicy: mockFn(),
         fetchRoles: mockFn(),
         getAuditLogDate: mockFn(),
+        getAuthenticationConfiguration: mockFn(),
         getDeletionSummaries: mockFn(),
         getGroupMemberships: mockFn(),
         getPrincipalById: mockFn(),

--- a/packages/components/src/theme/panel.scss
+++ b/packages/components/src/theme/panel.scss
@@ -67,6 +67,11 @@
     margin-top: 3px;
 }
 
+// Override the default margin for h* elements within a panel heading
+.panel-heading:is(h1, h2, h3, h4, h5, h6) {
+    margin: 0;
+}
+
 
 // revert panel heading font-size for those within a tabbed-grid-panel
 .tabbed-grid-panel .panel-heading {


### PR DESCRIPTION
#### Rationale
This PR adds the new getAuthenticationConfiguration API to the SecurityAPIWrapper

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7732
- https://github.com/LabKey/premiumModules/pull/598
- https://github.com/LabKey/labkey-ui-components/pull/2016
- https://github.com/LabKey/labkey-ui-premium/pull/967
- https://github.com/LabKey/limsModules/pull/2250
- https://github.com/LabKey/testAutomation/pull/3041

#### Changes
- panel.scss: disable margin on h1, h2, etc elements within panel-heading components
  - this made panel headings look bad in many cases (e.g. notebook review panel)
- SecurityAPIWrapper: Add getAuthenticationConfiguration
