### PR TITLE
GitHub Issue #1023: Add redirect() helper that uses core-safeRedirect 

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.2-fb-redirectGH1023.0",
+  "version": "7.45.2-fb-redirectGH1023.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.2-fb-redirectGH1023.0",
+      "version": "7.45.2-fb-redirectGH1023.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.0",
+  "version": "7.45.1-fb-redirectGH1023.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.0",
+      "version": "7.45.1-fb-redirectGH1023.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.2-fb-redirectGH1023.1",
+  "version": "7.45.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.2-fb-redirectGH1023.1",
+      "version": "7.45.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.1-fb-redirectGH1023.0",
+  "version": "7.45.1-fb-redirectGH1023.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.1-fb-redirectGH1023.0",
+      "version": "7.45.1-fb-redirectGH1023.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-fb-redirectGH1023.0",
+  "version": "7.42.3-fb-redirectGH1023.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.3-fb-redirectGH1023.0",
+      "version": "7.42.3-fb-redirectGH1023.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-fb-redirectGH1023.1",
+  "version": "7.42.3-fb-redirectGH1023.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.3-fb-redirectGH1023.1",
+      "version": "7.42.3-fb-redirectGH1023.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.42.3-fb-redirectGH1023.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.2",
+      "version": "7.42.3-fb-redirectGH1023.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.1",
+  "version": "7.45.2-fb-redirectGH1023.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.1",
+      "version": "7.45.2-fb-redirectGH1023.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.43.0",
+  "version": "7.43.1-fb-redirectGH1023.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.43.0",
+      "version": "7.43.1-fb-redirectGH1023.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.2-fb-redirectGH1023.0",
+  "version": "7.45.2-fb-redirectGH1023.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.43.0",
+  "version": "7.43.1-fb-redirectGH1023.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-fb-redirectGH1023.0",
+  "version": "7.42.3-fb-redirectGH1023.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.2-fb-redirectGH1023.1",
+  "version": "7.45.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.0",
+  "version": "7.45.1-fb-redirectGH1023.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.42.3-fb-redirectGH1023.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.1-fb-redirectGH1023.0",
+  "version": "7.45.1-fb-redirectGH1023.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-fb-redirectGH1023.1",
+  "version": "7.42.3-fb-redirectGH1023.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.1",
+  "version": "7.45.2-fb-redirectGH1023.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.45.2
+*Released*: 29 June 2026
 - GitHub Issue #1023: Add redirect() helper that uses core-safeRedirect when necessary to check url before redirecting
 
 ### version 7.45.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -3,7 +3,7 @@ Components, models, actions, and utility functions for LabKey applications and p
 
 ### version TBD
 *Released*: TBD
-- GitHub Issue #1023: Add redirect() helper that uses core-safeRedirect
+- GitHub Issue #1023: Add redirect() helper that uses core-safeRedirect when necessary to check url before redirecting
 
 ### version 7.45.0
 *Released*: 25 June 2026

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue #1023: Add redirect() helper that uses core-safeRedirect
+
 ### version 7.42.2
 *Released*: 22 June 2026
 - Styling update for user comment on large storage modal

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -7,7 +7,7 @@ import { enableMapSet, enablePatches } from 'immer';
 import { applyURL, AppURL, buildURL, spliceURL } from './internal/url/AppURL';
 import { AppLink } from './internal/url/AppLink';
 import { useAppNavigate } from './internal/url/useAppNavigate';
-import { hasParameter, imageURL, toggleParameter } from './internal/url/ActionURL';
+import { hasParameter, imageURL, redirect, toggleParameter } from './internal/url/ActionURL';
 import { getIntegerSearchParam } from './internal/url/utils';
 import { Container } from './internal/components/base/models/Container';
 import { hasAllPermissions, hasAnyPermissions, hasPermissions, User } from './internal/components/base/models/User';
