### PR TITLE
GH Issues 254 & 1191: Fixes for navigation menu display

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-menuFixes.0",
+  "version": "7.42.3-menuFixes.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.3-menuFixes.0",
+      "version": "7.42.3-menuFixes.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.43.1-menuFixes.1",
+  "version": "7.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.43.1-menuFixes.1",
+      "version": "7.44.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.42.3-menuFixes.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.42.2",
+      "version": "7.42.3-menuFixes.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.3-menuFixes.0",
+  "version": "7.42.3-menuFixes.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.44.1-menuFixes.1",
+  "version": "7.44.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.42.2",
+  "version": "7.42.3-menuFixes.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version TBD
-*Released*: TBD
+### version 7.44.1
+*Released*: 25 June 2026
 - GH Issue 1191: Don't remove product switch menu from narrow browsers
 - GH Issue 254: Use primary product id to get user menu items instead of current product id.
 

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version TBD
+*Released*: TBD
+- GH Issue 1191: Don't remove product switch menu from narrow browsers
+- GH Issue 254: Use primary product id to get user menu items instead of current product id.
+
 ### version 7.42.2
 *Released*: 22 June 2026
 - Styling update for user comment on large storage modal

--- a/packages/components/src/internal/components/navigation/NavigationAPIWrapper.ts
+++ b/packages/components/src/internal/components/navigation/NavigationAPIWrapper.ts
@@ -18,7 +18,7 @@ export interface NavigationAPIWrapper {
         containerId: string,
         containerPath?: string
     ) => Promise<ProductMenuModel>;
-    loadUserMenu: (currentProductId: string, containerPath?: string) => Promise<MenuSectionModel>;
+    loadUserMenu: (productId: string, containerPath?: string) => Promise<MenuSectionModel>;
 }
 
 export class ServerNavigationAPIWrapper implements NavigationAPIWrapper {
@@ -45,9 +45,9 @@ export class ServerNavigationAPIWrapper implements NavigationAPIWrapper {
         }
     };
 
-    loadUserMenu = async (currentProductId: string, containerPath?: string): Promise<MenuSectionModel> => {
+    loadUserMenu = async (productId: string, containerPath?: string): Promise<MenuSectionModel> => {
         try {
-            return await getUserMenuSection(currentProductId, containerPath);
+            return await getUserMenuSection(productId, containerPath);
         } catch (e) {
             return undefined;
         }

--- a/packages/components/src/internal/components/navigation/NavigationBar.test.tsx
+++ b/packages/components/src/internal/components/navigation/NavigationBar.test.tsx
@@ -65,6 +65,7 @@ describe('NavigationBar', () => {
         maxRows: 1,
         markAllNotificationsRead,
         serverActivity: new ServerNotificationModel(),
+        onRead: jest.fn(),
     };
 
     test('default props', async () => {

--- a/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
@@ -193,7 +193,6 @@ export const UserMenuGroup: FC<UserMenuProps> = props => {
     const { api } = useAppContext<AppContext>();
     const { container, moduleContext } = useServerContext();
     const { appProperties = getPrimaryAppProperties(moduleContext) } = props;
-    const productId = getCurrentAppProperties()?.productId ?? appProperties.productId;
 
     const [model, setModel] = useState<MenuSectionModel>();
 
@@ -203,7 +202,7 @@ export const UserMenuGroup: FC<UserMenuProps> = props => {
             const sectionModel = await api.navigation.loadUserMenu(appProperties.productId, container.path);
             setModel(sectionModel);
         })();
-    }, [api.navigation, appProperties, container.path, moduleContext, productId]);
+    }, [api.navigation, appProperties, container.path, moduleContext]);
 
     return <UserMenuGroupImpl {...props} model={model} />;
 };

--- a/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
+++ b/packages/components/src/internal/components/navigation/UserMenuGroup.tsx
@@ -200,7 +200,7 @@ export const UserMenuGroup: FC<UserMenuProps> = props => {
     useEffect(() => {
         (async () => {
             // no try/catch as the loadUserMenu will catch errors and return undefined
-            const sectionModel = await api.navigation.loadUserMenu(productId, container.path);
+            const sectionModel = await api.navigation.loadUserMenu(appProperties.productId, container.path);
             setModel(sectionModel);
         })();
     }, [api.navigation, appProperties, container.path, moduleContext, productId]);

--- a/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
+++ b/packages/components/src/internal/components/productnavigation/ProductNavigation.tsx
@@ -14,7 +14,7 @@ export const ProductNavigation: FC = memo(() => {
     const onCloseMenu = useCallback(() => setShow(false), []);
     const toggleMenu = useCallback(() => setShow(s => !s), []);
     return (
-        <div className="navbar-item pull-right product-navigation-menu hidden-xs navbar-menu">
+        <div className="navbar-item pull-right product-navigation-menu navbar-menu">
             <button
                 aria-haspopup="true"
                 aria-expanded={show}

--- a/packages/components/src/internal/productFixtures.ts
+++ b/packages/components/src/internal/productFixtures.ts
@@ -104,6 +104,7 @@ export const TEST_LKS_STARTER_MODULE_CONTEXT = {
     },
     core: {
         productFeatures: [ProductFeature.ApiKeys, ProductFeature.Assay],
+        primaryApplicationId: SAMPLE_MANAGER_PRODUCT_ID,
     },
 };
 


### PR DESCRIPTION
#### Rationale
- Issue [254](https://github.com/LabKey/internal-issues/issues/254)
- Issue [1191](https://github.com/LabKey/internal-issues/issues/1191)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2297

#### Changes
- Don't remove product switch menu from narrow browsers
- Use primary product id to get user menu items instead of current product id.