### PR TITLE
EditableGrid: Fix issue with dropdown toggle overlapping with rest of column

### DIFF
--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -873,10 +873,12 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const metadata = editorModel.getColumnMetadata(metadataKey);
         const showOverlayFromMetadata = !!metadata?.toolTip;
         const showLabelOverlay = !showOverlayFromMetadata && qColumn?.hasHelpTipData;
+        const className = classNames(GRID_HEADER_CELL_BODY, {
+            'grid-header-cell__body--with-remove-column': metadata?.onRemoveColumn !== undefined,
+        });
 
-        // TODO should be able to just use LabelOverlay here since it can handle an alternate tooltip renderer
         return (
-            <div className={GRID_HEADER_CELL_BODY}>
+            <div className={className}>
                 {!showLabelOverlay && (
                     <>
                         {label}

--- a/packages/components/src/internal/components/editable/EditableGrid.tsx
+++ b/packages/components/src/internal/components/editable/EditableGrid.tsx
@@ -873,8 +873,9 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
         const metadata = editorModel.getColumnMetadata(metadataKey);
         const showOverlayFromMetadata = !!metadata?.toolTip;
         const showLabelOverlay = !showOverlayFromMetadata && qColumn?.hasHelpTipData;
+        const renderRemove = !!metadata?.onRemoveColumn;
         const className = classNames(GRID_HEADER_CELL_BODY, {
-            'grid-header-cell__body--with-remove-column': metadata?.onRemoveColumn !== undefined,
+            'grid-header-cell__body--with-remove-column': renderRemove,
         });
 
         return (
@@ -893,7 +894,7 @@ export class EditableGrid extends PureComponent<EditableGridProps, EditableGridS
                 {showLabelOverlay && (
                     <LabelOverlay column={qColumn} label={metadata?.caption} placement="bottom" required={req} />
                 )}
-                {metadata?.onRemoveColumn && (
+                {renderRemove && (
                     <DropdownMenu
                         asAnchor={false}
                         className="grid-panel__menu-toggle editable-grid-column-header__dropdown"

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -72,7 +72,8 @@
 }
 
 // Note: this is necessary because the editable grid column headers use a normal dropdown menu, not the custom one
-// defined in HeaderCellDropdownMenu. Without absolute positioning the dropdown renders inside the header cell.
+// defined in HeaderCellDropdownMenu. Without absolute positioning the dropdown renders inside the header cell, hidden
+// in overflow space, instead of above it.
 .dropdown.editable-grid-column-header__dropdown {
     position: absolute;
     bottom: 6px;

--- a/packages/components/src/theme/grid.scss
+++ b/packages/components/src/theme/grid.scss
@@ -66,12 +66,16 @@
     overflow-y: auto;
 }
 
+// GH Issue 1270
+.grid-header-cell__body--with-remove-column {
+    padding-right: 16px;
+}
+
 // Note: this is necessary because the editable grid column headers use a normal dropdown menu, not the custom one
-// defined in HeaderCellDropdownMenu. This forces the dropdown icon for editable grid dropdowns to the bottom right of
-// the th element.
+// defined in HeaderCellDropdownMenu. Without absolute positioning the dropdown renders inside the header cell.
 .dropdown.editable-grid-column-header__dropdown {
     position: absolute;
-    bottom: 4px;
+    bottom: 6px;
     right: 4px;
 }
 


### PR DESCRIPTION
#### Rationale
This PR resolves LabKey/internal-issues#1270

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2052
- https://github.com/LabKey/limsModules/pull/2390

#### Changes
- EditableGrid: Add padding to the right hand side of grid columns if they have a dropdown menu