@@ -1613,6 +1613,7 @@ export {
     QuerySort,
     quoteValueWithDelimiters,
     RANGE_URIS,
+    redirect,
     registerDefaultURLMappers,
     registerFilterType,
     registerInputRenderer,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -423,7 +423,7 @@ import {
     TestLineageAPIWrapper,
 } from './internal/components/lineage/actions';
 import { withLineage } from './internal/components/lineage/withLineage';
-import { DEFAULT_LINEAGE_DISTANCE, LINEAGE_GRAPH_FILTER_METRIC} from './internal/components/lineage/constants';
+import { DEFAULT_LINEAGE_DISTANCE, LINEAGE_GRAPH_FILTER_METRIC } from './internal/components/lineage/constants';
 import {
     LINEAGE_DIRECTIONS,
     LINEAGE_GROUPING_GENERATIONS,

--- a/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
+++ b/packages/components/src/internal/components/domainproperties/AdvancedSettings.tsx
@@ -47,6 +47,7 @@ import {
 } from './constants';
 
 import { DomainFieldLabel } from './DomainFieldLabel';
+import { redirect } from '../../url/ActionURL';
 
 interface AdvancedSettingsProps {
     allowUniqueConstraintProperties: boolean;
@@ -231,7 +232,7 @@ export class AdvancedSettings extends React.PureComponent<AdvancedSettingsProps,
                 params['providerName'] = ActionURL.getParameter('providerName');
             }
 
-            window.location.href = ActionURL.buildURL(controller, action, undefined, params);
+            redirect(ActionURL.buildURL(controller, action, undefined, params));
         }
     };
 

--- a/packages/components/src/internal/components/entities/FindDerivativesButton.tsx
+++ b/packages/components/src/internal/components/entities/FindDerivativesButton.tsx
@@ -7,6 +7,7 @@ import React, { FC, memo, useCallback, useMemo } from 'react';
 import { ActionURL, Filter } from '@labkey/api';
 
 import { AppURL } from '../../url/AppURL';
+import { redirect } from '../../url/ActionURL';
 import { FIND_SAMPLES_BY_FILTER_KEY } from '../../app/constants';
 import { DisableableMenuItem } from '../samples/DisableableMenuItem';
 import { formatDateTime } from '../../util/Date';
@@ -228,9 +229,7 @@ export const FindDerivativesMenuItem: FC<Props> = memo(props => {
         sessionStorage.setItem(getSampleFinderLocalStorageKey(), searchFiltersToJson(filterProps, 0, currentTimestamp));
         api.query.incrementClientSideMetricCount(metricFeatureArea, 'sampleFinderFindDerivatives');
 
-        window.location.href = AppURL.create('search', FIND_SAMPLES_BY_FILTER_KEY)
-            .addParam('view', sessionViewName)
-            .toHref();
+        redirect(AppURL.create('search', FIND_SAMPLES_BY_FILTER_KEY).addParam('view', sessionViewName));
     }, [api.query, baseFilter, baseModel, entityDataType, metricFeatureArea, model, viewAndUserFilters]);
 
     if (!model.queryInfo) return null;

--- a/packages/components/src/internal/components/entities/FindDerivativesButton.tsx
+++ b/packages/components/src/internal/components/entities/FindDerivativesButton.tsx
@@ -7,7 +7,7 @@ import React, { FC, memo, useCallback, useMemo } from 'react';
 import { ActionURL, Filter } from '@labkey/api';
 
 import { AppURL } from '../../url/AppURL';
-import { redirect } from '../../url/ActionURL';
+import { useAppNavigate } from '../../url/useAppNavigate';
 import { FIND_SAMPLES_BY_FILTER_KEY } from '../../app/constants';
 import { DisableableMenuItem } from '../samples/DisableableMenuItem';
 import { formatDateTime } from '../../util/Date';
