### PR TITLE
GitHub Issue 1234: User management page update to use SiteUsers for inactive users grid

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.42.3-fb-usersGH1234.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.2",
+      "version": "7.42.3-fb-usersGH1234.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-fb-usersGH1234.0",
+  "version": "7.42.3-fb-usersGH1234.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.3-fb-usersGH1234.0",
+      "version": "7.42.3-fb-usersGH1234.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.44.2-fb-usersGH1234.0",
+  "version": "7.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.44.2-fb-usersGH1234.0",
+      "version": "7.45.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.43.0",
+  "version": "7.43.1-fb-usersGH1234.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.43.0",
+      "version": "7.43.1-fb-usersGH1234.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.44.1",
+  "version": "7.44.2-fb-usersGH1234.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.44.1",
+      "version": "7.44.2-fb-usersGH1234.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.44.1",
+  "version": "7.44.2-fb-usersGH1234.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.42.3-fb-usersGH1234.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.43.0",
+  "version": "7.43.1-fb-usersGH1234.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.44.2-fb-usersGH1234.0",
+  "version": "7.45.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-fb-usersGH1234.0",
+  "version": "7.42.3-fb-usersGH1234.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.45.0
+*Released*: 25 June 2026
 - GitHub Issue 1234: User management page update to use SiteUsers for inactive users grid
 
 ### version 7.44.1

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GitHub Issue 1234: User management page update to use SiteUsers for inactive users grid
+
 ### version 7.42.2
 *Released*: 22 June 2026
 - Styling update for user comment on large storage modal

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -190,13 +190,9 @@ export const UserDetailsPanel: FC<Props> = props => {
     const handleUsersStateChangeComplete = useCallback(
         (response: any, isDelete = false): void => {
             toggleDialog(undefined); // close dialog
-            if (!isDelete) {
-                loadUserDetails(); // reload to pickup new user state
-            }
-
             onUsersStateChangeComplete?.(response, isDelete);
         },
-        [loadUserDetails, onUsersStateChangeComplete, toggleDialog]
+        [onUsersStateChangeComplete, toggleDialog]
     );
 
     const onUserDeleteComplete = useCallback(

--- a/packages/components/src/internal/components/user/UserDetailsPanel.tsx
+++ b/packages/components/src/internal/components/user/UserDetailsPanel.tsx
@@ -75,7 +75,7 @@ interface Props {
     currentUser: User;
     displayName?: string;
     isSelf?: boolean;
-    onUsersStateChangeComplete?: (response: any, resetSelection: boolean) => void;
+    onUsersStateChangeComplete?: (response: any) => void;
     policy?: SecurityPolicy;
     rolesByUniqueName?: Map<string, SecurityRole>;
     rootPolicy?: SecurityPolicy;
@@ -188,16 +188,16 @@ export const UserDetailsPanel: FC<Props> = props => {
     const toggleDeactivateDialog = useCallback(() => toggleDialog('deactivate'), [toggleDialog]);
 
     const handleUsersStateChangeComplete = useCallback(
-        (response: any, isDelete = false): void => {
+        (response: any): void => {
             toggleDialog(undefined); // close dialog
-            onUsersStateChangeComplete?.(response, isDelete);
+            onUsersStateChangeComplete?.(response);
         },
         [onUsersStateChangeComplete, toggleDialog]
     );
 
     const onUserDeleteComplete = useCallback(
         (response: any) => {
-            handleUsersStateChangeComplete(response, true);
+            handleUsersStateChangeComplete(response);
         },
         [handleUsersStateChangeComplete]
     );

--- a/packages/components/src/internal/components/user/UsersGridPanel.test.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.test.tsx
@@ -41,16 +41,8 @@ describe('<UsersGridPanel/>', () => {
                 0,
                 'user-management-users-all'
             ),
-            'user-management-users-active': makeTestQueryModel(
-                SCHEMAS.CORE_TABLES.USERS,
-                new QueryInfo({}),
-                {},
-                [],
-                0,
-                'user-management-users-active'
-            ),
             'user-management-users-inactive': makeTestQueryModel(
-                SCHEMAS.CORE_TABLES.USERS,
+                SCHEMAS.CORE_TABLES.SITE_USERS,
                 new QueryInfo({}),
                 {},
                 [],
@@ -70,93 +62,8 @@ describe('<UsersGridPanel/>', () => {
         setSearchParams: jest.fn(),
     };
 
-    test('active users view', async () => {
+    test('default (all) users view', async () => {
         const component = <UsersGridPanelImpl {...DEFAULT_PROPS} />;
-
-        renderWithAppContext(component);
-        expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.user-details-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Active Application Users');
-        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
-        expect(buttons).toHaveLength(4);
-        expect(buttons[0].textContent).toBe('Create');
-        expect(buttons[1].textContent).toBe('Manage');
-        expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).toEqual('Manage');
-
-        const menuItems = document.querySelectorAll('.lk-menu-item');
-        expect(menuItems).toHaveLength(11);
-        expect(menuItems[0].textContent).toBe('Deactivate Users');
-        expect(menuItems[1].textContent).toBe('Delete Users');
-        expect(menuItems[2].textContent).toBe('View All Application Users');
-        expect(menuItems[3].textContent).toBe('View All Site Users');
-        expect(menuItems[4].textContent).toBe('View Inactive Application Users');
-    });
-
-    test('without delete or deactivate', () => {
-        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_PROJECT_ADMIN} />;
-
-        renderWithAppContext(component);
-        expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.user-details-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Active Application Users');
-        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
-        expect(buttons).toHaveLength(4);
-        expect(buttons[0].textContent).toBe('Create');
-        expect(buttons[1].textContent).toBe('Manage');
-        expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).toEqual('Manage');
-
-        const menuItems = document.querySelectorAll('.lk-menu-item');
-        expect(menuItems).toHaveLength(8);
-        expect(menuItems[0].textContent).toBe('View All Application Users');
-        expect(menuItems[1].textContent).toBe('View Inactive Application Users');
-    });
-
-    test('without create, delete, or deactivate', () => {
-        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_FOLDER_ADMIN} />;
-
-        renderWithAppContext(component);
-        expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.user-details-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Active Application Users');
-        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
-        expect(buttons).toHaveLength(3);
-        expect(buttons[0].textContent).toBe('Manage');
-        expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).toEqual('Manage');
-
-        const menuItems = document.querySelectorAll('.lk-menu-item');
-        expect(menuItems).toHaveLength(8);
-        expect(menuItems[0].textContent).toBe('View All Application Users');
-        expect(menuItems[1].textContent).toBe('View Inactive Application Users');
-    });
-
-    test('inactive users view', () => {
-        const component = (
-            <UsersGridPanelImpl {...DEFAULT_PROPS} searchParams={new URLSearchParams({ usersView: 'inactive' })} />
-        );
-
-        renderWithAppContext(component);
-        expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.user-details-panel')).toHaveLength(1);
-        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Inactive Application Users');
-        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
-        expect(buttons).toHaveLength(4);
-        expect(buttons[0].textContent).toBe('Create');
-        expect(buttons[1].textContent).toBe('Manage');
-        expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).toEqual('Manage');
-
-        const menuItems = document.querySelectorAll('.lk-menu-item');
-        expect(menuItems).toHaveLength(11);
-        expect(menuItems[0].textContent).toBe('Delete Users');
-        expect(menuItems[1].textContent).toBe('Reactivate Users');
-        expect(menuItems[2].textContent).toBe('View All Application Users');
-        expect(menuItems[3].textContent).toBe('View All Site Users');
-        expect(menuItems[4].textContent).toBe('View Active Application Users');
-    });
-
-    test('all users view', () => {
-        const component = (
-            <UsersGridPanelImpl {...DEFAULT_PROPS} searchParams={new URLSearchParams({ usersView: 'all' })} />
-        );
 
         renderWithAppContext(component);
         expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
@@ -170,10 +77,86 @@ describe('<UsersGridPanel/>', () => {
 
         const menuItems = document.querySelectorAll('.lk-menu-item');
         expect(menuItems).toHaveLength(10);
+        expect(menuItems[0].textContent).toBe('Deactivate Users');
+        expect(menuItems[1].textContent).toBe('Delete Users');
+        expect(menuItems[2].textContent).toBe('View All Site Users');
+        expect(menuItems[3].textContent).toBe('View Inactive Site Users');
+    });
+
+    test('with create but without manage users permission', () => {
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_PROJECT_ADMIN} />;
+
+        renderWithAppContext(component);
+        expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.user-details-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Application Users');
+        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
+        expect(buttons).toHaveLength(3);
+        expect(buttons[0].textContent).toBe('Create');
+        // no Manage dropdown without manage users permission
+        expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).not.toEqual('Manage');
+
+        const menuItems = document.querySelectorAll('.lk-menu-item');
+        expect(menuItems).toHaveLength(6);
+    });
+
+    test('without create or manage users permission', () => {
+        const component = <UsersGridPanelImpl {...DEFAULT_PROPS} user={TEST_USER_FOLDER_ADMIN} />;
+
+        renderWithAppContext(component);
+        expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.user-details-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Application Users');
+        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
+        expect(buttons).toHaveLength(2);
+        expect(buttons[0].textContent).not.toBe('Create');
+        expect(buttons[0].textContent).not.toBe('Manage');
+
+        const menuItems = document.querySelectorAll('.lk-menu-item');
+        expect(menuItems).toHaveLength(6);
+    });
+
+    test('inactive users view', () => {
+        const component = (
+            <UsersGridPanelImpl {...DEFAULT_PROPS} searchParams={new URLSearchParams({ usersView: 'inactive' })} />
+        );
+
+        renderWithAppContext(component);
+        expect(document.querySelectorAll('.grid-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.user-details-panel')).toHaveLength(1);
+        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Inactive Site Users');
+        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
+        expect(buttons).toHaveLength(4);
+        expect(buttons[0].textContent).toBe('Create');
+        expect(buttons[1].textContent).toBe('Manage');
+        expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).toEqual('Manage');
+
+        const menuItems = document.querySelectorAll('.lk-menu-item');
+        expect(menuItems).toHaveLength(10);
         expect(menuItems[0].textContent).toBe('Delete Users');
-        expect(menuItems[1].textContent).toBe('View All Site Users');
-        expect(menuItems[2].textContent).toBe('View Active Application Users');
-        expect(menuItems[3].textContent).toBe('View Inactive Application Users');
+        expect(menuItems[1].textContent).toBe('Reactivate Users');
+        expect(menuItems[2].textContent).toBe('View All Application Users');
+        expect(menuItems[3].textContent).toBe('View All Site Users');
+    });
+
+    test('inactive users view not available without manage users permission', () => {
+        const component = (
+            <UsersGridPanelImpl
+                {...DEFAULT_PROPS}
+                searchParams={new URLSearchParams({ usersView: 'inactive' })}
+                user={TEST_USER_PROJECT_ADMIN}
+            />
+        );
+
+        renderWithAppContext(component);
+        // falls back to the default (all) application users view
+        expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Application Users');
+        const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
+        expect(buttons).toHaveLength(3);
+        expect(buttons[0].textContent).toBe('Create');
+
+        const menuItems = document.querySelectorAll('.lk-menu-item');
+        expect(menuItems).toHaveLength(6);
     });
 
     test('site users view', () => {
@@ -192,14 +175,13 @@ describe('<UsersGridPanel/>', () => {
         expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).toEqual('Manage');
 
         const menuItems = document.querySelectorAll('.lk-menu-item');
-        expect(menuItems).toHaveLength(10);
+        expect(menuItems).toHaveLength(9);
         expect(menuItems[0].textContent).toBe('Delete Users');
         expect(menuItems[1].textContent).toBe('View All Application Users');
-        expect(menuItems[2].textContent).toBe('View Active Application Users');
-        expect(menuItems[3].textContent).toBe('View Inactive Application Users');
+        expect(menuItems[2].textContent).toBe('View Inactive Site Users');
     });
 
-    test('active user limit reached', () => {
+    test('user limit reached', () => {
         const component = (
             <UsersGridPanelImpl
                 {...DEFAULT_PROPS}
@@ -214,15 +196,14 @@ describe('<UsersGridPanel/>', () => {
         expect(buttons[0].hasAttribute('disabled')).toBe(true);
 
         const menuItems = document.querySelectorAll('.lk-menu-item');
-        expect(menuItems).toHaveLength(11);
+        expect(menuItems).toHaveLength(10);
         expect(menuItems[0].textContent).toBe('Delete Users');
         expect(menuItems[1].textContent).toBe('Reactivate Users');
         expect(menuItems[2].textContent).toBe('View All Application Users');
         expect(menuItems[3].textContent).toBe('View All Site Users');
-        expect(menuItems[4].textContent).toBe('View Active Application Users');
     });
 
-    test('active user limit not reached', () => {
+    test('user limit not reached', () => {
         const component = (
             <UsersGridPanelImpl
                 {...DEFAULT_PROPS}
@@ -237,15 +218,14 @@ describe('<UsersGridPanel/>', () => {
         expect(buttons[0].hasAttribute('disabled')).toBe(false);
 
         const menuItems = document.querySelectorAll('.lk-menu-item');
-        expect(menuItems).toHaveLength(11);
+        expect(menuItems).toHaveLength(10);
         expect(menuItems[0].textContent).toBe('Delete Users');
         expect(menuItems[1].textContent).toBe('Reactivate Users');
         expect(menuItems[2].textContent).toBe('View All Application Users');
         expect(menuItems[3].textContent).toBe('View All Site Users');
-        expect(menuItems[4].textContent).toBe('View Active Application Users');
     });
 
-    test('active user limit disabled', () => {
+    test('user limit disabled', () => {
         const component = (
             <UsersGridPanelImpl {...DEFAULT_PROPS} userLimitSettings={{ userLimit: false, remainingUsers: 0 }} />
         );

--- a/packages/components/src/internal/components/user/UsersGridPanel.test.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.test.tsx
@@ -23,7 +23,7 @@ const POLICY = SecurityPolicy.create(policyJSON);
 const ROLES = processGetRolesResponse(rolesJSON.roles);
 const ROLES_BY_NAME = getRolesByUniqueName(ROLES);
 
-describe('<UsersGridPanel/>', () => {
+describe('UsersGridPanel', () => {
     const DEFAULT_PROPS = {
         container: TEST_PROJECT_CONTAINER_ADMIN,
         user: TEST_USER_APP_ADMIN,
@@ -73,6 +73,8 @@ describe('<UsersGridPanel/>', () => {
         expect(buttons).toHaveLength(4);
         expect(buttons[0].textContent).toBe('Create');
         expect(buttons[1].textContent).toBe('Manage');
+        expect(buttons[2].textContent).toBe(' Filters');
+        expect(buttons[3].textContent).toBe('Filters');
         expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).toEqual('Manage');
 
         const menuItems = document.querySelectorAll('.lk-menu-item');
@@ -93,8 +95,13 @@ describe('<UsersGridPanel/>', () => {
         const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
         expect(buttons).toHaveLength(3);
         expect(buttons[0].textContent).toBe('Create');
+        expect(buttons[1].textContent).toBe(' Filters');
+        expect(buttons[2].textContent).toBe('Filters');
         // no Manage dropdown without manage users permission
-        expect(document.querySelectorAll('.dropdown-toggle')[0].textContent.trim()).not.toEqual('Manage');
+        const dropdowns = document.querySelectorAll('.dropdown-toggle');
+        expect(dropdowns).toHaveLength(2);
+        expect(dropdowns[0].textContent).toBe('Export');
+        expect(dropdowns[1].textContent).toBe(' Views');
 
         const menuItems = document.querySelectorAll('.lk-menu-item');
         expect(menuItems).toHaveLength(6);
@@ -109,8 +116,8 @@ describe('<UsersGridPanel/>', () => {
         expect(document.querySelectorAll('.view-header')[0].textContent).toBe('Application Users');
         const buttons = document.querySelectorAll('.grid-panel__button-bar-left button');
         expect(buttons).toHaveLength(2);
-        expect(buttons[0].textContent).not.toBe('Create');
-        expect(buttons[0].textContent).not.toBe('Manage');
+        expect(buttons[0].textContent).toBe(' Filters');
+        expect(buttons[1].textContent).toBe('Filters');
 
         const menuItems = document.querySelectorAll('.lk-menu-item');
         expect(menuItems).toHaveLength(6);

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -48,9 +48,8 @@ const OMITTED_COLUMNS = [
 ];
 
 export enum UsersView {
-    ACTIVE = 'active',
-    INACTIVE = 'inactive',
     ALL = 'all',
+    INACTIVE = 'inactive',
     SITE = 'site',
 }
 
@@ -125,8 +124,12 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
     initQueryModel = (usersView: UsersView): void => {
         const { actions, container, user } = this.props;
         // GitHub Issue 847: if user has manageUsersPermission allow them to select / view all site users
-        const schemaQuery = usersView === UsersView.SITE && user.hasManageUsersPermission() ? SCHEMAS.CORE_TABLES.SITE_USERS : SCHEMAS.CORE_TABLES.USERS;
-        const baseFilters = usersView === UsersView.ALL || usersView === UsersView.SITE ? [] : [Filter.create('active', usersView === UsersView.ACTIVE)];
+        // GitHub Issue 1234: use site users view for the inactive users grid view
+        const schemaQuery =
+            (usersView === UsersView.SITE || usersView === UsersView.INACTIVE) && user.hasManageUsersPermission()
+                ? SCHEMAS.CORE_TABLES.SITE_USERS
+                : SCHEMAS.CORE_TABLES.USERS;
+        const baseFilters = usersView === UsersView.INACTIVE ? [Filter.create('active', false)] : [];
 
         actions.addModel(
             {
@@ -147,12 +150,14 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
 
     getUsersView(paramVal: string): UsersView {
         // only allow 'site' view for user.hasManageUsersPermission()
-        if (paramVal === UsersView.SITE && this.props.user.hasManageUsersPermission()) {
-            return UsersView.SITE;
+        if (this.props.user.hasManageUsersPermission()) {
+            if (paramVal === UsersView.SITE) {
+                return UsersView.SITE;
+            } else if (paramVal === UsersView.INACTIVE) {
+                return UsersView.INACTIVE;
+            }
         }
-        if (paramVal === UsersView.INACTIVE) return UsersView.INACTIVE;
-        if (paramVal === UsersView.ALL) return UsersView.ALL;
-        return UsersView.ACTIVE; // default to view active application users
+        return UsersView.ALL; // default to view application users
     }
 
     getUsersModelId(): string {
@@ -192,10 +197,10 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
 
     onUsersStateChangeComplete = (response: any, isDelete: boolean = false): void => {
         this.closeDialog();
-        if (isDelete) this.updateSelectedUserId(undefined); // clear selected user details
+        this.updateSelectedUserId(undefined); // clear selected user details
         this.props.onUsersStateChangeComplete(response);
         this.props.actions.onModelChange(this.getUsersModelId(), {
-            changeType: isDelete ? ChangeType.delete : ChangeType.update,
+            changeType: ChangeType.delete, // treat all as delete since row count changes with activate/inactivate actions
         });
     };
 
@@ -281,49 +286,46 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                         Create
                     </DisableableButton>
                 )}
-                <ManageDropdownButton showIcon={false} pullRight={false}>
-                    {user.hasManageUsersPermission() && usersView === UsersView.ACTIVE && (
-                        <SelectionMenuItem
-                            text="Deactivate Users"
-                            onClick={() => this.toggleDialog('deactivate', true)}
-                            queryModel={model}
-                            nounPlural="users"
-                        />
-                    )}
-                    {user.hasManageUsersPermission() && (
+                {user.hasManageUsersPermission() && (
+                    <ManageDropdownButton showIcon={false} pullRight={false}>
+                        {usersView === UsersView.ALL && (
+                            <SelectionMenuItem
+                                text="Deactivate Users"
+                                onClick={() => this.toggleDialog('deactivate', true)}
+                                queryModel={model}
+                                nounPlural="users"
+                            />
+                        )}
                         <SelectionMenuItem
                             text="Delete Users"
                             onClick={() => this.toggleDialog('delete', true)}
                             queryModel={model}
                             nounPlural="users"
                         />
-                    )}
-                    {user.hasManageUsersPermission() && usersView === UsersView.INACTIVE && (
-                        <SelectionMenuItem
-                            text="Reactivate Users"
-                            maxSelection={this.getUserLimitRemainingUsers()}
-                            maxSelectionDisabledMsg={
-                                this.getUserLimitRemainingUsers() === 0 ? 'User limit has been reached' : undefined
-                            }
-                            onClick={() => this.toggleDialog('reactivate', true)}
-                            queryModel={model}
-                            nounPlural="users"
-                        />
-                    )}
-                    {user.hasManageUsersPermission() && <MenuDivider />}
-                    {usersView !== UsersView.ALL && (
-                        <MenuItem onClick={() => this.toggleViewActive(UsersView.ALL)}>View All Application Users</MenuItem>
-                    )}
-                    {user.hasManageUsersPermission() && usersView !== UsersView.SITE && (
-                        <MenuItem onClick={() => this.toggleViewActive(UsersView.SITE)}>View All Site Users</MenuItem>
-                    )}
-                    {usersView !== UsersView.ACTIVE && (
-                        <MenuItem onClick={() => this.toggleViewActive(UsersView.ACTIVE)}>View Active Application Users</MenuItem>
-                    )}
-                    {usersView !== UsersView.INACTIVE && (
-                        <MenuItem onClick={() => this.toggleViewActive(UsersView.INACTIVE)}>View Inactive Application Users</MenuItem>
-                    )}
-                </ManageDropdownButton>
+                        {usersView === UsersView.INACTIVE && (
+                            <SelectionMenuItem
+                                text="Reactivate Users"
+                                maxSelection={this.getUserLimitRemainingUsers()}
+                                maxSelectionDisabledMsg={
+                                    this.getUserLimitRemainingUsers() === 0 ? 'User limit has been reached' : undefined
+                                }
+                                onClick={() => this.toggleDialog('reactivate', true)}
+                                queryModel={model}
+                                nounPlural="users"
+                            />
+                        )}
+                        <MenuDivider />
+                        {usersView !== UsersView.ALL && (
+                            <MenuItem onClick={() => this.toggleViewActive(UsersView.ALL)}>View All Application Users</MenuItem>
+                        )}
+                        {usersView !== UsersView.SITE && (
+                            <MenuItem onClick={() => this.toggleViewActive(UsersView.SITE)}>View All Site Users</MenuItem>
+                        )}
+                        {usersView !== UsersView.INACTIVE && (
+                            <MenuItem onClick={() => this.toggleViewActive(UsersView.INACTIVE)}>View Inactive Site Users</MenuItem>
+                        )}
+                    </ManageDropdownButton>
+                )}
             </div>
         );
     };
@@ -339,9 +341,8 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
         let title = 'Application Users';
         if (user.hasManageUsersPermission() && usersView === UsersView.SITE) {
             title = 'Site Users';
-        }
-        else if (usersView !== UsersView.ALL) {
-            title = capitalizeFirstChar(usersView) + ' Application Users';
+        } else if (user.hasManageUsersPermission() && usersView === UsersView.INACTIVE) {
+            title = 'Inactive Site Users';
         }
 
         return (

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -38,13 +38,7 @@ import { UserDetailsPanel } from './UserDetailsPanel';
 import { UserActivateChangeConfirmModal } from './UserActivateChangeConfirmModal';
 import { UserDeleteConfirmModal } from './UserDeleteConfirmModal';
 
-const OMITTED_COLUMNS = [
-    'phone',
-    'im',
-    'mobile',
-    'pager',
-    'groups',
-];
+const OMITTED_COLUMNS = ['phone', 'im', 'mobile', 'pager', 'groups'];
 
 export enum UsersView {
     ALL = 'all',
@@ -71,7 +65,7 @@ interface OwnProps {
     userLimitSettings?: Partial<UserLimitSettings>;
 }
 
-type Props = OwnProps & InjectedQueryModels;
+type Props = InjectedQueryModels & OwnProps;
 
 interface State {
     selectedUserId: number;
@@ -277,51 +271,57 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                 {user.hasAddUsersPermission() && (
                     <DisableableButton
                         bsStyle="success"
-                        onClick={() => this.toggleDialog('create')}
                         disabledMsg={
                             this.getUserLimitRemainingUsers() === 0 ? 'User limit has been reached' : undefined
                         }
+                        onClick={() => this.toggleDialog('create')}
                     >
                         Create
                     </DisableableButton>
                 )}
                 {user.hasManageUsersPermission() && (
-                    <ManageDropdownButton showIcon={false} pullRight={false}>
+                    <ManageDropdownButton pullRight={false} showIcon={false}>
                         {usersView === UsersView.ALL && (
                             <SelectionMenuItem
-                                text="Deactivate Users"
+                                nounPlural="users"
                                 onClick={() => this.toggleDialog('deactivate', true)}
                                 queryModel={model}
-                                nounPlural="users"
+                                text="Deactivate Users"
                             />
                         )}
                         <SelectionMenuItem
-                            text="Delete Users"
+                            nounPlural="users"
                             onClick={() => this.toggleDialog('delete', true)}
                             queryModel={model}
-                            nounPlural="users"
+                            text="Delete Users"
                         />
                         {usersView === UsersView.INACTIVE && (
                             <SelectionMenuItem
-                                text="Reactivate Users"
                                 maxSelection={this.getUserLimitRemainingUsers()}
                                 maxSelectionDisabledMsg={
                                     this.getUserLimitRemainingUsers() === 0 ? 'User limit has been reached' : undefined
                                 }
+                                nounPlural="users"
                                 onClick={() => this.toggleDialog('reactivate', true)}
                                 queryModel={model}
-                                nounPlural="users"
+                                text="Reactivate Users"
                             />
                         )}
                         <MenuDivider />
                         {usersView !== UsersView.ALL && (
-                            <MenuItem onClick={() => this.toggleViewActive(UsersView.ALL)}>View All Application Users</MenuItem>
+                            <MenuItem onClick={() => this.toggleViewActive(UsersView.ALL)}>
+                                View All Application Users
+                            </MenuItem>
                         )}
                         {usersView !== UsersView.SITE && (
-                            <MenuItem onClick={() => this.toggleViewActive(UsersView.SITE)}>View All Site Users</MenuItem>
+                            <MenuItem onClick={() => this.toggleViewActive(UsersView.SITE)}>
+                                View All Site Users
+                            </MenuItem>
                         )}
                         {usersView !== UsersView.INACTIVE && (
-                            <MenuItem onClick={() => this.toggleViewActive(UsersView.INACTIVE)}>View Inactive Site Users</MenuItem>
+                            <MenuItem onClick={() => this.toggleViewActive(UsersView.INACTIVE)}>
+                                View Inactive Site Users
+                            </MenuItem>
                         )}
                     </ManageDropdownButton>
                 )}
@@ -352,12 +352,12 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                         {model && (
                             <GridPanel
                                 actions={actions}
-                                model={model}
-                                loadOnMount={false}
-                                title={title}
                                 ButtonsComponent={() => this.renderButtons()}
                                 highlightLastSelectedRow
+                                loadOnMount={false}
+                                model={model}
                                 showChartMenu={false}
+                                title={title}
                             />
                         )}
                     </div>
@@ -366,9 +366,9 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                             <UserDetailsPanel
                                 {...this.props}
                                 currentUser={user}
-                                userId={selectedUserId}
                                 onUsersStateChangeComplete={this.onUsersStateChangeComplete}
                                 showPermissionListLinks={isAppHome}
+                                userId={selectedUserId}
                             />
                         </div>
                     )}
@@ -376,25 +376,25 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
                 {user.hasAddUsersPermission() && showDialog === 'create' && (
                     <CreateUsersModal
                         container={container}
-                        userLimitSettings={userLimitSettings}
-                        roleOptions={newUserRoleOptions}
-                        onComplete={this.onCreateComplete}
                         onCancel={this.closeDialog}
+                        onComplete={this.onCreateComplete}
+                        roleOptions={newUserRoleOptions}
+                        userLimitSettings={userLimitSettings}
                     />
                 )}
                 {user.hasManageUsersPermission() && (showDialog === 'reactivate' || showDialog === 'deactivate') && (
                     <UserActivateChangeConfirmModal
-                        userIds={model.intSelections}
-                        reactivate={showDialog === 'reactivate'}
-                        onComplete={this.onUsersStateChangeComplete}
                         onCancel={this.closeDialog}
+                        onComplete={this.onUsersStateChangeComplete}
+                        reactivate={showDialog === 'reactivate'}
+                        userIds={model.intSelections}
                     />
                 )}
                 {user.hasManageUsersPermission() && showDialog === 'delete' && (
                     <UserDeleteConfirmModal
-                        userIds={model.intSelections}
-                        onComplete={this.onUserDelete}
                         onCancel={this.closeDialog}
+                        onComplete={this.onUserDelete}
+                        userIds={model.intSelections}
                     />
                 )}
             </>

--- a/packages/components/src/internal/components/user/UsersGridPanel.tsx
+++ b/packages/components/src/internal/components/user/UsersGridPanel.tsx
@@ -24,7 +24,6 @@ import { ManageDropdownButton } from '../buttons/ManageDropdownButton';
 import { SelectionMenuItem } from '../menus/SelectionMenuItem';
 import { GridPanel } from '../../../public/QueryModel/GridPanel';
 import { LoadingSpinner } from '../base/LoadingSpinner';
-import { capitalizeFirstChar } from '../../util/utils';
 
 import { ChangeType, InjectedQueryModels, withQueryModels } from '../../../public/QueryModel/withQueryModels';
 
@@ -195,7 +194,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
         this.props.actions.loadModel(this.getUsersModelId(), true, true);
     }
 
-    onUsersStateChangeComplete = (response: any, isDelete: boolean = false): void => {
+    onUsersStateChangeComplete = (response: any): void => {
         this.closeDialog();
         this.updateSelectedUserId(undefined); // clear selected user details
         this.props.onUsersStateChangeComplete(response);
@@ -205,7 +204,7 @@ export class UsersGridPanelImpl extends PureComponent<Props, State> {
     };
 
     onUserDelete = (response: any): void => {
-        this.onUsersStateChangeComplete(response, true);
+        this.onUsersStateChangeComplete(response);
     };
 
     onRowSelectionChange = (model: QueryModel, row: any, checked: boolean): void => {


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/1234

 The change reworks the User Management grid: it removes the separate "Active" view and makes "All" the default (which already shows only active application users via the core.Users table); the "Inactive" view now queries      
  core.SiteUsers with a active=false base filter and is gated behind hasManageUsersPermission(); and the entire Manage dropdown is now only rendered for users with manage permission. Activate/deactivate/delete now always clear the selection and reload the grid because the row count of the current view changes.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2023
- https://github.com/LabKey/labkey-ui-premium/pull/974
- https://github.com/LabKey/limsModules/pull/2296

#### Changes
- clear selection and reload grid model on activate/inactive (since it changes grid row count)
- remove Active grid view and default to All (which is now the active application users)
- inactive view is now a baseFilter on the SiteUsers grid (so only shown for user with hasManageUsersPermission())