### PR TITLE
Improve dirty state handling

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.51.1-fb-improve-dirty.0",
+  "version": "7.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.51.1-fb-improve-dirty.0",
+      "version": "7.52.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.51.0",
+  "version": "7.51.1-fb-improve-dirty.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.51.0",
+      "version": "7.51.1-fb-improve-dirty.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.51.0",
+  "version": "7.51.1-fb-improve-dirty.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.51.1-fb-improve-dirty.0",
+  "version": "7.52.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/src/internal/components/forms/formsy/Formsy.test.tsx
+++ b/packages/components/src/internal/components/forms/formsy/Formsy.test.tsx
@@ -77,6 +77,43 @@ class TestComponent extends React.Component<TestComponentProps> {
 
 const TestInputHoc = withFormsy<TestComponentProps, any>(TestComponent);
 
+// Mirrors the <QuerySelect/> + <SelectInput/> arrangement: on change the input calls setValue() and notifies its
+// parent, and the parent owns the value and feeds it back down through the "value" prop in the same React batch.
+type ControlledInputProps = FormsyInjectedProps<string> & {
+    onValueChange: (value: string) => void;
+    testId?: string;
+};
+
+const ControlledInput = withFormsy<ControlledInputProps, string>(props => {
+    const { onValueChange, setValue, testId, value } = props;
+
+    const onChange = useCallback(
+        evt => {
+            setValue(evt.target.value);
+            onValueChange(evt.target.value);
+        },
+        [onValueChange, setValue]
+    );
+
+    return <input data-testid={testId} onChange={onChange} value={value ?? ''} />;
+});
+
+interface ControlledFormProps {
+    initialValue?: string;
+    onChange: (model: any, isChanged: boolean) => void;
+}
+
+const ControlledForm: FC<ControlledFormProps> = props => {
+    const { initialValue, onChange } = props;
+    const [value, setValue] = useState<string>(initialValue);
+
+    return (
+        <Formsy onChange={onChange}>
+            <ControlledInput name="one" onValueChange={setValue} testId="test-input" value={value} />
+        </Formsy>
+    );
+};
+
 describe('Formsy', () => {
     describe('Setting up a form', () => {
         it('should expose the users DOM node through an innerRef prop', () => {
@@ -982,6 +1019,36 @@ describe('Formsy', () => {
                 </Formsy>
             );
             const input = screen.getByTestId('test-input');
+            fireEvent.change(input, {
+                target: { value: 'bar' },
+            });
+            expect(hasOnChanged).toHaveBeenCalledWith({ one: 'bar' }, true);
+
+            fireEvent.change(input, {
+                target: { value: 'foo' },
+            });
+            expect(hasOnChanged).toHaveBeenCalledWith({ one: 'foo' }, false);
+        });
+
+        it('returns true when a controlled input echoes the value back through props', () => {
+            const hasOnChanged = jest.fn();
+            const screen = render(<ControlledForm initialValue="foo" onChange={hasOnChanged} />);
+
+            fireEvent.change(screen.getByTestId('test-input'), {
+                target: { value: 'bar' },
+            });
+
+            // The pristine baseline is captured when the input mounts, so a parent that writes the new value back
+            // into the "value" prop must not mask the change.
+            expect(hasOnChanged).toHaveBeenCalledWith({ one: 'bar' }, true);
+            expect(hasOnChanged).not.toHaveBeenCalledWith({ one: 'bar' }, false);
+        });
+
+        it('returns false when a controlled input is restored to its initial value', () => {
+            const hasOnChanged = jest.fn();
+            const screen = render(<ControlledForm initialValue="foo" onChange={hasOnChanged} />);
+            const input = screen.getByTestId('test-input');
+
             fireEvent.change(input, {
                 target: { value: 'bar' },
             });

--- a/packages/components/src/internal/components/forms/formsy/Formsy.test.tsx
+++ b/packages/components/src/internal/components/forms/formsy/Formsy.test.tsx
@@ -954,6 +954,49 @@ describe('Formsy', () => {
             expect(input.value).toEqual('');
         });
 
+        it('rebases the pristine baseline when reset with explicit values', () => {
+            const formRef = React.createRef<Formsy>();
+            const screen = render(
+                <Formsy ref={formRef}>
+                    <TestInput name="one" testId="test-input" value="foo" />
+                </Formsy>
+            );
+            const input = screen.getByTestId('test-input') as HTMLInputElement;
+
+            fireEvent.change(input, { target: { value: 'bar' } });
+            expect(formRef.current.isChanged()).toEqual(true);
+
+            act(() => {
+                formRef.current.reset({ one: 'baz' });
+            });
+
+            // The supplied value becomes the new baseline, so the form is no longer dirty against it.
+            expect(input.value).toEqual('baz');
+            expect(input.dataset.isPristine).toEqual('true');
+            expect(formRef.current.isChanged()).toEqual(false);
+        });
+
+        it('restores the mount value and stays pristine when reset without values', () => {
+            const formRef = React.createRef<Formsy>();
+            const screen = render(
+                <Formsy ref={formRef}>
+                    <TestInput name="one" testId="test-input" value="foo" />
+                </Formsy>
+            );
+            const input = screen.getByTestId('test-input') as HTMLInputElement;
+
+            fireEvent.change(input, { target: { value: 'bar' } });
+            expect(formRef.current.isChanged()).toEqual(true);
+
+            act(() => {
+                formRef.current.reset();
+            });
+
+            expect(input.value).toEqual('foo');
+            expect(input.dataset.isPristine).toEqual('true');
+            expect(formRef.current.isChanged()).toEqual(false);
+        });
+
         it('should be able to reset the form using a button', () => {
             function TestForm() {
                 return (
@@ -1042,6 +1085,29 @@ describe('Formsy', () => {
             // into the "value" prop must not mask the change.
             expect(hasOnChanged).toHaveBeenCalledWith({ one: 'bar' }, true);
             expect(hasOnChanged).not.toHaveBeenCalledWith({ one: 'bar' }, false);
+
+            // The echoed prop must not re-apply a value the input already holds, which would fire onChange twice.
+            expect(hasOnChanged).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns true when the value prop is changed by the parent', () => {
+            const hasOnChanged = jest.fn();
+
+            function TestForm() {
+                const [value, setValue] = useState('foo');
+                return (
+                    <Formsy onChange={hasOnChanged}>
+                        <TestInput name="one" testId="test-input" value={value} />
+                        <button data-testid="change-btn" onClick={() => setValue('bar')} type="button" />
+                    </Formsy>
+                );
+            }
+
+            const screen = render(<TestForm />);
+            fireEvent.click(screen.getByTestId('change-btn'));
+
+            // The baseline stays at the mount value, so an externally driven change still counts as a change.
+            expect(hasOnChanged).toHaveBeenCalledWith({ one: 'bar' }, true);
         });
 
         it('returns false when a controlled input is restored to its initial value', () => {

--- a/packages/components/src/internal/components/forms/formsy/Formsy.tsx
+++ b/packages/components/src/internal/components/forms/formsy/Formsy.tsx
@@ -155,12 +155,11 @@ export class Formsy extends Component<FormsyProps, FormsyState> {
 
     getModel = (): IModel => this.mapModel(this.getCurrentValues());
 
-    getPristineValues = () => {
-        return this.inputs.reduce((values, component) => {
-            const {
-                props: { name, value },
-            } = component;
-            values[name] = protectAgainstParamReassignment(value);
+    // Read the baseline captured by withFormsy when the input was constructed rather than the current "value" prop.
+    // Inputs whose parent feeds the changed value back down through "value" would otherwise always compare as unchanged.
+    getPristineValues = (): Values => {
+        return this.inputs.reduce<Values>((values, component) => {
+            values[component.props.name] = protectAgainstParamReassignment(component.state.pristineValue);
             return values;
         }, {});
     };

--- a/packages/components/src/internal/components/forms/formsy/Formsy.tsx
+++ b/packages/components/src/internal/components/forms/formsy/Formsy.tsx
@@ -197,12 +197,15 @@ export class Formsy extends Component<FormsyProps, FormsyState> {
         onReset?.();
     };
 
-    // Reset each key in the model to the original / initial / specified value
+    /**
+     * Reset each key in the model to the original / initial / specified value. A specified value becomes that
+     * input's new pristine baseline, so a form reset with explicit values is not immediately reported as changed.
+     */
     resetModel: IResetModel = (data): void => {
         this.inputs.forEach(component => {
             const { name } = component.props;
             if (data && data.hasOwnProperty(name)) {
-                component.setValue(data[name]);
+                component.resetValue(data[name]);
             } else {
                 component.resetValue();
             }

--- a/packages/components/src/internal/components/forms/formsy/types.ts
+++ b/packages/components/src/internal/components/forms/formsy/types.ts
@@ -3,26 +3,22 @@
 // Repository: https://github.com/formsy/formsy-react/tree/0226fab133a25
 import React, { ComponentClass } from 'react';
 
-export interface Values {
-    [key: string]: any;
-}
+export type Values = Record<string, any>;
 
 export type IModel = any;
 export type IResetModel = (model?: IModel) => void;
-export type IUpdateInputsWithValue<V> = (values: { [key: string]: V }, validate?: boolean) => void;
-export type IUpdateInputsWithError = (errors: { [key: string]: ValidationError }, invalidate?: boolean) => void;
+export type IUpdateInputsWithValue<V> = (values: Record<string, V>, validate?: boolean) => void;
+export type IUpdateInputsWithError = (errors: Record<string, ValidationError>, invalidate?: boolean) => void;
 
-export type ValidationError = string | React.ReactNode;
+export type ValidationError = React.ReactNode | string;
 
 export type ValidationFunction<V> = (values: Values, value: V, extra?: any) => boolean | ValidationError;
 
-export type Validation<V> = string | boolean | ValidationFunction<V>;
+export type Validation<V> = boolean | string | ValidationFunction<V>;
 
-export type Validations<V> = ValidationsStructure<V> | string | object;
+export type Validations<V> = object | string | ValidationsStructure<V>;
 
-export interface ValidationsStructure<V> {
-    [key: string]: Validation<V>;
-}
+export type ValidationsStructure<V> = Record<string, Validation<V>>;
 
 export type RequiredValidation<V> = boolean | Validations<V>;
 
@@ -35,7 +31,7 @@ export interface WrapperProps<V> {
     name: string;
     required?: RequiredValidation<V>;
     validationError?: ValidationError;
-    validationErrors?: { [key: string]: ValidationError };
+    validationErrors?: Record<string, ValidationError>;
     validations?: Validations<V>;
     value?: V;
 }
@@ -81,7 +77,7 @@ export interface WrapperInstanceMethods<V> {
     setValue: (value: V, validate?: boolean) => void;
 }
 
-export type FormsyInjectedProps<V> = WrapperProps<V> & InjectedProps<V>;
+export type FormsyInjectedProps<V> = InjectedProps<V> & WrapperProps<V>;
 
 export interface InputComponent<V> extends React.Component<WrapperProps<V>, WrapperState<V>> {
     requiredValidations?: Validations<V>;

--- a/packages/components/src/internal/components/forms/formsy/types.ts
+++ b/packages/components/src/internal/components/forms/formsy/types.ts
@@ -63,7 +63,7 @@ export interface InjectedProps<V> {
     isValid: boolean;
     isValidValue: (value: V) => boolean;
     ref?: React.Ref<any>;
-    resetValue: () => void;
+    resetValue: (...args: [] | [V]) => void;
     setValidations: (validations: Validations<V>, required: RequiredValidation<V>) => void;
     setValue: (value: V, validate?: boolean) => void;
     showError: boolean;

--- a/packages/components/src/internal/components/forms/formsy/withFormsy.tsx
+++ b/packages/components/src/internal/components/forms/formsy/withFormsy.tsx
@@ -7,8 +7,8 @@ import { FormsyContext } from './FormsyContext';
 import {
     ComponentWithStaticAttributes,
     FormsyContextInterface,
-    InjectedProps,
     FormsyInjectedProps,
+    InjectedProps,
     RequiredValidation,
     ValidationError,
     Validations,
@@ -55,9 +55,9 @@ function isChanged(a: object, b: object): boolean {
 }
 
 export function withFormsy<T, V>(
-    WrappedComponent: React.ComponentType<T & FormsyInjectedProps<V>>
+    WrappedComponent: React.ComponentType<FormsyInjectedProps<V> & T>
 ): React.ComponentType<Omit<T & WrapperProps<V>, keyof InjectedProps<V>>> {
-    type WrappedProps = T & WrapperProps<V> & FormsyContextInterface;
+    type WrappedProps = FormsyContextInterface & T & WrapperProps<V>;
 
     class WithFormsyWrapper
         extends React.Component<WrappedProps, WrapperState<V>>
@@ -111,9 +111,11 @@ export function withFormsy<T, V>(
         componentDidUpdate = (prevProps: WrappedProps): void => {
             const { required, value, validations, validate } = this.props;
 
-            // If the value passed has changed, set it. If value is not passed it will
-            // internally update, and this will never run
-            if (!isSame(value, prevProps.value)) {
+            // If the value passed has changed, set it. If a value is not passed, it will internally update, and this
+            // will never run. Skip when the input already holds the value: a parent that owns the value and echoes it
+            // back would otherwise run a redundant validation pass and fire a duplicate onChange for a value that is
+            // already applied.
+            if (!isSame(value, prevProps.value) && !isSame(value, this.state.value)) {
                 this.setValue(value);
             }
 
@@ -129,7 +131,7 @@ export function withFormsy<T, V>(
             this.props.detachFromForm(this);
         };
 
-        getErrorMessage = (): ValidationError | null => {
+        getErrorMessage = (): null | ValidationError => {
             const messages = this.getErrorMessages();
             return messages.length ? messages[0] : null;
         };
@@ -157,10 +159,20 @@ export function withFormsy<T, V>(
 
         isValidValue = (value: V) => this.props.isValidValue(this, value);
 
-        resetValue = (): void => {
+        /**
+         * Restores the input to a pristine state. A supplied value becomes the new pristine baseline, which is how
+         * Formsy.resetModel() rebases the form (e.g., after a successful save) so it no longer reports as changed.
+         * Called with no arguments, the existing baseline is restored. A rest parameter is used rather than an
+         * optional one so that an explicit {undefined} baseline is distinguishable from "no baseline supplied".
+         * @param args
+         */
+        resetValue = (...args: [] | [V]): void => {
             if (!this._mounted) return;
             this.setState(
-                state => ({ isPristine: true, value: state.pristineValue }),
+                state => {
+                    const pristineValue = args.length ? args[0] : state.pristineValue;
+                    return { isPristine: true, pristineValue, value: pristineValue };
+                },
                 () => {
                     this.props.validate(this);
                 }

--- a/packages/components/src/internal/util/RouteLeave.test.tsx
+++ b/packages/components/src/internal/util/RouteLeave.test.tsx
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
+ * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+// This package mocks react-router-dom (see __mocks__/react-router-dom.ts), which stubs out unstable_usePrompt. These
+// tests exercise navigation blocking against a real router, so the mock is not used here.
+jest.unmock('react-router-dom');
+
+import React, { FC, useEffect, useState } from 'react';
+import { act, render } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+import { CONFIRM_MESSAGE, InjectedRouteLeaveProps, useRouteLeave } from './RouteLeave';
+
+const OTHER_ROUTE = '/other';
+const MODAL_MESSAGE = 'Modal confirm message';
+
+class MockRequest {
+    readonly method = 'GET';
+    readonly signal: AbortSignal;
+    readonly url: string;
+
+    constructor(url: string, init: { signal: AbortSignal }) {
+        this.signal = init.signal;
+        this.url = url;
+    }
+}
+// @ts-expect-error jsdom does not implement Request, which React Router instantiates whenever a navigation is allowed
+// to complete.
+global.Request = MockRequest as unknown as typeof Request;
+
+type OnMount = (routeLeave: InjectedRouteLeaveProps) => void;
+
+interface ConsumerProps {
+    confirmMessage?: string;
+    onMount: OnMount;
+}
+
+/**
+ * Test consumer of useRouteLeave. The getIsDirty/setIsDirty pair is handed to the test on mount so that tests can drive
+ * and inspect the dirty bit of an individual consumer.
+ */
+const Consumer: FC<ConsumerProps> = ({ confirmMessage, onMount }) => {
+    const [getIsDirty, setIsDirty] = useRouteLeave(confirmMessage);
+
+    useEffect(() => {
+        onMount({ getIsDirty, setIsDirty });
+    }, [getIsDirty, onMount, setIsDirty]);
+
+    return null;
+};
+
+interface HarnessProps {
+    onModalMount: OnMount;
+    onPageMount: OnMount;
+    onReady: (showModal: (show: boolean) => void) => void;
+}
+
+/**
+ * Models a page that uses useRouteLeave and can mount a second, unrelated consumer (i.e., a modal) over itself.
+ */
+const Harness: FC<HarnessProps> = ({ onModalMount, onPageMount, onReady }) => {
+    const [showModal, setShowModal] = useState<boolean>(false);
+
+    useEffect(() => {
+        onReady(setShowModal);
+    }, [onReady]);
+
+    return (
+        <>
+            <Consumer onMount={onPageMount} />
+            {showModal && <Consumer confirmMessage={MODAL_MESSAGE} onMount={onModalMount} />}
+        </>
+    );
+};
+
+const renderHarness = () => {
+    // Handles are populated as each consumer mounts. The modal handle is replaced every time the modal is re-shown.
+    const modal = {} as InjectedRouteLeaveProps;
+    const page = {} as InjectedRouteLeaveProps;
+    let showModal: (show: boolean) => void;
+
+    // A memory router is used instead of the apps' hash router because blocking is history-agnostic (the blocker lives
+    // in the router itself) and initialEntries keeps each test isolated from the window.location left by the last one.
+    const router = createMemoryRouter(
+        [
+            {
+                element: (
+                    <Harness
+                        onModalMount={routeLeave => Object.assign(modal, routeLeave)}
+                        onPageMount={routeLeave => Object.assign(page, routeLeave)}
+                        onReady={setter => {
+                            showModal = setter;
+                        }}
+                    />
+                ),
+                path: '/',
+            },
+            { element: null, path: OTHER_ROUTE },
+        ],
+        { initialEntries: ['/'] }
+    );
+    const rendered = render(<RouterProvider router={router} />);
+
+    return {
+        modal,
+        page,
+        router,
+        setDirty: (handle: InjectedRouteLeaveProps, dirty: boolean) => act(() => handle.setIsDirty(dirty)),
+        showModal: (show: boolean) => act(() => showModal(show)),
+        unmount: rendered.unmount,
+    };
+};
+
+// Attempt an in-app navigation, flushing the timeout usePrompt uses when the user confirms leaving.
+const navigateAway = async (router: ReturnType<typeof createMemoryRouter>): Promise<void> => {
+    await act(() => router.navigate(OTHER_ROUTE));
+    await act(() => new Promise(resolve => setTimeout(resolve, 0)));
+};
+
+// A single beforeunload listener is expected to be shared by all consumers.
+const getBeforeUnloadListener = (addEventListener: jest.SpyInstance): EventListener => {
+    const calls = addEventListener.mock.calls.filter(([type]) => type === 'beforeunload');
+    expect(calls).toHaveLength(1);
+    return calls[0][1] as EventListener;
+};
+
+const fireBeforeUnload = (listener: EventListener): boolean | undefined => {
+    const event = { returnValue: undefined };
+    listener(event as unknown as Event);
+    return event.returnValue;
+};
+
+describe('useRouteLeave', () => {
+    let confirmSpy: jest.SpyInstance;
+
+    beforeAll(() => {
+        // React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7.
+        // A router only supports one blocker at a time
+        console.warn = jest.fn();
+    });
+
+    beforeEach(() => {
+        // Deny navigation by default. The "leave anyway" case is asserted explicitly.
+        confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('route blocking', () => {
+        test('allows navigation when no consumer is dirty', async () => {
+            const { router } = renderHarness();
+
+            await navigateAway(router);
+
+            expect(confirmSpy).not.toHaveBeenCalled();
+            expect(router.state.location.pathname).toEqual(OTHER_ROUTE);
+        });
+
+        test('blocks navigation when a consumer is dirty', async () => {
+            const { page, router, setDirty } = renderHarness();
+            setDirty(page, true);
+
+            await navigateAway(router);
+
+            expect(confirmSpy).toHaveBeenCalledWith(CONFIRM_MESSAGE);
+            expect(router.state.location.pathname).toEqual('/');
+        });
+
+        test('navigates when the user confirms leaving a dirty consumer', async () => {
+            confirmSpy.mockReturnValue(true);
+            const { page, router, setDirty } = renderHarness();
+            setDirty(page, true);
+
+            await navigateAway(router);
+
+            expect(confirmSpy).toHaveBeenCalled();
+            expect(router.state.location.pathname).toEqual(OTHER_ROUTE);
+        });
+
+        test('blocks navigation when a consumer other than the most recently mounted one is dirty', async () => {
+            const { modal, page, router, setDirty, showModal } = renderHarness();
+            setDirty(page, true);
+            showModal(true);
+            setDirty(modal, false);
+
+            await navigateAway(router);
+
+            expect(confirmSpy).toHaveBeenCalled();
+            expect(router.state.location.pathname).toEqual('/');
+        });
+
+        test('stops blocking navigation once the dirty consumer unmounts', async () => {
+            const { modal, router, setDirty, showModal } = renderHarness();
+            showModal(true);
+            setDirty(modal, true);
+
+            await navigateAway(router);
+            expect(confirmSpy).toHaveBeenCalled();
+            expect(router.state.location.pathname).toEqual('/');
+
+            confirmSpy.mockClear();
+            showModal(false);
+            await navigateAway(router);
+
+            expect(confirmSpy).not.toHaveBeenCalled();
+            expect(router.state.location.pathname).toEqual(OTHER_ROUTE);
+        });
+
+        test('displays the confirmMessage of the consumer holding the blocker', async () => {
+            const { modal, router, setDirty, showModal } = renderHarness();
+            showModal(true);
+            setDirty(modal, true);
+
+            await navigateAway(router);
+
+            expect(confirmSpy).toHaveBeenCalledWith(MODAL_MESSAGE);
+        });
+    });
+
+    describe('dirty bit ownership', () => {
+        test('inherits the aggregate dirty state when mounted', () => {
+            const { modal, page, setDirty, showModal } = renderHarness();
+
+            showModal(true);
+            expect(modal.getIsDirty()).toBe(false);
+            showModal(false);
+
+            setDirty(page, true);
+            showModal(true);
+            expect(modal.getIsDirty()).toBe(true);
+        });
+
+        test('setIsDirty only affects the calling consumer', () => {
+            const { modal, page, setDirty, showModal } = renderHarness();
+            setDirty(page, true);
+            showModal(true);
+
+            setDirty(modal, false);
+
+            expect(modal.getIsDirty()).toBe(false);
+            expect(page.getIsDirty()).toBe(true);
+        });
+
+        test('discards only its own dirty bit when unmounting', async () => {
+            const addEventListener = jest.spyOn(window, 'addEventListener');
+            const { modal, page, router, setDirty, showModal } = renderHarness();
+            setDirty(page, true);
+            showModal(true);
+            setDirty(modal, true);
+
+            showModal(false);
+
+            expect(page.getIsDirty()).toBe(true);
+            expect(fireBeforeUnload(getBeforeUnloadListener(addEventListener))).toBe(true);
+            await navigateAway(router);
+            expect(router.state.location.pathname).toEqual('/');
+        });
+    });
+
+    describe('beforeunload', () => {
+        test('warns when any consumer is dirty', () => {
+            const addEventListener = jest.spyOn(window, 'addEventListener');
+            const { modal, setDirty, showModal } = renderHarness();
+            showModal(true);
+
+            const listener = getBeforeUnloadListener(addEventListener);
+            expect(fireBeforeUnload(listener)).toBeUndefined();
+
+            setDirty(modal, true);
+            expect(fireBeforeUnload(listener)).toBe(true);
+
+            setDirty(modal, false);
+            expect(fireBeforeUnload(listener)).toBeUndefined();
+        });
+
+        test('removes the listener only after the last consumer unmounts', () => {
+            const addEventListener = jest.spyOn(window, 'addEventListener');
+            const removeEventListener = jest.spyOn(window, 'removeEventListener');
+            const { showModal, unmount } = renderHarness();
+            showModal(true);
+            const listener = getBeforeUnloadListener(addEventListener);
+
+            showModal(false);
+            expect(removeEventListener).not.toHaveBeenCalledWith('beforeunload', listener);
+
+            unmount();
+            expect(removeEventListener).toHaveBeenCalledWith('beforeunload', listener);
+        });
+    });
+});

--- a/packages/components/src/internal/util/RouteLeave.test.tsx
+++ b/packages/components/src/internal/util/RouteLeave.test.tsx
@@ -10,7 +10,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { act, render } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
-import { CONFIRM_MESSAGE, InjectedRouteLeaveProps, useRouteLeave } from './RouteLeave';
+import { CONFIRM_MESSAGE, InjectedRouteLeaveProps, SetIsDirty, useRouteLeave } from './RouteLeave';
 
 const OTHER_ROUTE = '/other';
 const MODAL_MESSAGE = 'Modal confirm message';
@@ -112,9 +112,56 @@ const renderHarness = () => {
     };
 };
 
+const FirstPage: FC<ConsumerProps> = props => <Consumer {...props} />;
+const SecondPage: FC<ConsumerProps> = props => <Consumer {...props} />;
+
+const renderPages = () => {
+    // Handles are populated as each page mounts.
+    const first = {} as InjectedRouteLeaveProps;
+    const second = {} as InjectedRouteLeaveProps;
+
+    const router = createMemoryRouter(
+        [
+            { element: <FirstPage onMount={routeLeave => Object.assign(first, routeLeave)} />, path: '/' },
+            { element: <SecondPage onMount={routeLeave => Object.assign(second, routeLeave)} />, path: OTHER_ROUTE },
+        ],
+        { initialEntries: ['/'] }
+    );
+    render(<RouterProvider router={router} />);
+
+    return {
+        first,
+        router,
+        second,
+        setDirty: (handle: InjectedRouteLeaveProps, dirty: boolean) => act(() => handle.setIsDirty(dirty)),
+    };
+};
+
+/**
+ * Marks its parent's consumer dirty from its own mount effect. React runs child effects before parent effects, so this
+ * fires before the parent consumer has had a chance to inherit.
+ */
+const DirtyOnMount: FC<{ setIsDirty: SetIsDirty }> = ({ setIsDirty }) => {
+    useEffect(() => {
+        setIsDirty(true);
+    }, [setIsDirty]);
+
+    return null;
+};
+
+const PageWithEagerChild: FC<ConsumerProps> = ({ onMount }) => {
+    const [getIsDirty, setIsDirty] = useRouteLeave();
+
+    useEffect(() => {
+        onMount({ getIsDirty, setIsDirty });
+    }, [getIsDirty, onMount, setIsDirty]);
+
+    return <DirtyOnMount setIsDirty={setIsDirty} />;
+};
+
 // Attempt an in-app navigation, flushing the timeout usePrompt uses when the user confirms leaving.
-const navigateAway = async (router: ReturnType<typeof createMemoryRouter>): Promise<void> => {
-    await act(() => router.navigate(OTHER_ROUTE));
+const navigateAway = async (router: ReturnType<typeof createMemoryRouter>, route = OTHER_ROUTE): Promise<void> => {
+    await act(() => router.navigate(route));
     await act(() => new Promise(resolve => setTimeout(resolve, 0)));
 };
 
@@ -241,6 +288,46 @@ describe('useRouteLeave', () => {
             setDirty(modal, false);
 
             expect(modal.getIsDirty()).toBe(false);
+            expect(page.getIsDirty()).toBe(true);
+        });
+
+        test('does not inherit from the consumer it replaces on a route change', async () => {
+            // "Leave anyway" -- the outgoing page stays dirty right up until it unmounts.
+            confirmSpy.mockReturnValue(true);
+            const { first, router, second, setDirty } = renderPages();
+            setDirty(first, true);
+
+            await navigateAway(router);
+
+            expect(confirmSpy).toHaveBeenCalledWith(CONFIRM_MESSAGE);
+            expect(router.state.location.pathname).toEqual(OTHER_ROUTE);
+
+            // The replacing page was never edited. Inheritance is resolved once the outgoing consumer has already
+            // unsubscribed, so a consumer on its way out must not hand its dirty bit to the one taking its place.
+            expect(second.getIsDirty()).toBe(false);
+
+            // Leaving the replacing page must not prompt.
+            confirmSpy.mockClear();
+            await navigateAway(router, '/');
+
+            expect(confirmSpy).not.toHaveBeenCalled();
+            expect(router.state.location.pathname).toEqual('/');
+        });
+
+        test('keeps a dirty bit set by a descendant before the consumer inherits', () => {
+            const page = {} as InjectedRouteLeaveProps;
+            const router = createMemoryRouter(
+                [
+                    {
+                        element: <PageWithEagerChild onMount={routeLeave => Object.assign(page, routeLeave)} />,
+                        path: '/',
+                    },
+                ],
+                { initialEntries: ['/'] }
+            );
+            render(<RouterProvider router={router} />);
+
+            // Inheriting must never clear a bit, only set one: the descendant's setIsDirty(true) ran first.
             expect(page.getIsDirty()).toBe(true);
         });
 

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -2,64 +2,92 @@
  * Copyright (c) 2020-2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
  * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { useCallback, useEffect, useRef } from 'react';
+import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 import { unstable_usePrompt as usePrompt } from 'react-router-dom';
 
 export const CONFIRM_MESSAGE = 'You have unsaved changes that will be lost. Are you sure you want to continue?';
 
+export type GetIsDirty = () => boolean;
+export type SetIsDirty = (isDirty: boolean) => void;
+
 export interface InjectedRouteLeaveProps {
-    // getIsDirty is a function that returns a boolean because we use a ref in order to prevent this component from
+    // getIsDirty is a function that returns a boolean because we use a ref to prevent this component from
     // re-rendering child components every time the dirty bit changes.
-    getIsDirty: () => boolean;
-    setIsDirty: (isDirty: boolean) => void;
+    getIsDirty: GetIsDirty;
+    setIsDirty: SetIsDirty;
 }
 
 export interface WrappedRouteLeaveProps {
     confirmMessage?: string;
 }
 
-type GetSetIsDirty = [() => boolean, (dirty: boolean) => void];
+type GetSetIsDirty = [GetIsDirty, SetIsDirty];
+
+/**
+ * The dirty bit for every mounted useRouteLeave() consumer. Each consumer owns its own bit -- it can only ever set or
+ * clear its own -- but navigation is blocked based on the aggregate, so unrelated consumers (e.g., a modal opened from a
+ * dirty form) cannot mask one another. Unmounting a consumer removes only its own bit from the registry.
+ */
+const subscribers = new Set<MutableRefObject<boolean>>();
+
+const isAnyDirty = (): boolean => {
+    for (const subscriber of subscribers) {
+        if (subscriber.current) return true;
+    }
+    return false;
+};
+
+const beforeUnload = (event: BeforeUnloadEvent): void => {
+    if (isAnyDirty()) {
+        event.returnValue = true;
+    }
+};
+
+const subscribe = (isDirty: MutableRefObject<boolean>): (() => void) => {
+    if (subscribers.size === 0) {
+        window.addEventListener('beforeunload', beforeUnload);
+    }
+    subscribers.add(isDirty);
+
+    // Unsubscribe
+    return () => {
+        subscribers.delete(isDirty);
+        if (subscribers.size === 0) {
+            window.removeEventListener('beforeunload', beforeUnload);
+        }
+    };
+};
 
 /**
  * The useRouteLeave hook is useful if you want to display a confirmation dialog when the user tries to navigate away
- * from a "dirty" form or page. This hook ties into both the React Router RouteLeave event, and the browser beforeunload
+ * from a "dirty" form or page. This hook ties into both the React Router RouteLeave event and the browser beforeunload
  * event. This allows us to prevent navigation via back button, link clicking, or browser window/tab closing.
- * @param confirmMessage: The confirm message you want to display to the user, this message is only displayed when
+ *
+ * Multiple, unrelated components may use this hook at the same time (e.g., a page and a modal rendered by that page).
+ * Each consumer gets its own dirty bit, initialized from the dirty state of the consumers already mounted, and only
+ * that bit is discarded when the consumer unmounts. Navigation is blocked whenever any consumer is dirty.
+ *
+ * @param confirmMessage The confirm message you want to display to the user, this message is only displayed when
  * navigating away from the page, not when closing the tab or browser window. Browsers do not let you customize the
- * message displayed when the browser/tab is closed.
+ * message displayed when the browser/tab is closed. When multiple consumers are mounted, the message from the most
+ * recently mounted consumer is used.
  */
 export const useRouteLeave = (confirmMessage = CONFIRM_MESSAGE): GetSetIsDirty => {
-    const isDirty = useRef<boolean>(false);
-    const setIsDirty = useCallback(
-        (dirty: boolean) => {
-            isDirty.current = dirty;
-        },
-        [isDirty]
-    );
-    const getIsDirty = useCallback((): boolean => {
-        return isDirty.current;
+    // Inherit the current dirty state so a consumer mounted over a dirty consumer starts out dirty as well. The
+    // initial value is only applied on the first render, subsequent isAnyDirty() calls here are discarded by useRef.
+    const isDirty = useRef<boolean>(isAnyDirty());
+    const setIsDirty = useCallback<SetIsDirty>(dirty => {
+        isDirty.current = dirty;
     }, []);
+    const getIsDirty = useCallback<GetIsDirty>(() => isDirty.current, []);
 
-    // usePrompt prevents users from going to URLs within our App
-    usePrompt({ when: getIsDirty, message: confirmMessage });
+    // Register this consumer's dirty bit and attach the beforeunload listener (shared by all consumers) if this is
+    // the first one. BeforeUnload is needed so we can prevent the user from going to URLs outside our App.
+    useEffect(() => subscribe(isDirty), []);
 
-    // BeforeUnload is needed so we can prevent the user from going to URLs outside our App (e.g. to FM or LKS)
-    const beforeUnload = useCallback(
-        event => {
-            if (getIsDirty() === true) {
-                event.returnValue = true;
-            }
-        },
-        [getIsDirty]
-    );
-
-    useEffect(() => {
-        window.addEventListener('beforeunload', beforeUnload);
-
-        return () => {
-            window.removeEventListener('beforeunload', beforeUnload);
-        };
-    }, [beforeUnload]);
+    // usePrompt prevents users from going to URLs within our App. Note that React Router only honors a single blocker,
+    // the most recently registered one, so every consumer must block on the aggregate dirty state rather than its own.
+    usePrompt({ message: confirmMessage, when: isAnyDirty });
 
     return [getIsDirty, setIsDirty];
 };

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -73,20 +73,19 @@ const subscribe = (isDirty: MutableRefObject<boolean>): (() => void) => {
  * recently mounted consumer is used.
  */
 export const useRouteLeave = (confirmMessage = CONFIRM_MESSAGE): GetSetIsDirty => {
-    // Inherit the current dirty state so a consumer mounted over a dirty consumer starts out dirty as well. The
-    // initial value is only applied on the first render, subsequent isAnyDirty() calls here are discarded by useRef.
-    const isDirty = useRef<boolean>(isAnyDirty());
+    const isDirty = useRef<boolean>(false);
     const setIsDirty = useCallback<SetIsDirty>(dirty => {
         isDirty.current = dirty;
     }, []);
     const getIsDirty = useCallback<GetIsDirty>(() => isDirty.current, []);
 
-    // Register this consumer's dirty bit and attach the beforeunload listener (shared by all consumers) if this is
-    // the first one. BeforeUnload is needed so we can prevent the user from going to URLs outside our App.
-    useEffect(() => subscribe(isDirty), []);
+    // BeforeUnload is needed so we can prevent the user from going to URLs outside our App.
+    useEffect(() => {
+        isDirty.current = isDirty.current || isAnyDirty();
+        return subscribe(isDirty);
+    }, []);
 
-    // usePrompt prevents users from going to URLs within our App. Note that React Router only honors a single blocker,
-    // the most recently registered one, so every consumer must block on the aggregate dirty state rather than its own.
+    // usePrompt prevents users from going to URLs within our App.
     usePrompt({ message: confirmMessage, when: isAnyDirty });
 
     return [getIsDirty, setIsDirty];

--- a/packages/components/src/internal/util/RouteLeave.tsx
+++ b/packages/components/src/internal/util/RouteLeave.tsx
@@ -44,6 +44,7 @@ const beforeUnload = (event: BeforeUnloadEvent): void => {
 };
 
 const subscribe = (isDirty: MutableRefObject<boolean>): (() => void) => {
+    // BeforeUnload is needed so we can prevent the user from going to URLs outside our App.
     if (subscribers.size === 0) {
         window.addEventListener('beforeunload', beforeUnload);
     }
@@ -79,7 +80,6 @@ export const useRouteLeave = (confirmMessage = CONFIRM_MESSAGE): GetSetIsDirty =
     }, []);
     const getIsDirty = useCallback<GetIsDirty>(() => isDirty.current, []);
 
-    // BeforeUnload is needed so we can prevent the user from going to URLs outside our App.
     useEffect(() => {
         isDirty.current = isDirty.current || isAnyDirty();
         return subscribe(isDirty);


### PR DESCRIPTION
#### Rationale
This improves our dirty state handling to catch a couple of cases we are missing:

1. Changes to a `SelectInput` in a `Formsy` form are not being recorded as a dirty state change.
2. Nested components that make use of `useRouteLeave` override `beforeunload` handling allowing the user to navigate away from dirty page (e.g., from a modal) and not receive an alert.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2044
- https://github.com/LabKey/labkey-ui-premium/pull/1002
- https://github.com/LabKey/limsModules/pull/2371

#### Changes
In `useRouteLeave`:
- Each consumer now owns its dirty bit; setIsDirty and unmount only affect that bit
- `usePrompt` and `beforeunload` now block on the aggregate, so React Router's single-blocker limit no longer masks consumers
- New consumers inherit the dirty state at mount, and one ref-counted `beforeunload` listener replaces one per consumer

In `Formsy`:
- `isChanged()` now uses each input's mount-time `pristineValue`, not the live value prop a controlled parent overwrites                                                                                                                                                                                                       
- `resetModel()` applies explicit values via `resetValue()`, making them the new baseline so a reset isn't reported dirty                                                                                                                                                                                                      
- `withFormsy` skips re-applying a value the input already holds, dropping a redundant validation and duplicate `onChange`
