### PR TITLE
FileInput: configure required and value properties

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.53.0",
+  "version": "7.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.53.0",
+      "version": "7.54.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.53.0",
+  "version": "7.54.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -299,6 +299,7 @@ import {
 import { QueryFormInputs } from './internal/components/forms/QueryFormInputs';
 import { LookupSelectInput } from './internal/components/forms/input/LookupSelectInput';
 import { SelectInput } from './internal/components/forms/input/SelectInput';
+import { RequiredSymbol } from './internal/components/forms/input/RequiredSymbol';
 import { dividedOptionsRenderer, filterDividedOptions } from './internal/components/forms/input/DividedOptionsRenderer';
 import { DatePickerInput } from './internal/components/forms/input/DatePickerInput';
 import { FileInput } from './internal/components/forms/input/FileInput';
@@ -1651,6 +1652,7 @@ export {
     ReportItemModal,
     ReportList,
     request,
+    RequiredSymbol,
     RequiresPermission,
     resolveDetailFieldValue,
     resolveDetailRenderer,

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -63,6 +63,7 @@ import { AddRowsControl, AddRowsControlProps, PlacementType } from './Controls';
 import { CellMessage, EditableColumnMetadata, EditorModel, EditorModelProps, ValueDescriptor } from './models';
 import { computeRangeChange, genCellKey, getValidatedEditableGridValue, parseCellKey } from './utils';
 import { RemoveColumnMenuItem } from './RemoveColumnMenuItem';
+import { RequiredSymbol } from '../forms/input/RequiredSymbol';
 
 function anyCell(values: List<ValueDescriptor>): boolean {
     return true;
@@ -880,7 +881,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 {!showLabelOverlay && (
                     <>
                         {label}
-                        {req && <span className="required-symbol"> *</span>}
+                        <RequiredSymbol required={req} />
                     </>
                 )}
                 {showOverlayFromMetadata && (

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -695,7 +695,10 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
             changesMade = true;
             const col = columnMap.get(parseCellKey(cellKey).fieldKey);
             const isMultiChoiceCol = col?.isMultiChoice;
-            const { message } = getValidatedEditableGridValue(isMultiChoiceCol ? newValues : newValues[0].display, column ?? col);
+            const { message } = getValidatedEditableGridValue(
+                isMultiChoiceCol ? newValues : newValues[0].display,
+                column ?? col
+            );
             changes.cellMessages = cellMessages.set(cellKey, message);
         } else if (mod === MODIFICATION_TYPES.REMOVE) {
             let values: List<ValueDescriptor> = editorModel.getIn(keyPath);
@@ -1024,6 +1027,22 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         let selectionType: SELECTION_TYPES = isShift ? SELECTION_TYPES.AREA_CHANGE : undefined;
 
         switch (event.key) {
+            case Key.ARROW_DOWN: {
+                const predicate = isMeta ? not(isCellEmpty) : anyCell;
+                const found = editorModel.findNextCell(
+                    colIdx,
+                    rowIdx,
+                    predicate,
+                    moveDown,
+                    hideReadonlyRows,
+                    readonlyRows
+                );
+                if (found) {
+                    nextCol = found.colIdx;
+                    nextRow = found.rowIdx;
+                }
+                break;
+            }
             case Key.ARROW_LEFT: {
                 if (isMeta) {
                     const found = editorModel.findNextCell(
@@ -1044,22 +1063,6 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 } else {
                     nextCol = colIdx - 1;
                     nextRow = rowIdx;
-                }
-                break;
-            }
-            case Key.ARROW_UP: {
-                const predicate = isMeta ? not(isCellEmpty) : anyCell;
-                const found = editorModel.findNextCell(
-                    colIdx,
-                    rowIdx,
-                    predicate,
-                    moveUp,
-                    hideReadonlyRows,
-                    readonlyRows
-                );
-                if (found) {
-                    nextCol = found.colIdx;
-                    nextRow = found.rowIdx;
                 }
                 break;
             }
@@ -1086,13 +1089,13 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 }
                 break;
             }
-            case Key.ARROW_DOWN: {
+            case Key.ARROW_UP: {
                 const predicate = isMeta ? not(isCellEmpty) : anyCell;
                 const found = editorModel.findNextCell(
                     colIdx,
                     rowIdx,
                     predicate,
-                    moveDown,
+                    moveUp,
                     hideReadonlyRows,
                     readonlyRows
                 );
@@ -1102,15 +1105,15 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 }
                 break;
             }
-            case Key.HOME: {
-                nextCol = 0;
+            case Key.END: {
+                nextCol = editorModel.orderedColumns.size - 1;
                 nextRow = rowIdx;
                 // Issue 51421
                 if (isShift) selectionType = SELECTION_TYPES.AREA;
                 break;
             }
-            case Key.END: {
-                nextCol = editorModel.orderedColumns.size - 1;
+            case Key.HOME: {
+                nextCol = 0;
                 nextRow = rowIdx;
                 // Issue 51421
                 if (isShift) selectionType = SELECTION_TYPES.AREA;

--- a/packages/components/src/internal/components/forms/FieldLabel.test.tsx
+++ b/packages/components/src/internal/components/forms/FieldLabel.test.tsx
@@ -9,6 +9,8 @@ import { QueryColumn } from '../../../public/QueryColumn';
 
 import { Formsy } from './formsy';
 import { FieldLabel } from './FieldLabel';
+import { LabelOverlayProps } from './LabelOverlay';
+import { INPUT_LABEL_CLASS_NAME_WITH_TOGGLE } from './constants';
 
 const queryColumn = new QueryColumn({
     name: 'testColumn',
@@ -21,20 +23,20 @@ describe('FieldLabel', () => {
     });
 
     test("don't show label", () => {
-        render(<FieldLabel showLabel={false} label="Label" />);
-        expect(document.body.textContent).toBe('');
+        render(<FieldLabel label="Label" showLabel={false} />);
+        expect(document.body).toHaveTextContent('');
     });
 
     test('without overlay, with label', () => {
         const label = <span className="label-span">This is the label</span>;
-        render(<FieldLabel withLabelOverlay={false} label={label} />);
-        expect(document.querySelector('span.label-span').textContent).toBe('This is the label');
+        render(<FieldLabel label={label} withLabelOverlay={false} />);
+        expect(document.querySelector('span.label-span')).toHaveTextContent('This is the label');
         expect(document.querySelectorAll('.overlay-trigger')).toHaveLength(0);
     });
 
     test('without overlay, with column', () => {
-        render(<FieldLabel withLabelOverlay={false} column={queryColumn} />);
-        expect(document.body.textContent).toBe(queryColumn.caption);
+        render(<FieldLabel column={queryColumn} withLabelOverlay={false} />);
+        expect(document.body).toHaveTextContent(queryColumn.caption);
         expect(document.querySelectorAll('.span.label-span')).toHaveLength(0);
         expect(document.querySelectorAll('.overlay-trigger')).toHaveLength(0);
     });
@@ -57,11 +59,23 @@ describe('FieldLabel', () => {
     test('showToggle', () => {
         render(
             <Formsy>
-                <FieldLabel id="test" column={queryColumn} showToggle />
+                <FieldLabel column={queryColumn} id="test" showToggle />
             </Formsy>
         );
         expect(document.querySelectorAll('.toggle')).toHaveLength(1);
         expect(document.querySelectorAll('.overlay-trigger')).toHaveLength(1);
+    });
+
+    test('showToggle requires a column or an id and fieldName', () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        expect(() => render(<FieldLabel showToggle />)).toThrow(
+            'FieldLabel: when showing the toggle, either a column or an id and fieldName must be provided.'
+        );
+        expect(() => render(<FieldLabel fieldName="test" showToggle />)).toThrow();
+        expect(() => render(<FieldLabel id="test" showToggle />)).toThrow();
+
+        consoleError.mockRestore();
     });
 
     test('showToggle, with labelOverlayProps, not formsy', () => {
@@ -72,12 +86,59 @@ describe('FieldLabel', () => {
         };
         render(
             <Formsy>
-                <FieldLabel id="test" column={queryColumn} showToggle labelOverlayProps={props} />
+                <FieldLabel column={queryColumn} id="test" labelOverlayProps={props} showToggle />
             </Formsy>
         );
         expect(document.querySelectorAll('.toggle')).toHaveLength(1);
         expect(document.querySelectorAll('.control-label-toggle-input')).toHaveLength(1);
         expect(document.querySelectorAll('.overlay-trigger')).toHaveLength(1);
+    });
+
+    test('showToggle, with labelOverlayProps, not formsy, sizes the label and toggle columns', () => {
+        const props: LabelOverlayProps = { isFormsy: false, label: 'This is the label' };
+        const { rerender } = render(
+            <Formsy>
+                <FieldLabel column={queryColumn} id="test" labelOverlayProps={props} showToggle />
+            </Formsy>
+        );
+
+        const expectToggleColumns = (): void => {
+            expect(document.querySelector('.control-label')).toHaveClass(INPUT_LABEL_CLASS_NAME_WITH_TOGGLE);
+            expect(document.querySelector('.control-label-toggle-input')).toHaveClass(
+                'control-label-toggle-input-size-fixed'
+            );
+            expect(document.querySelector('.control-label-toggle-input').parentElement).toHaveClass('col-xs-1');
+        };
+
+        expectToggleColumns();
+
+        // The labelOverlayProps supplied by the caller are not modified, so the columns are sized
+        // consistently no matter how many times the same props object is rendered.
+        expect(props.labelClass).toBeUndefined();
+
+        rerender(
+            <Formsy>
+                <FieldLabel column={queryColumn} id="test" labelOverlayProps={props} showToggle />
+            </Formsy>
+        );
+
+        expectToggleColumns();
+    });
+
+    test('showToggle, with labelOverlayProps, not formsy, respects a supplied labelClass', () => {
+        const props: LabelOverlayProps = { isFormsy: false, label: 'This is the label', labelClass: 'custom-label' };
+        render(
+            <Formsy>
+                <FieldLabel column={queryColumn} id="test" labelOverlayProps={props} showToggle />
+            </Formsy>
+        );
+
+        expect(document.querySelector('.custom-label')).toBeInTheDocument();
+        expect(document.querySelector('.custom-label')).not.toHaveClass(INPUT_LABEL_CLASS_NAME_WITH_TOGGLE);
+        expect(document.querySelector('.control-label-toggle-input')).not.toHaveClass(
+            'control-label-toggle-input-size-fixed'
+        );
+        expect(document.querySelector('.control-label-toggle-input').parentElement).not.toHaveClass('col-xs-1');
     });
 
     test('showToggle, with labelOverlayProps, formsy', () => {
@@ -88,7 +149,7 @@ describe('FieldLabel', () => {
         };
         render(
             <Formsy>
-                <FieldLabel id="test" column={queryColumn} showToggle labelOverlayProps={props} />
+                <FieldLabel column={queryColumn} id="test" labelOverlayProps={props} showToggle />
             </Formsy>
         );
         expect(document.querySelectorAll('.toggle')).toHaveLength(1);
@@ -105,10 +166,10 @@ describe('FieldLabel', () => {
         render(
             <Formsy>
                 <FieldLabel
-                    id="test"
                     column={queryColumn}
-                    showToggle
+                    id="test"
                     labelOverlayProps={props}
+                    showToggle
                     toggleClassName="toggle-wrapper"
                 />
             </Formsy>
@@ -127,10 +188,10 @@ describe('FieldLabel', () => {
         render(
             <Formsy>
                 <FieldLabel
-                    id="test"
                     column={queryColumn}
-                    showToggle
+                    id="test"
                     labelOverlayProps={props}
+                    showToggle
                     toggleClassName="toggle-wrapper"
                 />
             </Formsy>
@@ -143,7 +204,7 @@ describe('FieldLabel', () => {
     test('showToggle, toggleProps disabled', () => {
         render(
             <Formsy>
-                <FieldLabel id="test" column={queryColumn} showToggle toggleProps={{ toolTip: 'This is a tooltip' }} />
+                <FieldLabel column={queryColumn} id="test" showToggle toggleProps={{ toolTip: 'This is a tooltip' }} />
             </Formsy>
         );
         expect(document.querySelectorAll('.toggle')).toHaveLength(1);
@@ -154,7 +215,7 @@ describe('FieldLabel', () => {
     test('showToggle, toggleProps not disabled', () => {
         render(
             <Formsy>
-                <FieldLabel id="test" column={queryColumn} showToggle toggleProps={{ onClick: jest.fn() }} />
+                <FieldLabel column={queryColumn} id="test" showToggle toggleProps={{ onClick: jest.fn() }} />
             </Formsy>
         );
         expect(document.querySelectorAll('.toggle')).toHaveLength(1);

--- a/packages/components/src/internal/components/forms/FieldLabel.tsx
+++ b/packages/components/src/internal/components/forms/FieldLabel.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2019-2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { Component, CSSProperties, ReactNode } from 'react';
+import React, { FC, memo, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -14,7 +14,7 @@ import { getFieldEnabledFieldName } from './utils';
 import { LabelOverlay, LabelOverlayProps } from './LabelOverlay';
 import { INPUT_LABEL_CLASS_NAME_WITH_TOGGLE } from './constants';
 
-interface ToggleProps {
+export interface ToggleProps {
     onClick: () => void;
     toolTip?: string;
 }
@@ -28,80 +28,68 @@ export interface FieldLabelProps {
     labelOverlayProps?: LabelOverlayProps;
     showLabel?: boolean;
     showToggle?: boolean;
-    style?: CSSProperties;
     toggleClassName?: string;
     toggleProps?: Partial<ToggleProps>;
     withLabelOverlay?: boolean;
 }
 
-export class FieldLabel extends Component<FieldLabelProps> {
-    static defaultProps = {
-        showLabel: true,
-        withLabelOverlay: true,
-    };
+export const FieldLabel: FC<FieldLabelProps> = memo(props => {
+    const {
+        column,
+        fieldName,
+        id,
+        isDisabled,
+        label,
+        labelOverlayProps,
+        showLabel = true,
+        showToggle,
+        toggleClassName,
+        toggleProps,
+        withLabelOverlay = true,
+    } = props;
 
-    constructor(props: FieldLabelProps) {
-        super(props);
-
-        if (props.showToggle && !props.column && (!props.id || !props.fieldName)) {
-            throw new Error(
-                'FieldLabel: when showing the toggle, either a column or an id and fieldName must be provided.'
-            );
-        }
-    }
-
-    render() {
-        const {
-            label,
-            column,
-            fieldName,
-            id,
-            labelOverlayProps,
-            showLabel,
-            showToggle,
-            isDisabled,
-            toggleProps,
-            withLabelOverlay,
-            toggleClassName,
-        } = this.props;
-
-        if (!showLabel) return null;
-
-        // when not displaying with Formsy and we are displaying the field toggle, we adjust
-        // the columns since the toggle appears outside the label.
-        let toggleContainerClassName,
-            toggleWrapperClassName = 'control-label-toggle-input';
-        if (showToggle && labelOverlayProps && !labelOverlayProps.isFormsy && !labelOverlayProps.labelClass) {
-            labelOverlayProps.labelClass = INPUT_LABEL_CLASS_NAME_WITH_TOGGLE;
-            toggleContainerClassName = 'col-xs-1';
-            toggleWrapperClassName += ' control-label-toggle-input-size-fixed';
-        }
-
-        let labelBody;
-        if (withLabelOverlay) {
-            labelBody = <LabelOverlay column={column} {...labelOverlayProps} />;
-        } else {
-            labelBody = label ? label : column ? column.caption : null;
-        }
-
-        return (
-            <>
-                {labelBody}
-                {showToggle && (
-                    <span className={classNames(toggleContainerClassName)}>
-                        <div className={classNames(toggleClassName, toggleWrapperClassName)}>
-                            <ToggleIcon
-                                id={(id ?? column?.fieldKey) + '::toggle'}
-                                inputFieldName={getFieldEnabledFieldName(column, fieldName)}
-                                active={!isDisabled ? 'on' : 'off'}
-                                onClick={toggleProps?.onClick}
-                                disabled={!toggleProps?.onClick}
-                                toolTip={toggleProps?.toolTip}
-                            />
-                        </div>
-                    </span>
-                )}
-            </>
+    if (showToggle && !column && (!id || !fieldName)) {
+        throw new Error(
+            'FieldLabel: when showing the toggle, either a column or an id and fieldName must be provided.'
         );
     }
-}
+
+    if (!showLabel) return null;
+
+    // When not displaying with Formsy and we are displaying the field toggle, we adjust
+    // the columns since the toggle appears outside the label. A label class supplied by the
+    // caller always takes precedence.
+    const adjustColumnsForToggle = !!(
+        showToggle &&
+        labelOverlayProps &&
+        !labelOverlayProps.isFormsy &&
+        !labelOverlayProps.labelClass
+    );
+
+    const labelClass = adjustColumnsForToggle ? INPUT_LABEL_CLASS_NAME_WITH_TOGGLE : labelOverlayProps?.labelClass;
+    const toggleWrapperClassName = classNames(toggleClassName, 'control-label-toggle-input', {
+        'control-label-toggle-input-size-fixed': adjustColumnsForToggle,
+    });
+
+    return (
+        <>
+            {withLabelOverlay && <LabelOverlay column={column} {...labelOverlayProps} labelClass={labelClass} />}
+            {!withLabelOverlay && (label ? label : column ? column.caption : null)}
+            {showToggle && (
+                <span className={classNames({ 'col-xs-1': adjustColumnsForToggle })}>
+                    <div className={toggleWrapperClassName}>
+                        <ToggleIcon
+                            active={!isDisabled ? 'on' : 'off'}
+                            disabled={!toggleProps?.onClick}
+                            id={(id ?? column?.fieldKey) + '::toggle'}
+                            inputFieldName={getFieldEnabledFieldName(column, fieldName)}
+                            onClick={toggleProps?.onClick}
+                            toolTip={toggleProps?.toolTip}
+                        />
+                    </div>
+                </span>
+            )}
+        </>
+    );
+});
+FieldLabel.displayName = 'FieldLabel';

--- a/packages/components/src/internal/components/forms/LabelOverlay.test.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.test.tsx
@@ -9,52 +9,52 @@ import { LabelOverlay } from './LabelOverlay';
 describe('LabelOverlay', () => {
     it('renders label with overlay, not formsy', () => {
         render(<LabelOverlay isFormsy={false} label="Test Label" />);
-        expect(document.querySelector('.control-label')?.textContent).toBe('Test Label ');
+        expect(document.querySelector('.control-label')).toHaveTextContent('Test Label');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay and required symbol when required, not formsy', () => {
-        render(<LabelOverlay isFormsy={false} label="Test Label" required={true} />);
-        expect(document.querySelector('.control-label')?.textContent).toBe('Test Label * ');
+        render(<LabelOverlay isFormsy={false} label="Test Label" required />);
+        expect(document.querySelector('.control-label')).toHaveTextContent('Test Label *');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay and required, but addLabelAsterisk = false, not formsy', () => {
-        render(<LabelOverlay addLabelAsterisk={false} isFormsy={false} label="Test Label" required={true} />);
-        expect(document.querySelector('.control-label')?.textContent).toBe('Test Label * ');
+        render(<LabelOverlay addLabelAsterisk={false} isFormsy={false} label="Test Label" required />);
+        expect(document.querySelector('.control-label')).toHaveTextContent('Test Label *');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay, required = false, and addLabelAsterisk = true, not formsy', () => {
         render(<LabelOverlay addLabelAsterisk={true} isFormsy={false} label="Test Label" required={false} />);
-        expect(document.querySelector('.control-label')?.textContent).toBe('Test Label * ');
+        expect(document.querySelector('.control-label')).toHaveTextContent('Test Label *');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with no overlay and required symbol when required, not formsy', () => {
-        render(<LabelOverlay helpTipRenderer="NONE" isFormsy={false} label="Test Label" required={true} />);
-        expect(document.querySelector('.control-label')?.textContent).toBe('Test Label * ');
+        render(<LabelOverlay helpTipRenderer="NONE" isFormsy={false} label="Test Label" required />);
+        expect(document.querySelector('.control-label')).toHaveTextContent('Test Label *');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(0);
     });
 
     it('renders label with overlay, isFormsy = true (default)', () => {
         render(<LabelOverlay label="Test Label" />);
         expect(document.querySelector('.control-label')).toBeNull();
-        expect(document.querySelector('span')?.textContent).toBe('Test Label ');
+        expect(document.querySelector('span')).toHaveTextContent('Test Label');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay and required', () => {
-        render(<LabelOverlay isFormsy={true} label="Test Label" required={true} />);
+        render(<LabelOverlay isFormsy label="Test Label" required />);
         expect(document.querySelector('.control-label')).toBeNull();
-        expect(document.querySelector('span')?.textContent).toBe('Test Label * ');
+        expect(document.querySelector('span')).toHaveTextContent('Test Label *');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 
     it('renders label with overlay and addLabelAsterisk', () => {
-        render(<LabelOverlay addLabelAsterisk={true} isFormsy={true} label="Test Label" />);
+        render(<LabelOverlay addLabelAsterisk isFormsy label="Test Label" />);
         expect(document.querySelector('.control-label')).toBeNull();
-        expect(document.querySelector('span')?.textContent).toBe('Test Label * ');
+        expect(document.querySelector('span')).toHaveTextContent('Test Label *');
         expect(document.querySelectorAll('.fa-question-circle')).toHaveLength(1);
     });
 });

--- a/packages/components/src/internal/components/forms/LabelOverlay.tsx
+++ b/packages/components/src/internal/components/forms/LabelOverlay.tsx
@@ -14,6 +14,7 @@ import { Placement } from '../../useOverlayPositioning';
 import { HelpTipRenderer } from './HelpTipRenderer';
 import { INPUT_LABEL_CLASS_NAME } from './constants';
 import { DOMAIN_FIELD, DomainFieldHelpTipContents } from './DomainFieldHelpTipContents';
+import { RequiredSymbol } from './input/RequiredSymbol';
 
 export interface LabelOverlayProps extends PropsWithChildren {
     addLabelAsterisk?: boolean;
@@ -46,7 +47,7 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
         this._popoverId = generateId();
     }
 
-    overlayBody = (): any => {
+    overlayBody = (): ReactNode => {
         const { column, required, description, type, children, helpTipRenderer } = this.props;
 
         if (column?.helpTipRenderer || helpTipRenderer) {
@@ -97,15 +98,16 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
         const label = this.props.label ? this.props.label : column ? column.caption : null;
 
         const overlay = this.getOverlay();
+        const isSymbolRequired = required || addLabelAsterisk;
 
         if (isFormsy) {
-            // when being used as a label for a formsy component directly this will use just a span without the
+            // When being used as a label for a formsy component directly, this will use just a span without the
             // classes applied as well as not needing to handle 'required' display
             return (
                 <span data-fieldkey={dataKey ?? column?.fieldKey} id={column?.labelId}>
                     {label}&nbsp;
                     {overlay}
-                    {required || addLabelAsterisk ? <span className="required-symbol">* </span> : null}
+                    <RequiredSymbol required={isSymbolRequired} />
                 </span>
             );
         }
@@ -115,10 +117,11 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
                 <span className={(labelClass ? labelClass + ' ' : '') + 'text__truncate-and-wrap'} id={column?.labelId}>
                     <span data-fieldkey={dataKey ?? column?.fieldKey}>{label}</span>&nbsp;
                     {overlay}
-                    {required || addLabelAsterisk ? <span className="required-symbol">* </span> : null}
+                    <RequiredSymbol required={isSymbolRequired} />
                 </span>
             );
         }
+
         return (
             <label
                 className={(labelClass ? labelClass + ' ' : '') + 'text__truncate-and-wrap'}
@@ -127,7 +130,7 @@ export class LabelOverlay extends React.Component<LabelOverlayProps> {
             >
                 <span data-fieldkey={inputId}>{label}</span>&nbsp;
                 {overlay}
-                {required || addLabelAsterisk ? <span className="required-symbol">* </span> : null}
+                <RequiredSymbol required={isSymbolRequired} />
             </label>
         );
     }

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -200,10 +200,12 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (!shouldDisableField) {
                         this._fieldEnabledCount++;
                     }
-                    let showAsteriskSymbol = undefined;
+
+                    // Default to undefined so that this factory does not override downstream defaults
+                    let addLabelAsterisk: boolean = undefined;
                     if (!checkRequiredFields && required) {
                         col = col.mutate({ required: false });
-                        showAsteriskSymbol = showLabelAsterisk;
+                        addLabelAsterisk = showLabelAsterisk;
                     }
 
                     let value = caseInsensitive(fieldValues, col.name);
@@ -238,7 +240,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 onToggleDisable={this.onToggleDisable}
                                 queryFilters={queryFilters}
                                 renderLabelField={this.renderLabelField}
-                                showAsteriskSymbol={showAsteriskSymbol}
+                                showAsteriskSymbol={addLabelAsterisk}
                                 showLabel
                                 value={value}
                             />
@@ -267,7 +269,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                                 <React.Fragment key={fieldKey}>
                                     {this.renderLabelField(col)}
                                     <QuerySelect
-                                        addLabelAsterisk={showAsteriskSymbol}
+                                        addLabelAsterisk={addLabelAsterisk}
                                         allowDisable={allowFieldDisable}
                                         containerFilter={
                                             col.lookup.containerFilter ??
@@ -308,7 +310,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (col.validValues) {
                         return (
                             <TextChoiceInput
-                                addLabelAsterisk={showAsteriskSymbol}
+                                addLabelAsterisk={addLabelAsterisk}
                                 allowDisable={allowFieldDisable}
                                 description={col.description}
                                 formsy
@@ -328,7 +330,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (col.inputType === 'textarea') {
                         return (
                             <TextAreaInput
-                                addLabelAsterisk={showAsteriskSymbol}
+                                addLabelAsterisk={addLabelAsterisk}
                                 allowDisable={allowFieldDisable}
                                 hasMixedValue={hasMixedValue}
                                 initiallyDisabled={shouldDisableField}
@@ -342,7 +344,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     } else if (col.inputType === 'file' && renderFileInputs) {
                         return (
                             <FileInput
-                                addLabelAsterisk={showAsteriskSymbol}
+                                addLabelAsterisk={addLabelAsterisk}
                                 allowDisable={allowFieldDisable}
                                 formsy
                                 hasMixedValue={hasMixedValue}
@@ -361,7 +363,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         case 'boolean':
                             return (
                                 <CheckboxInput
-                                    addLabelAsterisk={showAsteriskSymbol}
+                                    addLabelAsterisk={addLabelAsterisk}
                                     allowDisable={allowFieldDisable}
                                     hasMixedValue={hasMixedValue}
                                     initiallyDisabled={shouldDisableField}
@@ -376,7 +378,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                         case 'time':
                             return (
                                 <DatePickerInput
-                                    addLabelAsterisk={showAsteriskSymbol}
+                                    addLabelAsterisk={addLabelAsterisk}
                                     allowDisable={allowFieldDisable}
                                     hasMixedValue={hasMixedValue}
                                     initiallyDisabled={shouldDisableField}
@@ -391,7 +393,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                             return (
                                 <React.Fragment key={fieldKey}>
                                     <TextInput
-                                        addLabelAsterisk={showAsteriskSymbol}
+                                        addLabelAsterisk={addLabelAsterisk}
                                         allowDisable={allowFieldDisable}
                                         hasMixedValue={hasMixedValue}
                                         initiallyDisabled={shouldDisableField}

--- a/packages/components/src/internal/components/forms/QueryFormInputs.tsx
+++ b/packages/components/src/internal/components/forms/QueryFormInputs.tsx
@@ -200,7 +200,7 @@ export class QueryFormInputs extends React.Component<QueryFormInputsProps, State
                     if (!shouldDisableField) {
                         this._fieldEnabledCount++;
                     }
-                    let showAsteriskSymbol = false;
+                    let showAsteriskSymbol = undefined;
                     if (!checkRequiredFields && required) {
                         col = col.mutate({ required: false });
                         showAsteriskSymbol = showLabelAsterisk;

--- a/packages/components/src/internal/components/forms/detail/DetailDisplay.test.tsx
+++ b/packages/components/src/internal/components/forms/detail/DetailDisplay.test.tsx
@@ -2,18 +2,11 @@
  * Copyright (c) 2024-2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
  * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import { fromJS, List } from 'immutable';
 import React from 'react';
 import { render } from '@testing-library/react';
+import { fromJS, List } from 'immutable';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
-
-import { MultiValueRenderer } from '../../../renderers/MultiValueRenderer';
-import { AliasRenderer } from '../../../renderers/AliasRenderer';
-import { AppendUnits } from '../../../renderers/AppendUnits';
-import { AssayRunReferenceRenderer } from '../../../renderers/AssayRunReferenceRenderer';
-import { LabelColorRenderer } from '../../../renderers/LabelColorRenderer';
-import { FileColumnRenderer } from '../../../renderers/FileColumnRenderer';
 
 import { defaultTitleRenderer, DetailDisplay, Renderer, resolveDetailRenderer } from './DetailDisplay';
 
@@ -135,7 +128,7 @@ describe('DetailDisplay', () => {
 
         render(
             <DetailDisplay
-                asPanel={true}
+                asPanel
                 data={data}
                 displayColumns={cols}
                 editingMode={false}
@@ -159,7 +152,7 @@ describe('defaultTitleRenderer', () => {
         });
         render(<div>{defaultTitleRenderer(col)}</div>);
         expect(document.querySelector('span').innerHTML).toEqual(
-            'test&nbsp;<div class="overlay-trigger"><i class="fa fa-question-circle"></i></div><span class="required-symbol">* </span>'
+            'test&nbsp;<div class="overlay-trigger"><i class="fa fa-question-circle"></i></div><span class="required-symbol"> *</span>'
         );
     });
 

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -17,6 +17,7 @@ import {
 } from '../constants';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
+import { RequiredSymbol } from './RequiredSymbol';
 
 interface CheckboxInputProps extends DisableableInputProps {
     addLabelAsterisk?: boolean;
@@ -99,14 +100,14 @@ class CheckboxInputImpl extends DisableableInput<CheckboxInputImplProps, Checkbo
         // React.Nodes as labels.  Using a label that is anything but a string when using Checkbox
         // produces a "Converting circular structure to JSON" error.
         // TODO: This label generation is inconsistent and does not align with other input elements.
-        // This should not be responsible for rendering the "required-symbol" and should allow for component prop
+        // This should not be responsible for rendering the RequiredSymbol and should allow for component prop
         // to define label wrapper classes.
         return (
             <div className={`${containerClassName} checkbox-input-form-row`}>
                 {renderFieldLabel ? (
                     <label className={labelClassName} htmlFor={queryColumn.fieldKey}>
                         {renderFieldLabel(queryColumn)}
-                        {queryColumn?.required && <span className="required-symbol"> *</span>}
+                        <RequiredSymbol required={queryColumn.required || addLabelAsterisk} />
                     </label>
                 ) : (
                     <FieldLabel

--- a/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
+++ b/packages/components/src/internal/components/forms/input/CheckboxInput.tsx
@@ -182,8 +182,7 @@ export const IndeterminateCheckbox: FC<IndeterminateCheckboxProps> = props => {
     const ref = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
-        if (ref?.current)
-            ref.current.indeterminate = true;
+        if (ref?.current) ref.current.indeterminate = true;
     }, [ref?.current]);
 
     return <input id={queryColumn.fieldKey} ref={ref} type="checkbox" {...rest} />;

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -163,8 +163,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputImplPro
         if (relativeInputValue) {
             if (isRelativeDateFilterValue(relativeInputValue, false)) {
                 onChange?.(relativeInputValue);
-            }
-            else {
+            } else {
                 validSelect = undefined;
                 onChange?.(undefined);
             }
@@ -204,12 +203,15 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputImplPro
         onCalendarClose?.();
 
         if (relativeInputValue) {
-            if (isRelativeDateFilterValue(relativeInputValue, true) && !isRelativeDateFilterValue(relativeInputValue, false)) {
+            if (
+                isRelativeDateFilterValue(relativeInputValue, true) &&
+                !isRelativeDateFilterValue(relativeInputValue, false)
+            ) {
                 // clear out invalid relative date input on calendar close
                 onChange?.(undefined);
             }
         }
-    }
+    };
 
     onIconClick = (): void => {
         this.input.current?.setFocus();
@@ -278,9 +280,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputImplPro
                 : (placeholderText ?? `Select ${queryColumn.caption.toLowerCase()}`);
         const picker = (
             <DatePicker
-                ariaLabelledBy={
-                    !showLabel && !renderFieldLabel ? queryColumn.labelId : undefined
-                }
+                ariaLabelledBy={!showLabel && !renderFieldLabel ? queryColumn.labelId : undefined}
                 autoComplete="off"
                 autoFocus={autoFocus}
                 className={inputClassName}

--- a/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DatePickerInput.tsx
@@ -29,6 +29,7 @@ import {
 } from '../constants';
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
+import { RequiredSymbol } from './RequiredSymbol';
 
 export interface DatePickerInputProps extends DisableableInputProps {
     addLabelAsterisk?: boolean;
@@ -327,7 +328,7 @@ export class DatePickerInputImpl extends DisableableInput<DatePickerInputImplPro
                 {renderFieldLabel ? (
                     <label className={labelClassName} htmlFor={queryColumn.fieldKey}>
                         {renderFieldLabel(queryColumn)}
-                        {queryColumn?.required && <span className="required-symbol"> *</span>}
+                        <RequiredSymbol required={queryColumn.required || addLabelAsterisk} />
                     </label>
                 ) : (
                     <FieldLabel

--- a/packages/components/src/internal/components/forms/input/DisableableInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/DisableableInput.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
+ * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { useDisableableInput } from './DisableableInput';
+
+describe('DisableableInput', () => {
+    describe('useDisableableInput', () => {
+        test('inputValue only reflects local edits when allowDisable is true', () => {
+            const disableable = renderHook(() =>
+                useDisableableInput<string>({ allowDisable: true, value: 'fromProps' })
+            );
+
+            expect(disableable.result.current.inputValue).toBe('fromProps');
+
+            act(() => {
+                disableable.result.current.setInputValue('edited');
+            });
+
+            expect(disableable.result.current.inputValue).toBe('edited');
+
+            // Without allowDisable the value from props always wins, mirroring DisableableInput.getInputValue()
+            const notDisableable = renderHook(() => useDisableableInput<string>({ value: 'fromProps' }));
+
+            act(() => {
+                notDisableable.result.current.setInputValue('edited');
+            });
+
+            expect(notDisableable.result.current.inputValue).toBe('fromProps');
+        });
+
+        test('discards local edits when the input is disabled', () => {
+            const { result } = renderHook(() =>
+                useDisableableInput<string>({ allowDisable: true, value: 'fromProps' })
+            );
+
+            act(() => {
+                result.current.setInputValue('edited');
+            });
+
+            expect(result.current.inputValue).toBe('edited');
+
+            // Disabling reverts to the value from props ...
+            act(() => {
+                result.current.toggleDisabled();
+            });
+
+            expect(result.current.isDisabled).toBe(true);
+            expect(result.current.inputValue).toBe('fromProps');
+
+            // ... and re-enabling does not resurrect the discarded edit
+            act(() => {
+                result.current.toggleDisabled();
+            });
+
+            expect(result.current.isDisabled).toBe(false);
+            expect(result.current.inputValue).toBe('fromProps');
+        });
+
+        test('preserves a null local edit, falling back to props only for undefined', () => {
+            // FileInput uses null to mean "the attached file was removed", so a null edit must not be treated as
+            // an absent edit the way undefined is.
+            const { result } = renderHook(() =>
+                useDisableableInput<null | string>({ allowDisable: true, value: 'attachedFile.txt' })
+            );
+
+            act(() => {
+                result.current.setInputValue(null);
+            });
+
+            expect(result.current.inputValue).toBeNull();
+
+            act(() => {
+                result.current.setInputValue(undefined);
+            });
+
+            expect(result.current.inputValue).toBe('attachedFile.txt');
+        });
+
+        test('notifies onToggleDisable with the new disabled state', () => {
+            const onToggleDisable = jest.fn();
+            const { result } = renderHook(() =>
+                useDisableableInput<string>({
+                    allowDisable: true,
+                    initiallyDisabled: true,
+                    onToggleDisable,
+                    value: 'fromProps',
+                })
+            );
+
+            // initiallyDisabled seeds the state without notifying
+            expect(result.current.isDisabled).toBe(true);
+            expect(onToggleDisable).not.toHaveBeenCalled();
+
+            act(() => {
+                result.current.toggleDisabled();
+            });
+
+            expect(result.current.isDisabled).toBe(false);
+            expect(onToggleDisable).toHaveBeenLastCalledWith(false);
+
+            act(() => {
+                result.current.toggleDisabled();
+            });
+
+            expect(result.current.isDisabled).toBe(true);
+            expect(onToggleDisable).toHaveBeenLastCalledWith(true);
+            expect(onToggleDisable).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/components/src/internal/components/forms/input/DisableableInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DisableableInput.tsx
@@ -4,12 +4,12 @@
  */
 import React, { useCallback, useState } from 'react';
 
-export interface DisableableInputProps {
+export interface DisableableInputProps<V = any> {
     allowDisable?: boolean;
     hasMixedValue?: boolean;
     initiallyDisabled?: boolean;
     onToggleDisable?: (disabled: boolean) => void;
-    value?: any;
+    value?: V;
 }
 
 export interface DisableableInputState {
@@ -99,7 +99,7 @@ export interface UseDisableableInput<V> {
  * };
  * ```
  */
-export function useDisableableInput<V>(props: DisableableInputProps): UseDisableableInput<V> {
+export function useDisableableInput<V>(props: DisableableInputProps<V>): UseDisableableInput<V> {
     const { allowDisable = false, initiallyDisabled = false, onToggleDisable, value } = props;
     const [isDisabled, setIsDisabled] = useState<boolean>(initiallyDisabled);
     const [inputValue, setInputValue] = useState<V>(value);

--- a/packages/components/src/internal/components/forms/input/DisableableInput.tsx
+++ b/packages/components/src/internal/components/forms/input/DisableableInput.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2019-2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
  * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 export interface DisableableInputProps {
     allowDisable?: boolean;
@@ -17,7 +17,9 @@ export interface DisableableInputState {
     isDisabled?: boolean;
 }
 
-// TODO: convert this to a hook, use the hook instead of inheriting from this class
+/**
+ * @deprecated use the useDisableableInput() hook from a function component instead of inheriting from this class.
+ */
 export class DisableableInput<P extends DisableableInputProps, S extends DisableableInputState> extends React.Component<
     P,
     S
@@ -46,5 +48,76 @@ export class DisableableInput<P extends DisableableInputProps, S extends Disable
                 this.props.onToggleDisable?.(this.state.isDisabled);
             }
         );
+    };
+}
+
+export interface UseDisableableInput<V> {
+    /**
+     * The value the input should render. This accounts for the disabled state, falling back to the value from props
+     * when the input is not disableable or when the user has not yet edited it. Equivalent to the
+     * DisableableInput class's getInputValue().
+     */
+    inputValue: V;
+    isDisabled: boolean;
+    /**
+     * Records the value as the user edits it so it can be reverted when the input is subsequently disabled.
+     * Call this from the input's onChange handler.
+     */
+    setInputValue: (value: V) => void;
+    /** Toggles the disabled state, notifying onToggleDisable with the new state. */
+    toggleDisabled: () => void;
+}
+
+/**
+ * React hook that provides the "disableable input" behavior offered by the DisableableInput class to function
+ * components. Field labels render a toggle when allowDisable is true (see FieldLabel's showToggle/toggleProps);
+ * wiring that toggle to toggleDisabled lets the user turn the field off, which reverts any local edits back to the
+ * value from props.
+ *
+ * Example:
+ * ```tsx
+ * const MyInput: FC<MyInputProps> = props => {
+ *     const { onChange, queryColumn } = props;
+ *     const { inputValue, isDisabled, setInputValue, toggleDisabled } = useDisableableInput<string | undefined>(props);
+ *
+ *     const onInputChange = useCallback<ChangeEventHandler<HTMLInputElement>>(event => {
+ *         setInputValue(event.target.value);
+ *         onChange?.(event.target.value);
+ *     }, [onChange, setInputValue]);
+ *
+ *     return (
+ *         <>
+ *             <FieldLabel
+ *                 column={queryColumn}
+ *                 isDisabled={isDisabled}
+ *                 showToggle={props.allowDisable}
+ *                 toggleProps={{ onClick: toggleDisabled }}
+ *             />
+ *             <input disabled={isDisabled} onChange={onInputChange} type="text" value={inputValue} />
+ *         </>
+ *     );
+ * };
+ * ```
+ */
+export function useDisableableInput<V>(props: DisableableInputProps): UseDisableableInput<V> {
+    const { allowDisable = false, initiallyDisabled = false, onToggleDisable, value } = props;
+    const [isDisabled, setIsDisabled] = useState<boolean>(initiallyDisabled);
+    const [inputValue, setInputValue] = useState<V>(value);
+
+    const toggleDisabled = useCallback(() => {
+        const disabled = !isDisabled;
+
+        // When disabling, discard any local edits so the value from props is restored
+        if (disabled) setInputValue(value);
+
+        setIsDisabled(disabled);
+        onToggleDisable?.(disabled);
+    }, [isDisabled, onToggleDisable, value]);
+
+    return {
+        inputValue: !allowDisable || inputValue === undefined ? value : inputValue,
+        isDisabled,
+        setInputValue,
+        toggleDisabled,
     };
 }

--- a/packages/components/src/internal/components/forms/input/FileInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.test.tsx
@@ -2,9 +2,51 @@
  * Copyright (c) 2025-2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
  * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { Map } from 'immutable';
 
-import { initializeValue } from './FileInput';
+import { QueryColumn } from '../../../../public/QueryColumn';
+import { Formsy } from '../formsy';
+
+import { FileInput, FileInputProps, initializeValue } from './FileInput';
+
+const FILE_COLUMN = new QueryColumn({
+    caption: 'Attached File',
+    fieldKey: 'attachedFile',
+    inputType: 'file',
+    name: 'attachedFile',
+});
+
+const REQUIRED_FILE_COLUMN = FILE_COLUMN.mutate({ required: true }) as QueryColumn;
+
+interface FormsyResult extends RenderResult {
+    onChange: jest.Mock;
+    onInvalid: jest.Mock;
+    onValid: jest.Mock;
+}
+
+function renderInForm(props?: Partial<FileInputProps>): FormsyResult {
+    const onChange = jest.fn();
+    const onInvalid = jest.fn();
+    const onValid = jest.fn();
+
+    const result = render(
+        <Formsy onChange={onChange} onInvalid={onInvalid} onValid={onValid}>
+            <FileInput formsy name={FILE_COLUMN.fieldKey} queryColumn={REQUIRED_FILE_COLUMN} {...props} />
+        </Formsy>
+    );
+
+    return { ...result, onChange, onInvalid, onValid };
+}
+
+function selectFile(): Promise<void> {
+    return userEvent.upload(
+        document.querySelector('input[type="file"]'),
+        new File(['file contents'], 'attachment.txt', { type: 'text/plain' })
+    );
+}
 
 describe('FileInput', () => {
     test('initializeValue', () => {
@@ -24,6 +66,57 @@ describe('FileInput', () => {
         expect(initializeValue(Map({ value: 'some/file/path' }))).toEqual({
             data: Map({ value: 'some/file/path' }),
             formValue: 'some/file/path',
+        });
+    });
+
+    describe('required', () => {
+        test('invalidates the form when a required field does not have a value', async () => {
+            const { container, onInvalid, onValid } = renderInForm();
+
+            expect(onInvalid).toHaveBeenCalled();
+            expect(onValid).not.toHaveBeenCalled();
+            expect(container.querySelector('.required-symbol')).toBeInTheDocument();
+
+            // Selecting a file supplies the value the "required" validation is looking for
+            await selectFile();
+
+            expect(onValid).toHaveBeenCalled();
+        });
+
+        test('does not invalidate the form when the field is not required', () => {
+            const { container, onInvalid, onValid } = renderInForm({ queryColumn: FILE_COLUMN });
+
+            expect(onValid).toHaveBeenCalled();
+            expect(onInvalid).not.toHaveBeenCalled();
+            expect(container.querySelector('.required-symbol')).not.toBeInTheDocument();
+        });
+
+        test('respects the "required" prop when a queryColumn is not supplied', () => {
+            const { onInvalid, onValid } = renderInForm({ queryColumn: undefined, required: true });
+
+            expect(onInvalid).toHaveBeenCalled();
+            expect(onValid).not.toHaveBeenCalled();
+        });
+
+        test('an initial value satisfies a required field without dirtying the form', () => {
+            const { onChange, onInvalid, onValid } = renderInForm({
+                initialValue: Map({ value: 'some/file/path.txt' }),
+            });
+
+            expect(onValid).toHaveBeenCalled();
+            expect(onInvalid).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalled();
+        });
+
+        test('invalidates the form when the value of a required field is removed', async () => {
+            const { container, onInvalid, onValid } = renderInForm({ initialValue: 'some/file/path.txt' });
+
+            expect(onValid).toHaveBeenCalled();
+            expect(onInvalid).not.toHaveBeenCalled();
+
+            await userEvent.click(container.querySelector('.attached-file__remove-icon'));
+
+            expect(onInvalid).toHaveBeenCalled();
         });
     });
 });

--- a/packages/components/src/internal/components/forms/input/FileInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.test.tsx
@@ -56,7 +56,8 @@ function clickToggle(): Promise<void> {
     return userEvent.click(document.querySelector('.toggle-group-icon button'));
 }
 
-// FieldLabel sizes the label/toggle columns for a disableable input by mutating the labelOverlayProps it is given
+// FieldLabel sizes the label/toggle columns for a disableable input, deriving the classes from the
+// labelOverlayProps it is given without modifying them
 function expectToggleLayout(container: HTMLElement): void {
     expect(container.querySelector('.control-label')).toHaveClass(INPUT_LABEL_CLASS_NAME_WITH_TOGGLE);
     expect(container.querySelector('.control-label-toggle-input')).toHaveClass('control-label-toggle-input-size-fixed');
@@ -82,22 +83,22 @@ function expectDisabled(container: HTMLElement): void {
 
 describe('FileInput', () => {
     test('initializeValue', () => {
-        expect(initializeValue(undefined)).toEqual({ data: undefined, formValue: undefined });
-        expect(initializeValue(null)).toEqual({ data: undefined, formValue: undefined });
-        expect(initializeValue('')).toEqual({ data: undefined, formValue: undefined });
-        expect(initializeValue('   ')).toEqual({ data: undefined, formValue: undefined });
+        expect(initializeValue(undefined)).toEqual({ data: undefined, value: undefined });
+        expect(initializeValue(null)).toEqual({ data: undefined, value: undefined });
+        expect(initializeValue('')).toEqual({ data: undefined, value: undefined });
+        expect(initializeValue('   ')).toEqual({ data: undefined, value: undefined });
         expect(initializeValue('  some/file/path1 ')).toEqual({
             data: 'some/file/path1',
-            formValue: 'some/file/path1',
+            value: 'some/file/path1',
         });
-        expect(initializeValue(Map())).toEqual({ data: Map(), formValue: undefined });
+        expect(initializeValue(Map())).toEqual({ data: Map(), value: undefined });
         expect(initializeValue(Map({ path: 'some/file/path' }))).toEqual({
             data: Map({ path: 'some/file/path' }),
-            formValue: undefined,
+            value: undefined,
         });
         expect(initializeValue(Map({ value: 'some/file/path' }))).toEqual({
             data: Map({ value: 'some/file/path' }),
-            formValue: 'some/file/path',
+            value: 'some/file/path',
         });
     });
 
@@ -149,6 +150,65 @@ describe('FileInput', () => {
             await userEvent.click(container.querySelector('.attached-file__remove-icon'));
 
             expect(onInvalid).toHaveBeenCalled();
+        });
+
+        // Formsy does not produce a message for a bare "required" violation, so an empty required field is
+        // communicated by the asterisk and by the form being invalid, not by an error on the input itself.
+        test('does not display an error for an empty required field', async () => {
+            const { container } = renderInForm({ initialValue: 'some/file/path.txt' });
+
+            expect(container.querySelector('.has-error')).not.toBeInTheDocument();
+
+            await userEvent.click(container.querySelector('.attached-file__remove-icon'));
+
+            expect(container.querySelector('.has-error')).not.toBeInTheDocument();
+            expect(container.querySelector('.help-block')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('validation errors', () => {
+        const VALIDATION_ERROR = 'Unable to attach this file.';
+
+        function renderWithFormErrors(validationErrors?: Record<string, string>): RenderResult {
+            return render(
+                <Formsy validationErrors={validationErrors}>
+                    <FileInput formsy name={FILE_COLUMN.fieldKey} queryColumn={FILE_COLUMN} />
+                </Formsy>
+            );
+        }
+
+        test('displays an error supplied by the form', () => {
+            const { container, rerender } = renderWithFormErrors();
+
+            expect(container.querySelector('.has-error')).not.toBeInTheDocument();
+
+            // Errors are pushed down by Formsy after the initial render, e.g., in response to a failed submission
+            rerender(
+                <Formsy validationErrors={{ [FILE_COLUMN.fieldKey]: VALIDATION_ERROR }}>
+                    <FileInput formsy name={FILE_COLUMN.fieldKey} queryColumn={FILE_COLUMN} />
+                </Formsy>
+            );
+
+            expect(container.querySelector('.has-error')).toBeInTheDocument();
+            expect(container.querySelector('.help-block')).toHaveTextContent(VALIDATION_ERROR);
+        });
+
+        test('does not display an error belonging to a different field', () => {
+            const { container, rerender } = renderWithFormErrors();
+
+            rerender(
+                <Formsy validationErrors={{ someOtherField: VALIDATION_ERROR }}>
+                    <FileInput formsy name={FILE_COLUMN.fieldKey} queryColumn={FILE_COLUMN} />
+                </Formsy>
+            );
+
+            expect(container.querySelector('.has-error')).not.toBeInTheDocument();
+        });
+
+        test('does not display an error when not bound to formsy', () => {
+            const { container } = render(<FileInput name={FILE_COLUMN.fieldKey} queryColumn={FILE_COLUMN} />);
+
+            expect(container.querySelector('.has-error')).not.toBeInTheDocument();
         });
     });
 
@@ -224,7 +284,10 @@ describe('FileInput', () => {
             await selectFile();
             await clickToggle();
 
-            // Disabling the field reverts local edits for editable inputs, but a selected file is retained
+            // Unlike other disableable inputs, which revert to the value from props when toggled off, FileInput
+            // retains the selected file. This intentionally preserves the behavior it had before it adopted
+            // useDisableableInput(): it never recorded the selection via setInputValue()/getInputValue(). The retained
+            // value is still excluded when submitting by getUpdatedFields().
             expect(container.querySelector('.attached-file__inline-container')).toHaveTextContent('attachment.txt');
             expect(onFormChange).toHaveBeenLastCalledWith(
                 expect.objectContaining({ [FILE_COLUMN.fieldKey]: expect.any(File) }),

--- a/packages/components/src/internal/components/forms/input/FileInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.test.tsx
@@ -9,6 +9,7 @@ import { Map } from 'immutable';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
 import { Formsy } from '../formsy';
+import { INPUT_LABEL_CLASS_NAME_WITH_TOGGLE, MIXED_VALUE_DISPLAY } from '../constants';
 
 import { FileInput, FileInputProps, initializeValue } from './FileInput';
 
@@ -46,6 +47,37 @@ function selectFile(): Promise<void> {
         document.querySelector('input[type="file"]'),
         new File(['file contents'], 'attachment.txt', { type: 'text/plain' })
     );
+}
+
+const ENABLED_FIELD_SELECTOR = `input[name="${FILE_COLUMN.fieldKey}::enabled"]`;
+const FILE_INPUT_SELECTOR = 'input[type="file"]';
+
+function clickToggle(): Promise<void> {
+    return userEvent.click(document.querySelector('.toggle-group-icon button'));
+}
+
+// FieldLabel sizes the label/toggle columns for a disableable input by mutating the labelOverlayProps it is given
+function expectToggleLayout(container: HTMLElement): void {
+    expect(container.querySelector('.control-label')).toHaveClass(INPUT_LABEL_CLASS_NAME_WITH_TOGGLE);
+    expect(container.querySelector('.control-label-toggle-input')).toHaveClass('control-label-toggle-input-size-fixed');
+}
+
+function expectEnabled(container: HTMLElement): void {
+    expectToggleLayout(container);
+    expect(container.querySelector('.fa-toggle-on')).toBeInTheDocument();
+    expect(container.querySelector('.fa-toggle-off')).not.toBeInTheDocument();
+    expect(container.querySelector(ENABLED_FIELD_SELECTOR)).toHaveAttribute('value', 'true');
+    expect(container.querySelector(FILE_INPUT_SELECTOR)).toBeEnabled();
+    expect(container.querySelector('.file-upload--compact-label')).not.toHaveClass('file-upload--is-disabled');
+}
+
+function expectDisabled(container: HTMLElement): void {
+    expectToggleLayout(container);
+    expect(container.querySelector('.fa-toggle-off')).toBeInTheDocument();
+    expect(container.querySelector('.fa-toggle-on')).not.toBeInTheDocument();
+    expect(container.querySelector(ENABLED_FIELD_SELECTOR)).toHaveAttribute('value', 'false');
+    expect(container.querySelector(FILE_INPUT_SELECTOR)).toBeDisabled();
+    expect(container.querySelector('.file-upload--compact-label')).toHaveClass('file-upload--is-disabled');
 }
 
 describe('FileInput', () => {
@@ -117,6 +149,103 @@ describe('FileInput', () => {
             await userEvent.click(container.querySelector('.attached-file__remove-icon'));
 
             expect(onInvalid).toHaveBeenCalled();
+        });
+    });
+
+    describe('disabled state', () => {
+        const DISABLEABLE_PROPS: Partial<FileInputProps> = { allowDisable: true, queryColumn: FILE_COLUMN };
+
+        test('does not render a toggle when allowDisable is not specified', () => {
+            const { container } = renderInForm({ queryColumn: FILE_COLUMN });
+
+            expect(container.querySelector('.toggle-group-icon')).not.toBeInTheDocument();
+            expect(container.querySelector(ENABLED_FIELD_SELECTOR)).not.toBeInTheDocument();
+            expect(container.querySelector(FILE_INPUT_SELECTOR)).toBeEnabled();
+        });
+
+        test('renders an enabled field when allowDisable', () => {
+            const { container } = renderInForm(DISABLEABLE_PROPS);
+            expectEnabled(container);
+        });
+
+        test('renders a disabled field when initiallyDisabled', () => {
+            const { container } = renderInForm({ ...DISABLEABLE_PROPS, initiallyDisabled: true });
+            expectDisabled(container);
+        });
+
+        test('toggling notifies onToggleDisable with the new disabled state', async () => {
+            const onToggleDisable = jest.fn();
+            const { container } = renderInForm({ ...DISABLEABLE_PROPS, onToggleDisable });
+
+            await clickToggle();
+
+            expect(onToggleDisable).toHaveBeenLastCalledWith(true);
+            expectDisabled(container);
+
+            await clickToggle();
+
+            expect(onToggleDisable).toHaveBeenLastCalledWith(false);
+            expectEnabled(container);
+            expect(onToggleDisable).toHaveBeenCalledTimes(2);
+        });
+
+        test('does not allow toggling when toggleDisabledTooltip is supplied', async () => {
+            const onToggleDisable = jest.fn();
+            const { container } = renderInForm({
+                ...DISABLEABLE_PROPS,
+                onToggleDisable,
+                toggleDisabledTooltip: 'Cannot be updated',
+            });
+
+            expect(container.querySelector('.toggle-group-icon')).toHaveClass('disabled');
+            expect(container.querySelector('.label-help-target')).toBeInTheDocument();
+
+            await clickToggle();
+
+            expect(onToggleDisable).not.toHaveBeenCalled();
+            expectEnabled(container);
+        });
+
+        test('displays mixed values only while disabled', async () => {
+            const { container } = renderInForm({ ...DISABLEABLE_PROPS, hasMixedValue: true, initiallyDisabled: true });
+
+            expect(container.querySelector('.field__un-editable')).toHaveTextContent(MIXED_VALUE_DISPLAY);
+            expect(container.querySelector('.fa-cloud-upload')).not.toBeInTheDocument();
+
+            await clickToggle();
+
+            expect(container.querySelector('.field__un-editable')).not.toBeInTheDocument();
+            expect(container.querySelector('.fa-cloud-upload')).toBeInTheDocument();
+        });
+
+        test('retains a selected file when the field is subsequently disabled', async () => {
+            const { container, onChange: onFormChange } = renderInForm(DISABLEABLE_PROPS);
+
+            await selectFile();
+            await clickToggle();
+
+            // Disabling the field reverts local edits for editable inputs, but a selected file is retained
+            expect(container.querySelector('.attached-file__inline-container')).toHaveTextContent('attachment.txt');
+            expect(onFormChange).toHaveBeenLastCalledWith(
+                expect.objectContaining({ [FILE_COLUMN.fieldKey]: expect.any(File) }),
+                expect.anything()
+            );
+        });
+
+        test('does not allow removing an existing attachment while disabled', async () => {
+            const { container } = renderInForm({
+                ...DISABLEABLE_PROPS,
+                initialValue: Map({ value: 'some/file/path.txt' }),
+                initiallyDisabled: true,
+            });
+
+            await userEvent.click(container.querySelector('.attachment-card__menu button'));
+            expect(document.querySelector('.dropdown-menu')).not.toHaveTextContent('Remove');
+
+            await clickToggle();
+            await userEvent.click(container.querySelector('.attachment-card__menu button'));
+
+            expect(document.querySelector('.dropdown-menu')).toHaveTextContent('Remove');
         });
     });
 });

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -32,6 +32,7 @@ import { getTransferItemDirectoryEntry } from '../../files/FileAttachmentContain
 import { DisableableInputProps, useDisableableInput } from './DisableableInput';
 import { generateId } from '../../../util/utils';
 import { LabelOverlayProps } from '../LabelOverlay';
+import { RequiredSymbol } from './RequiredSymbol';
 
 type FileInputData = Map<string, any> | string | undefined;
 type FileInputValue = File | null | string | undefined;
@@ -292,7 +293,7 @@ const FileInputImpl: FC<FileInputImplProps> = props => {
             {hasCustomFieldLabel && (
                 <span className={labelClassName} data-fieldkey={inputName}>
                     {renderFieldLabel(queryColumn)}
-                    {required && <span className="required-symbol"> *</span>}
+                    <RequiredSymbol required={required} />
                 </span>
             )}
             {!hasCustomFieldLabel && (

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -22,6 +22,7 @@ import { getTransferItemDirectoryEntry } from '../../files/FileAttachmentContain
 
 import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
 import { generateId } from '../../../util/utils';
+import { LabelOverlayProps } from '../LabelOverlay';
 
 type FileInputData = Map<string, any> | string | undefined;
 
@@ -269,20 +270,28 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
             );
         }
 
-        const labelOverlayProps = {
+        const labelOverlayProps: LabelOverlayProps = {
             addLabelAsterisk,
             dataKey: this.getInputName(),
+            inputId: this.inputId,
             // While this component supports binding Formsy, it does not use a Formsy component
             // to render the associated label. As such, the label overlay is always configured as isFormsy={false}.
             isFormsy: false,
             labelClass: labelClassName,
+            required: queryColumn?.required,
         };
+
+        const hasCustomFieldLabel = !!renderFieldLabel;
 
         return (
             <div className="form-group row">
-                {renderFieldLabel ? (
-                    renderFieldLabel(queryColumn)
-                ) : (
+                {hasCustomFieldLabel && (
+                    <label className={labelClassName} htmlFor={queryColumn?.fieldKey}>
+                        {renderFieldLabel(queryColumn)}
+                        {queryColumn?.required && <span className="required-symbol"> *</span>}
+                    </label>
+                )}
+                {!hasCustomFieldLabel && (
                     <FieldLabel
                         column={queryColumn}
                         isDisabled={isDisabled}
@@ -314,5 +323,4 @@ export const FileInput: FC<FileInputProps> = props => {
     }
     return <FileInputImpl {...(props as FileInputImplProps)} formsy={false} />;
 };
-
 FileInput.displayName = 'FileInput';

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -2,13 +2,22 @@
  * Copyright (c) 2019-2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
  * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, ReactNode, RefObject, useMemo } from 'react';
+import React, {
+    DragEventHandler,
+    FC,
+    FormEventHandler,
+    ReactNode,
+    useCallback,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import classNames from 'classnames';
 import { Map } from 'immutable';
 
 import { FormsyInjectedProps, withFormsy } from '../formsy';
 import { INPUT_WRAPPER_CLASS_NAME, MIXED_VALUE_DISPLAY } from '../constants';
-import { FieldLabel } from '../FieldLabel';
+import { FieldLabel, ToggleProps } from '../FieldLabel';
 import { cancelEvent } from '../../../events';
 
 import { QueryColumn } from '../../../../public/QueryColumn';
@@ -20,7 +29,7 @@ import { fileMatchesAcceptedFormat } from '../../files/actions';
 
 import { getTransferItemDirectoryEntry } from '../../files/FileAttachmentContainer';
 
-import { DisableableInput, DisableableInputProps, DisableableInputState } from './DisableableInput';
+import { DisableableInputProps, useDisableableInput } from './DisableableInput';
 import { generateId } from '../../../util/utils';
 import { LabelOverlayProps } from '../LabelOverlay';
 
@@ -64,259 +73,239 @@ export interface FileInputProps extends DisableableInputProps {
 
 type FileInputImplProps = FileInputProps & FormsyInjectedProps<any>;
 
-interface State extends DisableableInputState {
-    data: FileInputData;
-    error: string;
-    file: File;
-    isHover: boolean;
-}
+const FileInputImpl: FC<FileInputImplProps> = props => {
+    const {
+        acceptedFormats,
+        addLabelAsterisk,
+        allowDisable = false,
+        elementWrapperClassName = INPUT_WRAPPER_CLASS_NAME,
+        emptyFileNotAllowed,
+        formsy,
+        hasMixedValue,
+        initialValue,
+        labelClassName,
+        maxFileSize,
+        name,
+        onChange,
+        queryColumn,
+        renderFieldLabel,
+        required,
+        setValue,
+        showLabel = true,
+        toggleDisabledTooltip,
+    } = props;
+    const { isDisabled, toggleDisabled } = useDisableableInput<File | null | undefined>(props);
+    const [data, setData] = useState<FileInputData>(() => initializeValue(initialValue).data);
+    const [error, setError] = useState<string>('');
+    const [file, setFile] = useState<File>(null);
+    const [isHover, setIsHover] = useState<boolean>(false);
+    const fileInput = useRef<HTMLInputElement>(null);
 
-class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
-    fileInput: RefObject<HTMLInputElement>;
-    inputId: string;
+    // Issue 53394: Distinct input ID so it does not collide with other elements on the page
+    const inputId = useMemo(() => generateId('fileUpload-'), []);
+    const inputName = name ?? queryColumn.fieldKey;
+    const hasCustomFieldLabel = !!renderFieldLabel;
 
-    static defaultProps = {
-        ...DisableableInput.defaultProps,
-        ...{
-            changeDebounceInterval: 0,
-            elementWrapperClassName: INPUT_WRAPPER_CLASS_NAME,
-            showLabel: true,
+    const setFormValue = useCallback(
+        (file_: File): void => {
+            setData(undefined);
+            setError('');
+            setFile(file_);
+            onChange?.({ [inputName]: file_ });
+
+            if (formsy) {
+                setValue?.(file_);
+            }
         },
-    };
+        [formsy, inputName, onChange, setValue]
+    );
 
-    constructor(props: FileInputImplProps) {
-        super(props);
-        this.toggleDisabled = this.toggleDisabled.bind(this);
-
-        // Issue 53394: Distinct input ID so it does not collide with other elements on the page
-        this.inputId = generateId('fileUpload-');
-        this.fileInput = React.createRef<HTMLInputElement>();
-        const { data, formValue } = initializeValue(props.initialValue);
-
-        this.state = {
-            data,
-            file: null,
-            error: '',
-            isDisabled: props.initiallyDisabled,
-            isHover: false,
-        };
-
-        if (!props.formsy && formValue) {
-            props.setValue?.(formValue);
-        }
-    }
-
-    getInputName(): string {
-        return this.props.name ?? this.props.queryColumn.fieldKey;
-    }
-
-    processFiles = (fileList: FileList, transferItems?: DataTransferItemList): void => {
-        const { acceptedFormats, maxFileSize, emptyFileNotAllowed } = this.props;
-        if (fileList.length > 1) {
-            this.setState({ error: 'Only one file allowed' });
-            return;
-        }
-
-        if (getTransferItemDirectoryEntry(transferItems, 0)) {
-            this.setState({ error: 'Folders are not supported, only one file allowed' });
-            return;
-        }
-
-        const file = fileList[0];
-        if (acceptedFormats) {
-            const formatCheck = fileMatchesAcceptedFormat(file.name, acceptedFormats);
-            if (!formatCheck.isMatch) {
-                this.setState({ error: 'Invalid file type.' });
+    const processFiles = useCallback(
+        (fileList: FileList, transferItems?: DataTransferItemList): void => {
+            if (fileList.length > 1) {
+                setError('Only one file allowed');
                 return;
             }
-        }
 
-        if (maxFileSize && file.size > maxFileSize) {
-            this.setState({
-                error: `File size must not exceed ${Math.round(maxFileSize / 1024).toLocaleString()} KB.`,
-            });
-            return;
-        }
-        if (emptyFileNotAllowed && file.size === 0) {
-            this.setState({ error: 'Empty file is not allowed.' });
-            return;
-        }
-        this.setFormValue(file);
-    };
+            if (getTransferItemDirectoryEntry(transferItems, 0)) {
+                setError('Folders are not supported, only one file allowed');
+                return;
+            }
 
-    setFormValue = (file: File): void => {
-        const { formsy, onChange, setValue } = this.props;
-        this.setState({ data: undefined, file, error: '' });
-        onChange?.({ [this.getInputName()]: file });
+            const file_ = fileList[0];
+            if (acceptedFormats) {
+                const formatCheck = fileMatchesAcceptedFormat(file_.name, acceptedFormats);
+                if (!formatCheck.isMatch) {
+                    setError('Invalid file type.');
+                    return;
+                }
+            }
 
-        if (formsy) {
-            setValue?.(file);
-        }
-    };
+            if (maxFileSize && file_.size > maxFileSize) {
+                setError(`File size must not exceed ${Math.round(maxFileSize / 1024).toLocaleString()} KB.`);
+                return;
+            }
+            if (emptyFileNotAllowed && file_.size === 0) {
+                setError('Empty file is not allowed.');
+                return;
+            }
+            setFormValue(file_);
+        },
+        [acceptedFormats, emptyFileNotAllowed, maxFileSize, setFormValue]
+    );
 
-    onChange = (event: React.FormEvent<HTMLInputElement>): void => {
+    const onInputChange = useCallback<FormEventHandler<HTMLInputElement>>(
+        event => {
+            cancelEvent(event);
+            processFiles(fileInput.current.files);
+        },
+        [processFiles]
+    );
+
+    const onDrag = useCallback<DragEventHandler<HTMLElement>>(event => {
         cancelEvent(event);
-        this.processFiles(this.fileInput.current.files);
-    };
+        setIsHover(true);
+    }, []);
 
-    onDrag = (event: React.DragEvent<HTMLElement>): void => {
+    const onDragLeave = useCallback<DragEventHandler<HTMLElement>>(event => {
         cancelEvent(event);
+        setIsHover(false);
+    }, []);
 
-        if (!this.state.isHover) {
-            this.setState({ isHover: true });
-        }
-    };
+    const onDrop = useCallback<DragEventHandler<HTMLElement>>(
+        event => {
+            cancelEvent(event);
 
-    onDragLeave = (event: React.DragEvent<HTMLElement>): void => {
-        cancelEvent(event);
+            if (event.dataTransfer && event.dataTransfer.files) {
+                processFiles(event.dataTransfer.files, event.dataTransfer.items);
+                setIsHover(false);
+            }
+        },
+        [processFiles]
+    );
 
-        if (this.state.isHover) {
-            this.setState({ isHover: false });
-        }
-    };
-
-    onDrop = (event: React.DragEvent<HTMLElement>): void => {
-        cancelEvent(event);
-
-        if (event.dataTransfer && event.dataTransfer.files) {
-            this.processFiles(event.dataTransfer.files, event.dataTransfer.items);
-            this.setState({ isHover: false });
-        }
-    };
-
-    onRemove = (): void => {
+    const onRemove = useCallback((): void => {
         // A value of null is supported by server APIs to clear/remove a file field's value.
-        this.setFormValue(null);
-    };
+        setFormValue(null);
+    }, [setFormValue]);
 
-    render() {
-        const {
+    const labelOverlayProps = useMemo<LabelOverlayProps>(() => {
+        if (hasCustomFieldLabel) return undefined;
+        return {
             addLabelAsterisk,
-            allowDisable,
-            elementWrapperClassName,
-            hasMixedValue,
-            labelClassName,
-            queryColumn,
-            renderFieldLabel,
-            required,
-            showLabel,
-            toggleDisabledTooltip,
-        } = this.props;
-        const { data, error, file, isDisabled, isHover } = this.state;
-        const name = this.getInputName();
-
-        let body: ReactNode;
-
-        if (file || typeof data === 'string') {
-            body = (
-                <div
-                    className={classNames('attached-file__inline-container text__wrap', {
-                        'file-upload__is-hover': isHover,
-                    })}
-                    onDragEnter={this.onDrag}
-                    onDragLeave={this.onDragLeave}
-                    onDragOver={this.onDrag}
-                    onDrop={this.onDrop}
-                >
-                    <span className="fa fa-times-circle attached-file__remove-icon" onClick={this.onRemove} />
-                    <span className="fa fa-file-text attached-file--icon" />
-                    <span>{file ? file.name : (data as string)}</span>
-                    <div className="file-upload__error-message">{error}</div>
-                </div>
-            );
-        } else if (Map.isMap(data) && data.get('value')) {
-            body = (
-                <FileColumnRenderer
-                    data={data}
-                    isFileLink={queryColumn?.rangeURI === FILELINK_RANGE_URI}
-                    onRemove={isDisabled ? undefined : this.onRemove}
-                />
-            );
-        } else {
-            body = (
-                <>
-                    <input
-                        className="file-upload__input" // This class makes the file input hidden
-                        disabled={isDisabled}
-                        id={this.inputId}
-                        multiple={false}
-                        name={name}
-                        onChange={this.onChange}
-                        ref={this.fileInput}
-                        type="file"
-                    />
-
-                    {/* We render a label here, so click and drag events propagate to the input above */}
-                    <label
-                        className={classNames('file-upload--compact-label', {
-                            'file-upload--is-disabled': isDisabled,
-                            'file-upload__is-hover': isHover && !isDisabled,
-                        })}
-                        htmlFor={this.inputId}
-                        onDragEnter={this.onDrag}
-                        onDragLeave={this.onDragLeave}
-                        onDragOver={this.onDrag}
-                        onDrop={this.onDrop}
-                    >
-                        {isDisabled && hasMixedValue ? (
-                            <span className="field__un-editable">{MIXED_VALUE_DISPLAY}</span>
-                        ) : (
-                            <>
-                                <i aria-hidden="true" className="fa fa-cloud-upload" />
-                                &nbsp;
-                                <span>Select file or drag and drop here.</span>
-                                <div className="file-upload__error-message">{error}</div>
-                            </>
-                        )}
-                    </label>
-                </>
-            );
-        }
-
-        const labelOverlayProps: LabelOverlayProps = {
-            addLabelAsterisk,
-            dataKey: name,
-            inputId: this.inputId,
+            dataKey: inputName,
+            inputId,
             // While this component supports binding Formsy, it does not use a Formsy component
             // to render the associated label. As such, the label overlay is always configured as isFormsy={false}.
             isFormsy: false,
             labelClass: allowDisable ? undefined : labelClassName,
             required,
         };
+    }, [addLabelAsterisk, allowDisable, hasCustomFieldLabel, inputName, inputId, labelClassName, required]);
 
-        const hasCustomFieldLabel = !!renderFieldLabel;
+    const toggleProps = useMemo<Partial<ToggleProps>>(() => {
+        if (hasCustomFieldLabel) return undefined;
+        return {
+            onClick: toggleDisabledTooltip ? undefined : toggleDisabled,
+            toolTip: toggleDisabledTooltip,
+        };
+    }, [hasCustomFieldLabel, toggleDisabled, toggleDisabledTooltip]);
 
-        return (
-            <div className="form-group row">
-                {hasCustomFieldLabel && (
-                    <span className={labelClassName} data-fieldkey={name}>
-                        {renderFieldLabel(queryColumn)}
-                        {required && <span className="required-symbol"> *</span>}
-                    </span>
-                )}
-                {!hasCustomFieldLabel && (
-                    <FieldLabel
-                        column={queryColumn}
-                        fieldName={name}
-                        isDisabled={isDisabled}
-                        labelOverlayProps={labelOverlayProps}
-                        showLabel={showLabel}
-                        showToggle={allowDisable}
-                        toggleProps={{
-                            onClick: toggleDisabledTooltip ? undefined : this.toggleDisabled,
-                            toolTip: toggleDisabledTooltip,
-                        }}
-                    />
-                )}
-                <div className={elementWrapperClassName}>{body}</div>
+    let body: ReactNode;
+
+    if (file || typeof data === 'string') {
+        body = (
+            <div
+                className={classNames('attached-file__inline-container text__wrap', {
+                    'file-upload__is-hover': isHover,
+                })}
+                onDragEnter={onDrag}
+                onDragLeave={onDragLeave}
+                onDragOver={onDrag}
+                onDrop={onDrop}
+            >
+                <span className="fa fa-times-circle attached-file__remove-icon" onClick={onRemove} />
+                <span className="fa fa-file-text attached-file--icon" />
+                <span>{file ? file.name : (data as string)}</span>
+                <div className="file-upload__error-message">{error}</div>
             </div>
         );
+    } else if (Map.isMap(data) && data.get('value')) {
+        body = (
+            <FileColumnRenderer
+                data={data}
+                isFileLink={queryColumn?.rangeURI === FILELINK_RANGE_URI}
+                onRemove={isDisabled ? undefined : onRemove}
+            />
+        );
+    } else {
+        body = (
+            <>
+                <input
+                    className="file-upload__input" // This class makes the file input hidden
+                    disabled={isDisabled}
+                    id={inputId}
+                    multiple={false}
+                    name={inputName}
+                    onChange={onInputChange}
+                    ref={fileInput}
+                    type="file"
+                />
+
+                {/* We render a label here, so click and drag events propagate to the input above */}
+                <label
+                    className={classNames('file-upload--compact-label', {
+                        'file-upload--is-disabled': isDisabled,
+                        'file-upload__is-hover': isHover && !isDisabled,
+                    })}
+                    htmlFor={inputId}
+                    onDragEnter={onDrag}
+                    onDragLeave={onDragLeave}
+                    onDragOver={onDrag}
+                    onDrop={onDrop}
+                >
+                    {isDisabled && hasMixedValue ? (
+                        <span className="field__un-editable">{MIXED_VALUE_DISPLAY}</span>
+                    ) : (
+                        <>
+                            <i aria-hidden="true" className="fa fa-cloud-upload" />
+                            &nbsp;
+                            <span>Select file or drag and drop here.</span>
+                            <div className="file-upload__error-message">{error}</div>
+                        </>
+                    )}
+                </label>
+            </>
+        );
     }
-}
+
+    return (
+        <div className="form-group row">
+            {hasCustomFieldLabel && (
+                <span className={labelClassName} data-fieldkey={inputName}>
+                    {renderFieldLabel(queryColumn)}
+                    {required && <span className="required-symbol"> *</span>}
+                </span>
+            )}
+            {!hasCustomFieldLabel && (
+                <FieldLabel
+                    column={queryColumn}
+                    fieldName={inputName}
+                    isDisabled={isDisabled}
+                    labelOverlayProps={labelOverlayProps}
+                    showLabel={showLabel}
+                    showToggle={allowDisable}
+                    toggleProps={toggleProps}
+                />
+            )}
+            <div className={elementWrapperClassName}>{body}</div>
+        </div>
+    );
+};
+FileInputImpl.displayName = 'FileInputImpl';
 
 /**
- * This class is a wrapper around FileInputImpl to be able to bind formsy-react. It uses
- * the Formsy.Decorator to bind formsy-react so the element can be validated, submitted, etc.
+ * A wrapper around FileInputImpl that binds formsy-react so the element can be validated, submitted, etc.
  */
 const FileInputFormsy = withFormsy<FileInputProps, any>(FileInputImpl);
 

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -34,25 +34,27 @@ import { generateId } from '../../../util/utils';
 import { LabelOverlayProps } from '../LabelOverlay';
 
 type FileInputData = Map<string, any> | string | undefined;
+type FileInputValue = File | null | string | undefined;
 
-export function initializeValue(initialValue: any): { data: FileInputData; formValue: string | undefined } {
+export function initializeValue(initialValue: any): { data: FileInputData; value: string | undefined } {
     let data: Map<string, any> | string | undefined;
-    let formValue: string;
+    let value: string;
+
     if (Map.isMap(initialValue)) {
         data = initialValue;
-        formValue = initialValue.get('value');
+        value = initialValue.get('value');
     } else if (typeof initialValue === 'string') {
         const trimmedValue = initialValue.trim();
         if (trimmedValue !== '') {
             data = trimmedValue;
-            formValue = trimmedValue;
+            value = trimmedValue;
         }
     }
 
-    return { data, formValue };
+    return { data, value };
 }
 
-export interface FileInputProps extends DisableableInputProps {
+export interface FileInputProps extends DisableableInputProps<FileInputValue> {
     acceptedFormats?: string;
     addLabelAsterisk?: boolean;
     changeDebounceInterval?: number;
@@ -71,18 +73,23 @@ export interface FileInputProps extends DisableableInputProps {
     toggleDisabledTooltip?: string;
 }
 
-type FileInputImplProps = FileInputProps & FormsyInjectedProps<any>;
+interface FileInputImplOwnProps {
+    initialData: FileInputData;
+}
+
+type FileInputImplProps = FileInputImplOwnProps & FileInputProps & FormsyInjectedProps<FileInputValue>;
 
 const FileInputImpl: FC<FileInputImplProps> = props => {
     const {
         acceptedFormats,
         addLabelAsterisk,
         allowDisable = false,
+        initialData,
         elementWrapperClassName = INPUT_WRAPPER_CLASS_NAME,
         emptyFileNotAllowed,
+        errorMessage,
         formsy,
         hasMixedValue,
-        initialValue,
         labelClassName,
         maxFileSize,
         name,
@@ -94,17 +101,19 @@ const FileInputImpl: FC<FileInputImplProps> = props => {
         showLabel = true,
         toggleDisabledTooltip,
     } = props;
-    const { isDisabled, toggleDisabled } = useDisableableInput<File | null | undefined>(props);
-    const [data, setData] = useState<FileInputData>(() => initializeValue(initialValue).data);
+    // The initialValue prop is only respected on mount.
+    const [data, setData] = useState<FileInputData>(initialData);
     const [error, setError] = useState<string>('');
     const [file, setFile] = useState<File>(null);
     const [isHover, setIsHover] = useState<boolean>(false);
     const fileInput = useRef<HTMLInputElement>(null);
+    const { isDisabled, toggleDisabled } = useDisableableInput<FileInputValue>(props);
 
     // Issue 53394: Distinct input ID so it does not collide with other elements on the page
     const inputId = useMemo(() => generateId('fileUpload-'), []);
     const inputName = name ?? queryColumn.fieldKey;
     const hasCustomFieldLabel = !!renderFieldLabel;
+    const hasError = formsy && !!errorMessage;
 
     const setFormValue = useCallback(
         (file_: File): void => {
@@ -201,7 +210,7 @@ const FileInputImpl: FC<FileInputImplProps> = props => {
             labelClass: allowDisable ? undefined : labelClassName,
             required,
         };
-    }, [addLabelAsterisk, allowDisable, hasCustomFieldLabel, inputName, inputId, labelClassName, required]);
+    }, [addLabelAsterisk, allowDisable, hasCustomFieldLabel, inputName, labelClassName, required]);
 
     const toggleProps = useMemo<Partial<ToggleProps>>(() => {
         if (hasCustomFieldLabel) return undefined;
@@ -280,7 +289,7 @@ const FileInputImpl: FC<FileInputImplProps> = props => {
     }
 
     return (
-        <div className="form-group row">
+        <div className={classNames('form-group row', { 'has-error': hasError })}>
             {hasCustomFieldLabel && (
                 <span className={labelClassName} data-fieldkey={inputName}>
                     {renderFieldLabel(queryColumn)}
@@ -290,7 +299,6 @@ const FileInputImpl: FC<FileInputImplProps> = props => {
             {!hasCustomFieldLabel && (
                 <FieldLabel
                     column={queryColumn}
-                    fieldName={inputName}
                     isDisabled={isDisabled}
                     labelOverlayProps={labelOverlayProps}
                     showLabel={showLabel}
@@ -298,7 +306,10 @@ const FileInputImpl: FC<FileInputImplProps> = props => {
                     toggleProps={toggleProps}
                 />
             )}
-            <div className={elementWrapperClassName}>{body}</div>
+            <div className={elementWrapperClassName}>
+                {body}
+                {hasError && <span className="help-block">{errorMessage}</span>}
+            </div>
         </div>
     );
 };
@@ -307,21 +318,19 @@ FileInputImpl.displayName = 'FileInputImpl';
 /**
  * A wrapper around FileInputImpl that binds formsy-react so the element can be validated, submitted, etc.
  */
-const FileInputFormsy = withFormsy<FileInputProps, any>(FileInputImpl);
+const FileInputFormsy = withFormsy<FileInputImplProps, FileInputValue>(FileInputImpl);
 
 export const FileInput: FC<FileInputProps> = props => {
     const { formsy = false, initialValue, queryColumn, required = queryColumn?.required ?? false } = props;
-
-    const value = useMemo(() => {
-        if (!formsy) return undefined;
-        return initializeValue(initialValue).formValue;
-    }, [formsy, initialValue]);
+    const [{ data, value }] = useState(() => initializeValue(initialValue));
 
     if (formsy) {
         // GitHub Issue 1388: Pass required and value props to formsy for initialization
-        return <FileInputFormsy name={undefined} {...props} formsy required={required} value={value} />;
+        return (
+            <FileInputFormsy name={undefined} {...props} formsy initialData={data} required={required} value={value} />
+        );
     }
 
-    return <FileInputImpl {...(props as FileInputImplProps)} formsy={false} required={required} />;
+    return <FileInputImpl {...(props as FileInputImplProps)} formsy={false} initialData={data} required={required} />;
 };
 FileInput.displayName = 'FileInput';

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2019-2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
  * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React, { FC, ReactNode, RefObject } from 'react';
+import React, { FC, ReactNode, RefObject, useMemo } from 'react';
 import classNames from 'classnames';
 import { Map } from 'immutable';
 
@@ -57,6 +57,7 @@ export interface FileInputProps extends DisableableInputProps {
     onChange?: (fileMap: Record<string, File>) => void;
     queryColumn?: QueryColumn;
     renderFieldLabel?: (queryColumn: QueryColumn, label?: string, description?: string) => ReactNode;
+    required?: boolean;
     showLabel?: boolean;
     toggleDisabledTooltip?: string;
 }
@@ -100,7 +101,7 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
             isHover: false,
         };
 
-        if (formValue) {
+        if (!props.formsy && formValue) {
             props.setValue?.(formValue);
         }
     }
@@ -193,14 +194,16 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
             addLabelAsterisk,
             allowDisable,
             elementWrapperClassName,
+            hasMixedValue,
             labelClassName,
             queryColumn,
             renderFieldLabel,
+            required,
             showLabel,
             toggleDisabledTooltip,
-            hasMixedValue,
         } = this.props;
         const { data, error, file, isDisabled, isHover } = this.state;
+        const name = this.getInputName();
 
         let body: ReactNode;
 
@@ -237,7 +240,7 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
                         disabled={isDisabled}
                         id={this.inputId}
                         multiple={false}
-                        name={this.getInputName()}
+                        name={name}
                         onChange={this.onChange}
                         ref={this.fileInput}
                         type="file"
@@ -272,13 +275,13 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
 
         const labelOverlayProps: LabelOverlayProps = {
             addLabelAsterisk,
-            dataKey: this.getInputName(),
+            dataKey: name,
             inputId: this.inputId,
             // While this component supports binding Formsy, it does not use a Formsy component
             // to render the associated label. As such, the label overlay is always configured as isFormsy={false}.
             isFormsy: false,
-            labelClass: labelClassName,
-            required: queryColumn?.required,
+            labelClass: allowDisable ? undefined : labelClassName,
+            required,
         };
 
         const hasCustomFieldLabel = !!renderFieldLabel;
@@ -286,14 +289,15 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
         return (
             <div className="form-group row">
                 {hasCustomFieldLabel && (
-                    <label className={labelClassName} htmlFor={queryColumn?.fieldKey}>
+                    <span className={labelClassName} data-fieldkey={name}>
                         {renderFieldLabel(queryColumn)}
-                        {queryColumn?.required && <span className="required-symbol"> *</span>}
-                    </label>
+                        {required && <span className="required-symbol"> *</span>}
+                    </span>
                 )}
                 {!hasCustomFieldLabel && (
                     <FieldLabel
                         column={queryColumn}
+                        fieldName={name}
                         isDisabled={isDisabled}
                         labelOverlayProps={labelOverlayProps}
                         showLabel={showLabel}
@@ -317,10 +321,20 @@ class FileInputImpl extends DisableableInput<FileInputImplProps, State> {
 const FileInputFormsy = withFormsy<FileInputProps, any>(FileInputImpl);
 
 export const FileInput: FC<FileInputProps> = props => {
-    const { formsy = false } = props;
+    const { formsy = false, initialValue, queryColumn, required = queryColumn?.required ?? false } = props;
+
+    // GitHub Issue 1387: The Formsy value for a file field is either the path of the currently attached file or the
+    // File itself (once one has been selected). Seed the wrapper with the initial path so the field participates in
+    // validation from the outset without being marked as dirty.
+    const value = useMemo(() => {
+        if (!formsy) return undefined;
+        return initializeValue(initialValue).formValue;
+    }, [formsy, initialValue]);
+
     if (formsy) {
-        return <FileInputFormsy name={undefined} {...props} formsy />;
+        return <FileInputFormsy name={undefined} {...props} formsy required={required} value={value} />;
     }
-    return <FileInputImpl {...(props as FileInputImplProps)} formsy={false} />;
+
+    return <FileInputImpl {...(props as FileInputImplProps)} formsy={false} required={required} />;
 };
 FileInput.displayName = 'FileInput';

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -203,7 +203,6 @@ const FileInputImpl: FC<FileInputImplProps> = props => {
         return {
             addLabelAsterisk,
             dataKey: inputName,
-            inputId,
             // While this component supports binding Formsy, it does not use a Formsy component
             // to render the associated label. As such, the label overlay is always configured as isFormsy={false}.
             isFormsy: false,

--- a/packages/components/src/internal/components/forms/input/FileInput.tsx
+++ b/packages/components/src/internal/components/forms/input/FileInput.tsx
@@ -312,15 +312,13 @@ const FileInputFormsy = withFormsy<FileInputProps, any>(FileInputImpl);
 export const FileInput: FC<FileInputProps> = props => {
     const { formsy = false, initialValue, queryColumn, required = queryColumn?.required ?? false } = props;
 
-    // GitHub Issue 1387: The Formsy value for a file field is either the path of the currently attached file or the
-    // File itself (once one has been selected). Seed the wrapper with the initial path so the field participates in
-    // validation from the outset without being marked as dirty.
     const value = useMemo(() => {
         if (!formsy) return undefined;
         return initializeValue(initialValue).formValue;
     }, [formsy, initialValue]);
 
     if (formsy) {
+        // GitHub Issue 1388: Pass required and value props to formsy for initialization
         return <FileInputFormsy name={undefined} {...props} formsy required={required} value={value} />;
     }
 

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -84,7 +84,6 @@ const ErrorMessages: FC<ErrorMessageProps> = memo(props => {
     return (
         <div>
             {messages.map((message, key) => (
-                // eslint-disable-next-line react/no-array-index-key
                 <span className="help-block validation-message" key={key}>
                     {message}
                 </span>
@@ -358,7 +357,7 @@ FormsyCheckbox.displayName = 'FormsyCheckbox';
 
 export type FormsyInputProps = BaseComponentProps & InputGroupProps & InputHTMLProps;
 
-const InputImpl: FC<FormsyInputProps & FormsyInjectedProps<string>> = props => {
+const InputImpl: FC<FormsyInjectedProps<string> & FormsyInputProps> = props => {
     // Extract InputGroupProps
     const { addonAfter, addonBefore, buttonAfter, buttonBefore, ...rest } = props;
     const { baseProps, formsyProps, htmlProps } = useControlProps<InputHTMLProps, string>(rest);
@@ -455,7 +454,7 @@ type SelectHTMLProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'onBlur' | 
 
 export type FormsySelectProps = SelectBaseProps & SelectHTMLProps;
 
-const SelectImpl: FC<FormsySelectProps & FormsyInjectedProps<any>> = props => {
+const SelectImpl: FC<FormsyInjectedProps<any> & FormsySelectProps> = props => {
     const { multiple = false, options, ...rest } = props;
     const { baseProps, formsyProps, htmlProps } = useControlProps<SelectHTMLProps, any>(rest);
     const { componentRef, markAsInvalid, onChange } = baseProps;
@@ -507,7 +506,7 @@ type TextAreaHTMLProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onBl
 
 export type FormsyTextAreaProps = BaseComponentProps & TextAreaHTMLProps;
 
-const TextAreaImpl: FC<FormsyTextAreaProps & FormsyInjectedProps<string>> = props => {
+const TextAreaImpl: FC<FormsyInjectedProps<string> & FormsyTextAreaProps> = props => {
     const { baseProps, formsyProps, htmlProps } = useControlProps<TextAreaHTMLProps, string>(props);
     const { componentRef, markAsInvalid, onChange } = baseProps;
     const { isFormDisabled, setValue, value = '' } = formsyProps;

--- a/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
+++ b/packages/components/src/internal/components/forms/input/FormsyReactComponents.tsx
@@ -26,6 +26,7 @@ import { FormsyInjectedProps, withFormsy } from '../formsy';
 import { INPUT_WRAPPER_CLASS_NAME } from '../constants';
 
 import { Help } from './Help';
+import { RequiredSymbol } from './RequiredSymbol';
 
 type LayoutType = 'elementOnly' | 'horizontal' | 'vertical';
 
@@ -92,17 +93,6 @@ const ErrorMessages: FC<ErrorMessageProps> = memo(props => {
     );
 });
 ErrorMessages.displayName = 'ErrorMessages';
-
-interface RequiredSymbolProps {
-    required: boolean;
-    symbol?: ReactNode;
-}
-
-const RequiredSymbol: FC<RequiredSymbolProps> = memo(({ required, symbol = ' *' }) => {
-    if (required === false) return null;
-    return <span className="required-symbol">{symbol}</span>;
-});
-RequiredSymbol.displayName = 'RequiredSymbol';
 
 interface LabelProps extends PropsWithChildren {
     fakeLabel?: boolean;

--- a/packages/components/src/internal/components/forms/input/RequiredSymbol.tsx
+++ b/packages/components/src/internal/components/forms/input/RequiredSymbol.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation. All rights reserved. No portion of this work may be reproduced
+ * in any form or by any electronic or mechanical means without written permission from LabKey Corporation.
+ */
+import React, { FC, memo, ReactNode } from 'react';
+
+interface RequiredSymbolProps {
+    required: boolean;
+    symbol?: ReactNode;
+}
+
+export const RequiredSymbol: FC<RequiredSymbolProps> = memo(({ required, symbol = ' *' }) => {
+    if (required === false) return null;
+    return <span className="required-symbol">{symbol}</span>;
+});
+RequiredSymbol.displayName = 'RequiredSymbol';

--- a/packages/components/src/internal/components/forms/input/SelectInput.test.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.test.tsx
@@ -77,9 +77,9 @@ describe('SelectInput', () => {
     //     expect(component.state().selectedOptions[0].value).toEqual('two');
     // });
 
-    function validateFieldLabel(component: any, labelText?: string): void {
+    function validateFieldLabel(labelText?: string): void {
         if (labelText !== undefined) {
-            expect(document.querySelector('.control-label').textContent).toBe(labelText);
+            expect(document.querySelector('.control-label')).toHaveTextContent(labelText);
         } else {
             expect(document.querySelectorAll('.control-label')).toHaveLength(0);
         }
@@ -90,11 +90,11 @@ describe('SelectInput', () => {
         const customLabel = 'Jest Custom Label Test';
 
         test('renderFieldLabel', () => {
-            const component = render(<SelectInputImpl {...defaultProps()} label={defaultLabel} showLabel />);
-            validateFieldLabel(component, defaultLabel + ' ');
+            render(<SelectInputImpl {...defaultProps()} label={defaultLabel} showLabel />);
+            validateFieldLabel(defaultLabel);
         });
         test('renderFieldLabel, customLabel', () => {
-            const component = render(
+            render(
                 <SelectInputImpl
                     {...defaultProps()}
                     label={defaultLabel}
@@ -102,19 +102,17 @@ describe('SelectInput', () => {
                     showLabel
                 />
             );
-            validateFieldLabel(component, customLabel);
+            validateFieldLabel(customLabel);
         });
 
         test('renderFieldLabel, required', () => {
-            const component = render(<SelectInputImpl {...defaultProps()} label={defaultLabel} required showLabel />);
-            validateFieldLabel(component, defaultLabel + ' * ');
+            render(<SelectInputImpl {...defaultProps()} label={defaultLabel} required showLabel />);
+            validateFieldLabel(defaultLabel + ' *');
         });
 
         test('renderFieldLabel, showLabel=false', () => {
-            const component = render(
-                <SelectInputImpl {...defaultProps()} label={defaultLabel} required showLabel={false} />
-            );
-            validateFieldLabel(component);
+            render(<SelectInputImpl {...defaultProps()} label={defaultLabel} required showLabel={false} />);
+            validateFieldLabel();
         });
     });
 

--- a/packages/components/src/internal/components/forms/input/SelectInput.tsx
+++ b/packages/components/src/internal/components/forms/input/SelectInput.tsx
@@ -32,6 +32,7 @@ import {
 import { QueryColumn } from '../../../../public/QueryColumn';
 import { generateId, joinMultiValueForExport } from '../../../util/utils';
 import { naturalSortByProperty } from '../../../../public/sort';
+import { RequiredSymbol } from './RequiredSymbol';
 
 const WARN_COLOR = '#8A6D3B';
 const WARN_BG_COLOR = '#FCF8E3';
@@ -597,7 +598,7 @@ export class SelectInputImpl extends Component<SelectInputImplProps, State> {
                     return (
                         <span className={labelClass} data-fieldkey={name}>
                             {renderFieldLabel(undefined, label, description_)}
-                            {required && <span className="required-symbol"> *</span>}
+                            <RequiredSymbol required={required || addLabelAsterisk} />
                         </span>
                     );
                 }

--- a/packages/components/src/theme/form.scss
+++ b/packages/components/src/theme/form.scss
@@ -318,10 +318,6 @@ textarea.form-control {
     }
 }
 
-.required-symbol {
-    margin-left: 4px;
-}
-
 // Borrowed from here: https://css-tricks.com/auto-growing-inputs-textareas/#aa-other-ideas
 .input-sizer {
     display: inline-grid;


### PR DESCRIPTION
#### Rationale
This addresses [#1388](https://github.com/LabKey/internal-issues/issues/1388) by updating the `FileInput` to pass the `required` and `value` properties into the Formsy wrapper.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2045
- https://github.com/LabKey/labkey-ui-premium/pull/1007
- https://github.com/LabKey/limsModules/pull/2373

#### Changes
- Update `FileInput` to prepare the `required` and `value` properties for Formsy so that it can participate in form validation.
- Introduce `useDisableableInput` hook as a replacement for the now deprecated `DisableableInput` class.
- Refactor `FileInput` to a functional component and use `useDisableableInput`.
- Refactor `FieldLabel` to a functional component and stop mutating props.
- Add unit tests