### PR TITLE
Adjust width of API key display control

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.6-fb-api-key-styling.1",
+  "version": "7.45.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.6-fb-api-key-styling.1",
+      "version": "7.45.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.5",
+  "version": "7.45.6-fb-api-key-styling.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.45.5",
+      "version": "7.45.6-fb-api-key-styling.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.5",
+  "version": "7.45.6-fb-api-key-styling.1",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.45.6-fb-api-key-styling.1",
+  "version": "7.45.6",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,8 +1,8 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
-### version 7.45.6-fb-api-key-styling.0
-*Released*: TBD
+### version 7.45.6
+*Released*: 8 July 2026
 - Adjust width of API key display control so its copy-to-clipboard button doesn't wrap to the next line
 
 ### version 7.45.5

--- a/packages/components/releaseNotes/components.md
+++ b/packages/components/releaseNotes/components.md
@@ -1,6 +1,10 @@
 # @labkey/components
 Components, models, actions, and utility functions for LabKey applications and pages
 
+### version 7.45.6-fb-api-key-styling.0
+*Released*: TBD
+- Adjust width of API key display control so its copy-to-clipboard button doesn't wrap to the next line
+
 ### version 7.45.5
 *Released*: 7 July 2026
 - Export DetailDisplay

--- a/packages/components/src/internal/components/user/APIKeysPanel.tsx
+++ b/packages/components/src/internal/components/user/APIKeysPanel.tsx
@@ -201,7 +201,7 @@ export const KeyGeneratorModal: FC<ModalProps> = props => {
                     <div className="top-padding form-group">
                         <input
                             aria-label={type + ' value'}
-                            className="form-control api-key__input"
+                            className="form-control api-key__display"
                             disabled
                             name={type + '_token'}
                             type="text"

--- a/packages/components/src/theme/user.scss
+++ b/packages/components/src/theme/user.scss
@@ -32,3 +32,9 @@ div:has(> .user-detail-modal) > .modal-backdrop {
 .api-key__input {
     display: inline-block;
 }
+
+// 90% to leave room for the copy-to-clipboard button when displaying the newly generated API key
+.api-key__display {
+    width: 90%;
+    display: inline-block;
+}


### PR DESCRIPTION
#### Rationale
Related PR removed `width: 90%` from `api-key__input` so the "Description" and "Restrict Permissions" controls would use the full width of the "Generate API Key" dialog. However, this style was also used on the API key display element to ensure the copy-to-clipboard button would display next to the API key. This change restores the 90% width for just the display control.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2026
- https://github.com/LabKey/limsModules/pull/2327
- https://github.com/LabKey/platform/pull/7828

#### Changes
- Restore 90% width on API key display element
