### PR TITLE
Export DetailDisplay, remove unused styles

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.4",
+  "version": "7.45.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.4",
+      "version": "7.45.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.4",
+  "version": "7.45.5",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,11 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.45.5
+*Released*: ?
+- Export DetailDisplay
+- ExpandableContainer: Fix style issues
+
 ### version 7.45.4
 *Released*: 7 July 2026
 - GitHub Issue #1846: Add role-restriction option to API key dialog

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -5,6 +5,8 @@ Components, models, actions, and utility functions for LabKey applications and p
 *Released*: ?
 - Export DetailDisplay
 - ExpandableContainer: Fix style issues
+- Remove .component-detail and .detail-components styles
+  - These have been moved to Biologics where they are used exclusively
 
 ### version 7.45.4
 *Released*: 7 July 2026

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -2,7 +2,7 @@
 Components, models, actions, and utility functions for LabKey applications and pages
 
 ### version 7.45.5
-*Released*: ?
+*Released*: 7 July 2026
 - Export DetailDisplay
 - ExpandableContainer: Fix style issues
 - Remove .component-detail and .detail-components styles

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -309,7 +309,7 @@ import { ColorIcon } from './internal/components/base/ColorIcon';
 import { QuerySelect } from './internal/components/forms/QuerySelect';
 import { PageDetailHeader } from './internal/components/forms/PageDetailHeader';
 import { DetailPanelHeader } from './internal/components/forms/detail/DetailPanelHeader';