@@ -191,6 +191,7 @@ interface Props {
 export const FindDerivativesMenuItem: FC<Props> = memo(props => {
     const { baseEntityDataType, baseModel, baseFilter, model, entityDataType, metricFeatureArea, titleCol } = props;
     const { api } = useAppContext();
+    const { navigate } = useAppNavigate();
 
     const viewAndUserFilters = useMemo(
         () => (!model.queryInfo ? [] : [].concat(model.viewFilters).concat(model.filterArray)),
@@ -229,8 +230,19 @@ export const FindDerivativesMenuItem: FC<Props> = memo(props => {
         sessionStorage.setItem(getSampleFinderLocalStorageKey(), searchFiltersToJson(filterProps, 0, currentTimestamp));
         api.query.incrementClientSideMetricCount(metricFeatureArea, 'sampleFinderFindDerivatives');
 
-        redirect(AppURL.create('search', FIND_SAMPLES_BY_FILTER_KEY).addParam('view', sessionViewName));
-    }, [api.query, baseFilter, baseModel, entityDataType, metricFeatureArea, model, viewAndUserFilters]);
+        navigate(AppURL.create('search', FIND_SAMPLES_BY_FILTER_KEY).addParam('view', sessionViewName));
+    }, [
+        api.query,
+        baseEntityDataType,
+        baseFilter,
+        baseModel,
+        entityDataType,
+        metricFeatureArea,
+        model,
+        navigate,
+        titleCol,
+        viewAndUserFilters,
+    ]);
 
     if (!model.queryInfo) return null;
 

--- a/packages/components/src/internal/url/ActionURL.test.ts
+++ b/packages/components/src/internal/url/ActionURL.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
+ * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import { ActionURL, __setController } from '@labkey/api';
+
+import { getRedirectUrl } from './ActionURL';
+import { AppURL, buildURL } from './AppURL';
+
+// window.location.origin is "http://localhost" in the jsdom test environment.
+const safeRedirectUrl = (returnUrl: string): string =>
+    ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl });
+
+describe('getRedirectUrl', () => {
+    beforeEach(() => {
+        __setController('samplemanager');
+    });
+
+    describe('AppURL', () => {
+        test('navigates directly to an in-app AppURL via toHref()', () => {
+            const url = AppURL.create('registry', 'molecule');
+            expect(url.toHref()).toEqual('#/registry/molecule'); // sanity check: in-app hash path
+            expect(getRedirectUrl(url)).toEqual('#/registry/molecule');
+        });
+
+        test('navigates directly to a cross-app AppURL via toHref(), never through safeRedirect', () => {
+            const url = AppURL.create('registry', 'molecule').setProductId('biologics');
+            expect(url.toHref()).not.toMatch(/^#/); // sanity check: full cross-app URL, not a hash path
+            expect(getRedirectUrl(url)).toEqual(url.toHref());
+            expect(getRedirectUrl(url)).not.toContain('safeRedirect');
+        });
+    });
+
+    describe('same-origin string -> navigates directly', () => {
+        test.each([
+            ['relative path', '/labkey/MyContainer/some-action.view?rowId=4'],
+            ['relative path with hash', '/labkey/MyContainer/app.view#/samples/123'],
+            ['absolute same-origin URL', 'http://localhost/labkey/MyContainer/some-action.view'],
+            ['root-relative path', '/home/project-begin.view'],
+        ])('%s', (_label, url) => {
+            expect(getRedirectUrl(url)).toEqual(url);
+        });
+
+        test('a buildURL() result navigates directly', () => {
+            // Mirrors SamplesEditButton: a self-built server action URL is same-origin, so it is not wrapped.
+            const url = buildURL('publish', 'sampleTypePublishStart.view', { rowId: 4 });
+            expect(getRedirectUrl(url)).toEqual(url);
+            expect(getRedirectUrl(url)).not.toContain('safeRedirect');
+        });
+    });
+
+    describe('cross-origin / opaque string -> routes through safeRedirect', () => {
+        test.each([
+            ['external https URL', 'https://evil.example.com/phish'],
+            ['protocol-relative URL', '//evil.example.com/phish'],
+            ['userinfo confusion (real host is evil)', 'https://localhost@evil.example.com/phish'],
+            ['backslash trickery', 'https:/\\/\\evil.example.com/phish'],
+        ])('%s', (_label, url) => {
+            const result = getRedirectUrl(url);
+            expect(result).toEqual(safeRedirectUrl(url));
+            expect(result).toContain('core-safeRedirect.view');
+            expect(result).toContain('returnUrl=');
+            expect(result).not.toEqual(url);
+        });
+
+        test('javascript: URL has an opaque origin and is routed through safeRedirect', () => {
+            const url = 'javascript:alert(1)'; // eslint-disable-line no-script-url
+            expect(getRedirectUrl(url)).toEqual(safeRedirectUrl(url));
+        });
+
+        test('unparseable string is treated as unsafe and routed through safeRedirect', () => {
+            const url = 'http://[::::::]:not-a-port';
+            expect(getRedirectUrl(url)).toEqual(safeRedirectUrl(url));
+        });
+    });
+});

--- a/packages/components/src/internal/url/ActionURL.test.ts
+++ b/packages/components/src/internal/url/ActionURL.test.ts
@@ -33,6 +33,12 @@ describe('getRedirectUrl', () => {
             ['relative path with hash', '/labkey/MyContainer/app.view#/samples/123'],
             ['absolute same-origin URL', 'http://localhost/labkey/MyContainer/some-action.view'],
             ['root-relative path', '/home/project-begin.view'],
+            ['cross-container relative path', '/labkey/OtherProject/SubFolder/some-action.view?rowId=4'],
+            ['cross-container nested path', '/labkey/OtherProject/Sub/Deep/Folder/project-begin.view'],
+            [
+                'cross-container absolute same-origin URL',
+                'http://localhost/labkey/OtherProject/SubFolder/app.view#/samples/123',
+            ],
         ])('%s', (_label, url) => {
             expect(getRedirectUrl(url)).toEqual(url);
         });

--- a/packages/components/src/internal/url/ActionURL.test.ts
+++ b/packages/components/src/internal/url/ActionURL.test.ts
@@ -2,9 +2,9 @@
  * Copyright (c) 2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
  * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { ActionURL, __setController } from '@labkey/api';
+import { ActionURL } from '@labkey/api';
 
-import { getRedirectUrl } from './ActionURL';
+import { getRedirectUrl, isSameOrigin } from './ActionURL';
 import { AppURL, buildURL } from './AppURL';
 
 // window.location.origin is "http://localhost" in the jsdom test environment.
@@ -12,10 +12,6 @@ const safeRedirectUrl = (returnUrl: string): string =>
     ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl });
 
 describe('getRedirectUrl', () => {
-    beforeEach(() => {
-        __setController('samplemanager');
-    });
-
     describe('AppURL', () => {
         test('navigates directly to an in-app AppURL via toHref()', () => {
             const url = AppURL.create('registry', 'molecule');
@@ -72,5 +68,39 @@ describe('getRedirectUrl', () => {
             const url = 'http://[::::::]:not-a-port';
             expect(getRedirectUrl(url)).toEqual(safeRedirectUrl(url));
         });
+    });
+});
+
+describe('isSameOrigin', () => {
+    // jsdom sets window.location.origin to 'http://localhost'
+
+    test('returns true for a URL on the same origin', () => {
+        expect(isSameOrigin('http://localhost/some/path')).toBe(true);
+    });
+
+    test('returns true for a root-relative URL (same origin by construction)', () => {
+        expect(isSameOrigin('/labkey/plate/plateList.view')).toBe(true);
+    });
+
+    test('returns false for a different hostname', () => {
+        expect(isSameOrigin('http://evil.com/path')).toBe(false);
+    });
+
+    test('returns false for a different scheme', () => {
+        expect(isSameOrigin('https://localhost/path')).toBe(false);
+    });
+
+    test('returns false for a different port', () => {
+        expect(isSameOrigin('http://localhost:8080/path')).toBe(false);
+    });
+
+    test('returns false for a javascript: URL (XSS guard)', () => {
+        expect(isSameOrigin('javascript:alert(1)')).toBe(false);
+    });
+
+    test('returns false for an absolute URL with an invalid host (throws during construction)', () => {
+        // 'http://a b' has a space in the hostname which is invalid; the URL constructor throws,
+        // and the catch block returns false.
+        expect(isSameOrigin('http://a b/path')).toBe(false);
     });
 });

--- a/packages/components/src/internal/url/ActionURL.ts
+++ b/packages/components/src/internal/url/ActionURL.ts
@@ -110,7 +110,7 @@ export function getRedirectUrl(url: AppURL | string): string {
     return ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl: url });
 }
 
