### PR TITLE
Target ES2023 in @labkey/api

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.5",
+  "version": "7.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.5",
+      "version": "7.46.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.51.5",
+        "@labkey/api": "1.51.6-fb-target-es2023.2",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",
@@ -3775,9 +3775,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.51.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.5.tgz",
-      "integrity": "sha512-F7qo6roSBTqeh68Z4yWwel/AAWvt620SSVdCQauKBYjHRJao/Z29gOKWEQ7lWy0E66avDwBOVzpBZq8syhvP0g==",
+      "version": "1.51.6-fb-target-es2023.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.6-fb-target-es2023.2.tgz",
+      "integrity": "sha512-yEQxb/SCnh7VQYk89Khf0CQCWVPfnMVnvsyAKwqajcwyIyF/Qq1hKTbBr6hCL9sVTlaDn6X0yoPyR1geKyXvSQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.51.6-fb-target-es2023.3",
+        "@labkey/api": "1.52.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",
@@ -3775,9 +3775,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.51.6-fb-target-es2023.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.6-fb-target-es2023.3.tgz",
-      "integrity": "sha512-IG+pBIu9gtHdWtu+B3owgetiSBlmLHUChYyzkjjuqzqQZr1gAviWD64pctxP2le+6rA47eaA9kWAgIL4NXmOlg==",
+      "version": "1.52.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.52.0.tgz",
+      "integrity": "sha512-jpx4bmrJBNoNCS0oJ0PktkbljY27/9f1ZMKx0i2IGjyFPmK0KrQLWp11QiAwu4Yf0KzZ0NUYe1GdBMfpoH5Y8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.51.6-fb-target-es2023.2",
+        "@labkey/api": "1.51.6-fb-target-es2023.3",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",
@@ -3775,9 +3775,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.51.6-fb-target-es2023.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.6-fb-target-es2023.2.tgz",
-      "integrity": "sha512-yEQxb/SCnh7VQYk89Khf0CQCWVPfnMVnvsyAKwqajcwyIyF/Qq1hKTbBr6hCL9sVTlaDn6X0yoPyR1geKyXvSQ==",
+      "version": "1.51.6-fb-target-es2023.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.6-fb-target-es2023.3.tgz",
+      "integrity": "sha512-IG+pBIu9gtHdWtu+B3owgetiSBlmLHUChYyzkjjuqzqQZr1gAviWD64pctxP2le+6rA47eaA9kWAgIL4NXmOlg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.5",
+  "version": "7.46.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.51.5",
+    "@labkey/api": "1.51.6-fb-target-es2023.2",
     "@testing-library/dom": "~10.4.1",
     "@testing-library/jest-dom": "~6.9.1",
     "@testing-library/react": "~16.3.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.51.6-fb-target-es2023.2",
+    "@labkey/api": "1.51.6-fb-target-es2023.3",
     "@testing-library/dom": "~10.4.1",
     "@testing-library/jest-dom": "~6.9.1",
     "@testing-library/react": "~16.3.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/LabKey/labkey-ui-components#readme",
   "dependencies": {
     "@hello-pangea/dnd": "18.0.1",
-    "@labkey/api": "1.51.6-fb-target-es2023.3",
+    "@labkey/api": "1.52.0",
     "@testing-library/dom": "~10.4.1",
     "@testing-library/jest-dom": "~6.9.1",
     "@testing-library/react": "~16.3.2",


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-js/pull/219 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/219
- https://github.com/LabKey/labkey-ui-components/pull/2029
- https://github.com/LabKey/labkey-ui-premium/pull/982
- https://github.com/LabKey/limsModules/pull/2315
- https://github.com/LabKey/platform/pull/7813

#### Changes
- Bump `@labkey` packages