-import { resolveDetailRenderer } from './internal/components/forms/detail/DetailDisplay';
+import { DetailDisplay, resolveDetailRenderer } from './internal/components/forms/detail/DetailDisplay';
 import { useDataChangeCommentsRequired } from './internal/components/forms/input/useDataChangeCommentsRequired';
 import {
     InputRenderContext,
@@ -1238,6 +1238,7 @@ export {
     DERIVATION_DATA_SCOPES,
     DERIVATIVE_CREATION,
     DesignerDetailTooltip,
+    DetailDisplay,
     DetailPanel,
     DetailPanelHeader,
     DetailPanelWithModel,

--- a/packages/components/src/internal/UnidentifiedPill.tsx
+++ b/packages/components/src/internal/UnidentifiedPill.tsx
@@ -7,7 +7,12 @@ import { createPortal } from 'react-dom';
 import { generateId } from './util/utils';
 import { useOverlayTriggerState } from './OverlayTrigger';
 import { Popover } from './Popover';
-import { EMPTY_COMPOUND_WARNING, EMPTY_NS_SEQUENCE_WARNING, EMPTY_PS_SEQUENCE_WARNING } from './constants';
+import {
+    EMPTY_COMPOUND_WARNING,
+    EMPTY_NS_SEQUENCE_WARNING,
+    EMPTY_PS_SEQUENCE_WARNING,
+    UNIDENTIFIED_MOLECULE_WARNING,
+} from './constants';
 import { SchemaQuery } from '../public/SchemaQuery';
 import { SCHEMAS } from './schemas';
 
@@ -18,6 +23,8 @@ function getPopoverMessage(schemaQuery: SchemaQuery): string | undefined {
         return EMPTY_NS_SEQUENCE_WARNING;
     } else if (schemaQuery.isEqual(SCHEMAS.DATA_CLASSES.COMPOUND, false)) {
         return EMPTY_COMPOUND_WARNING;
+    } else if (schemaQuery.isEqual(SCHEMAS.DATA_CLASSES.MOLECULE, false)) {
+        return UNIDENTIFIED_MOLECULE_WARNING;
     }
 
     return undefined;

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.tsx
@@ -214,7 +214,7 @@ export const DetailDisplay: FC<DetailDisplayProps> = memo(props => {
                     // key safety
                     const newRow = row.reduce((newRow, value, key) => {
                         return newRow.set(key.toLowerCase(), value);
-                    }, OrderedMap<string, any>());
+                    }, OrderedMap<string, unknown>());
 
                     return (
                         <table className={classNames(DETAIL_TABLE_CLASSES, tableCls)} key={i}>

--- a/packages/components/src/internal/components/forms/detail/DetailPanelHeader.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailPanelHeader.tsx
@@ -40,12 +40,9 @@ export const DetailPanelHeader: FC<DetailPanelHeaderProps> = memo(props => {
             <span>{title}</span>
             <span className="detail__edit--heading">
                 {isEditable && (
-                    <>
-                        <button className="clickable-text detail__edit-button" onClick={onClick} type="button">
-                            <Icon iconClass="fa fa-pencil-square-o" srText={'Edit ' + title} />
-                        </button>
-                        <div className="clearfix" />
-                    </>
+                    <button className="clickable-text detail__edit-button" onClick={onClick} type="button">
+                        <Icon iconClass="fa fa-pencil-square-o" srText={'Edit ' + title} />
+                    </button>
                 )}
             </span>
         </h2>

--- a/packages/components/src/internal/components/lineage/node/NodeDetailHeader.tsx
+++ b/packages/components/src/internal/components/lineage/node/NodeDetailHeader.tsx
@@ -19,7 +19,7 @@ export interface DetailHeaderProps extends PropsWithChildren {
 
 export const DetailHeader: FC<DetailHeaderProps> = memo(({ children, header, iconSrc }) => (
     <div className="lineage-detail-header margin-bottom">
-        <i className="component-detail--child--img">
+        <i className="pull-left">
             <SVGIcon height="50px" iconSrc={iconSrc} theme={Theme.ORANGE} width="50px" />
         </i>
         <div className="text__truncate">

--- a/packages/components/src/internal/constants.ts
+++ b/packages/components/src/internal/constants.ts
@@ -256,3 +256,5 @@ export const EMPTY_PS_SEQUENCE_WARNING =
     'No sequence added. The structure format and physical properties of molecules using this sequence cannot be calculated.';
 export const EMPTY_COMPOUND_WARNING =
     'Without SMILES, Molecule component translation cannot be done automatically, and the system cannot prevent duplicates.';
+export const UNIDENTIFIED_MOLECULE_WARNING =
+    'Components not added or are unidentified. The structure format and physical properties cannot be calculated.';

--- a/packages/components/src/public/QueryModel/DetailPanel.tsx
+++ b/packages/components/src/public/QueryModel/DetailPanel.tsx
@@ -46,10 +46,12 @@ export const DetailPanel: FC<DetailPanelProps & RequiresModel> = memo(props => {
 
     return <DetailDisplay {...detailDisplayProps} data={fromJS(model.gridData)} displayColumns={displayColumns} />;
 });
+DetailPanel.displayName = 'DetailPanel';
 
 const DetailPanelWithModelBodyImpl: FC<DetailPanelProps & InjectedQueryModels> = memo(({ queryModels, ...rest }) => {
     return <DetailPanel {...rest} model={queryModels.model} />;
 });
+DetailPanelWithModelBodyImpl.displayName = 'DetailPanelWithModelBodyImpl';
 
 const DetailPanelWithModelBody = withQueryModels<DetailPanelProps>(DetailPanelWithModelBodyImpl);
 
@@ -63,7 +65,8 @@ export const DetailPanelWithModel: FC<DetailPanelWithModelProps> = memo(props =>
     const { keyValue, schemaQuery } = queryConfig;
     const { schemaName, queryName } = schemaQuery;
     // Key is used here to ensure we re-mount the DetailPanel when the queryConfig changes
-    const key = useMemo(() => `${schemaName}.${queryName}.${keyValue}`, [schemaQuery, keyValue]);
+    const key = useMemo(() => `${schemaName}.${queryName}.${keyValue}`, [schemaName, queryName, keyValue]);
 
     return <DetailPanelWithModelBody {...detailPanelProps} autoLoad key={key} queryConfigs={queryConfigs} />;
 });
+DetailPanelWithModel.displayName = 'DetailPanelWithModel';

--- a/packages/components/src/theme/container.scss
+++ b/packages/components/src/theme/container.scss
@@ -1,6 +1,6 @@
 
 .container-expandable {
-  border: 1px solid lightgray;
+  border-top: 1px solid lightgray;
 
   &:before, &:after {
     content: " ";
@@ -31,7 +31,10 @@
       background: $brand-primary;
       color: $white;
 
-      h4, a {
+      a,
+      h4,
+      .clickable-text,
+      .text-muted {
           color: $white;
       }
   }

--- a/packages/components/src/theme/detail.scss
+++ b/packages/components/src/theme/detail.scss
@@ -1,4 +1,3 @@
-
 .detail-component--table__fixed {
   table-layout: fixed;
   border: unset;
@@ -35,23 +34,6 @@
   right: 0;
 }
 
-.detail-component__expanded-container {
-  width: 100%;
-  height: 100%;
-  padding: 0 10px 10px;
-}
-
-.detail-component {
-  padding: 15px 20px 15px 5px;
-  max-width: 100%;
-  position: relative;
-
-  h4 {
-    display: inline;
-    color: $brand-primary;
-  }
-}
-
 .app-page-header__subtitle,
 .detail-subtitle {
     font-weight: 500;
@@ -61,75 +43,12 @@
     margin-bottom: 10px;
 }
 
-.detail-component__active {
-  background: $brand-primary;
-  color: $white;
-  position: relative;
-
-  a, h4 {
-    color: $white;
-  }
-}
-
-.detail-component__inactive {
-  background: $white;
-  color: inherit;
-}
-
-.detail-component__w-child {
-  padding-left: 5%;
-}
-
-.detail-component__w-out-child {
-  padding-left: 5px;
-}
-
 .ws-pre-wrap {
   white-space: pre-wrap;
 }
 
 .ws-no-wrap {
   white-space: nowrap;
-}
-
-.component-detail--child {
-  position: absolute;
-  width: 5%;
-  font-size: 20px;
-  cursor: pointer;
-  left: 0;
-  top: 0;
-  line-height: 80px;
-  padding-left: 1.5%;
-  background: white;
-  color: black !important; // override button.clickable-text
-  border-right: 1px solid lightgray !important; // override button.clickable-text
-}
-
-.component-detail--child--inactive {
-  border-bottom: 1px solid $brand-primary;
-}
-
-.component-detail--child--img {
-  float: left;
-}
-
-.component-detail--child--title {
-  max-width: calc(100% - 100px);
-  margin-left: 5px;
-  float: left;
-}
-
-.component-detail--child--chevron--container {
-  margin-top: 17px;
-
-  & i {
-    width: 14px;
-  }
-}
-
-.component-rmat-details {
-  margin-bottom: 3px;
 }
 
 // Editing styles

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -170,10 +170,6 @@
   color: #3495D2;
 }
 
-.container--action-button {
-  cursor: pointer;
-}
-
 .container--toolbar-button {
   display: inline-block;
   padding-right: 5px;


### PR DESCRIPTION
#### Rationale
This PR exports DetailDisplay (needed for provisional molecule changes in Biologics) and removes unused styles (they have been moved to Biologics where they are used).

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2310
- https://github.com/LabKey/labkey-ui-components/pull/2028
- https://github.com/LabKey/labkey-ui-premium/pull/981
- https://github.com/LabKey/limsModules/pull/2314

#### Changes
- Export DetailDisplay
- ExpandableContainer: Fix style issues
- Remove .component-detail and .detail-components styles
  - These have been moved to Biologics where they are used exclusively