-function isSameOrigin(url: string): boolean {
+export function isSameOrigin(url: string): boolean {
     try {
         return new URL(url, window.location.href).origin === window.location.origin;
     } catch {

--- a/packages/components/src/internal/url/ActionURL.ts
+++ b/packages/components/src/internal/url/ActionURL.ts
@@ -83,3 +83,10 @@ export function imageURL(iconDir: string, src: string): string {
 export function toggleParameter(parameterName: string, value: any): void {
     setParameter(parameterName, hasParameter(parameterName) ? undefined : value);
 }
+
+// Use the safeRedirect action to verify returnURL goes to local URLs only
+export function redirect(url: string): void {
+    if (url) {
+        window.location.href = ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl: url });
+    }
+}

--- a/packages/components/src/internal/url/ActionURL.ts
+++ b/packages/components/src/internal/url/ActionURL.ts
@@ -5,6 +5,8 @@
 import { OrderedMap } from 'immutable';
 import { ActionURL, Utils } from '@labkey/api';
 
+import { AppURL } from './AppURL';
+
 // This is similar to LABKEY.Filter.getSortFromUrl, however, it does not assume the urlPrefix.
 export function getSortFromUrl(queryString: string, urlPrefix?: string): string {
     const params = ActionURL.getParameters(queryString);
@@ -84,7 +86,34 @@ export function toggleParameter(parameterName: string, value: any): void {
     setParameter(parameterName, hasParameter(parameterName) ? undefined : value);
 }
 
-// GitHub Issue #1023: Use the safeRedirect action to verify returnURL goes to local URLs only
-export function redirect(url: string): void {
-    window.location.href = ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl: url });
+// GitHub Issue #1023: Navigate the browser to the given URL, guarding against open-redirect vulnerabilities.
+//  - AppURL: always constructed by us to point at one of our apps, so it is inherently local and we navigate directly.
+//  - A string that resolves to the current origin (relative URLs, buildURL() results, same-host absolute URLs):
+//    inherently local, so we navigate directly.
+//  - Any other string (a different origin, or an unparseable/opaque value such as a javascript: URL): treated as a
+//    potential open-redirect target and routed through core/safeRedirect for authoritative server-side validation
+//    (URLHelper.isAllowableHost, which also honors the admin external-redirect allowlist and the home-page fallback).
+// Note: For those rare cases where we do need to go to a trusted external URL, set window.location.href directly instead of using redirect().
+export function redirect(url: AppURL | string): void {
+    window.location.href = getRedirectUrl(url);
+}
+
+export function getRedirectUrl(url: AppURL | string): string {
+    if (url instanceof AppURL) {
+        return url.toHref();
+    }
+
+    if (isSameOrigin(url)) {
+        return url;
+    }
+
+    return ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl: url });
+}
+
+function isSameOrigin(url: string): boolean {
+    try {
+        return new URL(url, window.location.href).origin === window.location.origin;
+    } catch {
+        return false;
+    }
 }

