### PR TITLE
RequiredSymbol: support falsy values

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.54.1",
+  "version": "7.54.2-fb-less-required.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.54.1",
+      "version": "7.54.2-fb-less-required.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/components",
-  "version": "7.54.2-fb-less-required.0",
+  "version": "7.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/components",
-      "version": "7.54.2-fb-less-required.0",
+      "version": "7.54.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.54.2-fb-less-required.0",
+  "version": "7.54.2",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/components",
-  "version": "7.54.1",
+  "version": "7.54.2-fb-less-required.0",
   "description": "Components, models, actions, and utility functions for LabKey applications and pages",
   "sideEffects": false,
   "files": [

--- a/packages/components/src/internal/components/forms/input/RequiredSymbol.tsx
+++ b/packages/components/src/internal/components/forms/input/RequiredSymbol.tsx
@@ -10,7 +10,7 @@ interface RequiredSymbolProps {
 }
 
 export const RequiredSymbol: FC<RequiredSymbolProps> = memo(({ required, symbol = ' *' }) => {
-    if (required === false) return null;
+    if (!required) return null;
     return <span className="required-symbol">{symbol}</span>;
 });
 RequiredSymbol.displayName = 'RequiredSymbol';


### PR DESCRIPTION
#### Rationale
The initial introduction of the `<RequiredSymbol />` component is overly strict with needing a boolean value. Relaxing to allow for falsy `required` prop.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2049
- https://github.com/LabKey/limsModules/pull/2387
- https://github.com/LabKey/platform/pull/7911

#### Changes
Revise `RequiredSymbol` to a falsy check