--- a/packages/components/src/internal/url/ActionURL.ts
+++ b/packages/components/src/internal/url/ActionURL.ts
@@ -86,7 +86,5 @@ export function toggleParameter(parameterName: string, value: any): void {
 
 // GitHub Issue #1023: Use the safeRedirect action to verify returnURL goes to local URLs only
 export function redirect(url: string): void {
-    if (url) {
-        window.location.href = ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl: url });
-    }
+    window.location.href = ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl: url });
 }

--- a/packages/components/src/internal/url/ActionURL.ts
+++ b/packages/components/src/internal/url/ActionURL.ts
@@ -84,7 +84,7 @@ export function toggleParameter(parameterName: string, value: any): void {
     setParameter(parameterName, hasParameter(parameterName) ? undefined : value);
 }
 
-// Use the safeRedirect action to verify returnURL goes to local URLs only
+// GitHub Issue #1023: Use the safeRedirect action to verify returnURL goes to local URLs only
 export function redirect(url: string): void {
     if (url) {
         window.location.href = ActionURL.buildURL('core', 'safeRedirect', undefined, { returnUrl: url });

--- a/packages/components/src/internal/url/useAppNavigate.ts
+++ b/packages/components/src/internal/url/useAppNavigate.ts
@@ -43,7 +43,7 @@ export function useAppNavigate(): AppNavigateState {
                 return;
             }
 
-            redirect(url.toString());
+            redirect(url);
         },
         [rrNavigate]
     );

--- a/packages/components/src/internal/url/useAppNavigate.ts
+++ b/packages/components/src/internal/url/useAppNavigate.ts
@@ -5,6 +5,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useCallback, useMemo } from 'react';
 
+import { redirect } from './ActionURL';
 import { AppURL } from './AppURL';
 import { parseAppPath } from './AppLink';
 
@@ -16,9 +17,9 @@ export type NavigateFn = (url: string | AppURL, replace?: boolean) => void;
  *  - If url is an AppURL it navigates via React Router's navigate method
  *  - If url is a string prefixed with # it will assume the URL is an app path, and use RR's navigate method
  *  - If url is a string pointing to an app path for the current app it will navigate via RR's navigate method
- *  - In all other cases it will use window.location.href to navigate to the given URL
- * string it navigates via window.location.href = url. If you have an AppURL you should always pass it, instead of
- * AppURL.toString() or AppURL.toHref().
+ *  - In all other cases it navigates to the given URL via the redirect() helper, which routes through the
+ * core/safeRedirect action to guard against open-redirect vulnerabilities. If you have an AppURL you should always
+ * pass it, instead of AppURL.toString() or AppURL.toHref().
  */
 interface AppNavigateState {
     goBack: () => void;
@@ -42,7 +43,7 @@ export function useAppNavigate(): AppNavigateState {
                 return;
             }
 
-            window.location.href = url.toString();
+            redirect(url.toString());
         },
         [rrNavigate]
     );


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/1023

In the related PR, we added usages of the core-safeRedirect action. This PR moves that into a redirect() helper that can be used instead of setting window.location.href.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7695
- https://github.com/LabKey/labkey-ui-components/pull/2021
- https://github.com/LabKey/labkey-ui-premium/pull/978
- https://github.com/LabKey/platform/pull/7789 
- https://github.com/LabKey/limsModules/pull/2291

#### Changes
- Add redirect() helper that uses core-safeRedirect 
